### PR TITLE
chore(buttons): make all disabled states neutral 300

### DIFF
--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -50,12 +50,6 @@
     --primary-color: var(--eds-color-brand-800);
     --plain-background-color: var(--eds-color-brand-600);
   }
-
-  /* override the hover/focus values */
-  &:disabled {
-    --primary-color: var(--eds-color-brand-300);
-    --plain-background-color: transparent;
-  }
 }
 
 .colorAlert {
@@ -76,12 +70,6 @@
   &.stateActive {
     --primary-color: var(--eds-color-alert-800);
     --plain-background-color: var(--eds-color-alert-600);
-  }
-
-  /* override the hover/focus values */
-  &:disabled {
-    --primary-color: var(--eds-color-alert-300);
-    --plain-background-color: transparent;
   }
 }
 
@@ -104,12 +92,6 @@
     --primary-color: var(--eds-color-neutral-700);
     --plain-background-color: var(--eds-color-neutral-600);
   }
-
-  /* override the hover/focus values */
-  &:disabled {
-    --primary-color: var(--eds-color-neutral-300);
-    --plain-background-color: transparent;
-  }
 }
 
 .colorSuccess {
@@ -131,12 +113,6 @@
     --primary-color: var(--eds-color-success-800);
     --plain-background-color: var(--eds-color-success-600);
   }
-
-  /* override the hover/focus values */
-  &:disabled {
-    --primary-color: var(--eds-color-success-300);
-    --plain-background-color: transparent;
-  }
 }
 
 .colorWarning {
@@ -157,12 +133,6 @@
   &.stateActive {
     --primary-color: var(--eds-color-warning-800);
     --plain-background-color: var(--eds-color-warning-600);
-  }
-
-  /* override the hover/focus values */
-  &:disabled {
-    --primary-color: var(--eds-color-warning-300);
-    --plain-background-color: transparent;
   }
 }
 
@@ -263,4 +233,8 @@
 
 .button:disabled {
   @apply cursor-not-allowed;
+
+  /* override the hover/focus values */
+  --primary-color: var(--eds-color-neutral-300);
+  --plain-background-color: transparent;
 }


### PR DESCRIPTION
### Summary:
Currently, the buttons' disabled states are level 300 of the button hue (ex: warning buttons are warning 300 when disabled). In the Buttons v5 designs, all the buttons are neutral 300 when disabled. This PR just updates the disabled color for all the buttons to be neutral 300.

### Screenshots
#### Before
<img width="846" alt="Screen Shot 2021-10-25 at 2 10 25 PM" src="https://user-images.githubusercontent.com/7761701/138771692-b16d3333-4d09-4316-8078-1247a98dd35a.png">

#### After
<img width="846" alt="Screen Shot 2021-10-25 at 2 10 20 PM" src="https://user-images.githubusercontent.com/7761701/138771711-bc7643f4-a3b3-4d46-aeba-c9e7224c08e7.png">

### Test Plan:
`yarn start`,
navigate to `http://localhost:6008/?path=/story/button--all-variants`,
and verify that all buttons are neutral 300 when disabled regardless of the button's primary hue.