### PR TITLE
fix(svgicon): set inline-block

### DIFF
--- a/packages/components/src/SvgIcon/SvgIcon.module.css
+++ b/packages/components/src/SvgIcon/SvgIcon.module.css
@@ -1,5 +1,5 @@
 .svgIcon {
-  @apply inline;
+  @apply inline-block;
 
   /**
    * Size Priority:


### PR DESCRIPTION
### Summary:
Related to https://github.com/FB-PLP/traject/pull/8898 -- the old EDSCandidates icon set `flex-none`, while the new EDS icon only set `display: inline`. In trying to unravel why, I noticed that:
- when @dierat [originally copied over the icon](https://github.com/chanzuckerberg/edu-design-system/pull/509/files#diff-1919752300777d670a3ccc3f8c58b08e3ff2034c1125a0aade1026a75ea1d851R2), it had styling `@apply flex-none inline-block`
- when we [split off the icon changes into a separate PR](https://github.com/chanzuckerberg/edu-design-system/pull/516/commits/a9fd0b71076a34af1dcc9d5e3513ade35013809c#diff-aa5b180f76dda970207508580e582f9ca15b84f00f3a72b2ee5d2927e65dffb6R2), the styling became `@apply inline` (and then was landed)

I think we always wanted `@apply flex-none inline-block` and something got lost in the splitting 🤔  
- docs for `display: inline` state that "Any height and width properties will have no effect", which doesn't sound right for svg icon. In contrast, `inline-block` does respect height/width
- ~`flex: none` "sizes the flex item according to the width / height of the content, but doesn't allow it to shrink", which we do want~ dubious if we want -- consumer can set `flex` themselves

these also match the [Material UI icon styles](https://github.com/mui-org/material-ui/blob/53a1655143aa4ec36c29a6063ccdf89c48a74bfd/packages/material-ui/src/SvgIcon/SvgIcon.js#L14-L16)

### Test Plan:
no visual changes per Percy
