### PR TITLE
chore(text): make "body" default size

### DIFF
--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -21,7 +21,6 @@ const Template: Story<Args> = (args) => <Text {...args} />;
 
 export const Body = Template.bind(null);
 Body.args = {
-  size: "body",
   children: "Body paragraph 16/24",
 };
 
@@ -53,7 +52,6 @@ export const BodyColorInfoBold = Template.bind(null);
 BodyColorInfoBold.args = {
   children: "Info color body text, bold",
   color: "info",
-  size: "body",
   weight: "bold",
 };
 
@@ -66,5 +64,4 @@ export const TextColorInherit: Story<Args> = (args) => (
 TextColorInherit.args = {
   children: "Child Text",
   color: "inherit",
-  size: "body",
 };

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -12,19 +12,19 @@ type Props = {
   children: TypographyProps<TextElement>["children"];
   className?: TypographyProps<TextElement>["className"];
   color?: TypographyProps<TextElement>["color"];
-  size: TypographyProps<TextElement>["size"];
+  size?: TypographyProps<TextElement>["size"];
   spacing?: TypographyProps<TextElement>["spacing"];
   tabIndex?: number;
   weight?: TypographyProps<TextElement>["weight"];
 };
 
-const Text = forwardRef<HTMLElement, Props>(({ as, children, /**
+const Text = forwardRef<HTMLElement, Props>(({ as, children, size = "body", /**
    * Components that wrap typography sometimes requires props such as event handlers
    * to be passed down into the element. One example is the tooltip component.  It
    * attaches a onHover and onFocus event to the element to determine when to
    * trigger the overlay.
    */ ...rest }: Props, ref) => (
-  <Typography as={as || "p"} ref={ref} {...rest}>
+  <Typography as={as || "p"} ref={ref} size={size} {...rest}>
     {children}
   </Typography>
 ));


### PR DESCRIPTION
### Summary:
I figure most `Text` instances will be `"body"` sized, so why not make that the default and reduce a little repetition?

### Test Plan:
Verify there are no Percy changes on this story and typecheck passes.