### PR TITLE
chore(banner): remove padding props and long stories

### DIFF
--- a/packages/components/src/Banner/Banner.module.css
+++ b/packages/components/src/Banner/Banner.module.css
@@ -1,5 +1,5 @@
 .bannerDialog {
-  @apply w-full rounded border shadow-1;
+  @apply w-full p-8 rounded border shadow-1;
   @apply relative;
   @apply grid gap-4;
 
@@ -28,18 +28,6 @@
   @apply justify-self-center self-center;
 }
 
-.padding2x {
-  @apply p-8;
-}
-
-.padding3x {
-  @apply p-9;
-}
-
-.padding4x {
-  @apply p-10;
-}
-
 .dismiss {
   /* TODO: motion-safe does not seem to be stopping the animation when
      the user has the reduce motion accessibility setting on */
@@ -57,7 +45,7 @@
   .bannerDialog.horizontal {
     grid-template-columns: min-content 1fr;
 
-    @apply text-left;
+    @apply text-left p-4;
 
     /* Left border is thicker and a darker color than the surrounding border on desktop */
     @apply border border-l-4;
@@ -81,19 +69,6 @@
     @apply self-start;
   }
 
-  .padding2x.horizontal {
-    @apply p-4;
-  }
-
-  .padding3x.horizontal {
-    @apply p-6;
-  }
-
-  .padding4x.horizontal {
-    @apply p-8;
-  }
-
-  /* Must be below the padding variants */
   .dismissable.horizontal {
     @apply pr-18;
   }

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -68,27 +68,10 @@ Alert.args = {
   color: "alert",
 };
 
-export const LongContent = Template.bind(null);
-LongContent.args = {
-  ...dialogArgs,
-  content:
-    "Summit Learning is a research–based approach to education designed to drive student engagement, meaningful learning, and strong student–teacher relationships that prepare students for life beyond the classroom. Created by educators with experience in diverse classrooms, Summit Learning is grounded in decades of research about how children learn. With Summit Learning, students gain mastery of core subjects like math, history, English, and science, while also carefully developing the skills and habits of lifelong learners. The Summit Learning program offers schools customizable curriculum, a range of educational resources and technology tools, professional development for educators, and ongoing coaching and support for schools. The Summit Learning program supports over 80,000 students, 4,000 educators, and nearly 400 schools across the U.S.",
-  padding: "4x",
-};
-
 export const NoHeadingShort = Template.bind(null);
 NoHeadingShort.args = {
   ...dialogArgs,
   heading: null,
-};
-
-export const NoHeadingLong = Template.bind(null);
-NoHeadingLong.args = {
-  ...dialogArgs,
-  heading: null,
-  content:
-    "Summit Learning is a research–based approach to education designed to drive student engagement, meaningful learning, and strong student–teacher relationships that prepare students for life beyond the classroom. Created by educators with experience in diverse classrooms, Summit Learning is grounded in decades of research about how children learn. With Summit Learning, students gain mastery of core subjects like math, history, English, and science, while also carefully developing the skills and habits of lifelong learners. The Summit Learning program offers schools customizable curriculum, a range of educational resources and technology tools, professional development for educators, and ongoing coaching and support for schools. The Summit Learning program supports over 80,000 students, 4,000 educators, and nearly 400 schools across the U.S.",
-  padding: "3x",
 };
 
 export const NoContent = Template.bind(null);

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -38,11 +38,6 @@ type Props = {
    */
   onDismiss?: () => void;
   /**
-   * The amount of outside padding around the border- the longer and more important the content is,
-   * the more padding there should be. Defaults to 2x.
-   */
-  padding?: "2x" | "3x" | "4x";
-  /**
    * Whether the card is laid out horizontally or stacked vertically.
    * The vertical orientation makes the banner look more like a card. It has the same styling as
    * the horizontal banner in mobile view. This format is intended to be used in sidebars or
@@ -147,7 +142,6 @@ export default function Banner({
   children,
   action,
   onDismiss,
-  padding = "2x",
   orientation = "horizontal",
   elevation = 1,
 }: Props) {
@@ -167,10 +161,6 @@ export default function Banner({
         color === "success" && styles.colorSuccess,
         color === "warning" && styles.colorWarning,
         color === "alert" && styles.colorAlert,
-        // Padding props
-        padding === "2x" && styles.padding2x,
-        padding === "3x" && styles.padding3x,
-        padding === "4x" && styles.padding4x,
       )}
     >
       {onDismiss && <DismissButton color={color} onDismiss={onDismiss} />}

--- a/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Banner /> Alert story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorAlert padding2x"
+  class="bannerDialog horizontal colorAlert"
 >
   <div
     class="icon iconAlert"
@@ -55,7 +55,7 @@ exports[`<Banner /> Alert story renders snapshot 1`] = `
 
 exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorAlert padding2x"
+  class="bannerDialog horizontal dismissable colorAlert"
 >
   <button
     class="dismiss button variantLink colorAlert"
@@ -130,7 +130,7 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> Brand story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorBrand padding2x"
+  class="bannerDialog horizontal colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -173,7 +173,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
 
 exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorBrand padding2x"
+  class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
     class="dismiss button variantLink colorBrand"
@@ -238,7 +238,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorBrand padding2x"
+  class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
     class="dismiss button variantLink colorBrand"
@@ -315,7 +315,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
 
 exports[`<Banner /> Elevation0 story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal elevation0 colorBrand padding2x"
+  class="bannerDialog horizontal elevation0 colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -356,52 +356,9 @@ exports[`<Banner /> Elevation0 story renders snapshot 1`] = `
 </article>
 `;
 
-exports[`<Banner /> LongContent story renders snapshot 1`] = `
-<article
-  class="bannerDialog horizontal colorBrand padding4x"
->
-  <div
-    class="icon iconBrand"
-  >
-    <svg
-      class="svgIcon"
-      fill="currentColor"
-      role="img"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title>
-        attention
-      </title>
-      <path
-        d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
-      />
-    </svg>
-  </div>
-  <div
-    class="textAndAction horizontal"
-  >
-    <div
-      class="textContent horizontal"
-    >
-      <h1
-        class="typography sizeH3 colorInherit"
-      >
-        New curriculum updates are available for one or more of your courses.
-      </h1>
-      <p
-        class="typography sizeBody colorInherit"
-      >
-        Summit Learning is a research–based approach to education designed to drive student engagement, meaningful learning, and strong student–teacher relationships that prepare students for life beyond the classroom. Created by educators with experience in diverse classrooms, Summit Learning is grounded in decades of research about how children learn. With Summit Learning, students gain mastery of core subjects like math, history, English, and science, while also carefully developing the skills and habits of lifelong learners. The Summit Learning program offers schools customizable curriculum, a range of educational resources and technology tools, professional development for educators, and ongoing coaching and support for schools. The Summit Learning program supports over 80,000 students, 4,000 educators, and nearly 400 schools across the U.S.
-      </p>
-    </div>
-  </div>
-</article>
-`;
-
 exports[`<Banner /> Neutral story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorNeutral padding2x"
+  class="bannerDialog horizontal colorNeutral"
 >
   <div
     class="icon iconNeutral"
@@ -444,7 +401,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
 
 exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorNeutral padding2x"
+  class="bannerDialog horizontal dismissable colorNeutral"
 >
   <button
     class="dismiss button variantLink colorNeutral"
@@ -509,7 +466,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> NoContent story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorBrand padding2x"
+  class="bannerDialog horizontal colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -545,47 +502,9 @@ exports[`<Banner /> NoContent story renders snapshot 1`] = `
 </article>
 `;
 
-exports[`<Banner /> NoHeadingLong story renders snapshot 1`] = `
-<article
-  class="bannerDialog horizontal colorBrand padding3x"
->
-  <div
-    class="icon iconBrand"
-  >
-    <svg
-      class="svgIcon"
-      fill="currentColor"
-      role="img"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title>
-        attention
-      </title>
-      <path
-        d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.89 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"
-      />
-    </svg>
-  </div>
-  <div
-    class="textAndAction horizontal"
-  >
-    <div
-      class="textContent horizontal"
-    >
-      <p
-        class="typography sizeBody colorInherit"
-      >
-        Summit Learning is a research–based approach to education designed to drive student engagement, meaningful learning, and strong student–teacher relationships that prepare students for life beyond the classroom. Created by educators with experience in diverse classrooms, Summit Learning is grounded in decades of research about how children learn. With Summit Learning, students gain mastery of core subjects like math, history, English, and science, while also carefully developing the skills and habits of lifelong learners. The Summit Learning program offers schools customizable curriculum, a range of educational resources and technology tools, professional development for educators, and ongoing coaching and support for schools. The Summit Learning program supports over 80,000 students, 4,000 educators, and nearly 400 schools across the U.S.
-      </p>
-    </div>
-  </div>
-</article>
-`;
-
 exports[`<Banner /> NoHeadingShort story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorBrand padding2x"
+  class="bannerDialog horizontal colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -623,7 +542,7 @@ exports[`<Banner /> NoHeadingShort story renders snapshot 1`] = `
 
 exports[`<Banner /> Success story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorSuccess padding2x"
+  class="bannerDialog horizontal colorSuccess"
 >
   <div
     class="icon iconSuccess"
@@ -666,7 +585,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
 
 exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorSuccess padding2x"
+  class="bannerDialog horizontal dismissable colorSuccess"
 >
   <button
     class="dismiss button variantLink colorSuccess"
@@ -731,7 +650,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> Vertical story renders snapshot 1`] = `
 <article
-  class="bannerDialog colorBrand padding2x"
+  class="bannerDialog colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -774,7 +693,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
 
 exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog dismissable colorBrand padding2x"
+  class="bannerDialog dismissable colorBrand"
 >
   <button
     class="dismiss button variantLink colorBrand"
@@ -839,7 +758,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
 <article
-  class="bannerDialog dismissable colorBrand padding2x"
+  class="bannerDialog dismissable colorBrand"
 >
   <button
     class="dismiss button variantLink colorBrand"
@@ -916,7 +835,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
 
 exports[`<Banner /> VerticalElevation0 story renders snapshot 1`] = `
 <article
-  class="bannerDialog elevation0 colorBrand padding2x"
+  class="bannerDialog elevation0 colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -959,7 +878,7 @@ exports[`<Banner /> VerticalElevation0 story renders snapshot 1`] = `
 
 exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
 <article
-  class="bannerDialog colorBrand padding2x"
+  class="bannerDialog colorBrand"
 >
   <div
     class="icon iconBrand"
@@ -1014,7 +933,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
 
 exports[`<Banner /> Warning story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorWarning padding2x"
+  class="bannerDialog horizontal colorWarning"
 >
   <div
     class="icon iconWarning"
@@ -1057,7 +976,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
 
 exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal dismissable colorWarning padding2x"
+  class="bannerDialog horizontal dismissable colorWarning"
 >
   <button
     class="dismiss button variantLink colorWarning"
@@ -1122,7 +1041,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
 
 exports[`<Banner /> WithAction story renders snapshot 1`] = `
 <article
-  class="bannerDialog horizontal colorBrand padding2x"
+  class="bannerDialog horizontal colorBrand"
 >
   <div
     class="icon iconBrand"


### PR DESCRIPTION
### Summary:
We have 3 different levels of padding on the `Banner` component. The reasoning was that larger banners with lots of text need more padding or they look really cramped. But we actually don't want people to put lots of text into banners and are going to advice against it. So why would we support this version of the component?

This PR removes the padding props and also the stories that show the banner with lots of text. I verified with Sean that it's safe to remove these.

### Test Plan:
Verify Percy shows there are no changed stories (besides the ones removed).