### PR TITLE
feat(typography): allow ref to pass through Heading

### DIFF
--- a/packages/components/src/Heading/Heading.spec.tsx
+++ b/packages/components/src/Heading/Heading.spec.tsx
@@ -8,7 +8,7 @@ import { generateSnapshots } from "@chanzuckerberg/story-utils";
 describe("<Heading />", () => {
   generateSnapshots(HeadingStoryFile);
 
-  it("should pass the passthrough ref", () => {
+  it("should pass through ref", () => {
     const headingRef = React.createRef();
     render(
       <Heading ref={headingRef} size="h1" tabIndex={-1}>

--- a/packages/components/src/Heading/Heading.spec.tsx
+++ b/packages/components/src/Heading/Heading.spec.tsx
@@ -1,6 +1,25 @@
 import * as HeadingStoryFile from "./Heading.stories";
+
+import { render, screen } from "@testing-library/react";
+import Heading from "./Heading";
+import React from "react";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 
 describe("<Heading />", () => {
   generateSnapshots(HeadingStoryFile);
+
+  it("should pass the passthrough ref", () => {
+    const headingRef = React.createRef();
+    render(
+      <Heading ref={headingRef} size="h1" tabIndex={-1}>
+        Some Heading
+      </Heading>,
+    );
+
+    headingRef.current.focus();
+
+    const headingElement = screen.getByText("Some Heading");
+
+    expect(headingElement).toHaveFocus();
+  });
 });

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -1,6 +1,6 @@
-import Typography, { TypographyProps } from "../common/typography";
+import React, { forwardRef } from "react";
 
-import React from "react";
+import Typography, { TypographyProps } from "../common/typography";
 
 type HeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
@@ -21,23 +21,18 @@ type Props = {
   spacing?: TypographyProps<HeadingElement>["spacing"];
 };
 
-function Heading({
-  as,
-  children,
-  size,
-  /**
+const Heading = forwardRef<HTMLElement, Props>(({ as, children, size, /**
    * Components that wrap typography sometimes require props such as
    * event handlers, tabIndex, etc. to be passed down into the element.
    * TODO: add better typing or documentation for optional props,
    * e.g. React.HTMLAttributes<HTMLHeadingElement>
-   */
-  ...rest
-}: Props) {
-  return (
-    <Typography as={as || size} size={size} {...rest}>
-      {children}
-    </Typography>
-  );
-}
+   */ ...rest }: Props, ref) => (
+  <Typography as={as || size} size={size} ref={ref} {...rest}>
+    {children}
+  </Typography>
+));
+
+// TODO: make sure we need this
+Heading.displayName = "Heading"; // Satisfy eslint.
 
 export default Heading;

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -32,7 +32,6 @@ const Heading = forwardRef<HTMLElement, Props>(({ as, children, size, /**
   </Typography>
 ));
 
-// TODO: make sure we need this
 Heading.displayName = "Heading"; // Satisfy eslint.
 
 export default Heading;


### PR DESCRIPTION
### Summary:
Follow-up to https://github.com/chanzuckerberg/edu-design-system/pull/452 in which we allowed refs to pass through `Text` components. Because that one updated the underlying `Typography` component, this PR only has to update `Heading`.

### Test Plan:
Run the tests and verify they all pass.