### PR TITLE
feat(button + link): rename 'plain' variant to 'text'

### DIFF
--- a/packages/components/.storybook/clickableStyleUtils.stories.tsx
+++ b/packages/components/.storybook/clickableStyleUtils.stories.tsx
@@ -73,7 +73,7 @@ export const getStandardSet = (
   </ul>
 );
 
-export const getPlainRecommendedVariants = (
+export const getTextRecommendedVariants = (
   Component: typeof Button | typeof Link,
   componentName: "Button" | "Link",
 ) => (
@@ -84,7 +84,7 @@ export const getPlainRecommendedVariants = (
       </Heading>
       <ul className="grid gap-y-4">
         <li>
-          <Component variant="plain">
+          <Component variant="text">
             <ArrowBackRoundedIcon
               className={styles.arrowBackIcon}
               purpose="decorative"
@@ -93,7 +93,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component variant="plain">
+          <Component variant="text">
             {componentName}
             <ArrowForwardRoundedIcon
               className={styles.arrowForwardIcon}
@@ -102,7 +102,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li className="mb-4">
-          <Component variant="plain">
+          <Component variant="text">
             <ArrowForwardRoundedIcon
               className="mx-[-0.4em]"
               purpose="informative"
@@ -119,7 +119,7 @@ export const getPlainRecommendedVariants = (
       </Heading>
       <ul className="grid gap-y-4">
         <li>
-          <Component variant="plain" size="medium">
+          <Component variant="text" size="medium">
             <ArrowBackRoundedIcon
               className={styles.arrowBackIcon}
               purpose="decorative"
@@ -128,7 +128,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component variant="plain" size="medium">
+          <Component variant="text" size="medium">
             {componentName}
             <ArrowForwardRoundedIcon
               className={styles.arrowForwardIcon}
@@ -137,7 +137,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component variant="plain" size="medium">
+          <Component variant="text" size="medium">
             <AddRoundedIcon
               purpose="informative"
               title="add"
@@ -226,9 +226,9 @@ export const getAllRecommendedVariants = (
 
     <li>
       <Heading spacing="2x" size="h2">
-        Plain
+        Text
       </Heading>
-      {getPlainRecommendedVariants(Component, componentName)}
+      {getTextRecommendedVariants(Component, componentName)}
     </li>
 
     <li>
@@ -249,7 +249,7 @@ export const getAllRecommendedVariants = (
 
 const sizes = ["large", "medium", "small"] as const;
 // "link" is ommitted here because it's rendered separately since it only has one size
-const variants = ["flat", "outline", "plain"] as const;
+const variants = ["flat", "outline", "text"] as const;
 export const colors = [
   "alert",
   "brand",
@@ -268,7 +268,7 @@ const getVariantWithStates = (
   size?: ClickableStyleProps<"button">["size"],
 ) => {
   const states = tag === "button" ? buttonStates : linkStates;
-  const icon = variant === "plain" && (
+  const icon = variant === "text" && (
     <AddRoundedIcon className="ml-2" purpose="decorative" />
   );
 

--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -332,7 +332,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
     <h2
       class="typography sizeH2 colorBase spacing2"
     >
-      Plain
+      Text
     </h2>
     <ul>
       <li>
@@ -346,7 +346,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
         >
           <li>
             <button
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
               type="button"
             >
               ​
@@ -367,7 +367,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <button
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
               type="button"
             >
               ​
@@ -389,7 +389,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="mb-4"
           >
             <button
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
               type="button"
             >
               ​
@@ -422,7 +422,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
         >
           <li>
             <button
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
               type="button"
             >
               ​
@@ -443,7 +443,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <button
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
               type="button"
             >
               ​
@@ -463,7 +463,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <button
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
               type="button"
             >
               ​
@@ -632,161 +632,6 @@ exports[`<Button /> LinkRecommendedVariants story renders snapshot 1`] = `
         />
       </svg>
     </button>
-  </li>
-</ul>
-`;
-
-exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
-<ul>
-  <li>
-    <h3
-      class="typography sizeH3 colorBase spacing2"
-    >
-      Size Large
-    </h3>
-    <ul
-      class="grid gap-y-4"
-    >
-      <li>
-        <button
-          class="button sizeLarge variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          <svg
-            aria-hidden="true"
-            class="arrowBackIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
-            />
-          </svg>
-           
-          Button
-        </button>
-      </li>
-      <li>
-        <button
-          class="button sizeLarge variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          Button
-          <svg
-            aria-hidden="true"
-            class="arrowForwardIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </button>
-      </li>
-      <li
-        class="mb-4"
-      >
-        <button
-          class="button sizeLarge variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          <svg
-            class="mx-[-0.4em] svgIcon"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              forward
-            </title>
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </button>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <h3
-      class="typography sizeH3 colorBase spacing2"
-    >
-      Size Medium
-    </h3>
-    <ul
-      class="grid gap-y-4"
-    >
-      <li>
-        <button
-          class="button sizeMedium variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          <svg
-            aria-hidden="true"
-            class="arrowBackIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
-            />
-          </svg>
-           
-          Button
-        </button>
-      </li>
-      <li>
-        <button
-          class="button sizeMedium variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          Button
-          <svg
-            aria-hidden="true"
-            class="arrowForwardIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </button>
-      </li>
-      <li>
-        <button
-          class="button sizeMedium variantPlain colorBrand"
-          type="button"
-        >
-          ​
-          <svg
-            class="mx-[-0.55em] svgIcon"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              add
-            </title>
-            <path
-              d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-            />
-          </svg>
-        </button>
-      </li>
-    </ul>
   </li>
 </ul>
 `;
@@ -1099,6 +944,161 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         Button
       </button>
     </div>
+  </li>
+</ul>
+`;
+
+exports[`<Button /> TextRecommendedVariants story renders snapshot 1`] = `
+<ul>
+  <li>
+    <h3
+      class="typography sizeH3 colorBase spacing2"
+    >
+      Size Large
+    </h3>
+    <ul
+      class="grid gap-y-4"
+    >
+      <li>
+        <button
+          class="button sizeLarge variantText colorBrand"
+          type="button"
+        >
+          ​
+          <svg
+            aria-hidden="true"
+            class="arrowBackIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
+            />
+          </svg>
+           
+          Button
+        </button>
+      </li>
+      <li>
+        <button
+          class="button sizeLarge variantText colorBrand"
+          type="button"
+        >
+          ​
+          Button
+          <svg
+            aria-hidden="true"
+            class="arrowForwardIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </button>
+      </li>
+      <li
+        class="mb-4"
+      >
+        <button
+          class="button sizeLarge variantText colorBrand"
+          type="button"
+        >
+          ​
+          <svg
+            class="mx-[-0.4em] svgIcon"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              forward
+            </title>
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <h3
+      class="typography sizeH3 colorBase spacing2"
+    >
+      Size Medium
+    </h3>
+    <ul
+      class="grid gap-y-4"
+    >
+      <li>
+        <button
+          class="button sizeMedium variantText colorBrand"
+          type="button"
+        >
+          ​
+          <svg
+            aria-hidden="true"
+            class="arrowBackIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
+            />
+          </svg>
+           
+          Button
+        </button>
+      </li>
+      <li>
+        <button
+          class="button sizeMedium variantText colorBrand"
+          type="button"
+        >
+          ​
+          Button
+          <svg
+            aria-hidden="true"
+            class="arrowForwardIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </button>
+      </li>
+      <li>
+        <button
+          class="button sizeMedium variantText colorBrand"
+          type="button"
+        >
+          ​
+          <svg
+            class="mx-[-0.55em] svgIcon"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              add
+            </title>
+            <path
+              d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+            />
+          </svg>
+        </button>
+      </li>
+    </ul>
   </li>
 </ul>
 `;

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import {
   colors,
   getStandardSet,
-  getPlainRecommendedVariants,
+  getTextRecommendedVariants,
   getLinkRecommendedVariants,
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
@@ -48,8 +48,8 @@ export const SecondaryRecommendedVariants = () =>
 export const TertiaryRecommendedVariants = () =>
   getStandardSet(Button, "Button", "outline", "neutral");
 
-export const PlainRecommendedVariants = () =>
-  getPlainRecommendedVariants(Button, "Button");
+export const TextRecommendedVariants = () =>
+  getTextRecommendedVariants(Button, "Button");
 
 export const LinkRecommendedVariants = () =>
   getLinkRecommendedVariants(Button, "Button");

--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -9,7 +9,7 @@
   @apply font-bold;
 
   /* Default variable values */
-  --plain-background-color: transparent;
+  --text-background-color: transparent;
 }
 
 /* Style icons that may be in the button children */
@@ -41,13 +41,13 @@
   &.stateFocus {
     --primary-color: var(--eds-color-brand-700);
     --link-color: var(--eds-color-brand-800);
-    --plain-background-color: var(--eds-color-brand-100);
+    --text-background-color: var(--eds-color-brand-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-brand-800);
-    --plain-background-color: var(--eds-color-brand-600);
+    --text-background-color: var(--eds-color-brand-600);
   }
 }
 
@@ -61,13 +61,13 @@
   &.stateFocus {
     --primary-color: var(--eds-color-alert-700);
     --link-color: var(--eds-color-alert-800);
-    --plain-background-color: var(--eds-color-alert-100);
+    --text-background-color: var(--eds-color-alert-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-alert-800);
-    --plain-background-color: var(--eds-color-alert-600);
+    --text-background-color: var(--eds-color-alert-600);
   }
 }
 
@@ -81,13 +81,13 @@
   &.stateFocus {
     --primary-color: var(--eds-color-neutral-600);
     --link-color: var(--eds-color-neutral-700);
-    --plain-background-color: var(--eds-color-neutral-100);
+    --text-background-color: var(--eds-color-neutral-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-neutral-700);
-    --plain-background-color: var(--eds-color-neutral-500);
+    --text-background-color: var(--eds-color-neutral-500);
   }
 }
 
@@ -101,13 +101,13 @@
   &.stateFocus {
     --primary-color: var(--eds-color-success-700);
     --link-color: var(--eds-color-success-800);
-    --plain-background-color: var(--eds-color-success-100);
+    --text-background-color: var(--eds-color-success-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-success-800);
-    --plain-background-color: var(--eds-color-success-600);
+    --text-background-color: var(--eds-color-success-600);
   }
 }
 
@@ -121,13 +121,13 @@
   &.stateFocus {
     --primary-color: var(--eds-color-warning-700);
     --link-color: var(--eds-color-warning-800);
-    --plain-background-color: var(--eds-color-warning-100);
+    --text-background-color: var(--eds-color-warning-100);
   }
 
   &:active,
   &.stateActive {
     --primary-color: var(--eds-color-warning-800);
-    --plain-background-color: var(--eds-color-warning-600);
+    --text-background-color: var(--eds-color-warning-600);
   }
 }
 
@@ -194,10 +194,10 @@
   }
 }
 
-.variantPlain {
+.variantText {
   color: var(--link-color);
-  border: var(--plain-background-color);
-  background-color: var(--plain-background-color);
+  border: var(--text-background-color);
+  background-color: var(--text-background-color);
 
   &:hover,
   &.stateHover,
@@ -233,5 +233,5 @@
 
   /* override the hover/focus values */
   --primary-color: var(--eds-color-neutral-300);
-  --plain-background-color: transparent;
+  --text-background-color: transparent;
 }

--- a/packages/components/src/ClickableStyle/ClickableStyle.tsx
+++ b/packages/components/src/ClickableStyle/ClickableStyle.tsx
@@ -22,7 +22,7 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
   /**
    * The style of the element.
    */
-  variant: "flat" | "outline" | "link" | "plain";
+  variant: "flat" | "outline" | "link" | "text";
 } & React.ComponentProps<IComponent>;
 
 /**
@@ -59,7 +59,7 @@ const ClickableStyle = React.forwardRef(
           variant === "flat" && styles.variantFlat,
           variant === "outline" && styles.variantOutline,
           variant === "link" && styles.variantLink,
-          variant === "plain" && styles.variantPlain,
+          variant === "text" && styles.variantText,
           // Colors
           color === "alert" && styles.colorAlert,
           color === "brand" && styles.colorBrand,

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import {
   colors,
   getStandardSet,
-  getPlainRecommendedVariants,
+  getTextRecommendedVariants,
   getLinkRecommendedVariants,
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
@@ -76,8 +76,8 @@ export const SecondaryRecommendedVariants = () =>
 export const TertiaryRecommendedVariants = () =>
   getStandardSet(Link, "Link", "outline", "neutral");
 
-export const PlainRecommendedVariants = () =>
-  getPlainRecommendedVariants(Link, "Link");
+export const TextRecommendedVariants = () =>
+  getTextRecommendedVariants(Link, "Link");
 
 export const LinkRecommendedVariants = () =>
   getLinkRecommendedVariants(Link, "Link");

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -317,7 +317,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
     <h2
       class="typography sizeH2 colorBase spacing2"
     >
-      Plain
+      Text
     </h2>
     <ul>
       <li>
@@ -331,7 +331,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         >
           <li>
             <a
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
             >
               ​
               <svg
@@ -351,7 +351,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <a
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
             >
               ​
               Link
@@ -372,7 +372,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             class="mb-4"
           >
             <a
-              class="button sizeLarge variantPlain colorBrand"
+              class="button sizeLarge variantText colorBrand"
             >
               ​
               <svg
@@ -404,7 +404,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         >
           <li>
             <a
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
             >
               ​
               <svg
@@ -424,7 +424,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <a
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
             >
               ​
               Link
@@ -443,7 +443,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           </li>
           <li>
             <a
-              class="button sizeMedium variantPlain colorBrand"
+              class="button sizeMedium variantText colorBrand"
             >
               ​
               <svg
@@ -605,155 +605,6 @@ exports[`<Link /> LinkRecommendedVariants story renders snapshot 1`] = `
         />
       </svg>
     </a>
-  </li>
-</ul>
-`;
-
-exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
-<ul>
-  <li>
-    <h3
-      class="typography sizeH3 colorBase spacing2"
-    >
-      Size Large
-    </h3>
-    <ul
-      class="grid gap-y-4"
-    >
-      <li>
-        <a
-          class="button sizeLarge variantPlain colorBrand"
-        >
-          ​
-          <svg
-            aria-hidden="true"
-            class="arrowBackIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
-            />
-          </svg>
-           
-          Link
-        </a>
-      </li>
-      <li>
-        <a
-          class="button sizeLarge variantPlain colorBrand"
-        >
-          ​
-          Link
-          <svg
-            aria-hidden="true"
-            class="arrowForwardIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </a>
-      </li>
-      <li
-        class="mb-4"
-      >
-        <a
-          class="button sizeLarge variantPlain colorBrand"
-        >
-          ​
-          <svg
-            class="mx-[-0.4em] svgIcon"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              forward
-            </title>
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
-  </li>
-  <li>
-    <h3
-      class="typography sizeH3 colorBase spacing2"
-    >
-      Size Medium
-    </h3>
-    <ul
-      class="grid gap-y-4"
-    >
-      <li>
-        <a
-          class="button sizeMedium variantPlain colorBrand"
-        >
-          ​
-          <svg
-            aria-hidden="true"
-            class="arrowBackIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
-            />
-          </svg>
-           
-          Link
-        </a>
-      </li>
-      <li>
-        <a
-          class="button sizeMedium variantPlain colorBrand"
-        >
-          ​
-          Link
-          <svg
-            aria-hidden="true"
-            class="arrowForwardIcon svgIcon"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
-            />
-          </svg>
-        </a>
-      </li>
-      <li>
-        <a
-          class="button sizeMedium variantPlain colorBrand"
-        >
-          ​
-          <svg
-            class="mx-[-0.55em] svgIcon"
-            fill="currentColor"
-            role="img"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>
-              add
-            </title>
-            <path
-              d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
-            />
-          </svg>
-        </a>
-      </li>
-    </ul>
   </li>
 </ul>
 `;
@@ -1051,6 +902,155 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         Link
       </a>
     </div>
+  </li>
+</ul>
+`;
+
+exports[`<Link /> TextRecommendedVariants story renders snapshot 1`] = `
+<ul>
+  <li>
+    <h3
+      class="typography sizeH3 colorBase spacing2"
+    >
+      Size Large
+    </h3>
+    <ul
+      class="grid gap-y-4"
+    >
+      <li>
+        <a
+          class="button sizeLarge variantText colorBrand"
+        >
+          ​
+          <svg
+            aria-hidden="true"
+            class="arrowBackIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
+            />
+          </svg>
+           
+          Link
+        </a>
+      </li>
+      <li>
+        <a
+          class="button sizeLarge variantText colorBrand"
+        >
+          ​
+          Link
+          <svg
+            aria-hidden="true"
+            class="arrowForwardIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </a>
+      </li>
+      <li
+        class="mb-4"
+      >
+        <a
+          class="button sizeLarge variantText colorBrand"
+        >
+          ​
+          <svg
+            class="mx-[-0.4em] svgIcon"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              forward
+            </title>
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </a>
+      </li>
+    </ul>
+  </li>
+  <li>
+    <h3
+      class="typography sizeH3 colorBase spacing2"
+    >
+      Size Medium
+    </h3>
+    <ul
+      class="grid gap-y-4"
+    >
+      <li>
+        <a
+          class="button sizeMedium variantText colorBrand"
+        >
+          ​
+          <svg
+            aria-hidden="true"
+            class="arrowBackIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 11H7.83l4.88-4.88c.39-.39.39-1.03 0-1.42a.9959.9959 0 00-1.41 0l-6.59 6.59c-.39.39-.39 1.02 0 1.41l6.59 6.59c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L7.83 13H19c.55 0 1-.45 1-1s-.45-1-1-1z"
+            />
+          </svg>
+           
+          Link
+        </a>
+      </li>
+      <li>
+        <a
+          class="button sizeMedium variantText colorBrand"
+        >
+          ​
+          Link
+          <svg
+            aria-hidden="true"
+            class="arrowForwardIcon svgIcon"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 13h11.17l-4.88 4.88c-.39.39-.39 1.03 0 1.42.39.39 1.02.39 1.41 0l6.59-6.59c.39-.39.39-1.02 0-1.41l-6.58-6.6a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L16.17 11H5c-.55 0-1 .45-1 1s.45 1 1 1z"
+            />
+          </svg>
+        </a>
+      </li>
+      <li>
+        <a
+          class="button sizeMedium variantText colorBrand"
+        >
+          ​
+          <svg
+            class="mx-[-0.55em] svgIcon"
+            fill="currentColor"
+            role="img"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>
+              add
+            </title>
+            <path
+              d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1z"
+            />
+          </svg>
+        </a>
+      </li>
+    </ul>
   </li>
 </ul>
 `;


### PR DESCRIPTION
### Summary:
When I paired with design on the newest button styling, we had a conversation about the naming of the "plain" variant. The designs continue to refer to this variant as "icon", which design prefers, but I'm not in favor of (because any of the buttons can have an icon; this variant just happens to require an icon). They said if we can't do "icon", how about "text"? I believe that we on the code side also discussed the name of this thing at length, and it was suggested that "text" feels too vague when we also have the "link" variant. Design is confident that the other designers will not confused "text" and "link" because "link" is such a structural concept in web design. So we compromised on "text".

This PR updates references to the "plain" variant to now call it "text".

### Test Plan:
Verify that there are no visual changes in the Button and Link storybook pages except that the "plain" variant is now referred to as "text".