### PR TITLE
Scripts for easy package publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,34 +72,11 @@ npx lerna create '@chanzuckerberg/czedi-kit-<package-name>' \
 
 ### Publishing
 
-**We are only publishing alpha pre-releases at this time**
-
 1. Confirm that all checks are green on CI.
 2. Run `git checkout main`
-3. Increment `<version>` based on the latest alpha version:
-
-```bash
-npx lerna version --no-push --conventional-commits prerelease --message "chore(release): publish v0.0.1-alpha.<version>"
-```
-
-`--no-push` ensures the commit is not auto-pushed to remote git
-
-`--conventional-commits` automatically updates the CHANGELOGs based on the commit log
-
-4. Run
-
-```bash
-npx lerna publish from-git --no-push
-```
-
-and confirm that tags/commit/changelog etc. look correct
-
-5. Push commit and tags to remote:
-
-```bash
-git push origin --tags && git push origin main
-```
-
-In the future, we should have a `publish` script to handle all of this 🤓
+3. Run `npm run create-releases` to bump the package versions, create new git tags, and create git commits. The packages are not published, yet.
+4. Confirm that the git tags, git commits, and changelog updates look correct.
+5. Run `npm run publish-releases` to publish the packages to the NPM registry.
+6. Push commits and tags to the git remote with `git push origin main --follow-tags`
 
 You could also try directly running `lerna publish --canary --preid alpha`, though this gives a commit message that doesn't follow our lint rule for conventional commits.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "NODE_ENV=production lerna run build",
+    "create-releases": "lerna version --no-push --conventional-commits --message 'chore(release): %s'",
     "lint": "npm run lint:styles && npm run lint:scripts",
     "lint:fix": "npm run lint:styles:fix && npm run lint:scripts:fix",
     "lint:styles": "stylelint --ignore-path .gitignore packages/**/*.{css,js,jsx,ts,tsx}",
@@ -13,6 +14,7 @@
     "lint:scripts:fix": "npm run lint:scripts -- --fix",
     "postinstall": "lerna bootstrap",
     "prettier": "prettier --write \"**/*.{js,jsx,ts,tsx}\"",
+    "publish-releases": "lerna publish from-git --no-push",
     "start": "lerna run build --ignore=@chanzuckerberg/eds-components && lerna run start --parallel",
     "test": "lerna run test",
     "types": "lerna run types"


### PR DESCRIPTION
### Summary:

This PR adds scripts for publishing, to make it easier. Now to publish you'd

- Run `npm run create-releases`
- Check that everything looks right
- Run `npm run publish-releases`
- Run `git push origin head --follow-tags`

### Test Plan:

- Test publish