### PR TITLE
chore(banner): update api to use title and message instead of children

### DIFF
--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -30,7 +30,7 @@ const Template: Story<Args> = (args) => {
       textContent={
         <>
           <Banner.Title as="h1">{heading}</Banner.Title>{" "}
-          <Banner.Body>{content}</Banner.Body>
+          <Banner.Message>{content}</Banner.Message>
         </>
       }
     />
@@ -148,7 +148,7 @@ export const DismissableBelowContent = () => (
       textContent={
         <>
           <Banner.Title as="h1">{dialogArgs.heading}</Banner.Title>{" "}
-          <Banner.Body>{dialogArgs.content}</Banner.Body>
+          <Banner.Message>{dialogArgs.content}</Banner.Message>
         </>
       }
     />

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -27,8 +27,12 @@ const Template: Story<Args> = (args) => {
   return (
     <Banner
       {...restArgs}
-      title={<Banner.Title as="h1">{heading}</Banner.Title>}
-      message={<Banner.Body>{content}</Banner.Body>}
+      textContent={
+        <>
+          <Banner.Title as="h1">{heading}</Banner.Title>{" "}
+          <Banner.Body>{content}</Banner.Body>
+        </>
+      }
     />
   );
 };
@@ -141,8 +145,12 @@ export const DismissableBelowContent = () => (
     </Heading>
     <Banner
       onDismiss={() => console.log("dismissed!")}
-      title={<Banner.Title as="h1">{dialogArgs.heading}</Banner.Title>}
-      message={<Banner.Body>{dialogArgs.content}</Banner.Body>}
+      textContent={
+        <>
+          <Banner.Title as="h1">{dialogArgs.heading}</Banner.Title>{" "}
+          <Banner.Body>{dialogArgs.content}</Banner.Body>
+        </>
+      }
     />
   </>
 );

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -25,10 +25,11 @@ type Args = React.ComponentProps<typeof Banner> & {
 const Template: Story<Args> = (args) => {
   const { content, heading, ...restArgs } = args;
   return (
-    <Banner {...restArgs}>
-      <Banner.Title as="h1">{heading}</Banner.Title>
-      <Banner.Body>{content}</Banner.Body>
-    </Banner>
+    <Banner
+      {...restArgs}
+      title={<Banner.Title as="h1">{heading}</Banner.Title>}
+      message={<Banner.Body>{content}</Banner.Body>}
+    />
   );
 };
 
@@ -138,10 +139,11 @@ export const DismissableBelowContent = () => (
     <Heading size="h1" spacing="2x">
       Page Title
     </Heading>
-    <Banner onDismiss={() => console.log("dismissed!")}>
-      <Banner.Title as="h1">{dialogArgs.heading}</Banner.Title>
-      <Banner.Body>{dialogArgs.content}</Banner.Body>
-    </Banner>
+    <Banner
+      onDismiss={() => console.log("dismissed!")}
+      title={<Banner.Title as="h1">{dialogArgs.heading}</Banner.Title>}
+      message={<Banner.Body>{dialogArgs.content}</Banner.Body>}
+    />
   </>
 );
 DismissableBelowContent.parameters = {

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -19,9 +19,17 @@ type Props = {
    */
   color?: NotificationVariant;
   /**
-   * The contents of the banner in addition to the icon
+   * The heading of the banner.
+   *
+   * You need at least a `title` or `message` prop, but you don't need both.
    */
-  children: React.ReactNode;
+  title?: React.ReactNode;
+  /**
+   * The body of text that appears below the title (if there is one).
+   *
+   * You need at least a `title` or `message` prop, but you don't need both.
+   */
+  message?: React.ReactNode;
   /**
    * A button or link that's placed in the banner separately from the main content.
    */
@@ -76,12 +84,19 @@ Banner.Body = function BannerBody(props: { children?: React.ReactNode }) {
 export default function Banner({
   className,
   color = "brand",
-  children,
+  title,
+  message,
   action,
   onDismiss,
   orientation = "horizontal",
   elevation = 1,
 }: Props) {
+  if (!title && !message) {
+    throw new Error(
+      "You need to provide at least either a title or message prop in your Banner, but right now you don't have either.",
+    );
+  }
+
   const isHorizontal = orientation === "horizontal";
 
   return (
@@ -123,7 +138,8 @@ export default function Banner({
             isHorizontal && styles.horizontal,
           )}
         >
-          {children}
+          {title}
+          {message}
         </div>
         {action && (
           <div

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -19,17 +19,11 @@ type Props = {
    */
   color?: NotificationVariant;
   /**
-   * The heading of the banner.
+   * The text content of the banner.
    *
-   * You need at least a `title` or `message` prop, but you don't need both.
+   * Please note that this can contain text links, but block buttons should be passed in via the `action` prop.
    */
-  title?: React.ReactNode;
-  /**
-   * The body of text that appears below the title (if there is one).
-   *
-   * You need at least a `title` or `message` prop, but you don't need both.
-   */
-  message?: React.ReactNode;
+  textContent: React.ReactNode;
   /**
    * A button or link that's placed in the banner separately from the main content.
    */
@@ -84,19 +78,12 @@ Banner.Body = function BannerBody(props: { children?: React.ReactNode }) {
 export default function Banner({
   className,
   color = "brand",
-  title,
-  message,
+  textContent,
   action,
   onDismiss,
   orientation = "horizontal",
   elevation = 1,
 }: Props) {
-  if (!title && !message) {
-    throw new Error(
-      "You need to provide at least either a title or message prop in your Banner, but right now you don't have either.",
-    );
-  }
-
   const isHorizontal = orientation === "horizontal";
 
   return (
@@ -138,8 +125,7 @@ export default function Banner({
             isHorizontal && styles.horizontal,
           )}
         >
-          {title}
-          {message}
+          {textContent}
         </div>
         {action && (
           <div

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -64,7 +64,7 @@ Banner.Title = function BannerTitle(props: {
 /**
  * This should import a Text element type
  */
-Banner.Body = function BannerBody(props: { children?: React.ReactNode }) {
+Banner.Message = function BannerMessage(props: { children?: React.ReactNode }) {
   return props.children ? (
     <Text color={"inherit"} size="body">
       {props.children}

--- a/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -37,6 +37,7 @@ exports[`<Banner /> Alert story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -107,6 +108,7 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -150,6 +152,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -216,6 +219,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -282,6 +286,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -337,6 +342,7 @@ exports[`<Banner /> Elevation0 story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -380,6 +386,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -446,6 +453,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -489,6 +497,7 @@ exports[`<Banner /> NoContent story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
     </div>
   </div>
 </article>
@@ -522,6 +531,7 @@ exports[`<Banner /> NoHeadingShort story renders snapshot 1`] = `
     <div
       class="textContent horizontal"
     >
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -565,6 +575,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -631,6 +642,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -674,6 +686,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -740,6 +753,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -806,6 +820,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -861,6 +876,7 @@ exports[`<Banner /> VerticalElevation0 story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -904,6 +920,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -959,6 +976,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -1025,6 +1043,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >
@@ -1068,6 +1087,7 @@ exports[`<Banner /> WithAction story renders snapshot 1`] = `
       >
         New curriculum updates are available for one or more of your courses.
       </h1>
+       
       <p
         class="typography sizeBody colorInherit"
       >


### PR DESCRIPTION
### Summary:
Clubhouse ticket: https://app.clubhouse.io/czi-edu/story/157238/update-banner-api

The `Banner` component is pretty complex, and we're playing around with the API to hopefully be easier to reason about. We're concerned that it may be confusing to pass in the `action` as a prop while the heading and body are the `children`.

We want the `action` to be a prop to control its position (left side when the banner is laid out horizontally; centered when in mobile or card format) and the gab between it and the text. Right now, we're just assuming any `children` passed in is intended to be the text (heading and body) that appears above the `action`.

This PR removes the `children` prop and replaces it with one or more props for the text to be passed in.

#### First pass
https://github.com/chanzuckerberg/edu-design-system/pull/622/commits/448801c5897dbbc1177a8e0289c7253f8ad728a5

The suggested API in the clubhouse ticket looks like this:
```
<Banner
  action={<button>brew</button>}
  title={<h2>Coffee</h2>}
  message="is amazing"
/>
```
I'm a little concerned about the `title` usage here because I think it's confusing to usually expect devs to use components like `Heading` and `Text` for text except in this instance. So I was thinking that we wouldn't style `title` or wrap it in a `Heading` or anything so devs can pass in a `Heading` component or `Banner.Title` themselves.

But in that version, `title` and `message` don't really need to be passed in as separate props because we're not doing anything special to either of them.

#### Second pass
https://github.com/chanzuckerberg/edu-design-system/pull/622/commits/6ad905185de33bc40a465dba92b08a39ccd21a12

In the second commit, I combined `title` and `message` into one prop, `textContent`. So the only difference between this version and the current API is the `children` prop has another name and the contents needs to be passed in as a regular prop. If that makes sense.

### Test Plan:
There should be no UI changes picked up in the Percy test.