### PR TITLE
chore: use clsx instead of cx

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import SentimentVeryDissatisfiedIcon from "../SVGIcon/Icons/SentimentVeryDissatisfied";
 import Text from "../Text";
 import WarningIcon from "../SVGIcon/Icons/Warning";
-import cx from "classnames";
+import clsx from "clsx";
 import styles from "./Banner.module.css";
 
 type Color = "brand" | "neutral" | "success" | "warning" | "alert";
@@ -83,7 +83,7 @@ export const BannerIcon = ({ color }: { color: Color }) => {
   const iconAssets = colorToIconMap[color];
 
   return (
-    <div className={cx(styles.icon, iconAssets.style)}>
+    <div className={clsx(styles.icon, iconAssets.style)}>
       <iconAssets.icon role="img" title={iconAssets.title} />
     </div>
   );
@@ -146,7 +146,7 @@ export default function Banner({
 
   return (
     <article
-      className={cx(
+      className={clsx(
         className,
         styles.bannerDialog,
         isHorizontal && styles.horizontal,
@@ -165,15 +165,23 @@ export default function Banner({
       <BannerIcon color={color} />
 
       <div
-        className={cx(styles.textAndAction, isHorizontal && styles.horizontal)}
+        className={clsx(
+          styles.textAndAction,
+          isHorizontal && styles.horizontal,
+        )}
       >
         <div
-          className={cx(styles.textContent, isHorizontal && styles.horizontal)}
+          className={clsx(
+            styles.textContent,
+            isHorizontal && styles.horizontal,
+          )}
         >
           {children}
         </div>
         {action && (
-          <div className={cx(styles.action, isHorizontal && styles.horizontal)}>
+          <div
+            className={clsx(styles.action, isHorizontal && styles.horizontal)}
+          >
             {action}
           </div>
         )}

--- a/packages/components/src/SVGIcon/SVGIcon.tsx
+++ b/packages/components/src/SVGIcon/SVGIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import cx from "classnames";
+import clsx from "clsx";
 import styles from "./SVGIcon.module.css";
 
 interface IconPropsBase {
@@ -81,7 +81,7 @@ function SVGIcon(props: SVGIconProps) {
   };
 
   const svgCommonProps = {
-    className: cx(className, styles.svgIcon, block && styles.displayBlock),
+    className: clsx(className, styles.svgIcon, block && styles.displayBlock),
     fill: color,
     height: size,
     role,

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Text from "../Text";
-import cx from "classnames";
+import clsx from "clsx";
 import styles from "./Tag.module.css";
 
 export type Color =
@@ -48,7 +48,7 @@ function Tag({ color, children, icon, variant = "flat" }: Props) {
   return (
     <Text
       as="span"
-      className={cx(
+      className={clsx(
         styles.tag,
         color && stylesByColor[color],
         variant === "outline" && styles.outline,

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -3,7 +3,7 @@ import CloseIcon from "../SVGIcon/Icons/Close";
 import { BannerIcon as Icon } from "../Banner";
 import React from "react";
 import Text from "../Text";
-import cx from "classnames";
+import clsx from "clsx";
 import styles from "./Toast.module.css";
 // TODO: extract into a shared utility for Toast and Banner
 
@@ -61,7 +61,7 @@ export default function Toast({
 }: Props) {
   return (
     <div
-      className={cx(
+      className={clsx(
         className,
         styles.toastDialog,
         color === "success" && styles.colorSuccess,


### PR DESCRIPTION
### Summary:
I ported over several components that are using `cx` (`classnames`), but the rest of the components are using `clsx`. This PR just updates all usage of `cx` to `clsx`.

I added this to the list of things we might want to automatically update when porting over a component: https://app.clubhouse.io/czi-edu/story/150855/write-migration-script-for-components-from-traject-eds

### Test Plan:
Spot check that there are no changes in styling in storybook.