### PR TITLE
build: restrict importing from .storybook, docs into src

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -69,6 +69,25 @@
         "browser": false,
         "node": true
       }
+    },
+    {
+      "files": ["packages/components/src/**/*.stories.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error", {
+            "patterns": [
+              {
+                "group": [".storybook"],
+                "message": "Do not import files from `.storybook/` into `src`. If needed, move files into `src/storyUtils` instead."
+              },
+              {
+                "group": ["**/docs/*"],
+                "message": "Do not import files from `docs/` into `src`. If needed, move files into `src/storyUtils` instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ],
   "ignorePatterns": ["!.storybook"]


### PR DESCRIPTION
### Summary:
[ch172777]

### Test Plan:
forced an error:
![Screen Shot 2021-11-08 at 5 09 13 PM](https://user-images.githubusercontent.com/15840841/140843710-d4ffbf4a-3738-47e6-a212-a161ca6b9f55.png)

confirmed importing from something like `docs-editor/` doesn't trigger the error
