### PR TITLE
CI tweaks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,16 +9,11 @@ jobs:
   deploy_docs:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14.x
           cache: 'yarn'
 
       - name: Install Dependencies ⬆️

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -6,11 +6,6 @@ on:
 jobs:
   size:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     env:
       CI_JOB_NUMBER: 1
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build Dist 🔧
         run: yarn run build
 
-  chromatic-deployment:
+  storybook:
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
### Summary:

This PR
- Removes the unnecessary build matrices from the docs and size-limit jobs.
- Only runs tests on Node 14, instead of 14 and 12. We only have apps running on Node 14 at this point.
- Rename `chromatic-deployment` to `storybook`

### Test Plan:

- CI