### PR TITLE
docs(config): fix docs config to enable docgen docs

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,8 +1,6 @@
 module.exports = {
-  addons: [
-    "@storybook/addon-docs/react/preset",
-    "@storybook/preset-typescript",
-  ],
+  stories: ["../src/*.stories.mdx", "../src/**/*.stories.(ts|tsx|mdx)"],
+  addons: ["@storybook/preset-typescript", "@storybook/addon-docs"],
   webpackFinal: config => {
     return {
       ...config,

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -3,12 +3,17 @@ import "@chanzuckerberg/czedi-kit-styles/all.css";
 
 import * as React from "react";
 
+import { DocsContainer, DocsPage } from "@storybook/addon-docs/blocks";
+
 import { addDecorator } from "@storybook/react";
-import { configure } from "@storybook/react";
+import { addParameters } from "@storybook/react";
 import { withA11y } from "@storybook/addon-a11y";
 
 addDecorator(withA11y);
 addDecorator(storyFn => <div dir="ltr">{storyFn()}</div>);
-
-// automatically import all files ending in *.stories.js
-configure(require.context("../src", true, /\.stories\.(ts|tsx|mdx)$/), module);
+addParameters({
+  docs: {
+    container: DocsContainer,
+    page: DocsPage,
+  },
+});


### PR DESCRIPTION
### Summary:
Fix docs generation for storybook

### Test Plan:
`lerna bootstrap && npm start`. Confirm in `localhost:6006` that buttons have a docs tab which contains the list of props available to the buttons (it's very long).
![image](https://user-images.githubusercontent.com/1641405/82354051-252c1e00-99b5-11ea-8b2f-09c803ed6648.png)
