### PR TITLE
chore(button): add dark background stories

### DIFF
--- a/packages/components/.storybook/Button/button.stories.tsx
+++ b/packages/components/.storybook/Button/button.stories.tsx
@@ -36,7 +36,7 @@ const states: Array<ClickableProps<"button">["state"] | "disabled"> = [
 ];
 
 const renderSize = (
-  size: "small" | "medium" | "large",
+  size: ButtonProps["size"],
   textColor: "white" | "neutral",
   children,
 ) =>

--- a/packages/components/.storybook/Button/button.stories.tsx
+++ b/packages/components/.storybook/Button/button.stories.tsx
@@ -9,6 +9,15 @@ import styles from "./button.module.css";
 
 export { default } from "../../src/Button/button.stories";
 
+const defaultParameters = {
+  axe: {
+    skip: true,
+  },
+  snapshot: {
+    skip: true,
+  },
+};
+
 const sizes: Array<ButtonProps["size"]> = ["small", "medium", "large"];
 const colors: Array<ButtonProps["color"]> = [
   "alert",
@@ -26,58 +35,70 @@ const states: Array<ClickableProps<"button">["state"] | "disabled"> = [
   "disabled",
 ];
 
-export const allVariants = ({ children }) => {
-  return (
-    <ul>
-      {sizes.map((size) => (
-        <li key={size}>
-          {variants.map((variant) => (
-            <React.Fragment key={variant}>
-              <Heading size="h2">
-                {variant} - {size}
-              </Heading>
-              <table className={styles["variant"]}>
-                <tbody>
-                  {states.map((state) => (
-                    <tr key={state}>
-                      <th scope="row">
-                        <Text size="body">{state}</Text>
-                      </th>
-                      {colors.map((color) => (
-                        <td key={color} className={styles["color"]}>
-                          <Clickable
-                            as="button"
-                            size={size}
-                            color={color}
-                            variant={variant}
-                            state={state}
-                            disabled={state === "disabled"}
-                          >
-                            {children}
-                          </Clickable>
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </React.Fragment>
+const renderSize = (
+  size: "small" | "medium" | "large",
+  textColor: "white" | "neutral",
+  children,
+) =>
+  variants.map((variant) => (
+    <React.Fragment key={variant}>
+      <Heading size="h2" color={textColor}>
+        {variant} - {size}
+      </Heading>
+      <table className={styles["variant"]}>
+        <tbody>
+          {states.map((state) => (
+            <tr key={state}>
+              <th scope="row">
+                <Text size="body" color={textColor}>
+                  {state}
+                </Text>
+              </th>
+              {colors.map((color) => (
+                <td key={color} className={styles["color"]}>
+                  <Clickable
+                    as="button"
+                    size={size}
+                    color={color}
+                    variant={variant}
+                    state={state}
+                    disabled={state === "disabled"}
+                  >
+                    {children}
+                  </Clickable>
+                </td>
+              ))}
+            </tr>
           ))}
-        </li>
-      ))}
-    </ul>
-  );
-};
+        </tbody>
+      </table>
+    </React.Fragment>
+  ));
+
+export const allVariants = ({ children }) => (
+  <ul>
+    {sizes.map((size) => (
+      <li key={size}>{renderSize(size, "neutral", children)}</li>
+    ))}
+  </ul>
+);
 
 allVariants.args = {
   children: "Button",
 };
 
-allVariants.parameters = {
-  axe: {
-    skip: true,
-  },
-  snapshot: {
-    skip: true,
+allVariants.parameters = defaultParameters;
+
+export const mediumVariantsOnDarkBackground = ({ children }) =>
+  renderSize("medium", "white", children);
+
+mediumVariantsOnDarkBackground.args = {
+  children: "Button",
+};
+
+mediumVariantsOnDarkBackground.parameters = {
+  ...defaultParameters,
+  backgrounds: {
+    default: "dark",
   },
 };


### PR DESCRIPTION
### Summary:
Clubhouse story: https://app.clubhouse.io/czi-edu/story/143864/buttons

This PR pulls out part of the render template from the `All Variants` `Button`
story and renders it again with a dark dark background and white text.
We could also just render the whole `All Variants` again in this section, but
that felt like overkill to me when we just want to see one size for each color +
variant on a non-white background.

### Test Plan:
`npm start` to run storybook,
navigate to the `Button` component stories,
verify all the existing stories are unchanged (except the `All Variants` now has darker text outside the buttons),
and verify there is now a new story called `Medium Variants On Dark Background` that has the medium size buttons (flat, outline, and link) on a dark background with white text around the buttons.

### Screenshot
![Screen Shot 2021-07-06 at 10 15 52 AM](https://user-images.githubusercontent.com/7761701/124641304-67c3ea80-de43-11eb-8466-b26156c2ccdc.png)
