### PR TITLE
Export SvgIcon from the components package

### DIFF
--- a/packages/components/src/SvgIcon/SvgIcon.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.tsx
@@ -59,6 +59,19 @@ interface DecorativeIconProps extends IconPropsBase {
 
 export type SvgIconProps = DecorativeIconProps | InformativeIconProps;
 
+/**
+ * SvgIcon props, except `children`. Useful for creating specific icon components.
+ *
+ * @example
+ *
+ * function CircleIcon(props: IconProps) {
+ *   return (
+ *     <SvgIcon {...props}>
+ *       <circle cx="50" cy="50" r="50" />
+ *     </SvgIcon>
+ *   )
+ * }
+ */
 export type IconProps =
   | Omit<DecorativeIconProps, "children">
   | Omit<InformativeIconProps, "children">;

--- a/packages/components/src/SvgIcon/index.tsx
+++ b/packages/components/src/SvgIcon/index.tsx
@@ -1,1 +1,2 @@
 export { default } from "./SvgIcon";
+export type { IconProps } from "./SvgIcon";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,6 +2,8 @@ export { default as Banner } from "./Banner";
 export { default as Button } from "./Button";
 export { default as Clickable } from "./Clickable";
 export { default as Heading } from "./Heading";
+export { default as SvgIcon } from "./SvgIcon";
+export type { IconProps } from "./SvgIcon";
 export { default as Tag } from "./Tag";
 export { default as Text } from "./Text";
 export { default as Toast } from "./Toast";


### PR DESCRIPTION
### Summary:

Allow `<SvgIcon>` to be used from the components package. That way we can look at using it in Learning Platform and Along.

### Test Plan:

- CI