### PR TITLE
feat(tag): copy Tag over from traject

### DIFF
--- a/packages/components/src/Tag/Tag.module.css
+++ b/packages/components/src/Tag/Tag.module.css
@@ -1,0 +1,61 @@
+.tag {
+  @apply w-max max-w-xs py-1 px-3 inline-flex items-center rounded-full border;
+
+  /** 
+   * TODO: (dcwither) when adding SvgIcon to EDS, include this in tailwind font 
+   * size macro.
+   */
+  --svg-icon-size-default: 1.25rem;
+
+  background-color: var(--tag-secondary-color);
+  border-color: var(--tag-secondary-color);
+  color: var(--tag-primary-color);
+}
+
+.tag > :not(:last-child) {
+  @apply mr-1;
+}
+
+.body {
+  @apply flex-auto truncate;
+}
+
+.colorNeutral {
+  --tag-primary-color: var(--eds-color-neutral-700);
+  --tag-secondary-color: var(--eds-color-neutral-100);
+  --tag-outline-color: var(--eds-color-neutral-500);
+}
+
+.colorAlert {
+  --tag-primary-color: var(--eds-color-alert-700);
+  --tag-secondary-color: var(--eds-color-alert-100);
+  --tag-outline-color: var(--eds-color-alert-500);
+}
+
+.colorSuccess {
+  --tag-primary-color: var(--eds-color-success-700);
+  --tag-secondary-color: var(--eds-color-success-100);
+  --tag-outline-color: var(--eds-color-success-500);
+}
+
+.colorWarning {
+  --tag-primary-color: var(--eds-color-warning-700);
+  --tag-secondary-color: var(--eds-color-warning-100);
+  --tag-outline-color: var(--eds-color-warning-500);
+}
+
+.colorGradingYellow {
+  --tag-primary-color: var(--eds-color-neutral-700);
+  --tag-secondary-color: var(--eds-color-grading-yellow-100);
+  --tag-outline-color: var(--eds-color-grading-yellow-500);
+}
+
+.colorBrand {
+  --tag-primary-color: var(--eds-color-brand-700);
+  --tag-secondary-color: var(--eds-color-brand-100);
+  --tag-outline-color: var(--eds-color-brand-500);
+}
+
+.outline {
+  border-color: var(--tag-outline-color);
+}

--- a/packages/components/src/Tag/Tag.spec.tsx
+++ b/packages/components/src/Tag/Tag.spec.tsx
@@ -1,0 +1,8 @@
+// @flow
+
+import * as TagStoryFile from "./Tag.stories";
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+
+describe("<Tag />", () => {
+  generateSnapshots(TagStoryFile);
+});

--- a/packages/components/src/Tag/Tag.stories.module.css
+++ b/packages/components/src/Tag/Tag.stories.module.css
@@ -1,0 +1,3 @@
+.tagList > :not(:last-child) {
+  @apply mr-1;
+}

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -48,6 +48,17 @@ ColorVariants.args = {
   ...defaultArgs,
 };
 
+export const OutlineVariants: Story<Args> = (args) => (
+  <div className={styles.tagList}>
+    {colorOptions.map((color) => {
+      return <Tag key={color} {...args} color={color} variant="outline" />;
+    })}
+  </div>
+);
+OutlineVariants.args = {
+  ...defaultArgs,
+};
+
 export const WithIcon = Template.bind(null);
 WithIcon.args = {
   ...defaultArgs,

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -1,0 +1,62 @@
+// @flow
+
+import * as React from "react";
+import Tag, { stylesByColor } from "./Tag";
+import type { Color } from "./Tag";
+import type { Story } from "@storybook/react";
+import WarningIcon from "../SVGIcon/Icons/Warning";
+import styles from "./Tag.stories.module.css";
+
+const colorOptions: Array<Color> = Object.keys(stylesByColor);
+
+export default {
+  title: "Tag",
+  component: Tag,
+
+  argTypes: {
+    color: {
+      control: {
+        type: "select",
+        options: colorOptions,
+      },
+    },
+  },
+};
+
+type Args = React.ElementProps<typeof Tag>;
+
+const Template: Story<Args> = (args) => <Tag {...args} />;
+
+const defaultArgs = {
+  children: "Tag text",
+  color: "warning",
+};
+
+export const Default = Template.bind(null);
+Default.args = {
+  ...defaultArgs,
+};
+
+export const ColorVariants: Story<Args> = (args) => (
+  <div className={styles.tagList}>
+    {colorOptions.map((color) => {
+      return <Tag key={color} {...args} color={color} />;
+    })}
+  </div>
+);
+ColorVariants.args = {
+  ...defaultArgs,
+};
+
+export const WithIcon = Template.bind(null);
+WithIcon.args = {
+  ...defaultArgs,
+  icon: <WarningIcon key="icon" role="img" title="warning" />,
+};
+
+export const WithLongTextAndIcon = Template.bind(null);
+WithLongTextAndIcon.args = {
+  ...defaultArgs,
+  children: "This tag has a really long text message",
+  icon: <WarningIcon key="icon" role="img" title="warning" />,
+};

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -2,16 +2,18 @@
 
 import * as React from "react";
 import Text from "../Text";
-import { TypographyColor } from "../common/typography";
 import cx from "classnames";
 import styles from "./Tag.module.css";
 
-export type Color = Omit<
-  TypographyColor,
-  "white" | "base" | "info" | "inherit"
->;
+export type Color =
+  | "neutral"
+  | "alert"
+  | "success"
+  | "warning"
+  | "gradingYellow"
+  | "brand";
 
-export const stylesByColor: { [K in Color]: string } = {
+export const stylesByColor = {
   neutral: styles.colorNeutral,
   warning: styles.colorWarning,
   brand: styles.colorBrand,

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -1,0 +1,69 @@
+// @flow
+
+import * as React from "react";
+import Text from "../Text";
+import { TypographyColor } from "../common/typography";
+import cx from "classnames";
+import styles from "./Tag.module.css";
+
+export type Color = Omit<
+  TypographyColor,
+  "white" | "base" | "info" | "inherit"
+>;
+
+export const stylesByColor: { [K in Color]: string } = {
+  neutral: styles.colorNeutral,
+  warning: styles.colorWarning,
+  brand: styles.colorBrand,
+  alert: styles.colorAlert,
+  gradingYellow: styles.colorGradingYellow,
+  success: styles.colorSuccess,
+};
+
+type Props = {
+  /**
+   * The color of the tag. New colors should be supported in the flow type,
+   * in the stylesByColor object, and by its separate style in CSS file.
+   */
+  color: Color;
+  /**
+   * The contents of the tag in addition to the icon
+   */
+  children: React.ReactNode;
+  /**
+   * The tag icon (shouldn't provide color or size since those are determined
+   * by the color prop).
+   */
+  icon?: React.ReactNode;
+  /**
+   * Style of the tag.
+   */
+  variant?: "flat" | "outline";
+};
+
+/**
+ * This component provides a tag (pill shaped badge) wrapper.
+ */
+function Tag({ color, children, icon, variant = "flat" }: Props) {
+  return (
+    <Text
+      as="span"
+      className={cx(
+        styles.tag,
+        color && stylesByColor[color],
+        variant === "outline" && styles.outline,
+      )}
+      color={color}
+      size="sm"
+      spacing="none"
+      weight="bold"
+    >
+      {icon}
+      {/* No width space to ensure height of contents */}
+      {"\u200B"}
+      {children && <span className={styles.body}>{children}</span>}
+    </Text>
+  );
+}
+
+export default Tag;

--- a/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -87,11 +87,14 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
   <svg
     class="svgIcon"
     fill="currentColor"
+    role="img"
     style="color: currentColor;"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    warning
+    <title>
+      warning
+    </title>
     <path
       d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
     />
@@ -112,11 +115,14 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
   <svg
     class="svgIcon"
     fill="currentColor"
+    role="img"
     style="color: currentColor;"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    warning
+    <title>
+      warning
+    </title>
     <path
       d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
     />

--- a/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
+<div
+  class="tagList"
+>
+  <span
+    class="tag colorNeutral typography sizeSm colorNeutral weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorWarning typography sizeSm colorWarning weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorBrand typography sizeSm colorBrand weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorAlert typography sizeSm colorAlert weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorGradingYellow typography sizeSm weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorSuccess typography sizeSm colorSuccess weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Tag /> Default story renders snapshot 1`] = `
+<span
+  class="tag colorWarning typography sizeSm colorWarning weightBold spacingNone"
+>
+  ​
+  <span
+    class="body"
+  >
+    Tag text
+  </span>
+</span>
+`;
+
+exports[`<Tag /> WithIcon story renders snapshot 1`] = `
+<span
+  class="tag colorWarning typography sizeSm colorWarning weightBold spacingNone"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    style="color: currentColor;"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    warning
+    <path
+      d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+    />
+  </svg>
+  ​
+  <span
+    class="body"
+  >
+    Tag text
+  </span>
+</span>
+`;
+
+exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
+<span
+  class="tag colorWarning typography sizeSm colorWarning weightBold spacingNone"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    style="color: currentColor;"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    warning
+    <path
+      d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"
+    />
+  </svg>
+  ​
+  <span
+    class="body"
+  >
+    This tag has a really long text message
+  </span>
+</span>
+`;

--- a/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -80,6 +80,73 @@ exports[`<Tag /> Default story renders snapshot 1`] = `
 </span>
 `;
 
+exports[`<Tag /> OutlineVariants story renders snapshot 1`] = `
+<div
+  class="tagList"
+>
+  <span
+    class="tag colorNeutral outline typography sizeSm colorNeutral weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorWarning outline typography sizeSm colorWarning weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorBrand outline typography sizeSm colorBrand weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorAlert outline typography sizeSm colorAlert weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorGradingYellow outline typography sizeSm weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="tag colorSuccess outline typography sizeSm colorSuccess weightBold spacingNone"
+  >
+    ​
+    <span
+      class="body"
+    >
+      Tag text
+    </span>
+  </span>
+</div>
+`;
+
 exports[`<Tag /> WithIcon story renders snapshot 1`] = `
 <span
   class="tag colorWarning typography sizeSm colorWarning weightBold spacingNone"

--- a/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
+++ b/packages/components/src/Tag/__snapshots__/Tag.spec.tsx.snap
@@ -88,7 +88,6 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     class="svgIcon"
     fill="currentColor"
     role="img"
-    style="color: currentColor;"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
@@ -116,7 +115,6 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
     class="svgIcon"
     fill="currentColor"
     role="img"
-    style="color: currentColor;"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/packages/components/src/Tag/index.ts
+++ b/packages/components/src/Tag/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Tag";

--- a/packages/components/src/common/typography.tsx
+++ b/packages/components/src/common/typography.tsx
@@ -19,6 +19,7 @@ export type TypographyColor =
   | "alert"
   | "base"
   | "brand"
+  | "gradingYellow"
   | "info"
   | "inherit"
   | "neutral"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,5 +2,6 @@ export { default as Banner } from "./Banner";
 export { default as Button } from "./Button";
 export { default as Clickable } from "./Clickable";
 export { default as Heading } from "./Heading";
+export { default as Tag } from "./Tag";
 export { default as Text } from "./Text";
 export { default as Toast } from "./Toast";


### PR DESCRIPTION
### Summary:
Clubhouse ticket: https://app.clubhouse.io/czi-edu/story/149292/tags-done

Minimal changes made just to move from flow to typescript and to satisfy the linter.

### Screenshots
<img width="1402" alt="Tag in storybook with the 'Default' story visible" src="https://user-images.githubusercontent.com/7761701/126803501-ed69647c-7b33-4c09-982c-bd8a85ea07b3.png">
<img width="1402" alt="Tag in storybook with the 'Color Variants', 'With Icon', and 'With Long Text And Icon' stories visible" src="https://user-images.githubusercontent.com/7761701/126803506-474874da-b8ca-478c-afea-bfc663f21f31.png">

### Test Plan:
Run storybook (`npm start`),
navigate to `/?path=/docs/tag--default`,
and verify the stories output is identical to the ones in `traject`.