### PR TITLE
Stop running generateFlowTypes as part of the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "create-component": "plop",
     "create-releases": "lerna version --no-push --conventional-commits --message 'chore(release): %s'",
     "create-releases:alpha": "yarn create-releases --preid alpha prerelease",
+    "generateFlowTypes": "./packages/components/generateFlowTypes.sh",
     "lint": "yarn run lint:styles && yarn run lint:scripts",
     "lint:fix": "yarn run lint:styles:fix && yarn run lint:scripts:fix",
     "lint:styles": "stylelint --ignore-path .gitignore packages/**/*.{css,js,jsx,ts,tsx}",

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -43,7 +43,7 @@ body {
 Import any of the components from this package
 
 ```js
-import {Heading} from '@chanzuckerberg/eds-components';
+import { Heading } from "@chanzuckerberg/eds-components";
 ```
 
 and then use them in your React components
@@ -53,3 +53,49 @@ and then use them in your React components
   Coffee!
 </Heading>
 ```
+
+## Flow types
+
+For any component, run
+
+```bash
+yarn generateFlowtypes <Component>
+```
+
+to get automatically generated flowtypes.
+
+We use a combination of `flowgen` and common React mutations to get the best automatic types possible, but manual fixing may still be required. Thus, we recommend maintaining a `flow-typed` file with libdefs.
+
+```js
+// declare a module for each component
+declare module '@chanzuckerberg/eds-components/lib/<Component>' {
+  ...
+}
+
+// re-declare each component from a root-level index
+declare module '@chanzuckerberg/eds-components' {
+  declare export var <Component>: $Exports<"@chanzuckerberg/eds-components/lib/<Component>">;
+}
+```
+
+When translating your generated flow types to this `flow-typed` file, you will need to:
+
+- Update React type imports to follow `import type { ... } from "react"`
+- Update internal type imports to be from `"@chanzuckerberg/eds-components/lib/..."`
+- Update ForwardRef components. For example:
+
+```js
+declare var x: React.ForwardRefExoticComponent<{
+  ...Props,
+  ...React.RefAttributes<HTMLElement>,
+}>;
+```
+
+should become:
+
+```js
+import type { AbstractComponent } from "react";
+declare var x: AbstractComponent<Props, HTMLElement>;
+```
+
+- Preserve exact-typed objects when possible. If you must make them inexact, add an explicit `...` at the end of the object.

--- a/packages/components/generateFlowTypes.sh
+++ b/packages/components/generateFlowTypes.sh
@@ -19,7 +19,6 @@ REACT_SUB_PATTERNS=(
     's/React.ReactNode/Node/g'
     's/ReactNode/Node/g'
     's/React$Node/Node/g'
-    's/React.ForwardRefExoticComponent/AbstractComponent/g'
     's/declare export default/declare module.exports:/'
 )
 
@@ -34,3 +33,4 @@ do
 done
 
 echo -e "\033[0;32mGenerated flowtypes in $NAME.js.flow\033[0m"
+echo -e "Further manual edits may be needed. See \033[4mhttps://github.com/chanzuckerberg/edu-design-system/blob/main/packages/components/README.md#flow-types\033[0m"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -28,7 +28,7 @@
     "build:finish": "rm lib/**/*.spec.* lib/**/*.stories.*",
     "build:js": "babel src -d lib --extensions '.js,.jsx,.ts,.tsx'",
     "build:styles": "postcss \"src/**/*.css\" --dir lib/ --base src/ --verbose",
-    "build:types": "tsc --project . --declaration --emitDeclarationOnly && ./generateFlowTypes.sh",
+    "build:types": "tsc --project . --declaration --emitDeclarationOnly",
     "build:watch": "yarn run build:js --watch",
     "build:storybook": "build-storybook -o storybook-static",
     "deploy:docs": "storybook-to-ghpages --ci",


### PR DESCRIPTION
### Summary:
[ch154563]

Updates `generateFlowTypes.sh` to run on a specific Component, instead of as part of the build step. Also adds some instructions for maintaining the flow types.

Rough sequence of PRs:
1. https://github.com/FB-PLP/traject/pull/8176
2. https://github.com/FB-PLP/traject/pull/8177
3. https://github.com/FB-PLP/traject/pull/8191
4. https://github.com/FB-PLP/traject/pull/8200
5. **https://github.com/FB-PLP/traject/pull/8211**
6. **https://github.com/chanzuckerberg/edu-design-system/pull/613**
7. Add rule to traject to warn about updating types whenever `eds-components` is updated (I think `goodcheck` could work, need to test though)

### Test Plan:
- Output of running `yarn generateFlowTypes`:
![Screen Shot 2021-08-27 at 1 13 50 PM](https://user-images.githubusercontent.com/15840841/131166638-5fc79e3f-561c-4309-8348-524271ff4f8f.png)
- Confirm `.js.flow` files are gone from `lib/`