### PR TITLE
Upgrade axe-storybook-testing from 3.0.2 to 4.0.0

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
-    "@chanzuckerberg/axe-storybook-testing": "^3.0.2",
+    "@chanzuckerberg/axe-storybook-testing": "^4.0.0",
     "@chanzuckerberg/story-utils": "^2.0.0",
     "@percy/storybook": "^3.3.1",
     "@storybook/addon-a11y": "^6.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,22 +1580,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chanzuckerberg/axe-storybook-testing@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "@chanzuckerberg/axe-storybook-testing@npm:3.0.2"
+"@chanzuckerberg/axe-storybook-testing@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@chanzuckerberg/axe-storybook-testing@npm:4.0.0"
   dependencies:
-    chalk: ^4.1.0
+    chalk: ^4.1.2
     indent-string: ^4.0.0
     lodash: ^4.17.21
     p-timeout: ^4.1.0
-    playwright: ^1.10.0
-    ts-dedent: ^2.1.1
-    yargs: ^16.2.0
+    playwright: ^1.14.1
+    ts-dedent: ^2.2.0
+    yargs: ^17.1.1
   peerDependencies:
     axe-core: ^4.0.0
   bin:
     axe-storybook: bin/axe-storybook.js
-  checksum: c95ebd177d46a6a86b5509d9f3844bd93b231ebfdb0f8f2ac19a6843619690a2a95cbc5ee9d3fae6962d33513a083d3d8d7ab44e3d37706aa8ebcfffe768773d
+  checksum: dd6052d3b9517fb349803337aca938b277fa95df5cf901c5d72055461fee870801772128e7e027c479dd75f2ee5f80b305c2ce412ae3b2ebde6d23679fb18bfb
   languageName: node
   linkType: hard
 
@@ -1609,7 +1609,7 @@ __metadata:
     "@babel/preset-env": ^7.15.0
     "@babel/preset-react": ^7.14.5
     "@babel/preset-typescript": ^7.15.0
-    "@chanzuckerberg/axe-storybook-testing": ^3.0.2
+    "@chanzuckerberg/axe-storybook-testing": ^4.0.0
     "@chanzuckerberg/eds-tokens": ^0.2.0
     "@chanzuckerberg/story-utils": ^2.0.0
     "@percy/storybook": ^3.3.1
@@ -7282,7 +7282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -17073,9 +17073,9 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.10.0":
-  version: 1.13.1
-  resolution: "playwright@npm:1.13.1"
+"playwright@npm:^1.14.1":
+  version: 1.14.1
+  resolution: "playwright@npm:1.14.1"
   dependencies:
     commander: ^6.1.0
     debug: ^4.1.1
@@ -17093,7 +17093,7 @@ fsevents@^1.2.7:
     yazl: ^2.5.1
   bin:
     playwright: lib/cli/cli.js
-  checksum: 3b3102c37ad2cfdce52d59d974228181ba7d1146d549164587cc75a973411942a0b95531b2d7bbdc37f1b813e768f82d09368c6fcc4b72e72dae63036c047f6b
+  checksum: fbf0cd58f3d9eed01c2b5332bf388c89474494bff9027191baf27be2d0dba74af0c506b666ddab356e2f697c3df9ce158969d0b335be352a41710ce07db88b20
   languageName: node
   linkType: hard
 
@@ -21696,7 +21696,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"ts-dedent@npm:^2.0.0, ts-dedent@npm:^2.1.1":
+"ts-dedent@npm:^2.0.0, ts-dedent@npm:^2.1.1, ts-dedent@npm:^2.2.0":
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 93ed8f7878b6d5ed3c08d99b740010eede6bccfe64bce61c5a4da06a2c17d6ddbb80a8c49c2d15251de7594a4f93ffa21dd10e7be75ef66a4dc9951b4a94e2af
@@ -23198,6 +23198,21 @@ resolve@^2.0.0-next.3:
     y18n: ^5.0.5
     yargs-parser: ^20.2.2
   checksum: b14afbb51e3251a204d81937c86a7e9d4bdbf9a2bcee38226c900d00f522969ab675703bee2a6f99f8e20103f608382936034e64d921b74df82b63c07c5e8f59
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.1.1":
+  version: 17.1.1
+  resolution: "yargs@npm:17.1.1"
+  dependencies:
+    cliui: ^7.0.2
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.0
+    y18n: ^5.0.5
+    yargs-parser: ^20.2.2
+  checksum: b05a9467937172e01a4af7a7ad4361a22ee510cd12d1d5a3ad3b4c2e57eb8c35ca94ee22e4bdfbb40fe693fbf8000771e41824f77f6b224f1496c57f20f192b6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary:

Upgrade axe-storybook-testing from 3.0.2 to 4.0.0

### Test Plan:

- CI