### PR TITLE
Allow buttons to take a ref

### DIFF
--- a/packages/components/src/Button/button.spec.tsx
+++ b/packages/components/src/Button/button.spec.tsx
@@ -1,6 +1,19 @@
-import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { generateSnapshots, prepareStory } from "@chanzuckerberg/story-utils";
+import { render, screen } from "@testing-library/react";
+import React from "react";
 import * as ButtonStoryFile from "./button.stories";
 
 describe("<Button />", () => {
   generateSnapshots(ButtonStoryFile);
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(prepareStory(ButtonStoryFile.Primary, { ref }));
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ref.current!.focus();
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveFocus();
+  });
 });

--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, forwardRef } from "react";
 import Clickable, { ClickableProps } from "../Clickable";
 
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
@@ -15,26 +15,34 @@ export type ButtonProps = ButtonHTMLElementProps & {
   variant?: ClickableProps<"button">["variant"];
 };
 
-function Button({
-  as = "button",
-  variant = "flat",
-  color = "brand",
-  disabled = false,
-  type = "button",
-  size = "medium",
-  ...rest
-}: ButtonProps) {
-  return (
-    <Clickable
-      {...rest}
-      as={as}
-      variant={variant}
-      color={color}
-      disabled={disabled}
-      type={type}
-      size={size}
-    />
-  );
-}
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    {
+      as = "button",
+      variant = "flat",
+      color = "brand",
+      disabled = false,
+      type = "button",
+      size = "medium",
+      ...rest
+    },
+    ref,
+  ) => {
+    return (
+      <Clickable
+        {...rest}
+        as={as}
+        variant={variant}
+        color={color}
+        disabled={disabled}
+        type={type}
+        size={size}
+        ref={ref}
+      />
+    );
+  },
+);
+
+Button.displayName = "Button";
 
 export default Button;

--- a/packages/components/src/Clickable/Clickable.tsx
+++ b/packages/components/src/Clickable/Clickable.tsx
@@ -30,50 +30,57 @@ export type ClickableProps<IComponent extends React.ElementType> = {
  *
  * See the Button stories for usage examples.
  */
-function Clickable<IComponent extends React.ElementType>({
-  as,
-  children,
-  color,
-  size,
-  state,
-  variant,
-  className,
-  ...rest
-}: ClickableProps<IComponent>) {
-  const Component = as;
-  return (
-    <Component
-      className={clsx(
-        className,
-        styles.button,
-        // Sizes
-        variant !== "link" && [
-          size === "small" && styles.sizeSmall,
-          size === "medium" && styles.sizeMedium,
-          size === "large" && styles.sizeLarge,
-        ],
-        // Variants
-        variant === "flat" && styles.variantFlat,
-        variant === "outline" && styles.variantOutline,
-        variant === "link" && styles.variantLink,
-        // Colors
-        color === "alert" && styles.colorAlert,
-        color === "brand" && styles.colorBrand,
-        color === "neutral" && styles.colorNeutral,
-        color === "success" && styles.colorSuccess,
-        color === "warning" && styles.colorWarning,
-        // Interactive States (for testing)
-        state === "hover" && styles.stateHover,
-        state === "focus" && styles.stateFocus,
-        state === "active" && styles.stateActive,
-      )}
-      {...rest}
-    >
-      {/* No width space to ensure height of contents */}
-      {"\u200B"}
-      {children}
-    </Component>
-  );
-}
+const Clickable = React.forwardRef(
+  <IComponent extends React.ElementType>(
+    {
+      as: Component,
+      children,
+      color,
+      size,
+      state,
+      variant,
+      className,
+      ...rest
+    }: ClickableProps<IComponent>,
+    ref: React.ForwardedRef<HTMLElement>,
+  ) => {
+    return (
+      <Component
+        className={clsx(
+          className,
+          styles.button,
+          // Sizes
+          variant !== "link" && [
+            size === "small" && styles.sizeSmall,
+            size === "medium" && styles.sizeMedium,
+            size === "large" && styles.sizeLarge,
+          ],
+          // Variants
+          variant === "flat" && styles.variantFlat,
+          variant === "outline" && styles.variantOutline,
+          variant === "link" && styles.variantLink,
+          // Colors
+          color === "alert" && styles.colorAlert,
+          color === "brand" && styles.colorBrand,
+          color === "neutral" && styles.colorNeutral,
+          color === "success" && styles.colorSuccess,
+          color === "warning" && styles.colorWarning,
+          // Interactive States (for testing)
+          state === "hover" && styles.stateHover,
+          state === "focus" && styles.stateFocus,
+          state === "active" && styles.stateActive,
+        )}
+        ref={ref}
+        {...rest}
+      >
+        {/* No width space to ensure height of contents */}
+        {"\u200B"}
+        {children}
+      </Component>
+    );
+  },
+);
+
+Clickable.displayName = "Clickable";
 
 export default Clickable;


### PR DESCRIPTION
### Summary:

@pomfy113 and I were working on focus management for https://app.clubhouse.io/czi-edu/story/153582/screen-reader-ssp-adoption-setup-improvements-nvda-announces-extra-text-blank-when-press-enter-key-on-x-button-besides-the, and realized we can't use React refs (to manage focus) with the react-bootstrap buttons. 

React-bootstrap's buttons have refs, but get you an instance of the React class, not the element.

Decided it was a good opportunity to switch over to the EDS buttons, but realized that they don't take refs. This PR adds ref support to buttons.

### Test Plan:

- CI
