### PR TITLE
chore(button): remove 'WIP' from Button story name

### DIFF
--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -5,7 +5,7 @@ import { Story } from "@storybook/react/types-6-0";
 import Text from "../Text";
 
 export default {
-  title: "Button - WIP",
+  title: "Button",
   component: Button,
   argTypes: {
     children: {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Button } from "./Button";
 export { default as Clickable } from "./Clickable";
 export { default as Heading } from "./Heading";
 export { default as Text } from "./Text";


### PR DESCRIPTION
### Summary:
Since we're preparing to release the `Button` package, it seems like it's
the right time to remove the "WIP" title.

### Test Plan:
Navigate to the button stories in storybook,
and verify the component is just called "Button", not "Button - WIP".