### PR TITLE
chore(link, banner): export Banner props and Link from index

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -9,7 +9,7 @@ import NotificationIcon, {
 } from "../common/Notifications/NotificationIcon";
 import styles from "./Banner.module.css";
 
-type BannerProps = {
+export type BannerProps = {
   /**
    * Additional class names passed in for styling
    */

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -9,7 +9,7 @@ import NotificationIcon, {
 } from "../common/Notifications/NotificationIcon";
 import styles from "./Banner.module.css";
 
-type Props = {
+type BannerProps = {
   /**
    * Additional class names passed in for styling
    */
@@ -83,7 +83,7 @@ export default function Banner({
   onDismiss,
   orientation = "horizontal",
   elevation = 1,
-}: Props) {
+}: BannerProps) {
   const isHorizontal = orientation === "horizontal";
 
   return (

--- a/packages/components/src/Banner/index.ts
+++ b/packages/components/src/Banner/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./Banner";
+export type { BannerProps } from "./Banner";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Banner } from "./Banner";
+export type { BannerProps } from "./Banner";
 export { default as Button } from "./Button";
 export { default as ClickableStyle } from "./ClickableStyle";
 export { default as Heading } from "./Heading";

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -4,6 +4,7 @@ export { default as ClickableStyle } from "./ClickableStyle";
 export { default as Heading } from "./Heading";
 export { default as SvgIcon } from "./SvgIcon";
 export type { IconProps } from "./SvgIcon";
+export { default as Link } from "./Link";
 export { default as Tag } from "./Tag";
 export { default as Text } from "./Text";
 export { default as Toast } from "./Toast";


### PR DESCRIPTION
### Summary:
When updating the `eds/components` package in `traject`, I ran into 2 issues (one big; one small):
- we can't import the `Link` component because it's not being exported from `index.ts`
- we can't reuse the `Banner` props in `NuxMegaphone` because it's not being exported at all

Relevant PR: https://github.com/FB-PLP/traject/pull/8370

### Test Plan:
Verify `npx lerna run build:types` completes with no errors or warnings.