### PR TITLE
chore: add display: flex to Heading

### DIFF
--- a/packages/components/src/Heading/Heading.module.css
+++ b/packages/components/src/Heading/Heading.module.css
@@ -1,0 +1,3 @@
+.heading {
+  @apply flex;
+}

--- a/packages/components/src/Heading/Heading.stories.tsx
+++ b/packages/components/src/Heading/Heading.stories.tsx
@@ -55,3 +55,13 @@ Heading4ColorNeutral.args = {
   color: "neutral",
   size: "h4",
 };
+
+export const HeadingWithMultipleDivs = Template.bind(null);
+HeadingWithMultipleDivs.args = {
+  size: "h3",
+  children: (
+    <>
+      <div>Heading in a Div</div>&nbsp;<div>Followed by Another Div</div>
+    </>
+  ),
+};

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -2,6 +2,9 @@ import React, { forwardRef } from "react";
 
 import Typography, { TypographyProps } from "../common/typography";
 
+import clsx from "clsx";
+import styles from "./Heading.module.css";
+
 type HeadingElement = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 type Props = {
@@ -21,16 +24,33 @@ type Props = {
   spacing?: TypographyProps<HeadingElement>["spacing"];
 };
 
-const Heading = forwardRef<HTMLElement, Props>(({ as, children, size, /**
-   * Components that wrap typography sometimes require props such as
-   * event handlers, tabIndex, etc. to be passed down into the element.
-   * TODO: add better typing or documentation for optional props,
-   * e.g. React.HTMLAttributes<HTMLHeadingElement>
-   */ ...rest }: Props, ref) => (
-  <Typography as={as || size} size={size} ref={ref} {...rest}>
-    {children}
-  </Typography>
-));
+const Heading = forwardRef<HTMLElement, Props>(
+  (
+    {
+      as,
+      children,
+      size,
+      className,
+      /**
+       * Components that wrap typography sometimes require props such as
+       * event handlers, tabIndex, etc. to be passed down into the element.
+       * TODO: add better typing or documentation for optional props,
+       * e.g. React.HTMLAttributes<HTMLHeadingElement>
+       */ ...rest
+    }: Props,
+    ref,
+  ) => (
+    <Typography
+      as={as || size}
+      size={size}
+      ref={ref}
+      className={clsx(className, styles.heading)}
+      {...rest}
+    >
+      {children}
+    </Typography>
+  ),
+);
 
 Heading.displayName = "Heading"; // Satisfy eslint.
 

--- a/packages/components/src/Heading/__snapshots__/Heading.spec.tsx.snap
+++ b/packages/components/src/Heading/__snapshots__/Heading.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Heading /> Heading1 story renders snapshot 1`] = `
 <h1
-  class="typography sizeH1 colorBase"
+  class="heading typography sizeH1 colorBase"
 >
   Heading 1 24/32
 </h1>
@@ -10,7 +10,7 @@ exports[`<Heading /> Heading1 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading1AsHeading4 story renders snapshot 1`] = `
 <h1
-  class="typography sizeH4 colorBase"
+  class="heading typography sizeH4 colorBase"
 >
   Heading 1 styled as Heading 4
 </h1>
@@ -18,7 +18,7 @@ exports[`<Heading /> Heading1AsHeading4 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading2 story renders snapshot 1`] = `
 <h2
-  class="typography sizeH2 colorBase"
+  class="heading typography sizeH2 colorBase"
 >
   Heading 2 18/24
 </h2>
@@ -26,7 +26,7 @@ exports[`<Heading /> Heading2 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading3 story renders snapshot 1`] = `
 <h3
-  class="typography sizeH3 colorBase"
+  class="heading typography sizeH3 colorBase"
 >
   Heading 3 16/24
 </h3>
@@ -34,7 +34,7 @@ exports[`<Heading /> Heading3 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading4 story renders snapshot 1`] = `
 <h4
-  class="typography sizeH4 colorBase"
+  class="heading typography sizeH4 colorBase"
 >
   Heading 4 14/24
 </h4>
@@ -42,7 +42,7 @@ exports[`<Heading /> Heading4 story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading4ColorNeutral story renders snapshot 1`] = `
 <h4
-  class="typography sizeH4 colorNeutral"
+  class="heading typography sizeH4 colorNeutral"
 >
   Neutral color Heading 4
 </h4>
@@ -50,8 +50,22 @@ exports[`<Heading /> Heading4ColorNeutral story renders snapshot 1`] = `
 
 exports[`<Heading /> Heading5 story renders snapshot 1`] = `
 <h5
-  class="typography sizeH5 colorBase"
+  class="heading typography sizeH5 colorBase"
 >
   Heading 5 12/20
 </h5>
+`;
+
+exports[`<Heading /> HeadingWithMultipleDivs story renders snapshot 1`] = `
+<h3
+  class="heading typography sizeH3 colorBase"
+>
+  <div>
+    Heading in a Div
+  </div>
+   
+  <div>
+    Followed by Another Div
+  </div>
+</h3>
 `;


### PR DESCRIPTION
### Summary:
We're currently migrating the headings in `traject` to use the eds `Heading` component. In the process, we found a bug where icons are being pushed to a separate line than the text. https://app.clubhouse.io/czi-edu/story/144708/icon-truncated-into-second-line-and-hover-on-it-tooltip-position-shows-at-wrong-place-while-navigating-to-mentee-profile

To fix this, we either need to give all `block` elements in headings `display: inline-block` or we add `display: flex` to the `Heading` styles. I figure that the latter makes more sense because we will, I think, always want `Heading` children to sit next to each other (unless they're wrapping due to space constraints).

### Test Plan:
Verify all the text in the `Heading` story `HeadingWithMultipleDivs` is on one line.
<img width="878" alt="screenshot of HeadingWithMultipleDivs story" src="https://user-images.githubusercontent.com/7761701/123179569-8d61f480-d43e-11eb-8245-50a6d95d7492.png">
