### PR TITLE
fix(lint): fix styleint/eslint/prettier integration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
       "files": ["*.ts", "*.tsx"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "rules": {
+        "@typescript-eslint/no-explicit-any": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off"
       }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,7 +16,9 @@
           "screen"
         ]
       }
-    ]
+    ],
+    "custom-property-empty-line-before": "never",
+    "no-eol-whitespace": null
   },
   "ignoreFiles": [
     "packages/tokens/dist/**"

--- a/packages/components/.babelrc
+++ b/packages/components/.babelrc
@@ -15,6 +15,7 @@
     "@babel/preset-react"
   ],
   "plugins": [
+    "babel-plugin-styled-components",
     "babel-plugin-macros",
     "@babel/plugin-transform-modules-commonjs",
     [

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -75,6 +75,7 @@
     "babel-jest": "^26.6.3",
     "babel-loader": "^8.2.2",
     "babel-plugin-module-resolver": "^4.1.0",
+    "babel-plugin-styled-components": "^1.12.0",
     "flowgen": "^1.13.0",
     "jest": "^24.9.0",
     "jest-styled-components": "^7.0.3",


### PR DESCRIPTION
### Summary:
This fixes conflicts between stylelint's formatter and prettier - allowing prettier to win when they conflict.

### Test Plan:

```js
  css`
    property: value;
`
```
autocorrects to 
```js
  css`
    property: value;
  `
```

without stylelint complaining.