### PR TITLE
Upgrade axe-storybook-testing from 4.0.0 to 4.0.1

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.15.0",
-    "@chanzuckerberg/axe-storybook-testing": "^4.0.0",
+    "@chanzuckerberg/axe-storybook-testing": "^4.0.1",
     "@chanzuckerberg/story-utils": "^2.0.0",
     "@percy/storybook": "^3.3.1",
     "@storybook/addon-a11y": "^6.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1580,9 +1580,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chanzuckerberg/axe-storybook-testing@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "@chanzuckerberg/axe-storybook-testing@npm:4.0.0"
+"@chanzuckerberg/axe-storybook-testing@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@chanzuckerberg/axe-storybook-testing@npm:4.0.1"
   dependencies:
     chalk: ^4.1.2
     indent-string: ^4.0.0
@@ -1595,7 +1595,7 @@ __metadata:
     axe-core: ^4.0.0
   bin:
     axe-storybook: bin/axe-storybook.js
-  checksum: dd6052d3b9517fb349803337aca938b277fa95df5cf901c5d72055461fee870801772128e7e027c479dd75f2ee5f80b305c2ce412ae3b2ebde6d23679fb18bfb
+  checksum: 231a6338018be05e063f5edcac47ab033c09ab2e095d520499c4e4565a886b87cf7bd19a1e7b631f4b66c993eaf4e658603fd1812520e751f6e7d09f3ad0b20e
   languageName: node
   linkType: hard
 
@@ -1609,7 +1609,7 @@ __metadata:
     "@babel/preset-env": ^7.15.0
     "@babel/preset-react": ^7.14.5
     "@babel/preset-typescript": ^7.15.0
-    "@chanzuckerberg/axe-storybook-testing": ^4.0.0
+    "@chanzuckerberg/axe-storybook-testing": ^4.0.1
     "@chanzuckerberg/eds-tokens": ^0.2.0
     "@chanzuckerberg/story-utils": ^2.0.0
     "@percy/storybook": ^3.3.1


### PR DESCRIPTION
### Summary:

Upgrade axe-storybook-testing from 4.0.0 to 4.0.1

### Test Plan:

- CI