### PR TITLE
chore: remove flow remnants

### DIFF
--- a/packages/components/.storybook/Button/button.stories.tsx
+++ b/packages/components/.storybook/Button/button.stories.tsx
@@ -1,9 +1,7 @@
-import * as React from "react";
-
 import Clickable, { ClickableProps } from "../../src/Clickable";
-
 import { ButtonProps } from "../../src/Button";
 import Heading from "../../src/Heading";
+import React from "react";
 import Text from "../../src/Text";
 import styles from "./button.module.css";
 

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -2,7 +2,7 @@ import "@chanzuckerberg/eds-tokens/css/variables.css";
 import "../src/styles/fonts.css";
 import "../src/styles/global.css";
 
-import * as React from "react";
+import React from "react";
 
 export const decorators = [
   (Story) => (

--- a/packages/components/docs/token-table.tsx
+++ b/packages/components/docs/token-table.tsx
@@ -1,5 +1,4 @@
-import * as React from "react";
-
+import React from "react";
 import classNames from "classnames/bind";
 import styles from "./token-table.module.css";
 

--- a/packages/components/src/Banner/Banner.spec.tsx
+++ b/packages/components/src/Banner/Banner.spec.tsx
@@ -1,5 +1,3 @@
-// @flow
-
 import * as BannerStoryFile from "./Banner.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -1,9 +1,7 @@
-// @flow
-
-import * as React from "react";
 import Banner from "./Banner";
 import Button from "../Button";
 import Heading from "../Heading";
+import React from "react";
 import type { Story } from "@storybook/react";
 
 export default {
@@ -11,7 +9,7 @@ export default {
   component: Banner,
 };
 
-type Args = React.ElementProps<typeof Banner> & {
+type Args = React.ComponentProps<typeof Banner> & {
   content: string;
   heading: string;
 };

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -1,13 +1,10 @@
-// @flow
-
-import * as React from "react";
-
 import Heading, { HeadingElement } from "../Heading";
 import Button from "../Button";
 import CheckCircleIcon from "../SVGIcon/Icons/CheckCircle";
 import CloseIcon from "../SVGIcon/Icons/Close";
 import ForumIcon from "../SVGIcon/Icons/Forum";
 import NotificationsIcon from "../SVGIcon/Icons/Notifications";
+import React from "react";
 import SentimentVeryDissatisfiedIcon from "../SVGIcon/Icons/SentimentVeryDissatisfied";
 import Text from "../Text";
 import WarningIcon from "../SVGIcon/Icons/Warning";

--- a/packages/components/src/Banner/index.ts
+++ b/packages/components/src/Banner/index.ts
@@ -1,3 +1,1 @@
-// @flow
-
 export { default, BannerIcon } from "./Banner";

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import Button from "./button";
+import React from "react";
 import { Story } from "@storybook/react/types-6-0";
 import Text from "../Text";
 

--- a/packages/components/src/Clickable/Clickable.stories.tsx
+++ b/packages/components/src/Clickable/Clickable.stories.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import Clickable from "./Clickable";
+import React from "react";
 import { Story } from "@storybook/react/types-6-0";
 
 export default {

--- a/packages/components/src/Heading/Heading.stories.tsx
+++ b/packages/components/src/Heading/Heading.stories.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-
 import Heading from "./Heading";
+import React from "react";
 import { Story } from "@storybook/react/types-6-0";
 
 export default {

--- a/packages/components/src/SVGIcon/SVGIcon.stories.tsx
+++ b/packages/components/src/SVGIcon/SVGIcon.stories.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import * as allIcons from "./Icons";
+import React from "react";
 import SVGIcon from "./SVGIcon";
 import type { Story } from "@storybook/react";
 import Text from "../Text";

--- a/packages/components/src/SVGIcon/SVGIcon.tsx
+++ b/packages/components/src/SVGIcon/SVGIcon.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import cx from "classnames";
 import styles from "./SVGIcon.module.css";
 

--- a/packages/components/src/SVGIcon/index.tsx
+++ b/packages/components/src/SVGIcon/index.tsx
@@ -1,3 +1,1 @@
-// @flow
-
 export { default } from "./SVGIcon";

--- a/packages/components/src/Tag/Tag.spec.tsx
+++ b/packages/components/src/Tag/Tag.spec.tsx
@@ -1,5 +1,3 @@
-// @flow
-
 import * as TagStoryFile from "./Tag.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -1,8 +1,6 @@
-// @flow
-
-import * as React from "react";
 import Tag, { stylesByColor } from "./Tag";
 import type { Color } from "./Tag";
+import React from "react";
 import type { Story } from "@storybook/react";
 import WarningIcon from "../SVGIcon/Icons/Warning";
 import styles from "./Tag.stories.module.css";
@@ -23,7 +21,7 @@ export default {
   },
 };
 
-type Args = React.ElementProps<typeof Tag>;
+type Args = React.ComponentProps<typeof Tag>;
 
 const Template: Story<Args> = (args) => <Tag {...args} />;
 

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -1,6 +1,4 @@
-// @flow
-
-import * as React from "react";
+import React from "react";
 import Text from "../Text";
 import cx from "classnames";
 import styles from "./Tag.module.css";

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { Story } from "@storybook/react/types-6-0";
 import Text from "./Text";

--- a/packages/components/src/Toast/Toast.spec.tsx
+++ b/packages/components/src/Toast/Toast.spec.tsx
@@ -1,5 +1,3 @@
-// @flow
-
 import * as ToastStoryFile from "./Toast.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
 

--- a/packages/components/src/Toast/Toast.stories.tsx
+++ b/packages/components/src/Toast/Toast.stories.tsx
@@ -1,6 +1,4 @@
-// @flow
-
-import * as React from "react";
+import React from "react";
 import type { Story } from "@storybook/react";
 import Toast from "./Toast";
 
@@ -9,7 +7,7 @@ export default {
   component: Toast,
 };
 
-type Args = React.ElementProps<typeof Toast>;
+type Args = React.ComponentProps<typeof Toast>;
 
 const Template: Story<Args> = (args: Args) => <Toast {...args} />;
 

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -1,9 +1,7 @@
-// @flow
-
-import * as React from "react";
 import Button from "../Button";
 import CloseIcon from "../SVGIcon/Icons/Close";
 import { BannerIcon as Icon } from "../Banner";
+import React from "react";
 import Text from "../Text";
 import cx from "classnames";
 import styles from "./Toast.module.css";

--- a/packages/components/src/Toast/index.ts
+++ b/packages/components/src/Toast/index.ts
@@ -1,3 +1,1 @@
-// @flow
-
 export { default } from "./Toast";

--- a/plop-templates/Component/Component.stories.tsx.hbs
+++ b/plop-templates/Component/Component.stories.tsx.hbs
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 import {{pascalCase name}} from "./{{pascalCase name}}";
 import { Story } from "@storybook/react/types-6-0";
 


### PR DESCRIPTION
### Summary:
Follow-up to https://github.com/chanzuckerberg/edu-design-system/pull/519

This PR changes 3 recurring issues that are left over after bringing in code that once used flow but is now typescript:
- remove `// @flow` from the top of files
- change `React.ElementProps` to `React.ComponentProps`
- change `import * as React from "react";` to `import React from "react";`

The last pattern existed in a bunch of files, not just ones ported over recently, so I just updated everything to be consistent.

### Test Plan:
- automated tests pass
- check out storybook (`npm start`) and verify there are no changes to the UI