### PR TITLE
ci: set codecov to informational mode

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
### Summary:
[ch150553]

We already have pretty high code coverage, and it's not useful for codecov to block builds at this point. I'm choosing to keep it and just turn it to "informational" mode (non-blocking), in case it does start producing useful insights lol

### Test Plan:
- created a commit that removed all button tests, just for testing
- ensured that [codecov check passes](https://codecov.io/gh/chanzuckerberg/edu-design-system/commit/7f0b985fd561db14f5be886d5b3f86439ee9602b) even though coverage decreased

(I'll remove this commit after approval)