### PR TITLE
feat(clickable): remove animation for reduce motion setting

### DIFF
--- a/packages/components/src/Clickable/Clickable.module.css
+++ b/packages/components/src/Clickable/Clickable.module.css
@@ -1,6 +1,9 @@
 .button {
   /* Base Styles */
-  @apply rounded border-2 transition-colors inline-flex items-center;
+
+  /* Using motion-reduce:transition-none here because motion-safe:transition-colors doesn't seem to
+     be having an effect. :( */
+  @apply rounded border-2 transition-colors motion-reduce:transition-none inline-flex items-center;
 
   /* Base Text Styles */
   @apply font-bold;

--- a/packages/components/tailwind.config.js
+++ b/packages/components/tailwind.config.js
@@ -52,6 +52,8 @@ module.exports = {
       lineHeight: staticTokens.legacy.size["line-height"],
     },
   },
-  variants: {},
+  variants: {
+    transitionProperty: ["motion-safe", "motion-reduce"],
+  },
   plugins: [],
 };


### PR DESCRIPTION
### Summary:
The `Clickable` component has a transition for button color change, but
that animation currently does not respect the reduce motion accessibility
setting.

This commit removes the animation for the reduce motion setting.

### Implementation notes
For some reason I'm still having trouble getting `motion-safe` to work on
transitions. But `motion-reduce:transition-none` did work for me, so I
used that instead and added a comment.

Here's a video of the behavior I was seeing. To make the transition more
obvious, I changed the hover color to `fuchsia` and increased the transition
duration to 1000.

https://user-images.githubusercontent.com/7761701/125968460-97f01fda-eac8-4e9b-a30a-af92fca9f55c.mp4

### Test Plan:
Run storybook (`npm start`),
navigate to `/?path=/story/button--all-variants`,
hover over the "inactive" buttons,
verify the color change animates,
turn on the "reduce motion" accessibility setting (if you're using MacOS),
hover over the "inactive" buttons again,
and verify there is no animation (the color change should happen instantly).