### PR TITLE
 chore: add story with entire type ramp

### DIFF
--- a/packages/components/.storybook/typography.module.css
+++ b/packages/components/.storybook/typography.module.css
@@ -1,0 +1,19 @@
+.table {
+  @apply w-full text-left;
+  @apply lg:w-2/3;
+}
+
+.table thead {
+  @apply border-b-2;
+}
+
+/* Override default border styling */
+.table tr,
+.table tr td,
+.table tr th {
+  @apply border-none;
+}
+
+.table td:nth-child(2) {
+  font-family: monospace;
+}

--- a/packages/components/.storybook/typography.stories.mdx
+++ b/packages/components/.storybook/typography.stories.mdx
@@ -1,0 +1,80 @@
+import { Meta } from "@storybook/addon-docs/blocks";
+
+import Heading from "../src/Heading";
+import Text from "../src/Text";
+import styles from "./typography.module.css";
+
+<Meta title="Typography Ramp" />
+
+# Typography Size Ramp
+
+<table className={styles.table}>
+  <thead>
+    <tr>
+      <th>Size</th>
+      <th>Font-size / line-height (px)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <Heading size="h1">Heading 1</Heading>
+      </td>
+      <td>24 / 32</td>
+    </tr>
+    <tr>
+      <td>
+        <Heading size="h2">Heading 2</Heading>
+      </td>
+      <td>18 / 24</td>
+    </tr>
+    <tr>
+      <td>
+        <Heading size="h3">Heading 3</Heading>
+      </td>
+      <td>16 / 24</td>
+    </tr>
+    <tr>
+      <td>
+        <Heading size="h4">Heading 4</Heading>
+      </td>
+      <td>14 / 24</td>
+    </tr>
+    <tr>
+      <td>
+        <Heading size="h5">Heading 5</Heading>
+      </td>
+      <td>12 / 20</td>
+    </tr>
+    <tr>
+      <td>
+        <Text size="body">Body text</Text>
+      </td>
+      <td>16 / 24</td>
+    </tr>
+    <tr>
+      <td>
+        <Text size="sm">Small text</Text>
+      </td>
+      <td>14 / 20</td>
+    </tr>
+    <tr>
+      <td>
+        <Text size="xs">X-small text</Text>
+      </td>
+      <td>12 / 16</td>
+    </tr>
+    <tr>
+      <td>
+        <Text size="caption">Caption text</Text>
+      </td>
+      <td>12 / 20</td>
+    </tr>
+    <tr>
+      <td>
+        <Text size="overline">Overline text</Text>
+      </td>
+      <td>12 / 20</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
### Summary:
As teams start refactoring text, the current way we split up each type size into a story is kind of hard to reference. This adds a "Typography Ramp" table to Storybook:

![Screen Shot 2021-05-26 at 2 36 40 PM](https://user-images.githubusercontent.com/15840841/119734399-ca32cf80-be2f-11eb-891e-ff9d34aada2e.png)


### Test Plan:
build passes, no codecov or percy changes