### PR TITLE
feat(typography): allow color passthrough on text components

### DIFF
--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -56,3 +56,15 @@ BodyColorInfoBold.args = {
   size: "body",
   weight: "bold",
 };
+
+export const TextColorInherit = (args) => (
+  <Text color="alert" size="body">
+    This text surrounds the <Text {...args} /> and shows it should inherit color
+    from the parent
+  </Text>
+);
+TextColorInherit.args = {
+  children: "Child Text",
+  color: "inherit",
+  size: "body",
+};

--- a/packages/components/src/Text/__snapshots__/Text.spec.tsx.snap
+++ b/packages/components/src/Text/__snapshots__/Text.spec.tsx.snap
@@ -47,3 +47,17 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
   Overline 12/20
 </p>
 `;
+
+exports[`<Text /> TextColorInherit story renders snapshot 1`] = `
+<p
+  class="typography sizeBody colorAlert"
+>
+  This text surrounds the 
+  <p
+    class="typography sizeBody colorInherit"
+  >
+    Child Text
+  </p>
+   and shows it should inherit color from the parent
+</p>
+`;

--- a/packages/components/src/common/typography.module.css
+++ b/packages/components/src/common/typography.module.css
@@ -59,6 +59,10 @@
   @apply text-info-700;
 }
 
+.colorInherit {
+  color: inherit;
+}
+
 .colorNeutral {
   @apply text-neutral-500;
 }
@@ -92,7 +96,7 @@
  * font-weights
  * allows override for text components, shouldn't be used by heading components
  **/
- 
+
 .weightNormal {
   @apply font-normal;
 }

--- a/packages/components/src/common/typography.tsx
+++ b/packages/components/src/common/typography.tsx
@@ -20,6 +20,7 @@ export type TypographyColor =
   | "base"
   | "brand"
   | "info"
+  | "inherit"
   | "neutral"
   | "success"
   | "warning"
@@ -99,6 +100,7 @@ function Typography<IComponent extends React.ElementType>({
         color === "base" && styles.colorBase,
         color === "brand" && styles.colorBrand,
         color === "info" && styles.colorInfo,
+        color === "inherit" && styles.colorInherit,
         color === "neutral" && styles.colorNeutral,
         color === "success" && styles.colorSuccess,
         color === "warning" && styles.colorWarning,


### PR DESCRIPTION
### Summary:
TLDR: This is not a finished PR, just looking for feedback on the problem/possible solutions re: inheriting color for typography components

#### The Problem:
When working on the Banner EDS candidate (https://github.com/FB-PLP/traject/pull/6758), one of the suggestions was to pull out a `Banner.Title` component that ensures the `Heading` component styling stays consistent:

```
Banner.Title = function BannerTitle(props: {|
  children?: React$Node,
  as: string,
|}) {
  return (
    <Heading as={props.as} size="h3">
      {props.children}
    </Heading>
  );
};
```

and usage would look something like

```
<Banner>
  <Banner.Title> Title Content </Banner.Title>
  <Banner.Body> Body Content </Banner.Body> 
</Banner>
```

But Heading and Text have a default color value `base`, so the result is that the banner color was being overriden:
![image](https://user-images.githubusercontent.com/3467293/120537858-a37a1900-c39a-11eb-89f4-e3631b3f8282.png)


#### This PR:
This PR is an attempt to fix that by setting up Typography components to be able to "inherit" color, similar to SVGIcon (eg in the above screenshot, the icon gets the banner's color)

I say attempt because if the default is `currentColor` or `color: inherit`, and the parent doesn't have a color set, then it just uses black, which isn't actually what I want.

The ideal is "if the parent has a color, use that, but if not, use `base`", but I can't seem to figure out a way to do that. CSS variables can have a fallback, but the this doesn't seem to exist for `currentColor` or `inherit`. 


#### Other Options:
* Go back to having heading be a prop and the content being plain text, so we can set the color within the component
* When using `Banner.Title` and `Banner.Body`, you have to (redundantly) set the color scheme - pretty sure we dont want this, since it could lead to inconsistent looking banners
* Slightly wacky but we could [use cloneElement to inject the color elements into the children? ](https://stackoverflow.com/questions/50786382/how-to-safely-inject-props-into-react-children)(I can't tell if this is too 😬  or not) 

### Test Plan:
TBD