### PR TITLE
refactor(classnames): move to camelcase classnames

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "trailingComma": "es5"
+  "trailingComma": "all"
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -19,7 +19,7 @@
     ],
     "custom-property-empty-line-before": "never",
     "no-eol-whitespace": null,
-    "selector-nested-pattern": "^(&(:|\\.[\\w-]*--state-)(hover|focus|focus-within|active|disabled),?\\s*)+$",
+    "selector-nested-pattern": "^(&(:[\\w-]+|\\.state(Hover|Focus|FocusWithin|Active)),?\\s*)+$",
     "max-nesting-depth": 1
   },
   "ignoreFiles": [

--- a/packages/components/.storybook/Button/button.stories.tsx
+++ b/packages/components/.storybook/Button/button.stories.tsx
@@ -17,7 +17,7 @@ const colors: Array<ButtonProps["color"]> = [
   "success",
 ];
 const variants: Array<ButtonProps["variant"]> = ["flat", "outline", "link"];
-const states: Array<ClickableProps<"button">["state"]> = [
+const states: Array<ClickableProps<"button">["state"] | "disabled"> = [
   "inactive",
   "hover",
   "focus",

--- a/packages/components/package-lock.json
+++ b/packages/components/package-lock.json
@@ -8031,6 +8031,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@chanzuckerberg/eds-tokens": "^0.0.1-alpha.9",
+    "clsx": "^1.1.1",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> flat story renders snapshot 1`] = `
 <button
-  class="button button--variant-flat button--color-success button--size-medium"
+  class="button sizeMedium variantFlat colorSuccess"
   type="button"
 >
   ​
@@ -12,7 +12,7 @@ exports[`<Button /> flat story renders snapshot 1`] = `
 
 exports[`<Button /> link story renders snapshot 1`] = `
 <button
-  class="button button--variant-link button--color-alert"
+  class="button variantLink colorAlert"
   type="button"
 >
   ​
@@ -22,11 +22,11 @@ exports[`<Button /> link story renders snapshot 1`] = `
 
 exports[`<Button /> linkInBody story renders snapshot 1`] = `
 <p
-  class="typography--size-body typography--color-base"
+  class="typography sizeBody colorBase"
 >
   This text surrounds the 
   <button
-    class="button button--variant-link button--color-brand"
+    class="button variantLink colorBrand"
     type="button"
   >
     ​
@@ -38,11 +38,11 @@ exports[`<Button /> linkInBody story renders snapshot 1`] = `
 
 exports[`<Button /> linkInHeading story renders snapshot 1`] = `
 <p
-  class="typography--size-h1 typography--color-base"
+  class="typography sizeH1 colorBase"
 >
   This text surrounds the 
   <button
-    class="button button--variant-link button--color-brand"
+    class="button variantLink colorBrand"
     type="button"
   >
     ​
@@ -54,7 +54,7 @@ exports[`<Button /> linkInHeading story renders snapshot 1`] = `
 
 exports[`<Button /> outline story renders snapshot 1`] = `
 <button
-  class="button button--variant-outline button--color-brand button--size-medium"
+  class="button sizeMedium variantOutline colorBrand"
   type="button"
 >
   ​

--- a/packages/components/src/Heading/__snapshots__/Heading.spec.tsx.snap
+++ b/packages/components/src/Heading/__snapshots__/Heading.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Heading /> Heading1 story renders snapshot 1`] = `
 <h1
-  class="typography--size-h1 typography--color-base"
+  class="typography sizeH1 colorBase"
 >
   Heading 1 24/32
 </h1>
@@ -10,7 +10,7 @@ exports[`<Heading /> Heading1 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading1AsHeading4 story renders snapshot 1`] = `
 <h1
-  class="typography--size-h4 typography--color-base"
+  class="typography sizeH4 colorBase"
 >
   Heading 1 styled as Heading 4
 </h1>
@@ -18,7 +18,7 @@ exports[`<Heading /> Heading1AsHeading4 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading2 story renders snapshot 1`] = `
 <h2
-  class="typography--size-h2 typography--color-base"
+  class="typography sizeH2 colorBase"
 >
   Heading 2 18/24
 </h2>
@@ -26,7 +26,7 @@ exports[`<Heading /> Heading2 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading3 story renders snapshot 1`] = `
 <h3
-  class="typography--size-h3 typography--color-base"
+  class="typography sizeH3 colorBase"
 >
   Heading 3 16/24
 </h3>
@@ -34,7 +34,7 @@ exports[`<Heading /> Heading3 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading4 story renders snapshot 1`] = `
 <h4
-  class="typography--size-h4 typography--color-base"
+  class="typography sizeH4 colorBase"
 >
   Heading 4 14/24
 </h4>
@@ -42,7 +42,7 @@ exports[`<Heading /> Heading4 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading4ColorNeutral story renders snapshot 1`] = `
 <h4
-  class="typography--size-h4 typography--color-neutral"
+  class="typography sizeH4 colorNeutral"
 >
   Neutral color Heading 4
 </h4>
@@ -50,7 +50,7 @@ exports[`<Heading /> Heading4ColorNeutral story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading5 story renders snapshot 1`] = `
 <h5
-  class="typography--size-h5 typography--color-base"
+  class="typography sizeH5 colorBase"
 >
   Heading 5 12/20
 </h5>

--- a/packages/components/src/Text/__snapshots__/Text.spec.tsx.snap
+++ b/packages/components/src/Text/__snapshots__/Text.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Text /> Body story renders snapshot 1`] = `
 <p
-  class="typography--size-body typography--color-base"
+  class="typography sizeBody colorBase"
 >
   Body paragraph 16/24
 </p>
@@ -10,7 +10,7 @@ exports[`<Text /> Body story renders snapshot 1`] = `
 
 exports[`<Text /> BodyColorInfoBold story renders snapshot 1`] = `
 <p
-  class="typography--size-body typography--color-info typography--weight-bold"
+  class="typography sizeBody colorInfo weightBold"
 >
   Info color body text, bold
 </p>
@@ -18,7 +18,7 @@ exports[`<Text /> BodyColorInfoBold story renders snapshot 1`] = `
 
 exports[`<Text /> BodySmall story renders snapshot 1`] = `
 <p
-  class="typography--size-sm typography--color-base"
+  class="typography sizeSm colorBase"
 >
   Body small 14/20
 </p>
@@ -26,7 +26,7 @@ exports[`<Text /> BodySmall story renders snapshot 1`] = `
 
 exports[`<Text /> BodyXSmall story renders snapshot 1`] = `
 <p
-  class="typography--size-xs typography--color-base"
+  class="typography sizeXs colorBase"
 >
   Body Xsmall 12/16
 </p>
@@ -34,7 +34,7 @@ exports[`<Text /> BodyXSmall story renders snapshot 1`] = `
 
 exports[`<Text /> Caption story renders snapshot 1`] = `
 <p
-  class="typography--size-caption typography--color-base"
+  class="typography sizeCaption colorBase"
 >
   Caption 12/20
 </p>
@@ -42,7 +42,7 @@ exports[`<Text /> Caption story renders snapshot 1`] = `
 
 exports[`<Text /> Overline story renders snapshot 1`] = `
 <p
-  class="typography--size-overline typography--color-base"
+  class="typography sizeOverline colorBase"
 >
   Overline 12/20
 </p>

--- a/packages/components/src/util/clickable.module.css
+++ b/packages/components/src/util/clickable.module.css
@@ -8,152 +8,147 @@
 
 /* Component Sizes */
 
-.button--size-small {
+.sizeSmall {
   @apply px-5 py-2 text-xs leading-3;
 }
 
-.button--size-medium {
+.sizeMedium {
   @apply px-5 py-2 text-sm leading-5;
 }
 
-.button--size-large {
+.sizeLarge {
   @apply px-6 py-4 text-sm leading-5;
 }
 
 /* Button Colors */
 
-.button--color-brand {
+.colorBrand {
   --button-primary-color: var(--eds-color-brand-600);
   --button-secondary-color: var(--eds-color-white);
   --button-tertiary-color: var(--eds-color-brand-100);
 
   &:hover,
-  &.button--state-hover,
+  &.stateHover,
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     --button-primary-color: var(--eds-color-brand-700);
   }
 
   &:active,
-  &.button--state-active {
+  &.stateActive {
     /* TODO: Replace with brand active color */
     --button-primary-color: #312b9e;
   }
 
   /* override the hover/focus values */
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     --button-primary-color: var(--eds-color-brand-300);
   }
 }
 
-.button--color-alert {
+.colorAlert {
   --button-primary-color: var(--eds-color-alert-600);
   --button-secondary-color: var(--eds-color-white);
   --button-tertiary-color: var(--eds-color-alert-100);
 
   &:hover,
-  &.button--state-hover,
+  &.stateHover,
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     --button-primary-color: var(--eds-color-alert-700);
   }
 
   &:active,
-  &.button--state-active {
+  &.stateActive {
     /* TODO: Replace with alert active color */
     --button-primary-color: #a4002c;
   }
 
   /* override the hover/focus values */
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     --button-primary-color: var(--eds-color-alert-300);
   }
 }
   
-.button--color-neutral {
+.colorNeutral {
   --button-primary-color: var(--eds-color-neutral-600);
   --button-secondary-color: var(--eds-color-white);
   --button-tertiary-color: var(--eds-color-neutral-100);
 
   &:hover,
-  &.button--state-hover,
+  &.stateHover,
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     --button-primary-color: var(--eds-color-neutral-700);
   }
 
   &:active,
-  &.button--state-active {
+  &.stateActive {
     /* TODO: Replace with neutral active color */
     --button-primary-color: var(--eds-color-neutral-700);
   }
 
   /* override the hover/focus values */
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     --button-primary-color: var(--eds-color-neutral-300);
   }
 }
   
-.button--color-success {
+.colorSuccess {
   --button-primary-color: var(--eds-color-success-600);
   --button-secondary-color: var(--eds-color-white);
   --button-tertiary-color: var(--eds-color-success-100);
 
   &:hover,
-  &.button--state-hover,
+  &.stateHover,
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     --button-primary-color: var(--eds-color-success-700);
   }
 
   &:active,
-  &.button--state-active {
+  &.stateActive {
     /* TODO: Replace with success active color */
     --button-primary-color: #005a30;
   }
 
   /* override the hover/focus values */
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     --button-primary-color: var(--eds-color-success-300);
   }
 }
 
-.button--variant-flat {
+.variantFlat {
   background-color: var(--button-primary-color);
   border-color: var(--button-primary-color);
   color: var(--button-secondary-color);
 }
 
-.button--variant-outline {
+.variantOutline {
   background-color: var(--button-secondary-color);
   border-color: var(--button-primary-color);
   color: var(--button-primary-color);
 
   
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     background-color: var(--button-secondary-color);
     color: var(--button-primary-color);
   }
 
   &:hover,
-  &.button--state-hover {
+  &.stateHover {
     background-color: var(--button-primary-color);
     color: var(--button-secondary-color);
   }
   
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     background-color: var(--button-secondary-color);
     color: var(--button-primary-color);
   }
 }
 
-.button--variant-link {
+.variantLink {
   @apply px-0 py-0 underline border-none;
 
   color: var(--button-primary-color);
@@ -165,20 +160,19 @@
   text-transform: inherit;
 
   &:hover,
-  &.button--state-hover {
+  &.stateHover {
     background-color: var(--button-tertiary-color);
   }
   
   &:hover,
-  &.button--state-hover,
+  &.stateHover,
   &:focus,
-  &.button--state-focus {
+  &.stateFocus {
     text-decoration-thickness: 2px;
   }
 
   /* override the hover/focus values */
-  &:disabled,
-  &.button--state-disabled {
+  &:disabled {
     background-color: initial;
     text-decoration-thickness: auto;
   }
@@ -186,12 +180,11 @@
 
 /* comes after other styles to override hover behaviors */
 .button:focus,
-.button.button--state-focus {
+.button.stateFocus {
   /* Focus Outline */
   @apply outline-none ring-info-400 ring;
 }
 
-.button:disabled,
-.button.button--state-disabled {
+.button:disabled {
   @apply cursor-not-allowed;
 }

--- a/packages/components/src/util/clickable.tsx
+++ b/packages/components/src/util/clickable.tsx
@@ -1,8 +1,6 @@
 import React from "react";
-import classNames from "classnames/bind";
+import clsx from "clsx";
 import styles from "./clickable.module.css";
-
-const cx = classNames.bind(styles);
 
 export type ClickableProps<IComponent extends React.ElementType> = {
   /**
@@ -20,7 +18,7 @@ export type ClickableProps<IComponent extends React.ElementType> = {
   /**
    * A hidden prop for visual testing
    */
-  state?: "inactive" | "hover" | "focus" | "active" | "disabled";
+  state?: "inactive" | "hover" | "focus" | "active";
   /**
    * The style of the element.
    */
@@ -39,15 +37,28 @@ function Clickable<IComponent extends React.ElementType>({
   const Component = as;
   return (
     <Component
-      className={cx(
-        `button`,
-        `button--variant-${variant}`,
-        `button--color-${color}`,
-        {
-          // For testing in storybook and percy
-          [`button--state-${state}`]: state,
-          [`button--size-${size}`]: variant !== "link",
-        }
+      className={clsx(
+        styles.button,
+        // Sizes
+        variant !== "link" && [
+          size === "small" && styles.sizeSmall,
+          size === "medium" && styles.sizeMedium,
+          size === "large" && styles.sizeLarge,
+        ],
+        // Variants
+        variant === "flat" && styles.variantFlat,
+        variant === "outline" && styles.variantOutline,
+        variant === "link" && styles.variantLink,
+        // Colors
+        color === "alert" && styles.colorAlert,
+        color === "brand" && styles.colorBrand,
+        color === "neutral" && styles.colorNeutral,
+        color === "success" && styles.colorSuccess,
+        // Interactive States (for testing)
+        state === "inactive" && styles.stateInactive,
+        state === "hover" && styles.stateHover,
+        state === "focus" && styles.stateFocus,
+        state === "active" && styles.stateActive,
       )}
       {...rest}
     >

--- a/packages/components/src/util/typography.module.css
+++ b/packages/components/src/util/typography.module.css
@@ -1,87 +1,87 @@
 /* sizes */
 
 .typography,
-.typography--size-body {
+.sizeBody {
   @apply text-body leading-body;
   @apply font-normal;
 }
 
-.typography--size-h1 {
+.sizeH1 {
   @apply text-h1 leading-h1;
   @apply font-bold;
 }
 
-.typography--size-h2 {
+.sizeH2 {
   @apply text-h2 leading-body;
   @apply font-bold;
 }
 
-.typography--size-h3 {
+.sizeH3 {
   @apply text-body leading-body;
   @apply font-bold;
 }
 
-.typography--size-h4 {
+.sizeH4 {
   @apply text-sm leading-body;
   @apply font-bold;
 }
 
-.typography--size-h5 {
+.sizeH5 {
   @apply text-xs leading-sm;
   @apply font-bold;
 }
 
-.typography--size-sm {
+.sizeSm {
   @apply text-sm leading-sm;
   @apply font-normal;
 }
 
-.typography--size-xs {
+.sizeXs {
   @apply text-xs leading-xs;
   @apply font-normal;
 }
 
-.typography--size-caption,
-.typography--size-overline {
+.sizeCaption,
+.sizeOverline {
   @apply text-xs leading-sm;
   @apply font-normal;
 }
 
-.typography--size-overline {
+.sizeOverline {
   @apply uppercase;
   @apply font-normal;
 }
 
 /* colors */
-.typography--color-alert {
+.colorAlert {
   @apply text-alert-700;
 }
 
-.typography--color-base {
+.colorBase {
   @apply text-font-base;
 }
 
-.typography--color-brand {
+.colorBrand {
   @apply text-brand-700;
 }
 
-.typography--color-info {
+.colorInfo {
   @apply text-info-700;
 }
 
-.typography--color-neutral {
+.colorNeutral {
   @apply text-neutral-500;
 }
 
-.typography--color-success {
+.colorSuccess {
   @apply text-success-700;
 }
 
-.typography--color-warning {
+.colorWarning {
   @apply text-warning-700;
 }
 
-.typography--color-white {
+.colorWhite {
   @apply text-white;
 }
 
@@ -90,10 +90,10 @@
  * allows override for text components, shouldn't be used by heading components
  **/
  
-.typography--weight-normal {
+.weightNormal {
   @apply font-normal;
 }
 
-.typography--weight-bold {
+.weightBold {
   @apply font-bold;
 }

--- a/packages/components/src/util/typography.tsx
+++ b/packages/components/src/util/typography.tsx
@@ -1,9 +1,7 @@
 import React, { ReactNode } from "react";
 
-import classNames from "classnames/bind";
+import clsx from "clsx";
 import styles from "./typography.module.css";
-
-const cx = classNames.bind(styles);
 
 export type TypographySize =
   | "h1"
@@ -70,9 +68,32 @@ function Typography<IComponent extends React.ElementType>({
   const Component = as;
   return (
     <Component
-      className={cx(`typography--size-${size}`, `typography--color-${color}`, {
-        [`typography--weight-${weight}`]: weight,
-      })}
+      className={clsx(
+        styles.typography,
+        // Sizes
+        size === "h1" && styles.sizeH1,
+        size === "h2" && styles.sizeH2,
+        size === "h3" && styles.sizeH3,
+        size === "h4" && styles.sizeH4,
+        size === "h5" && styles.sizeH5,
+        size === "body" && styles.sizeBody,
+        size === "sm" && styles.sizeSm,
+        size === "xs" && styles.sizeXs,
+        size === "caption" && styles.sizeCaption,
+        size === "overline" && styles.sizeOverline,
+        // Colors
+        color === "alert" && styles.colorAlert,
+        color === "base" && styles.colorBase,
+        color === "brand" && styles.colorBrand,
+        color === "info" && styles.colorInfo,
+        color === "neutral" && styles.colorNeutral,
+        color === "success" && styles.colorSuccess,
+        color === "warning" && styles.colorWarning,
+        color === "white" && styles.colorWhite,
+        // Weights
+        weight === "bold" && styles.weightBold,
+        weight === "normal" && styles.weightNormal,
+      )}
       {...rest}
     >
       {children}

--- a/packages/tokens/style-dictionary.config.js
+++ b/packages/tokens/style-dictionary.config.js
@@ -108,7 +108,7 @@ EDSStyleDictionary.registerFormat({
     return JSON.stringify(
       minifyCSSVarDictionary(dictionary.properties),
       null,
-      2
+      2,
     );
   },
 });


### PR DESCRIPTION
### Summary:

Let's see what the repo would look like with a different way of referencing css modules! Also since this style doesn't use bind, we can use [`clsx`](https://github.com/lukeed/clsx) which is smaller and more performant than `classnames`.

### Test Plan:

- `npm test`
- CI
- Percy (should have no differences from buttons)

One benefit that looks like a downside is we have a more accurate picture of our coverage.