### PR TITLE
feat(clickable-style): add text variant

### DIFF
--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -179,6 +179,28 @@ exports[`<Button /> outlineWithIcon story renders snapshot 1`] = `
 </button>
 `;
 
+exports[`<Button /> plainSmall story renders snapshot 1`] = `
+<button
+  class="button sizeSmall variantPlain colorBrand"
+  type="button"
+>
+  ​
+  Button
+   
+  <svg
+    aria-hidden="true"
+    class="iconButton svgIcon"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+    />
+  </svg>
+</button>
+`;
+
 exports[`<Button /> withDataTestId story renders snapshot 1`] = `
 <button
   class="button sizeMedium variantFlat colorAlert"

--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -80,29 +80,6 @@ exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
 </button>
 `;
 
-exports[`<Button /> flatWithOnlyIcon story renders snapshot 1`] = `
-<button
-  class="button sizeMedium variantFlat colorBrand"
-  type="button"
->
-  ​
-  <svg
-    class="svgIcon"
-    fill="currentColor"
-    role="img"
-    viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <title>
-      add
-    </title>
-    <path
-      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-    />
-  </svg>
-</button>
-`;
-
 exports[`<Button /> linkInBody story renders snapshot 1`] = `
 <p
   class="typography sizeBody colorBase"
@@ -194,6 +171,29 @@ exports[`<Button /> plainSmall story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
+    <path
+      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`<Button /> plainWithOnlyIcon story renders snapshot 1`] = `
+<button
+  class="button sizeMedium variantPlain colorBrand"
+  type="button"
+>
+  ​
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    role="img"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      add
+    </title>
     <path
       d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
     />

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -9,7 +9,7 @@ import styles from "./button.stories.module.css";
 
 const sizes = ["small", "medium", "large"] as const;
 const allColors = ["alert", "brand", "neutral", "success", "warning"] as const;
-const variants = ["flat", "outline", "link"] as const;
+const variants = ["flat", "outline", "link", "plain"] as const;
 const states = ["inactive", "hover", "focus", "active", "disabled"] as const;
 
 // For now, the UI kit only includes alert & brand "flat" buttons
@@ -115,6 +115,19 @@ linkInHeading.args = {
   color: "brand",
 };
 
+export const plainSmall = Template.bind(null);
+plainSmall.args = {
+  children: (
+    <>
+      Button{" "}
+      <AddRoundedIcon className={styles.iconButton} purpose="decorative" />
+    </>
+  ),
+  color: "brand",
+  size: "small",
+  variant: "plain",
+};
+
 export const withDataTestId = Template.bind(null);
 withDataTestId.args = {
   children: "Button with data-testid",
@@ -179,6 +192,10 @@ const renderSize = (
 ) =>
   variants.map((variant) => {
     const colors = variant === "flat" ? flatColors : allColors;
+    const icon =
+      variant === "plain" ? (
+        <AddRoundedIcon className={styles.iconButton} purpose="decorative" />
+      ) : null;
 
     return (
       <React.Fragment key={variant}>
@@ -207,6 +224,7 @@ const renderSize = (
                       disabled={state === "disabled"}
                     >
                       {children}
+                      {icon}
                     </ClickableStyle>
                   </td>
                 ))}

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -160,10 +160,10 @@ outlineWithIcon.args = {
   variant: "outline",
 };
 
-export const flatWithOnlyIcon = Template.bind(null);
-flatWithOnlyIcon.args = {
+export const plainWithOnlyIcon = Template.bind(null);
+plainWithOnlyIcon.args = {
   children: <AddRoundedIcon purpose="informative" title="add" />,
-  variant: "flat",
+  variant: "plain",
 };
 
 export const withFakeClassName = Template.bind(null);

--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -7,6 +7,9 @@
 
   /* Base Text Styles */
   @apply font-bold;
+
+  /* Default variable values */
+  --plain-background-color: transparent;
 }
 
 /* Style icons that may be in the button children */
@@ -39,16 +42,19 @@
   &.stateFocus {
     --primary-color: var(--eds-color-brand-700);
     --link-color: var(--eds-color-brand-800);
+    --plain-background-color: var(--eds-color-brand-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-brand-800);
+    --plain-background-color: var(--eds-color-brand-600);
   }
 
   /* override the hover/focus values */
   &:disabled {
     --primary-color: var(--eds-color-brand-300);
+    --plain-background-color: transparent;
   }
 }
 
@@ -63,16 +69,19 @@
   &.stateFocus {
     --primary-color: var(--eds-color-alert-700);
     --link-color: var(--eds-color-alert-800);
+    --plain-background-color: var(--eds-color-alert-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-alert-800);
+    --plain-background-color: var(--eds-color-alert-600);
   }
 
   /* override the hover/focus values */
   &:disabled {
     --primary-color: var(--eds-color-alert-300);
+    --plain-background-color: transparent;
   }
 }
 
@@ -87,16 +96,19 @@
   &.stateFocus {
     --primary-color: var(--eds-color-neutral-600);
     --link-color: var(--eds-color-neutral-700);
+    --plain-background-color: var(--eds-color-neutral-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-neutral-700);
+    --plain-background-color: var(--eds-color-neutral-600);
   }
 
   /* override the hover/focus values */
   &:disabled {
     --primary-color: var(--eds-color-neutral-300);
+    --plain-background-color: transparent;
   }
 }
 
@@ -111,16 +123,19 @@
   &.stateFocus {
     --primary-color: var(--eds-color-success-700);
     --link-color: var(--eds-color-success-800);
+    --plain-background-color: var(--eds-color-success-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-success-800);
+    --plain-background-color: var(--eds-color-success-600);
   }
 
   /* override the hover/focus values */
   &:disabled {
     --primary-color: var(--eds-color-success-300);
+    --plain-background-color: transparent;
   }
 }
 
@@ -135,16 +150,19 @@
   &.stateFocus {
     --primary-color: var(--eds-color-warning-700);
     --link-color: var(--eds-color-warning-800);
+    --plain-background-color: var(--eds-color-warning-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-warning-800);
+    --plain-background-color: var(--eds-color-warning-600);
   }
 
   /* override the hover/focus values */
   &:disabled {
     --primary-color: var(--eds-color-warning-300);
+    --plain-background-color: transparent;
   }
 }
 
@@ -203,6 +221,31 @@
   /* override the hover/focus values */
   &:disabled {
     text-decoration-thickness: auto;
+  }
+}
+
+.variantPlain {
+  color: var(--link-color);
+  border: var(--plain-background-color);
+  background-color: var(--plain-background-color);
+
+  &:focus,
+  &.stateFocus {
+    color: var(--primary-color);
+  }
+
+  &:hover,
+  &.stateHover {
+    color: var(--primary-color);
+  }
+
+  &:active,
+  &.stateActive {
+    color: var(--secondary-color);
+  }
+
+  &:disabled {
+    color: var(--primary-color);
   }
 }
 

--- a/packages/components/src/ClickableStyle/ClickableStyle.tsx
+++ b/packages/components/src/ClickableStyle/ClickableStyle.tsx
@@ -22,7 +22,7 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
   /**
    * The style of the element.
    */
-  variant: "flat" | "outline" | "link";
+  variant: "flat" | "outline" | "link" | "plain";
 } & React.ComponentProps<IComponent>;
 
 /**
@@ -59,6 +59,7 @@ const ClickableStyle = React.forwardRef(
           variant === "flat" && styles.variantFlat,
           variant === "outline" && styles.variantOutline,
           variant === "link" && styles.variantLink,
+          variant === "plain" && styles.variantPlain,
           // Colors
           color === "alert" && styles.colorAlert,
           color === "brand" && styles.colorBrand,

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -186,10 +186,10 @@ buttonVariantWithIcon.args = {
   ),
 };
 
-export const buttonVariantWithOnlyIcon = Template.bind(null);
-buttonVariantWithOnlyIcon.args = {
+export const plainWithOnlyIcon = Template.bind(null);
+plainWithOnlyIcon.args = {
   children: <AddRoundedIcon purpose="informative" title="add" />,
-  variant: "flat",
+  variant: "plain",
 };
 
 export const withDataTestId = Template.bind(null);

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -9,7 +9,7 @@ import styles from "./Link.stories.module.css";
 
 const sizes = ["small", "medium", "large"] as const;
 const allColors = ["alert", "brand", "neutral", "success", "warning"] as const;
-const variants = ["flat", "outline", "link"] as const;
+const variants = ["flat", "outline", "link", "plain"] as const;
 const states = ["inactive", "hover", "focus", "active", "disabled"] as const;
 
 // For now, the UI kit only includes alert & brand "flat" buttons.
@@ -69,6 +69,18 @@ linkInHeading.args = {
   ...defaultArgs,
 };
 
+export const plainSmall = Template.bind(null);
+plainSmall.args = {
+  children: (
+    <>
+      Link <AddRoundedIcon className={styles.iconButton} purpose="decorative" />
+    </>
+  ),
+  color: "brand",
+  size: "small",
+  variant: "plain",
+};
+
 // Show grids with all variants
 
 const gridParameters = {
@@ -87,6 +99,10 @@ const renderSize = (
 ) =>
   variants.map((variant) => {
     const colors = variant === "flat" ? flatColors : allColors;
+    const icon =
+      variant === "plain" ? (
+        <AddRoundedIcon className={styles.iconButton} purpose="decorative" />
+      ) : null;
 
     return (
       <React.Fragment key={variant}>
@@ -115,6 +131,7 @@ const renderSize = (
                       href=""
                     >
                       {children}
+                      {icon}
                     </ClickableStyle>
                   </td>
                 ))}

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -31,28 +31,6 @@ exports[`<Link /> buttonVariantWithIcon story renders snapshot 1`] = `
 </a>
 `;
 
-exports[`<Link /> buttonVariantWithOnlyIcon story renders snapshot 1`] = `
-<a
-  class="button sizeMedium variantFlat colorBrand"
->
-  ​
-  <svg
-    class="svgIcon"
-    fill="currentColor"
-    role="img"
-    viewBox="0 0 24 24"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <title>
-      add
-    </title>
-    <path
-      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-    />
-  </svg>
-</a>
-`;
-
 exports[`<Link /> linkInBody story renders snapshot 1`] = `
 <p
   class="typography sizeBody colorBase"
@@ -119,6 +97,28 @@ exports[`<Link /> plainSmall story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
+    <path
+      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+    />
+  </svg>
+</a>
+`;
+
+exports[`<Link /> plainWithOnlyIcon story renders snapshot 1`] = `
+<a
+  class="button sizeMedium variantPlain colorBrand"
+>
+  ​
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    role="img"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      add
+    </title>
     <path
       d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
     />

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -106,6 +106,26 @@ exports[`<Link /> linkWithIcon story renders snapshot 1`] = `
 </a>
 `;
 
+exports[`<Link /> plainSmall story renders snapshot 1`] = `
+<a
+  class="button sizeSmall variantPlain colorBrand"
+>
+  ​
+  Link 
+  <svg
+    aria-hidden="true"
+    class="iconButton svgIcon"
+    fill="currentColor"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+    />
+  </svg>
+</a>
+`;
+
 exports[`<Link /> withClassName story renders snapshot 1`] = `
 <a
   class="example-className button variantLink colorBrand"


### PR DESCRIPTION
### Summary:
Shortcut ticket: https://app.shortcut.com/czi-edu/story/160030/icon-button
Design: https://www.figma.com/file/P9VPyI821gLq832tuU2WeY/UI-Kit-Master-Core?node-id=3072%3A11792

There is a style of button in the UI kit referred to as `TextButton`. This is floating text that has the same padding as the flat and outline buttons but doesn't have a background color in its default state. There was a bit of discussion around what this button is and how are we distinguishing that it's interactive in a way besides color since it doesn't have an underline.

I talked it out with Sean and I think I understand this variant now – it is only intended to be used with an icon. (I still have reservations about this from an accessibility point of view because there are also times when non-interactive text is paired with an icon, but that's pretty rare and this is better than just having text floating around with 0 indication.) In the UI sticker sheet, it's currently shown with no icon by default, but Sean said he'll remove that (or update them to all have icons maybe?) to make that clearer.

Now that we're on the same page there, I'm fine with adding the `TextButton` style. This PR adds it as a variant, called "text". I'm putting this out before going deeper to verify that we're all on board with this approach.

I have one follow-up task to address after this (left a TODO comment):
- We should probably make the types restrictive here so it's not possible to create a "text" button with no icon.

I also just noticed that the disabled states for all the buttons in the core UI kit design are light neutral. The code is following the sticker sheet, which uses a light version of the button color (ie success buttons are a light green when disabled). So, please ignore that discrepancy between this change and the design. https://app.shortcut.com/czi-edu/story/163311/button-link-disabled-states-should-be-gray

### Screenshots
#### Design
<img width="1370" alt="Screen Shot 2021-09-20 at 8 50 05 PM" src="https://user-images.githubusercontent.com/7761701/134108901-b067dd1b-7cc0-4f0d-888d-0f0b5cbbbbd6.png">

#### Storybook
<img width="1037" alt="Screen Shot 2021-09-20 at 8 46 29 PM" src="https://user-images.githubusercontent.com/7761701/134108909-e70888ea-7fda-42ad-8a00-ae796b2b0e5d.png">

### Test Plan:
`yarn start`,
navigate to `http://localhost:6008/?path=/docs/button--all-variants`,
verify there's now a "text" variant,
verify it looks like the design (except the disabled state is not gray),
hover over the disabled buttons,
and verify the background color doesn't change.