### PR TITLE
test(button + link): only show 1 size of link in 'all variants' story

### DIFF
--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -7,7 +7,7 @@ import Text from "../Text";
 import Button, { ButtonProps } from "./button";
 import styles from "./button.stories.module.css";
 
-const sizes = ["small", "medium", "large"] as const;
+const sizes = ["large", "medium", "small"] as const;
 const allColors = ["alert", "brand", "neutral", "success", "warning"] as const;
 // "link" is ommitted here because it's rendered separately since it only has one size
 const variants = ["flat", "outline", "plain"] as const;

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ import Text from "../Text";
 import Link, { LinkProps } from "./Link";
 import styles from "./Link.stories.module.css";
 
-const sizes = ["small", "medium", "large"] as const;
+const sizes = ["large", "medium", "small"] as const;
 const allColors = ["alert", "brand", "neutral", "success", "warning"] as const;
 // "link" is ommitted here because it's rendered separately since it only has one size
 const variants = ["flat", "outline", "plain"] as const;


### PR DESCRIPTION
### Summary:
Couple of things that have been bugging me about the "All Variants" story for the `Button` and `Link` components are:
- the "link" variant is shown in all sizes even though the "size" prop has no effect on that variant
- the `Link` component shows the "disabled" state for each variant + size combo even though `<a>` tags can't be disabled (so it looks like the disabled state is broken)

This PR updates the `Button` and `Link` stories to fix those issues. I also made some changes to variable names because I found them confusing when getting reacquainted with the code. I'm planning to pull this code out into a helper method because it's almost exactly the same for both components, but I'd like to do that separately so it's a little easier to review.

I also reordered the button sizes to go from largest to smallest.

### Test Plan:
Check out the `Button` and `Link` "All Variants" and "Large Variants On Dark Background" stories,
verify the disabled state is missing on the `Link` component,
verify the "link" variant is now shown at the beginning in one size,
and verify there are no other changes.

### Screenshots
#### Link storybook
##### Before
![Link "all variants" story before this change](https://user-images.githubusercontent.com/7761701/139306227-3b5a1834-99b6-4dea-bd0f-c54b7b48125a.png)

##### After
![Link "all variants" story after this change](https://user-images.githubusercontent.com/7761701/139306290-0826663c-1a12-4fef-a338-19c83e50f614.png)

#### Button storybook
##### Before
![Button "all variants" story before this change](https://user-images.githubusercontent.com/7761701/139306353-861a7ce5-55be-450b-b535-6b0b0092e433.png)

##### After
![Button "all variants" story after this change](https://user-images.githubusercontent.com/7761701/139306408-3bf5120a-5964-4946-b10c-e147e7b8b90f.png)
