### PR TITLE
refactor: remove font-arimo from components

### DIFF
--- a/packages/components/.storybook/preview-body.html
+++ b/packages/components/.storybook/preview-body.html
@@ -1,0 +1,9 @@
+<style>
+  html {
+    font-size: var(--legacy-size-font-base);
+  }
+
+  body {
+    font-family: Arimo, sans-serif;
+  }
+</style>

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -10,6 +10,24 @@ We currently use Arimo as our base font. This package does not export it, so you
 @import url("https://fonts.googleapis.com/css2?family=Arimo:wght@400;700&display=swap");
 ```
 
+and setting up base font settings:
+
+```css
+html {
+  font-size: 16px;
+
+  /* or if using Tailwind:
+  @apply text-base */
+}
+
+body {
+  font-family: Arimo, sans-serif;
+
+  /* or if using Tailwind:
+  @apply font-arimo */
+}
+```
+
 ## Usage
 
 ```

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -49,7 +49,6 @@ interface BaseHeadingProps {
 
 const HeadingComponent = styled.span<BaseHeadingProps>(
   ({ bold, color, size }) => [
-    tw`font-arimo`,
     bold ? tw`font-bold` : tw`font-normal`,
     styleFromColor(color),
     styleFromSize(size),

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -14,7 +14,6 @@ interface BaseTextProps {
 }
 
 const TextComponent = styled.p<BaseTextProps>(({ bold, color, size }) => [
-  tw`font-arimo`,
   bold ? tw`font-bold` : tw`font-normal`,
   styleFromColor(color),
   styleFromSize(size),

--- a/packages/components/src/playground/button.tsx
+++ b/packages/components/src/playground/button.tsx
@@ -12,7 +12,7 @@ const ButtonComponent = styled.button<BaseButtonProps>(({ variant }) => [
   // shape & spacing styles
   tw`py-2 px-4 rounded border-none`,
   // text styles
-  tw`font-arimo text-white font-bold text-sm leading-body`,
+  tw`text-white font-bold text-sm leading-body`,
   // background color
   variant === "secondary"
     ? tw`bg-neutral-500 hover:bg-neutral-600`


### PR DESCRIPTION
### Summary:
We shouldn't be setting `font-arimo` everywhere -- this adds it to root Storybook styles & add some instruction for external projects

### Test Plan:
Percy should show no visual changes