### PR TITLE
chore(svg-icon): add ExpandLessRounded icon

### DIFF
--- a/packages/components/src/Icons/ExpandLessRounded.tsx
+++ b/packages/components/src/Icons/ExpandLessRounded.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import createSvgIcon from "../SvgIcon/utils/createSvgIcon";
+
+export default createSvgIcon(
+  <path d="M12 8l-6 6 1.41 1.41L12 10.83l4.59 4.58L18 14z" />,
+);

--- a/packages/components/src/Icons/index.ts
+++ b/packages/components/src/Icons/index.ts
@@ -41,6 +41,7 @@ export { default as EventAvailableRoundedIcon } from "./EventAvailableRounded";
 export { default as EventBusyRoundedIcon } from "./EventBusyRounded";
 export { default as EventNoteRoundedIcon } from "./EventNoteRounded";
 export { default as EventRoundedIcon } from "./EventRounded";
+export { default as ExpandLessRoundedIcon } from "./ExpandLessRounded";
 export { default as ExpandMoreRoundedIcon } from "./ExpandMoreRounded";
 export { default as FaceRoundedIcon } from "./FaceRounded";
 export { default as FavoriteRoundedIcon } from "./FavoriteRounded";


### PR DESCRIPTION
### Summary:
Just what it says! Notebooks needs this one.

### Test Plan:
Verify the icon appears in the `All Icons` story.

### Screenshot:
<img width="1452" alt="'All Icons' story" src="https://user-images.githubusercontent.com/7761701/140843539-f731b8c8-2a27-4b1d-9b82-c59dfa6d58d4.png">