### PR TITLE
build: fixes to generateFlowTypes

### DIFF
--- a/packages/components/generateFlowTypes.sh
+++ b/packages/components/generateFlowTypes.sh
@@ -9,5 +9,7 @@ for i in $(find lib/* -name "*.d.ts"); do
     fi
     NAME=${i%%.*}
     echo "Generating flowtype for $NAME"
-    npx flowgen $i -o $NAME.flow.js
+    npx flowgen --add-flow-header $i -o $NAME.js.flow
+    # passing an empty string after -i tells OS X to skip creating a backup file
+    sed -i '' 's/^import React from "react"/import * as React from "react"/' $NAME.js.flow
 done


### PR DESCRIPTION
### Summary:
[ch154563]

Was investigating why flow errors weren't showing up when using EDS components in traject. This PR:
- ensures we add a `@flow` annotation
- changes extension to `.js.flow` instead of `.flow.js` (apparently this is a problem, even tho flowgen docs use both 🤷‍♀️)
- ensure React is imported as `import * as React`

There are still issues with how React internal types are converted 😭  Those are more complicated to address though, so for now they're just documented in the Clubhouse ticket. flowgen isn't super well maintained so I think we're on our own here

### Test Plan:
- to make sure the types would work, I was editing stuff directly in `traject`
- ran `./generateFlowTypes.sh` here and made sure output files had these changes