### PR TITLE
chore(lint): set github workflow max warnings allowed to 0

### DIFF
--- a/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.tsx
+++ b/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.tsx
@@ -1,6 +1,5 @@
 import clsx from "clsx";
 import * as React from "react";
-import { useEffect } from "react";
 
 import CheckCircleRoundedIcon from "../../../Icons/CheckCircleRounded";
 import ForumRoundedIcon from "../../../Icons/ForumRounded";


### PR DESCRIPTION
### Summary:
Shortcut ticket: https://app.shortcut.com/czi-edu/story/142427/change-lint-warnings-to-errors-in-eds-repo

This PR adds `--max-warnings=0` to the github workflow lint run so it's harder to miss a warning and merge in code that doesn't pass linting.

### Test Plan:
I added a commit to this PR that had an unused import and verified it caused the tests to fail.
Test results: https://github.com/chanzuckerberg/edu-design-system/pull/669/checks?check_run_id=3887355739
<img width="736" alt="the tests failing on this PR before reverting the offending commit" src="https://user-images.githubusercontent.com/7761701/137211354-d58d1c55-472e-42a0-a0e0-af57af00e68c.png">

