### PR TITLE
chore(banner): clean up dismiss hover styles

### DIFF
--- a/packages/components/src/Banner/Banner.module.css
+++ b/packages/components/src/Banner/Banner.module.css
@@ -34,7 +34,8 @@
 
 .dismiss:hover {
   /* The hover transition is inherited from the Button component */
-  color: var(--eds-color-white);
+  @apply text-white;
+
   background-color: var(--banner-dismiss-hover-color);
 }
 

--- a/packages/components/src/Banner/Banner.module.css
+++ b/packages/components/src/Banner/Banner.module.css
@@ -29,13 +29,12 @@
 }
 
 .dismiss {
-  /* TODO: motion-safe does not seem to be stopping the animation when
-     the user has the reduce motion accessibility setting on */
   @apply absolute top-1 right-1 w-12 h-12 justify-center rounded-full;
-  @apply hover:text-white motion-safe:transition ease-out;
 }
 
 .dismiss:hover {
+  /* The hover transition is inherited from the Button component */
+  color: var(--eds-color-white);
   background-color: var(--banner-dismiss-hover-color);
 }
 


### PR DESCRIPTION
### Summary:
Small cleanup here.

The dismiss button on the `Banner` component is inheriting it's `transition` styles, including `motion-reduce`, from the underlying `Button` component. This PR removes the transition logic from the `Banner`, updates the comment to state why there is no transition logic, and moves the 2nd hover style so the 2 are grouped together.

### Test Plan:
Run storybook (`npm start`),
navigate to `/?path=/story/banner--brand-dismissable`, 
hover over the dismiss icon,
verify there's a very subtle transition in the hover effect (you can add `duration-1000` to line 34 to make the transition more obvious),
open your accessibility software settings,
turn on "reduce motion",
hover over the dismiss button again,
verify the subtle transition is gone.