### PR TITLE
chore: show ts errors inline in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
   ],
   "css.validate": false,
   "scss.validate": false,
-  "stylelint.enable": true
+  "stylelint.enable": true,
+  "typescript.validate.enable": true,
+  "javascript.validate.enable": true,
 }


### PR DESCRIPTION
### Summary:
Typescript errors weren't showing up inline for me in VSCode 😢  I usually have validation set to false in my User workspace because of traject (sad), so this should turn it on for the EDS project always

### Test Plan:
Forced an error in a file and confirmed inline error shows up:
![Screen Shot 2021-07-21 at 12 01 32 PM](https://user-images.githubusercontent.com/15840841/126522061-6799f598-3a18-4ea8-91b7-54914ed0ea51.png)
