### PR TITLE
fix: turn off flow types for now

### DIFF
--- a/packages/components/generateFlowTypes.sh
+++ b/packages/components/generateFlowTypes.sh
@@ -9,7 +9,7 @@ for i in $(find lib/* -name "*.d.ts"); do
     fi
     NAME=${i%%.*}
     echo "Generating flowtype for $NAME"
-    npx flowgen --add-flow-header $i -o $NAME.js.flow
+    npx flowgen $i -o $NAME.js.flow
 
     # manually replace options that flowgen doesn't handle
     REACT_SUB_PATTERN='s/^import React from "react"/import * as React from "react"/'


### PR DESCRIPTION
### Summary:

some context: https://czi-edu.slack.com/archives/C0241M8DGLV/p1629414226047300

I don't feel good that we currently can't make any updates because of flow T_T would prefer enabling that now, then cutting a release with flow turned on only once I'm sure it works

### Test Plan:
double-check no `@flow` annotation in the built files