### PR TITLE
chore(clickable-style): reduce horizontal padding from 20px to 16px

### DIFF
--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -11,11 +11,11 @@
 
 /* Component Sizes */
 .sizeSmall {
-  @apply px-5 py-2 text-xs leading-3;
+  @apply px-4 py-2 text-xs leading-3;
 }
 
 .sizeMedium {
-  @apply px-5 py-2 text-sm;
+  @apply px-4 py-2 text-sm;
 }
 
 .sizeLarge {


### PR DESCRIPTION
### Summary:
I noticed that the horizontal padding for buttons in figma is 14px (not counting the border), but they have 20px in the code. I asked Sean about it, and he said he actually prefers 16px. So he's going to make the padding 2px higher in figma and I'm making it 4px lower in the code.

### Screenshots
#### Before
<img width="1268" alt="button all variants story in storybook before this change" src="https://user-images.githubusercontent.com/7761701/134070961-af708f5e-348e-41ae-a267-64a14370bd42.png">

#### After
<img width="1268" alt="button all variants story in storybook before this change" src="https://user-images.githubusercontent.com/7761701/134071054-727a9dda-9d3d-4820-bf81-2645d02a1ce6.png">

### Test Plan:
`yarn start`,
navigate to `http://localhost:6008/?path=/docs/button--all-variants`,
and verify the small and medium buttons have 1 rem horizontal padding.