### PR TITLE
chore(button): remove secondary color variable

### DIFF
--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -33,7 +33,6 @@
 /* Button Colors */
 .colorBrand {
   --primary-color: var(--eds-color-brand-600);
-  --secondary-color: var(--eds-color-white);
   --link-color: var(--eds-color-brand-700);
 
   &:hover,
@@ -54,7 +53,6 @@
 
 .colorAlert {
   --primary-color: var(--eds-color-alert-600);
-  --secondary-color: var(--eds-color-white);
   --link-color: var(--eds-color-alert-700);
 
   &:hover,
@@ -75,7 +73,6 @@
 
 .colorNeutral {
   --primary-color: var(--eds-color-neutral-500);
-  --secondary-color: var(--eds-color-white);
   --link-color: var(--eds-color-neutral-600);
 
   &:hover,
@@ -96,7 +93,6 @@
 
 .colorSuccess {
   --primary-color: var(--eds-color-success-600);
-  --secondary-color: var(--eds-color-white);
   --link-color: var(--eds-color-success-700);
 
   &:hover,
@@ -117,7 +113,6 @@
 
 .colorWarning {
   --primary-color: var(--eds-color-warning-600);
-  --secondary-color: var(--eds-color-white);
   --link-color: var(--eds-color-warning-700);
 
   &:hover,
@@ -139,7 +134,8 @@
 .variantFlat {
   background-color: var(--primary-color);
   border-color: var(--primary-color);
-  color: var(--secondary-color);
+
+  @apply text-white;
 }
 
 .variantOutline {
@@ -156,7 +152,8 @@
   &:hover,
   &.stateHover {
     background-color: var(--primary-color);
-    color: var(--secondary-color);
+
+    @apply text-white;
   }
 
   &:disabled {
@@ -211,7 +208,7 @@
 
   &:active,
   &.stateActive {
-    color: var(--secondary-color);
+    @apply text-white;
   }
 
   &:disabled {


### PR DESCRIPTION
### Summary:
Something I noticed when working on the button styles is that we have a `secondary-color` variable, but it's always set to white and only used in a couple of places. To clean this up a little before I make larger changes, I'm removing the variable and just setting the text as white directly in those 3 locations.

### Test Plan:
Verify there are no visual changes in Percy or in storybook.