### PR TITLE
Various cleanups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
           npm ci --no-optional
           npx lerna bootstrap
 
+      - name: Type check 📋
+        run: npm run types
+
       - name: Run CI Tests ✅
         run: npx lerna run test:ci --stream
         env:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postinstall": "lerna bootstrap",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx}\"",
     "start": "lerna run build --ignore=@chanzuckerberg/eds-components && lerna run start --parallel",
-    "test": "lerna run test"
+    "test": "lerna run test",
+    "types": "lerna run types"
   },
   "size-limit": [
     {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -35,7 +35,8 @@
     "storybook:axeOnly": "axe-storybook --build-dir storybook-static",
     "start": "npm run storybook",
     "test": "jest",
-    "test:ci": "npm run test -- --ci --coverage && cat ./coverage/lcov.info | codecov"
+    "test:ci": "npm run test -- --ci --coverage && cat ./coverage/lcov.info | codecov",
+    "types": "tsc --noEmit"
   },
   "bugs": {
     "url": "https://github.com/chanzuckerberg/edu-design-system/issues"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6,7 +6,7 @@
     "design system",
     "components"
   ],
-  "author": "Devin Witherspoon <dcwither@gmail.com>",
+  "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system/tree/main/packages/components",
   "license": "MIT",
   "main": "dist/index.js",

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -69,13 +69,13 @@ Alert.args = {
 export const NoHeadingShort = Template.bind(null);
 NoHeadingShort.args = {
   ...dialogArgs,
-  heading: null,
+  heading: undefined,
 };
 
 export const NoContent = Template.bind(null);
 NoContent.args = {
   ...dialogArgs,
-  content: null,
+  content: undefined,
 };
 
 export const WithAction = Template.bind(null);

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -15,9 +15,7 @@ export default {
   },
 };
 
-type Args = React.ComponentProps<typeof Button> & {
-  "data-testid"?: string;
-};
+type Args = React.ComponentProps<typeof Button>;
 
 const Template: Story<Args> = (args) => <Button {...args} />;
 

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -15,7 +15,10 @@ export default {
   },
 };
 
-type Args = React.ComponentProps<typeof Button>;
+type Args = React.ComponentProps<typeof Button> & {
+  "data-testid"?: string;
+};
+
 const Template: Story<Args> = (args) => <Button {...args} />;
 
 const heartIcon = (
@@ -44,7 +47,7 @@ link.args = {
   variant: "link",
 };
 
-export const linkInBody = (args) => (
+export const linkInBody: Story<Args> = (args) => (
   <Text size="body">
     This text surrounds the <Button {...args} /> and shows that the link should
     adhere to its appearance
@@ -56,7 +59,7 @@ linkInBody.args = {
   variant: "link",
 };
 
-export const linkInHeading = (args) => (
+export const linkInHeading: Story<Args> = (args) => (
   <Text size="h1">
     This text surrounds the <Button {...args} /> and shows that the link should
     adhere to its appearance

--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -10,6 +10,7 @@ export type ButtonProps = ButtonHTMLElementProps & {
    */
   children: ReactNode;
   color?: ClickableProps<"button">["color"];
+  "data-testid"?: string;
   size?: ClickableProps<"button">["size"];
   variant?: ClickableProps<"button">["variant"];
 };

--- a/packages/components/src/Heading/Heading.spec.tsx
+++ b/packages/components/src/Heading/Heading.spec.tsx
@@ -9,14 +9,15 @@ describe("<Heading />", () => {
   generateSnapshots(HeadingStoryFile);
 
   it("should pass through ref", () => {
-    const headingRef = React.createRef();
+    const headingRef = React.createRef<HTMLHeadingElement>();
     render(
       <Heading ref={headingRef} size="h1" tabIndex={-1}>
         Some Heading
       </Heading>,
     );
 
-    headingRef.current.focus();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    headingRef.current!.focus();
 
     const headingElement = screen.getByText("Some Heading");
 

--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -17,8 +17,9 @@ type Props = {
   className?: TypographyProps<HeadingElement>["className"];
   color?: TypographyProps<HeadingElement>["color"];
   size: TypographyProps<HeadingElement>["size"];
-  weight?: TypographyProps<HeadingElement>["weight"];
   spacing?: TypographyProps<HeadingElement>["spacing"];
+  tabIndex?: number;
+  weight?: TypographyProps<HeadingElement>["weight"];
 };
 
 const Heading = forwardRef<HTMLElement, Props>(({ as, children, size, /**

--- a/packages/components/src/SVGIcon/SVGIcon.stories.tsx
+++ b/packages/components/src/SVGIcon/SVGIcon.stories.tsx
@@ -59,24 +59,32 @@ const defaultArgs = {
 };
 
 export const Small = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 Small.args = {
   ...defaultArgs,
   size: "1em",
 };
 
 export const Medium = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 Medium.args = {
   ...defaultArgs,
   size: "2em",
 };
 
 export const Large = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 Large.args = {
   ...defaultArgs,
   size: "4em",
 };
 
 export const FullScreen = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 FullScreen.args = {
   ...defaultArgs,
   size: "min(100%, 100vh)",
@@ -89,12 +97,16 @@ FullScreen.parameters = {
 };
 
 export const CustomColor = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 CustomColor.args = {
   ...defaultArgs,
   color: "EdsColorBrand400",
 };
 
 export const CustomViewBox = Template.bind(null);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore todo: figure out SVGIcon types
 CustomViewBox.args = {
   ...defaultArgs,
   viewBox: "4 4 16 16",

--- a/packages/components/src/SVGIcon/SVGIcon.stories.tsx
+++ b/packages/components/src/SVGIcon/SVGIcon.stories.tsx
@@ -49,13 +49,13 @@ type Args = React.ComponentProps<typeof SVGIcon> & {
 
 const Template: Story<Args> = ({ icon, color, ...rest }) => {
   const Icon = allIcons[icon];
-  const computedColor = Tokens[color];
+  const computedColor = color && Tokens[color];
   return <Icon {...rest} color={computedColor} />;
 };
 
 const defaultArgs = {
   icon: Object.keys(allIcons)[0],
-  role: "presentation",
+  role: "presentation" as const,
 };
 
 export const Small = Template.bind(null);

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -5,7 +5,9 @@ import type { Story } from "@storybook/react";
 import WarningIcon from "../SVGIcon/Icons/Warning";
 import styles from "./Tag.stories.module.css";
 
-const colorOptions: Array<Color> = Object.keys(stylesByColor);
+// todo (Andrew): look into getting rid of the `as` cast. The `stylesByColor` object's keys are
+// members of Color. Can TypeScript understand that?
+const colorOptions = Object.keys(stylesByColor) as Color[];
 
 export default {
   title: "Tag",
@@ -27,7 +29,7 @@ const Template: Story<Args> = (args) => <Tag {...args} />;
 
 const defaultArgs = {
   children: "Tag text",
-  color: "warning",
+  color: "warning" as const,
 };
 
 export const Default = Template.bind(null);

--- a/packages/components/src/Text/Text.spec.tsx
+++ b/packages/components/src/Text/Text.spec.tsx
@@ -24,14 +24,15 @@ describe("<Text />", () => {
   });
 
   it("should pass the passthrough ref", () => {
-    const textRef = React.createRef();
+    const textRef = React.createRef<HTMLSpanElement>();
     render(
       <Text ref={textRef} size="body" tabIndex={-1}>
         Some Text
       </Text>,
     );
 
-    textRef.current.focus();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    textRef.current!.focus();
 
     const textElement = screen.getByText("Some Text");
     expect(textElement).toHaveFocus();

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -57,7 +57,7 @@ BodyColorInfoBold.args = {
   weight: "bold",
 };
 
-export const TextColorInherit = (args) => (
+export const TextColorInherit: Story<Args> = (args) => (
   <Text color="alert" size="body">
     This text surrounds the <Text {...args} /> and shows it should inherit color
     from the parent

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -13,8 +13,9 @@ type Props = {
   className?: TypographyProps<TextElement>["className"];
   color?: TypographyProps<TextElement>["color"];
   size: TypographyProps<TextElement>["size"];
-  weight?: TypographyProps<TextElement>["weight"];
   spacing?: TypographyProps<TextElement>["spacing"];
+  tabIndex?: number;
+  weight?: TypographyProps<TextElement>["weight"];
 };
 
 const Text = forwardRef<HTMLElement, Props>(({ as, children, /**

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -18,5 +18,5 @@
     "target": "es5"
   },
   "include": ["src/**/*", "css-modules.d.ts"],
-  "exclude": ["node_modules", "dist", "**/*.stories.*", "**/*.spec.*"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "node",
     "noUnusedLocals": true,
     "outDir": "dist/",
+    "resolveJsonModule": true,
     "sourceMap": true,
     "skipLibCheck": true,
     "strict": true,

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -6,7 +6,7 @@
     "design",
     "system"
   ],
-  "author": "Devin Witherspoon <dcwither@gmail.com>",
+  "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system/tree/main/packages/tokens",
   "license": "MIT",
   "main": "src/index.js",


### PR DESCRIPTION
[ch147126]

### Summary:

This PR
- Adds a script for running typescript locally. Can run `npm run types` at either the top level or packages/components.
- Adds a separate CI step for type checking. Technically this is duplicate work with the build step. But it could make what's going on more obvious.
- Enable type checking for stories and tests
- Allow Text and Heading components to receive `tabIndex`
- Ignore type errors in SvgIcon, for now. We'll need to figure out what the types should be there.
- ~~Use `React.ComponentProps` instead of `React.ElementProps`~~ Handled by #524
- ~~Remove the Flow pattern of `import * as React from "react"`, which isn't necessary here~~ Handled by #524
- Various type fixes
- Update package author to "CZI"

### Test Plan:

- CI
