### PR TITLE
feat(link + button): remove 'as' prop

### DIFF
--- a/packages/components/src/Button/button.tsx
+++ b/packages/components/src/Button/button.tsx
@@ -4,7 +4,6 @@ import Clickable, { ClickableProps } from "../Clickable";
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 export type ButtonProps = ButtonHTMLElementProps & {
-  as?: "button" | React.ComponentType<any>;
   /**
    * The button contents or label.
    */
@@ -25,7 +24,6 @@ export type ButtonProps = ButtonHTMLElementProps & {
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
-      as = "button",
       variant = "flat",
       color = "brand",
       disabled = false,
@@ -38,7 +36,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     return (
       <Clickable
         {...rest}
-        as={as}
+        as="button"
         variant={variant}
         color={color}
         disabled={disabled}

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -7,7 +7,6 @@ type LinkHTMLElementProps = Omit<
 >;
 
 export type LinkProps = LinkHTMLElementProps & {
-  as?: "a" | React.ComponentType<any>;
   /**
    * The link contents or label.
    */
@@ -25,18 +24,15 @@ export type LinkProps = LinkHTMLElementProps & {
  * however, it can be styled to look like a button. In terms of the look and feel of the
  * component in the UI, the Link and Button components are exactly the same.
  *
- * Note: when using a routing component like react-router, you'll probably want to pass
- * in its Link component via the `as` prop.
+ * Note: when using a routing component like react-router, you'll probably want to
+ * use Clickable and pass in the routing component via the `as` prop.
  */
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  (
-    { as = "a", variant = "link", color = "brand", size = "medium", ...rest },
-    ref,
-  ) => {
+  ({ variant = "link", color = "brand", size = "medium", ...rest }, ref) => {
     return (
       <Clickable
         {...rest}
-        as={as}
+        as="a"
         variant={variant}
         color={color}
         ref={ref}


### PR DESCRIPTION
### Summary:
Clubhouse ticket: https://app.clubhouse.io/czi-edu/story/150604/polish-eds-link-component

Our `Button` and `Link` components currently have an `as` prop that lets users pass in a component to be styled like a button or link. These wrap the `Clickable` component, which does the same thing and is available in `traject`, so we don't actually need `Button` and `Link` components to have an `as` prop at all. I think that it may also be clearer when to which components if the `Button` always returns a `button`, `Link` always returns an `a`, and `Clickable` is the only one that can return anything.

This PR updates the `Button` and `Link` components to no longer accept an `as` prop. Thoughts?

### Test Plan:
Automated tests should be sufficient for this change.