### PR TITLE
feat(typography): allow ref pass through on Text components

### DIFF
--- a/packages/components/src/Text/Text.spec.tsx
+++ b/packages/components/src/Text/Text.spec.tsx
@@ -24,7 +24,7 @@ describe("<Text />", () => {
     `);
   });
 
-  it("should pass the passthrough ref", async () => {
+  it("should pass the passthrough ref", () => {
     const textRef = React.createRef();
     render(
       <Text ref={textRef} size="body" tabIndex={-1}>
@@ -34,7 +34,7 @@ describe("<Text />", () => {
 
     textRef.current.focus();
 
-    const textElement = await screen.getByText("Some Text");
+    const textElement = screen.getByText("Some Text");
     expect(textElement).toEqual(document.activeElement);
   });
 });

--- a/packages/components/src/Text/Text.spec.tsx
+++ b/packages/components/src/Text/Text.spec.tsx
@@ -1,6 +1,6 @@
 import * as TextStoryFile from "./Text.stories";
 
-import React, { useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 
 import { render, screen } from "@testing-library/react";
 import Text from "./Text";
@@ -25,22 +25,16 @@ describe("<Text />", () => {
   });
 
   it("should pass the passthrough ref", async () => {
-    const TestComponent = () => {
-      const textRef = useRef<HTMLParagraphElement>(null);
+    const textRef = React.createRef();
+    render(
+      <Text ref={textRef} size="body" tabIndex={-1}>
+        Some Text
+      </Text>,
+    );
 
-      useEffect(() => {
-        textRef.current && textRef.current.focus();
-      });
+    textRef.current.focus();
 
-      return (
-        <Text ref={textRef} size="body" className="passthrough" tabIndex={-1}>
-          Some Text
-        </Text>
-      );
-    };
-    render(<TestComponent />);
     const textElement = await screen.getByText("Some Text");
-
     expect(textElement).toEqual(document.activeElement);
   });
 });

--- a/packages/components/src/Text/Text.spec.tsx
+++ b/packages/components/src/Text/Text.spec.tsx
@@ -1,8 +1,8 @@
 import * as TextStoryFile from "./Text.stories";
 
-import { render, screen } from "@testing-library/react";
+import React, { useEffect, useRef } from "react";
 
-import React from "react";
+import { render, screen } from "@testing-library/react";
 import Text from "./Text";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 
@@ -22,5 +22,25 @@ describe("<Text />", () => {
         Some Text
       </p>
     `);
+  });
+
+  it("should pass the passthrough ref", async () => {
+    const TestComponent = () => {
+      const textRef = useRef<HTMLParagraphElement>(null);
+
+      useEffect(() => {
+        textRef.current && textRef.current.focus();
+      });
+
+      return (
+        <Text ref={textRef} size="body" className="passthrough" tabIndex={-1}>
+          Some Text
+        </Text>
+      );
+    };
+    render(<TestComponent />);
+    const textElement = await screen.getByText("Some Text");
+
+    expect(textElement).toEqual(document.activeElement);
   });
 });

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -1,6 +1,6 @@
-import Typography, { TypographyProps } from "../common/typography";
+import React, { forwardRef } from "react";
 
-import React from "react";
+import Typography, { TypographyProps } from "../common/typography";
 
 type TextElement = "p" | "span";
 
@@ -17,22 +17,17 @@ type Props = {
   spacing?: TypographyProps<TextElement>["spacing"];
 };
 
-function Text({
-  as,
-  children,
-  /**
+const Text = forwardRef<HTMLElement, Props>(({ as, children, /**
    * Components that wrap typography sometimes requires props such as event handlers
    * to be passed down into the element. One example is the tooltip component.  It
    * attaches a onHover and onFocus event to the element to determine when to
    * trigger the overlay.
-   */
-  ...rest
-}: Props) {
-  return (
-    <Typography as={as || "p"} {...rest}>
-      {children}
-    </Typography>
-  );
-}
+   */ ...rest }: Props, ref) => (
+  <Typography as={as || "p"} ref={ref} {...rest}>
+    {children}
+  </Typography>
+));
+
+Text.displayName = "Text"; // Satisfy eslint.
 
 export default Text;

--- a/packages/components/src/common/typography.tsx
+++ b/packages/components/src/common/typography.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ForwardedRef, ReactNode, forwardRef } from "react";
 
 import clsx from "clsx";
 import styles from "./typography.module.css";
@@ -68,57 +68,65 @@ export type TypographyProps<IComponent extends React.ElementType> = {
   spacing?: TypographyMargin;
 } & React.ComponentProps<IComponent>;
 
-function Typography<IComponent extends React.ElementType>({
-  as,
-  children,
-  color = "base",
-  size,
-  weight = null,
-  spacing,
-  className,
-  ...rest
-}: TypographyProps<IComponent>) {
-  const Component = as;
-  return (
-    <Component
-      className={clsx(
-        className,
-        styles.typography,
-        // Sizes
-        size === "h1" && styles.sizeH1,
-        size === "h2" && styles.sizeH2,
-        size === "h3" && styles.sizeH3,
-        size === "h4" && styles.sizeH4,
-        size === "h5" && styles.sizeH5,
-        size === "body" && styles.sizeBody,
-        size === "sm" && styles.sizeSm,
-        size === "xs" && styles.sizeXs,
-        size === "caption" && styles.sizeCaption,
-        size === "overline" && styles.sizeOverline,
-        // Colors
-        color === "alert" && styles.colorAlert,
-        color === "base" && styles.colorBase,
-        color === "brand" && styles.colorBrand,
-        color === "info" && styles.colorInfo,
-        color === "inherit" && styles.colorInherit,
-        color === "neutral" && styles.colorNeutral,
-        color === "success" && styles.colorSuccess,
-        color === "warning" && styles.colorWarning,
-        color === "white" && styles.colorWhite,
-        // Weights
-        weight === "bold" && styles.weightBold,
-        weight === "normal" && styles.weightNormal,
-        // Spacing
-        spacing === "none" && styles.spacingNone,
-        spacing === "half" && styles.spacingHalf,
-        spacing === "1x" && styles.spacing1,
-        spacing === "2x" && styles.spacing2,
-      )}
-      {...rest}
-    >
-      {children}
-    </Component>
-  );
-}
+const Typography = forwardRef(
+  <IComponent extends React.ElementType>(
+    {
+      as,
+      children,
+      color = "base",
+      size,
+      weight = null,
+      spacing,
+      className,
+      ...rest
+    }: TypographyProps<IComponent>,
+    ref: ForwardedRef<HTMLElement>,
+  ) => {
+    const Component = as;
+    return (
+      <Component
+        ref={ref}
+        className={clsx(
+          className,
+          styles.typography,
+          // Sizes
+          size === "h1" && styles.sizeH1,
+          size === "h2" && styles.sizeH2,
+          size === "h3" && styles.sizeH3,
+          size === "h4" && styles.sizeH4,
+          size === "h5" && styles.sizeH5,
+          size === "body" && styles.sizeBody,
+          size === "sm" && styles.sizeSm,
+          size === "xs" && styles.sizeXs,
+          size === "caption" && styles.sizeCaption,
+          size === "overline" && styles.sizeOverline,
+          // Colors
+          color === "alert" && styles.colorAlert,
+          color === "base" && styles.colorBase,
+          color === "brand" && styles.colorBrand,
+          color === "info" && styles.colorInfo,
+          color === "inherit" && styles.colorInherit,
+          color === "neutral" && styles.colorNeutral,
+          color === "success" && styles.colorSuccess,
+          color === "warning" && styles.colorWarning,
+          color === "white" && styles.colorWhite,
+          // Weights
+          weight === "bold" && styles.weightBold,
+          weight === "normal" && styles.weightNormal,
+          // Spacing
+          spacing === "none" && styles.spacingNone,
+          spacing === "half" && styles.spacingHalf,
+          spacing === "1x" && styles.spacing1,
+          spacing === "2x" && styles.spacing2,
+        )}
+        {...rest}
+      >
+        {children}
+      </Component>
+    );
+  },
+);
+
+Typography.displayName = "Typography"; // Satisfy eslint.
 
 export default Typography;


### PR DESCRIPTION
### Summary:
Allow consumers of the `Text` componnent to pass down a `ref` to access the underlying DOM
element directly.

GitHub issue:
https://github.com/chanzuckerberg/edu-design-system/issues/295

Clubhouse story:
https://app.clubhouse.io/czi-edu/story/141247/add-forward-ref-to-heading-text-components

### Test Plan:
I added a unit test that uses a ref to focus on the text element produced by a <Text/>
element to verify the ref is correctly being passed down.