### PR TITLE
docs(icons): add instructions for adding new icons

### DIFF
--- a/packages/components/src/Icons/README.md
+++ b/packages/components/src/Icons/README.md
@@ -19,7 +19,7 @@ export { default as <IconName>Icon } from "./<IconName>.jsx";
 You can add one-off icons directly into your components by importing the generic `SvgIcon` and passing the paths/circles/etc. into the `SvgIcon`.
 
 ```tsx
-import SvgIcon from '@chanzuckerberg/eds-components/SvgIcon';
+import SvgIcon from '@chanzuckerberg/eds-components/lib/SvgIcon';
 ...
 <SvgIcon 
   purpose="informative"


### PR DESCRIPTION
### Summary:
Part of https://app.shortcut.com/czi-edu/story/155056/deprecate-svgicon-in-traject

Just what it says 👍 This is heavily based on https://czi.atlassian.net/wiki/spaces/ETE/pages/484737839/SvgIcons, but I edited it to be team-agnostic (e.g., I removed references to the `traject` codebase and the help slack channel) since this is a public repo.

### Screenshot
<img width="1064" alt="the icons readme file in preview mode in visual studio code" src="https://user-images.githubusercontent.com/7761701/137552652-dc25be66-ba0a-4e49-8685-f7a2d1b721f9.png">


### Test Plan:
Previewed the file in visual studio code to verify the formatting is correct.