### PR TITLE
Ensure the yarn.lock file gets updated when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "publish-releases:alpha": "yarn publish-releases --dist-tag alpha",
     "start": "yarn workspaces foreach run start",
     "test": "yarn workspaces foreach run test",
-    "types": "yarn workspaces foreach run types"
+    "types": "yarn workspaces foreach run types",
+    "version": "./scripts/updateYarnLockForLerna.sh"
   },
   "size-limit": [
     {

--- a/scripts/updateYarnLockForLerna.sh
+++ b/scripts/updateYarnLockForLerna.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Abort this script if any commands fail.
+set -e
+
+# Currently (August, 2021), Lerna does not update yarn.lock files when dependencies between
+# monorepo packages increment. See https://github.com/lerna/lerna/issues/1171. This causes failures
+# on CI builds because of the `--immutable` flag we use when installing deps on CI, since Yarn
+# wants to update the lock file for the updated inter-package dependencies.
+#
+# To work around that, we manually install deps so that the lock file gets updated. This should run
+# in a Lerna "version" lifecycle hook. See https://github.com/lerna/lerna/tree/a47fc294393a3e9507a8207a5a2f07648a524722/commands/version#lifecycle-scripts.
+#
+# Another workaround would be to use Yarn workspace ranges to specify dependencies between
+# packages. See https://yarnpkg.com/features/workspaces/#workspace-ranges-workspace.
+# Unfortunately, Lerna also doesn't support those - https://github.com/lerna/lerna/issues/2564.
+#
+# If either of these Lerna issues are resolved, we should remove this hack.
+yarn install
+git stage yarn.lock


### PR DESCRIPTION
Hat tip @anniehu4 for the idea here

### Summary:

Currently Lerna doesn't update yarn.lock files when dependencies between monorepo packages increment. See https://github.com/lerna/lerna/issues/1171.

To work around that, we manually install deps during publishing so that the lock file gets updated.

Another workaround would be to [use Yarn workspace ranges to specify dependencies between package](https://yarnpkg.com/features/workspaces/#workspace-ranges-workspace), so that there's no need to reference specific version numbers.

Unfortunately, Lerna also doesn't support that, either - https://github.com/lerna/lerna/issues/2564.

### Test Plan:

- [x] Create a test release (didn't publish it)
