### PR TITLE
chore: fix SvgIcon story types

### DIFF
--- a/packages/components/src/SvgIcon/SvgIcon.stories.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.stories.tsx
@@ -54,37 +54,29 @@ const Template: Story<Args> = ({ icon, color, ...rest }) => {
 };
 
 const defaultArgs = {
-  icon: Object.keys(allIcons)[0],
+  icon: Object.keys(allIcons)[0] as keyof typeof allIcons,
   role: "presentation" as const,
 };
 
 export const Small = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 Small.args = {
   ...defaultArgs,
   size: "1em",
 };
 
 export const Medium = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 Medium.args = {
   ...defaultArgs,
   size: "2em",
 };
 
 export const Large = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 Large.args = {
   ...defaultArgs,
   size: "4em",
 };
 
 export const FullScreen = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 FullScreen.args = {
   ...defaultArgs,
   size: "min(100%, 100vh)",
@@ -97,16 +89,12 @@ FullScreen.parameters = {
 };
 
 export const CustomColor = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 CustomColor.args = {
   ...defaultArgs,
   color: "EdsColorBrand400",
 };
 
 export const CustomViewBox = Template.bind(null);
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore todo: figure out SvgIcon types
 CustomViewBox.args = {
   ...defaultArgs,
   viewBox: "4 4 16 16",

--- a/packages/components/src/SvgIcon/SvgIcon.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.tsx
@@ -24,12 +24,6 @@ interface IconPropsBase {
    */
   color?: string;
   /**
-   * The role of the icon.
-   * "img" requires a title prop also being passed in
-   * "presentation" should not have a title prop because it will be hidden from screenreaders
-   */
-  role: "img" | "presentation";
-  /**
    * Width/Height string (px, rem, em, vh, etc.)
    * Recommendation: use "EdsSizeLineHeight" tokens from
    * @chanzuckerberg/eds-tokens/json/variables.json


### PR DESCRIPTION
### Summary:

Removes the `ts-ignore`s from SVGIcon.stories.tsx. Next PR will add `createSvgIcon` and a license statement

### Test Plan:
- tsc passes
- confirmed that passing something like `role: "test"` still
<img width="716" alt="Screen Shot 2021-07-28 at 4 52 27 PM" src="https://user-images.githubusercontent.com/15840841/127394273-4c62fc1f-bb50-4ef3-a7ed-5ff89819756e.png">
 fails type checking