### PR TITLE
feat(toast): copy Toast from traject

### DIFF
--- a/packages/components/src/Banner/index.ts
+++ b/packages/components/src/Banner/index.ts
@@ -1,3 +1,3 @@
 // @flow
 
-export { default } from "./Banner";
+export { default, BannerIcon } from "./Banner";

--- a/packages/components/src/Toast/Toast.module.css
+++ b/packages/components/src/Toast/Toast.module.css
@@ -1,0 +1,44 @@
+.toastDialog {
+  @apply w-full max-w-100 pl-4 pr-2 grid gap-2 items-center;
+  @apply border border-l-4 rounded shadow-1;
+
+  grid-template-columns: 1fr min-content;
+  --svg-icon-size-default: 1.25rem;
+}
+
+.content {
+  @apply py-4 grid gap-4;
+
+  grid-template-columns: min-content 1fr;
+}
+
+/* TODO: consolidate dismiss button styles with the Banner styles */
+.dismiss {
+  @apply w-12 h-12 justify-center rounded-full;
+
+  /* TODO: test motion-safe with new Clickable motion-reduce change */
+  @apply hover:text-white motion-safe:transition ease-out;
+}
+
+.dismiss:hover {
+  background-color: var(--dismiss-hover-color);
+}
+
+/* TODO: consolidate color styles with the Banner styles */
+.colorSuccess {
+  @apply text-success-700 bg-success-100;
+
+  /* Left border is thicker and a darker color than the surrounding border */
+  border-color: var(--eds-color-success-200);
+  border-left-color: var(--eds-color-success-500);
+  --dismiss-hover-color: var(--eds-color-success-600);
+}
+
+.colorAlert {
+  @apply text-alert-700 bg-alert-100;
+
+  /* Left border is thicker and a darker color than the surrounding border */
+  border-color: var(--eds-color-alert-200);
+  border-left-color: var(--eds-color-alert-500);
+  --dismiss-hover-color: var(--eds-color-alert-600);
+}

--- a/packages/components/src/Toast/Toast.spec.tsx
+++ b/packages/components/src/Toast/Toast.spec.tsx
@@ -1,0 +1,8 @@
+// @flow
+
+import * as ToastStoryFile from "./Toast.stories";
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+
+describe("<Toast />", () => {
+  generateSnapshots(ToastStoryFile);
+});

--- a/packages/components/src/Toast/Toast.stories.tsx
+++ b/packages/components/src/Toast/Toast.stories.tsx
@@ -1,0 +1,37 @@
+// @flow
+
+import * as React from "react";
+import type { Story } from "@storybook/react";
+import Toast from "./Toast";
+
+export default {
+  title: "Toast",
+  component: Toast,
+};
+
+type Args = React.ElementProps<typeof Toast>;
+
+const Template: Story<Args> = (args: Args) => <Toast {...args} />;
+
+const defaultArgs = {
+  children: "You've got toast!",
+};
+
+export const Success = Template.bind(null);
+Success.args = {
+  ...defaultArgs,
+  color: "success",
+};
+
+export const Alert = Template.bind(null);
+Alert.args = {
+  ...defaultArgs,
+  color: "alert",
+};
+
+export const Dismissable = Template.bind(null);
+Dismissable.args = {
+  ...defaultArgs,
+  color: "success",
+  onDismiss: () => console.log("dismissed!"),
+};

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -1,0 +1,83 @@
+// @flow
+
+import * as React from "react";
+import Button from "../Button";
+import CloseIcon from "../SVGIcon/Icons/Close";
+import { BannerIcon as Icon } from "../Banner";
+import Text from "../Text";
+import cx from "classnames";
+import styles from "./Toast.module.css";
+// TODO: extract into a shared utility for Toast and Banner
+
+export type Color = "success" | "alert";
+
+type Props = {
+  /**
+   * Additional class names passed in for styling.
+   */
+  className?: string;
+  /**
+   * The contents of the toast.
+   */
+  children: React.ReactNode;
+  /**
+   * The color of the Toast, based on EDS defined colors. Also determines the icon used.
+   * Note that the Icon mapping matches the style of Banners.
+   */
+  color: Color;
+  /**
+   * Callback when Toast is dismissed.
+   */
+  onDismiss?: () => void;
+};
+
+type DismissButtonProps = {
+  color: Color;
+  onDismiss: () => void;
+};
+
+// TODO: consolidate with Banner dismiss button
+const DismissButton = ({ color, onDismiss }: DismissButtonProps) => (
+  <Button
+    className={styles.dismiss}
+    color={color}
+    onClick={onDismiss}
+    variant="link"
+  >
+    <CloseIcon role="img" size="32px" title="close" />
+  </Button>
+);
+
+/**
+ * A toast used to provide information on the state of the page, usually in response to a
+ * user action. Ex: The user updates their profile, and a toast pop-up informs them that the
+ * data was successfully saved.
+ */
+export default function Toast({
+  children,
+  className,
+  color,
+  onDismiss,
+  // Allow for additional attributes such as aria roles
+  ...rest
+}: Props) {
+  return (
+    <div
+      className={cx(
+        className,
+        styles.toastDialog,
+        color === "success" && styles.colorSuccess,
+        color === "alert" && styles.colorAlert,
+      )}
+      {...rest}
+    >
+      <div className={styles.content}>
+        <Icon color={color} />
+        <Text color="inherit" size="sm">
+          {children}
+        </Text>
+      </div>
+      {onDismiss && <DismissButton color={color} onDismiss={onDismiss} />}
+    </div>
+  );
+}

--- a/packages/components/src/Toast/__snapshots__/Toast.spec.tsx.snap
+++ b/packages/components/src/Toast/__snapshots__/Toast.spec.tsx.snap
@@ -13,11 +13,13 @@ exports[`<Toast /> Alert story renders snapshot 1`] = `
       <svg
         class="svgIcon"
         fill="currentColor"
-        style="color: currentColor;"
+        role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        alert
+        <title>
+          alert
+        </title>
         <circle
           cx="15.5"
           cy="9.5"
@@ -55,11 +57,13 @@ exports[`<Toast /> Dismissable story renders snapshot 1`] = `
       <svg
         class="svgIcon"
         fill="currentColor"
-        style="color: currentColor;"
+        role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        success
+        <title>
+          success
+        </title>
         <path
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
         />
@@ -80,12 +84,14 @@ exports[`<Toast /> Dismissable story renders snapshot 1`] = `
       class="svgIcon"
       fill="currentColor"
       height="32px"
-      style="color: currentColor;"
+      role="img"
       viewBox="0 0 24 24"
       width="32px"
       xmlns="http://www.w3.org/2000/svg"
     >
-      close
+      <title>
+        close
+      </title>
       <path
         d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
       />
@@ -107,11 +113,13 @@ exports[`<Toast /> Success story renders snapshot 1`] = `
       <svg
         class="svgIcon"
         fill="currentColor"
-        style="color: currentColor;"
+        role="img"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        success
+        <title>
+          success
+        </title>
         <path
           d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
         />

--- a/packages/components/src/Toast/__snapshots__/Toast.spec.tsx.snap
+++ b/packages/components/src/Toast/__snapshots__/Toast.spec.tsx.snap
@@ -1,0 +1,127 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Toast /> Alert story renders snapshot 1`] = `
+<div
+  class="toastDialog colorAlert"
+>
+  <div
+    class="content"
+  >
+    <div
+      class="icon iconAlert"
+    >
+      <svg
+        class="svgIcon"
+        fill="currentColor"
+        style="color: currentColor;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        alert
+        <circle
+          cx="15.5"
+          cy="9.5"
+          r="1.5"
+        />
+        <circle
+          cx="8.5"
+          cy="9.5"
+          r="1.5"
+        />
+        <path
+          d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-6c-2.33 0-4.32 1.45-5.12 3.5h1.67c.69-1.19 1.97-2 3.45-2s2.75.81 3.45 2h1.67c-.8-2.05-2.79-3.5-5.12-3.5z"
+        />
+      </svg>
+    </div>
+    <p
+      class="typography sizeSm colorInherit"
+    >
+      You've got toast!
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Toast /> Dismissable story renders snapshot 1`] = `
+<div
+  class="toastDialog colorSuccess"
+>
+  <div
+    class="content"
+  >
+    <div
+      class="icon iconSuccess"
+    >
+      <svg
+        class="svgIcon"
+        fill="currentColor"
+        style="color: currentColor;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        success
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
+    </div>
+    <p
+      class="typography sizeSm colorInherit"
+    >
+      You've got toast!
+    </p>
+  </div>
+  <button
+    class="dismiss button variantLink colorSuccess"
+    type="button"
+  >
+    ​
+    <svg
+      class="svgIcon"
+      fill="currentColor"
+      height="32px"
+      style="color: currentColor;"
+      viewBox="0 0 24 24"
+      width="32px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      close
+      <path
+        d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`<Toast /> Success story renders snapshot 1`] = `
+<div
+  class="toastDialog colorSuccess"
+>
+  <div
+    class="content"
+  >
+    <div
+      class="icon iconSuccess"
+    >
+      <svg
+        class="svgIcon"
+        fill="currentColor"
+        style="color: currentColor;"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        success
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"
+        />
+      </svg>
+    </div>
+    <p
+      class="typography sizeSm colorInherit"
+    >
+      You've got toast!
+    </p>
+  </div>
+</div>
+`;

--- a/packages/components/src/Toast/index.ts
+++ b/packages/components/src/Toast/index.ts
@@ -1,0 +1,3 @@
+// @flow
+
+export { default } from "./Toast";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -3,3 +3,4 @@ export { default as Button } from "./Button";
 export { default as Clickable } from "./Clickable";
 export { default as Heading } from "./Heading";
 export { default as Text } from "./Text";
+export { default as Toast } from "./Toast";

--- a/packages/components/tailwind.config.js
+++ b/packages/components/tailwind.config.js
@@ -50,6 +50,9 @@ module.exports = {
     },
     extend: {
       lineHeight: staticTokens.legacy.size["line-height"],
+      maxWidth: {
+        100: "25rem",
+      },
       padding: {
         18: "4.5rem",
       },
@@ -60,9 +63,16 @@ module.exports = {
         2: "0px 0px 0px 1px var(--eds-color-neutral-200), 0px 10px 15px -3px rgba(0, 0, 0, 0.1), 0px 4px 6px -2px rgba(0, 0, 0, 0.05)",
         3: "0px 0px 0px 1px var(--eds-color-neutral-200), 0px 16px 20px -5px rgba(0, 0, 0, 0.1), 0px 10px 10px -5px rgba(0, 0, 0, 0.04)",
       },
+      transitionTimingFunction: {
+        // Used for Toast animations, referenced from
+        //https://github.com/timolins/react-hot-toast/blob/main/src/components/toast-bar.tsx
+        "slide-in": "cubic-bezier(0.21, 1.02, 0.73, 1)",
+        "slide-out": "cubic-bezier(0.06, 0.71, 0.55, 1)",
+      },
     },
   },
   variants: {
+    animation: ["motion-safe", "motion-reduce"],
     transitionProperty: ["motion-safe", "motion-reduce"],
   },
   plugins: [],


### PR DESCRIPTION
### Summary:
Clubhouse ticket: https://app.clubhouse.io/czi-edu/story/149308/toast-done

Minimal changes made from the `traject` version just for moving from flow to typescript and satisfying the linter.

### Screenshots
<img width="1436" alt="Toast in storybook with the 'success' story visible" src="https://user-images.githubusercontent.com/7761701/126801738-88d2c145-39e0-4bbd-86ff-6cf0d9266b84.png">
<img width="1436" alt="Toast in storybook with the 'alert' and 'dismissable' stories visible" src="https://user-images.githubusercontent.com/7761701/126801745-417f08be-c2b8-4689-bac0-ec38d3ebba34.png">

### Test Plan:
Run storybook (`npm start`),
navigate to `/?path=/docs/toast--success`,
verify the 3 stories are rendering just like in `traject` including the dark round hover state of the dismiss button.