### PR TITLE
chore: use eslint-plugin-import/order

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "browser": true
   },
   "parser": "@typescript-eslint/parser",
-  "plugins": ["react-hooks", "testing-library"],
+  "plugins": ["import", "react-hooks", "testing-library"],
   "extends": [
     "eslint:recommended",
     "plugin:react/recommended",
@@ -24,7 +24,11 @@
     }
   },
   "rules": {
-    "sort-imports": ["error"],
+    "import/order": ["error", {
+      "alphabetize": {
+        "order": "asc"
+      }
+    }],
     "react/prop-types": "off",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "error"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "^4.15.1",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^8.0.0",
+    "eslint-plugin-import": "^2.24.0",
     "eslint-plugin-jest": "^22.21.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",

--- a/packages/components/docs/token-table.tsx
+++ b/packages/components/docs/token-table.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import classNames from "classnames/bind";
+import React from "react";
 import styles from "./token-table.module.css";
 
 const cx = classNames.bind(styles);

--- a/packages/components/src/Banner/Banner.spec.tsx
+++ b/packages/components/src/Banner/Banner.spec.tsx
@@ -1,5 +1,5 @@
-import * as BannerStoryFile from "./Banner.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as BannerStoryFile from "./Banner.stories";
 
 describe("<Banner />", () => {
   generateSnapshots(BannerStoryFile);

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -1,8 +1,8 @@
-import Banner from "./Banner";
+import type { Story } from "@storybook/react";
+import React from "react";
 import Button from "../Button";
 import Heading from "../Heading";
-import React from "react";
-import type { Story } from "@storybook/react";
+import Banner from "./Banner";
 
 export default {
   title: "Banner",

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -1,12 +1,12 @@
+import clsx from "clsx";
+import React from "react";
 import Heading, { HeadingElement } from "../Heading";
+import Text from "../Text";
+import CloseButton from "../common/CloseButton";
+import colorStyles from "../common/Notifications/Notification.module.css";
 import NotificationIcon, {
   NotificationVariant,
 } from "../common/Notifications/NotificationIcon";
-import CloseButton from "../common/CloseButton";
-import React from "react";
-import Text from "../Text";
-import clsx from "clsx";
-import colorStyles from "../common/Notifications/Notification.module.css";
 import styles from "./Banner.module.css";
 
 type Props = {

--- a/packages/components/src/Button/button.spec.tsx
+++ b/packages/components/src/Button/button.spec.tsx
@@ -1,6 +1,5 @@
-import * as ButtonStoryFile from "./button.stories";
-
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as ButtonStoryFile from "./button.stories";
 
 describe("<Button />", () => {
   generateSnapshots(ButtonStoryFile);

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -1,10 +1,10 @@
-import Button, { ButtonProps } from "./button";
-import CheckCircleRoundedIcon from "../Icons/CheckCircleRounded";
+import { Story } from "@storybook/react/types-6-0";
+import React from "react";
 import Clickable from "../Clickable";
 import Heading from "../Heading";
-import React from "react";
-import { Story } from "@storybook/react/types-6-0";
+import CheckCircleRoundedIcon from "../Icons/CheckCircleRounded";
 import Text from "../Text";
+import Button, { ButtonProps } from "./button";
 import styles from "./button.stories.module.css";
 
 const sizes = ["small", "medium", "large"] as const;

--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -1,5 +1,5 @@
-import Clickable, { ClickableProps } from "../Clickable";
 import React, { ReactNode } from "react";
+import Clickable, { ClickableProps } from "../Clickable";
 
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 

--- a/packages/components/src/Clickable/Clickable.spec.tsx
+++ b/packages/components/src/Clickable/Clickable.spec.tsx
@@ -1,6 +1,5 @@
-import * as ClickableStoryFile from "./Clickable.stories";
-
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as ClickableStoryFile from "./Clickable.stories";
 
 describe("<Clickable />", () => {
   generateSnapshots(ClickableStoryFile);

--- a/packages/components/src/Clickable/Clickable.stories.tsx
+++ b/packages/components/src/Clickable/Clickable.stories.tsx
@@ -1,6 +1,6 @@
-import Clickable from "./Clickable";
-import React from "react";
 import { Story } from "@storybook/react/types-6-0";
+import React from "react";
+import Clickable from "./Clickable";
 
 export default {
   title: "Clickable",

--- a/packages/components/src/Clickable/Clickable.tsx
+++ b/packages/components/src/Clickable/Clickable.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import clsx from "clsx";
+import React from "react";
 import styles from "./Clickable.module.css";
 
 export type ClickableProps<IComponent extends React.ElementType> = {

--- a/packages/components/src/Heading/Heading.spec.tsx
+++ b/packages/components/src/Heading/Heading.spec.tsx
@@ -1,9 +1,8 @@
-import * as HeadingStoryFile from "./Heading.stories";
-
-import { render, screen } from "@testing-library/react";
-import Heading from "./Heading";
-import React from "react";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import Heading from "./Heading";
+import * as HeadingStoryFile from "./Heading.stories";
 
 describe("<Heading />", () => {
   generateSnapshots(HeadingStoryFile);

--- a/packages/components/src/Heading/Heading.stories.tsx
+++ b/packages/components/src/Heading/Heading.stories.tsx
@@ -1,6 +1,6 @@
-import Heading from "./Heading";
-import React from "react";
 import { Story } from "@storybook/react/types-6-0";
+import React from "react";
+import Heading from "./Heading";
 
 export default {
   title: "Heading",

--- a/packages/components/src/SvgIcon/SvgIcon.spec.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.spec.tsx
@@ -1,6 +1,5 @@
-import * as SvgIconStoryFile from "./SvgIcon.stories";
-
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as SvgIconStoryFile from "./SvgIcon.stories";
 
 describe("<SvgIcon />", () => {
   generateSnapshots(SvgIconStoryFile);

--- a/packages/components/src/SvgIcon/SvgIcon.stories.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.stories.tsx
@@ -1,9 +1,9 @@
 import * as ColorTokens from "@chanzuckerberg/eds-tokens/lib/ts/colors";
-import * as allIcons from "../Icons";
-import React from "react";
 import type { Story } from "@storybook/react";
-import SvgIcon from "./SvgIcon";
+import React from "react";
+import * as allIcons from "../Icons";
 import Text from "../Text";
+import SvgIcon from "./SvgIcon";
 import styles from "./SvgIcon.stories.module.css";
 
 export default {

--- a/packages/components/src/SvgIcon/SvgIcon.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import clsx from "clsx";
+import React from "react";
 import styles from "./SvgIcon.module.css";
 
 interface IconPropsBase {

--- a/packages/components/src/SvgIcon/utils/createSvgIcon.tsx
+++ b/packages/components/src/SvgIcon/utils/createSvgIcon.tsx
@@ -1,5 +1,5 @@
-import type { IconProps } from "../SvgIcon";
 import React from "react";
+import type { IconProps } from "../SvgIcon";
 import SvgIcon from "../SvgIcon";
 
 /**

--- a/packages/components/src/Tag/Tag.spec.tsx
+++ b/packages/components/src/Tag/Tag.spec.tsx
@@ -1,5 +1,5 @@
-import * as TagStoryFile from "./Tag.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as TagStoryFile from "./Tag.stories";
 
 describe("<Tag />", () => {
   generateSnapshots(TagStoryFile);

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -1,8 +1,8 @@
+import type { Story } from "@storybook/react";
+import React from "react";
+import WarningRoundedIcon from "../Icons/WarningRounded";
 import Tag, { stylesByColor } from "./Tag";
 import type { Color } from "./Tag";
-import React from "react";
-import type { Story } from "@storybook/react";
-import WarningRoundedIcon from "../Icons/WarningRounded";
 import styles from "./Tag.stories.module.css";
 
 // todo (Andrew): look into getting rid of the `as` cast. The `stylesByColor` object's keys are

--- a/packages/components/src/Tag/Tag.tsx
+++ b/packages/components/src/Tag/Tag.tsx
@@ -1,6 +1,6 @@
+import clsx from "clsx";
 import React from "react";
 import Text from "../Text";
-import clsx from "clsx";
 import styles from "./Tag.module.css";
 
 export type Color =

--- a/packages/components/src/Text/Text.spec.tsx
+++ b/packages/components/src/Text/Text.spec.tsx
@@ -1,9 +1,9 @@
-import * as TextStoryFile from "./Text.stories";
-
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
 import { render, screen } from "@testing-library/react";
+
 import React from "react";
 import Text from "./Text";
-import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as TextStoryFile from "./Text.stories";
 
 describe("<Text />", () => {
   generateSnapshots(TextStoryFile);

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -1,6 +1,6 @@
+import { Story } from "@storybook/react/types-6-0";
 import React from "react";
 
-import { Story } from "@storybook/react/types-6-0";
 import Text from "./Text";
 
 export default {

--- a/packages/components/src/Toast/Toast.spec.tsx
+++ b/packages/components/src/Toast/Toast.spec.tsx
@@ -1,5 +1,5 @@
-import * as ToastStoryFile from "./Toast.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as ToastStoryFile from "./Toast.stories";
 
 describe("<Toast />", () => {
   generateSnapshots(ToastStoryFile);

--- a/packages/components/src/Toast/Toast.stories.tsx
+++ b/packages/components/src/Toast/Toast.stories.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import type { Story } from "@storybook/react";
+import React from "react";
 import Toast from "./Toast";
 
 export default {

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -1,9 +1,9 @@
-import CloseButton from "../common/CloseButton";
-import NotificationIcon from "../common/Notifications/NotificationIcon";
+import clsx from "clsx";
 import React from "react";
 import Text from "../Text";
-import clsx from "clsx";
+import CloseButton from "../common/CloseButton";
 import colorStyles from "../common/Notifications/Notification.module.css";
+import NotificationIcon from "../common/Notifications/NotificationIcon";
 import styles from "./Toast.module.css";
 
 export type Color = "success" | "alert";

--- a/packages/components/src/common/CloseButton/CloseButton.stories.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.stories.tsx
@@ -1,6 +1,6 @@
-import CloseButton from "./CloseButton";
-import React from "react";
 import { Story } from "@storybook/react/types-6-0";
+import React from "react";
+import CloseButton from "./CloseButton";
 import styles from "./CloseButton.stories.module.css";
 
 export default {

--- a/packages/components/src/common/CloseButton/CloseButton.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.tsx
@@ -1,8 +1,8 @@
+import clsx from "clsx";
+import React from "react";
 import Button from "../../Button";
 import CloseRoundedIcon from "../../Icons/CloseRounded";
 import { NotificationVariant } from "../Notifications/NotificationIcon";
-import React from "react";
-import clsx from "clsx";
 import styles from "./CloseButton.module.css";
 
 type CloseButtonProps = {

--- a/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.spec.tsx
+++ b/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.spec.tsx
@@ -1,5 +1,5 @@
-import * as NotificationIconStoryFile from "./NotificationIcon.stories";
 import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import * as NotificationIconStoryFile from "./NotificationIcon.stories";
 
 describe("<NotificationIcon />", () => {
   generateSnapshots(NotificationIconStoryFile);

--- a/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.stories.tsx
+++ b/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.stories.tsx
@@ -1,10 +1,10 @@
+import { Story } from "@storybook/react/types-6-0";
 import * as React from "react";
+import Text from "../../../Text";
 import NotificationIcon, {
   NotificationVariant,
   variantToIconAssetsMap,
 } from "./NotificationIcon";
-import { Story } from "@storybook/react/types-6-0";
-import Text from "../../../Text";
 import styles from "./NotificationIcon.stories.module.css";
 
 // todo (Andrew): look into getting rid of the `as` cast. The `stylesByColor` object's keys are

--- a/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.tsx
+++ b/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
 import CheckCircleRoundedIcon from "../../../Icons/CheckCircleRounded";
-import DangerousRoundedIcon from "../../../Icons/custom/DangerousRounded";
 import ForumRoundedIcon from "../../../Icons/ForumRounded";
 import NotificationsRoundedIcon from "../../../Icons/NotificationsRounded";
 import WarningRoundedIcon from "../../../Icons/WarningRounded";
+import DangerousRoundedIcon from "../../../Icons/custom/DangerousRounded";
 import styles from "./NotificationIcon.module.css";
 
 export type NotificationVariant =

--- a/packages/components/src/common/typography.tsx
+++ b/packages/components/src/common/typography.tsx
@@ -1,6 +1,6 @@
+import clsx from "clsx";
 import React, { ForwardedRef, ReactNode, forwardRef } from "react";
 
-import clsx from "clsx";
 import styles from "./typography.module.css";
 
 export type TypographySize =

--- a/yarn.lock
+++ b/yarn.lock
@@ -6182,7 +6182,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.flat@npm:^1.2.1":
+"array.prototype.flat@npm:^1.2.1, array.prototype.flat@npm:^1.2.4":
   version: 1.2.4
   resolution: "array.prototype.flat@npm:1.2.4"
   dependencies:
@@ -8960,7 +8960,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^3.0.0, debug@npm:^3.1.0":
+"debug@npm:^3.0.0, debug@npm:^3.1.0, debug@npm:^3.2.7":
   version: 3.2.7
   resolution: "debug@npm:3.2.7"
   dependencies:
@@ -9556,6 +9556,7 @@ __metadata:
     "@typescript-eslint/parser": ^4.15.1
     eslint: ^7.20.0
     eslint-config-prettier: ^8.0.0
+    eslint-plugin-import: ^2.24.0
     eslint-plugin-jest: ^22.21.0
     eslint-plugin-prettier: ^3.3.1
     eslint-plugin-react: ^7.22.0
@@ -9986,6 +9987,51 @@ __metadata:
   bin:
     eslint-config-prettier: bin/cli.js
   checksum: df4cea3032671995bb5ab07e016169072f7fa59f44a53251664d9ca60951b66cdc872683b5c6a3729c91497c11490ca44a79654b395dd6756beb0c3903a37196
+  languageName: node
+  linkType: hard
+
+"eslint-import-resolver-node@npm:^0.3.5":
+  version: 0.3.5
+  resolution: "eslint-import-resolver-node@npm:0.3.5"
+  dependencies:
+    debug: ^3.2.7
+    resolve: ^1.20.0
+  checksum: 93a8176205f18c40d2c11c444fab89aa3990c5a5eed226ef03a893b5779e7cd4d1f5f52b2bbbbbe4b13fb2a75ef629278be0b52099480cbe6e7024888d9982dd
+  languageName: node
+  linkType: hard
+
+"eslint-module-utils@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "eslint-module-utils@npm:2.6.2"
+  dependencies:
+    debug: ^3.2.7
+    pkg-dir: ^2.0.0
+  checksum: 814591f494e4f4b04c1af0fde2a679e7a7664a5feb51175e02ba96d671e34ec60cb1835d174508eb81c07a6c92c243f84c6349f4169b3bec1a8dbdd36a0934f3
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-import@npm:^2.24.0":
+  version: 2.24.0
+  resolution: "eslint-plugin-import@npm:2.24.0"
+  dependencies:
+    array-includes: ^3.1.3
+    array.prototype.flat: ^1.2.4
+    debug: ^2.6.9
+    doctrine: ^2.1.0
+    eslint-import-resolver-node: ^0.3.5
+    eslint-module-utils: ^2.6.2
+    find-up: ^2.0.0
+    has: ^1.0.3
+    is-core-module: ^2.4.0
+    minimatch: ^3.0.4
+    object.values: ^1.1.3
+    pkg-up: ^2.0.0
+    read-pkg-up: ^3.0.0
+    resolve: ^1.20.0
+    tsconfig-paths: ^3.9.0
+  peerDependencies:
+    eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
+  checksum: 79fb1094197cd1dc720725bd29e5c5fe7d123fd9dd31eb182849993a81a8c18e2bfbc4d267a2caabe02bd4d21aafb1eca1da2f55aca7e5df99fd8ba908e7b869
   languageName: node
   linkType: hard
 
@@ -10822,7 +10868,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^2.0.0":
+"find-up@npm:^2.0.0, find-up@npm:^2.1.0":
   version: 2.1.0
   resolution: "find-up@npm:2.1.0"
   dependencies:
@@ -12929,7 +12975,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.2.0":
+"is-core-module@npm:^2.2.0, is-core-module@npm:^2.4.0":
   version: 2.5.0
   resolution: "is-core-module@npm:2.5.0"
   dependencies:
@@ -14315,7 +14361,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.1.2, json5@npm:^2.1.3":
+"json5@npm:^2.1.2, json5@npm:^2.1.3, json5@npm:^2.2.0":
   version: 2.2.0
   resolution: "json5@npm:2.2.0"
   dependencies:
@@ -16481,7 +16527,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.1.0, object.values@npm:^1.1.4":
+"object.values@npm:^1.1.0, object.values@npm:^1.1.3, object.values@npm:^1.1.4":
   version: 1.1.4
   resolution: "object.values@npm:1.1.4"
   dependencies:
@@ -17335,6 +17381,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"pkg-dir@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pkg-dir@npm:2.0.0"
+  dependencies:
+    find-up: ^2.1.0
+  checksum: 8c72b712305b51e1108f0ffda5ec1525a8307e54a5855db8fb1dcf77561a5ae98e2ba3b4814c9806a679f76b2f7e5dd98bde18d07e594ddd9fdd25e9cf242ea1
+  languageName: node
+  linkType: hard
+
 "pkg-dir@npm:^3.0.0":
   version: 3.0.0
   resolution: "pkg-dir@npm:3.0.0"
@@ -17368,6 +17423,15 @@ fsevents@^1.2.7:
   dependencies:
     find-up: ^3.0.0
   checksum: 5bac346b7c7c903613c057ae3ab722f320716199d753f4a7d053d38f2b5955460f3e6ab73b4762c62fd3e947f58e04f1343e92089e7bb6091c90877406fcd8c8
+  languageName: node
+  linkType: hard
+
+"pkg-up@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "pkg-up@npm:2.0.0"
+  dependencies:
+    find-up: ^2.1.0
+  checksum: de4b418175281a082e366ce1a919f032520ee53cf421578b35173f03816f6ec4c19e1552066840bb0988c3e1215859653948efd6ca3507a23f4f44229269500d
   languageName: node
   linkType: hard
 
@@ -22172,6 +22236,17 @@ resolve@^2.0.0-next.3:
     typescript:
       optional: true
   checksum: c2a698b85d521298fe6f2435fbf2d3dc5834b423ea25abd321805ead3f399dbeedce7ca09492d7eb005b9d2c009c6b9587055bc3ab273dc6b9e40eefd7edb5b2
+  languageName: node
+  linkType: hard
+
+"tsconfig-paths@npm:^3.9.0":
+  version: 3.10.1
+  resolution: "tsconfig-paths@npm:3.10.1"
+  dependencies:
+    json5: ^2.2.0
+    minimist: ^1.2.0
+    strip-bom: ^3.0.0
+  checksum: 014ec869276114031d3bd6d2d9ce07c32c96ca6912f32285f46eeb4ca5270bd4c5e4de1353b838c66282157f089dedc8c3377c4e72e2f3d910e706c7b9ac5e6d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary:
[ch151882]

our current lint rule doesn't auto-fix import order issues, which is hellaaa annoying. this switches to use the rule that `traject` already uses.

Note: one alternative was [eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort/#how-is-this-rule-different-from-importorder), which is mainly nice b/c it can also sort exports. Decided against it though because
- it's only maintained by one person, lol
- it's probably good to have more predictable behavior w/ traject

### Test Plan:
- ran `yarn run lint:scripts:fix` and verified all import order issues were fixed
- build passes