### PR TITLE
chore(button): specify HTML attr styles, use className on Clickable

### DIFF
--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -103,10 +103,10 @@ exports[`<Button /> outlineWithIcon story renders snapshot 1`] = `
 exports[`<Button /> withDataTestId story renders snapshot 1`] = `
 <button
   class="button sizeMedium variantFlat colorAlert"
-  data-test-id="fake-test-id"
+  data-testid="fake-test-id"
   type="button"
 >
   ​
-  Button with data-test-id
+  Button with data-testid
 </button>
 `;

--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -110,3 +110,13 @@ exports[`<Button /> withDataTestId story renders snapshot 1`] = `
   Button with data-testid
 </button>
 `;
+
+exports[`<Button /> withFakeClassName story renders snapshot 1`] = `
+<button
+  class="fake-className button sizeMedium variantOutline colorWarning"
+  type="button"
+>
+  ​
+  With fake className
+</button>
+`;

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -71,10 +71,10 @@ linkInHeading.args = {
 
 export const withDataTestId = Template.bind(null);
 withDataTestId.args = {
-  children: "Button with data-test-id",
+  children: "Button with data-testid",
   color: "alert",
   variant: "flat",
-  "data-test-id": "fake-test-id",
+  "data-testid": "fake-test-id",
 };
 
 export const linkWithIcon = Template.bind(null);

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -90,3 +90,11 @@ outlineWithIcon.args = {
   color: "warning",
   variant: "outline",
 };
+
+export const withFakeClassName = Template.bind(null);
+withFakeClassName.args = {
+  children: "With fake className",
+  color: "warning",
+  variant: "outline",
+  className: "fake-className",
+};

--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from "react";
 
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-type ButtonPropsBase = ButtonHTMLElementProps & {
+export type ButtonProps = ButtonHTMLElementProps & {
   as?: "button" | React.ComponentType<any>;
   /**
    * The button contents or label.
@@ -13,8 +13,6 @@ type ButtonPropsBase = ButtonHTMLElementProps & {
   size?: ClickableProps<"button">["size"];
   variant?: ClickableProps<"button">["variant"];
 };
-
-export type ButtonProps = Omit<ButtonPropsBase, "style">;
 
 function Button({
   as = "button",

--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -3,18 +3,18 @@ import React, { ReactNode } from "react";
 
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
-export type ButtonProps = {
+type ButtonPropsBase = ButtonHTMLElementProps & {
   as?: "button" | React.ComponentType<any>;
   /**
    * The button contents or label.
    */
   children: ReactNode;
   color?: ClickableProps<"button">["color"];
-  disabled?: ButtonHTMLElementProps["disabled"];
   size?: ClickableProps<"button">["size"];
-  type?: ButtonHTMLElementProps["type"];
   variant?: ClickableProps<"button">["variant"];
 };
+
+export type ButtonProps = Omit<ButtonPropsBase, "style">;
 
 function Button({
   as = "button",

--- a/packages/components/src/Clickable/Clickable.tsx
+++ b/packages/components/src/Clickable/Clickable.tsx
@@ -37,12 +37,14 @@ function Clickable<IComponent extends React.ElementType>({
   size,
   state,
   variant,
+  className,
   ...rest
 }: ClickableProps<IComponent>) {
   const Component = as;
   return (
     <Component
       className={clsx(
+        className,
         styles.button,
         // Sizes
         variant !== "link" && [


### PR DESCRIPTION
### Summary:
This PR accomplishes 2 tasks:
- explicitly allow HTML button attributes on the `Button` props
- use the `className` prop if it's passed into the `Clickable` component

The `Clickable` component already has `className` in the types, and we have a test to verify that it's being applied to the element, but it's currently **removing** the default styles we're adding to the element. This change adds the `className`, if passed in, to the styles list so it exists so they are both applied.

Question: should the `className` be applied at the top or bottom of the stack? I put it at the top so our default styles win out, which I think makes sense for highly opinionated design system components.

### Test Plan:
It looks like type checking is currently not running on story files, so, to test this, I added a little test component to the bottom of `button.tsx` and ran `npx lerna run build:types` in my terminal.

This test button should not raise any flow errors:
```
export const TestButton = (
  <Button
    data-testid="fake-data-test-id"
    role="alert"
    aria-live="polite"
    tabIndex={-1} 
  >
    Test button
  </Button>
);
```

For testing `className`, verify that the new story renders like a normal button, has the fake class name, and also has the usual class names.