### PR TITLE
chore(buttons): make outline button background transparent

### DIFF
--- a/packages/components/src/Clickable/Clickable.module.css
+++ b/packages/components/src/Clickable/Clickable.module.css
@@ -147,14 +147,14 @@
 }
 
 .variantOutline {
-  background-color: var(--button-secondary-color);
+  background-color: transparent;
   border-color: var(--button-primary-color);
   color: var(--button-primary-color);
 
   
   &:focus,
   &.stateFocus {
-    background-color: var(--button-secondary-color);
+    background-color: transparent;
     color: var(--button-primary-color);
   }
 
@@ -165,7 +165,7 @@
   }
   
   &:disabled {
-    background-color: var(--button-secondary-color);
+    background-color: transparent;
     color: var(--button-primary-color);
   }
 }


### PR DESCRIPTION
### Summary:
I was pairing with Sean over the `Banner` component and he pointed out that
the outline buttons have a white background when he intended for them to be
transparent.

Currently, these buttons aren't being used anywhere, so I think this is a safe
change to make. Thoughts?

### Screenshots
#### Buttons on dark background, before this change
<img width="1130" alt="b" src="https://user-images.githubusercontent.com/7761701/125642262-c1084e41-0a6a-4d4e-a5aa-dcfbeda754d0.png">

#### Buttons on dark background, after this change
<img width="1130" alt="a" src="https://user-images.githubusercontent.com/7761701/125642272-dd798f0a-b2c2-4f89-b53a-ce266059d090.png">

### Test Plan:
Run storybook,
navigate to the "Medium Variants on Dark Background" story,
verify the outline buttons have a transparent background (except for the hover state, which should be unchanged).