### PR TITLE
chore(clickable-style): remove empty space in children

### DIFF
--- a/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -56,7 +56,6 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorAlert"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -171,7 +170,6 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorBrand"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -238,7 +236,6 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
     class="close dismiss button variantLink colorBrand"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -301,7 +298,6 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
         style="white-space: nowrap;"
         type="button"
       >
-        ​
         See updates
       </button>
     </div>
@@ -405,7 +401,6 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorNeutral"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -594,7 +589,6 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorSuccess"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -705,7 +699,6 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorBrand"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -772,7 +765,6 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
     class="close dismiss button variantLink colorBrand"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -835,7 +827,6 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
         style="white-space: nowrap;"
         type="button"
       >
-        ​
         See updates
       </button>
     </div>
@@ -935,7 +926,6 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
         style="white-space: nowrap;"
         type="button"
       >
-        ​
         See updates
       </button>
     </div>
@@ -995,7 +985,6 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
     class="close dismiss button variantLink colorWarning"
     type="button"
   >
-    ​
     <svg
       class="svgIcon"
       fill="currentColor"
@@ -1102,7 +1091,6 @@ exports[`<Banner /> WithAction story renders snapshot 1`] = `
         style="white-space: nowrap;"
         type="button"
       >
-        ​
         See updates
       </button>
     </div>

--- a/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
+++ b/packages/components/src/Button/__snapshots__/button.spec.tsx.snap
@@ -25,7 +25,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantFlat colorBrand"
               type="button"
             >
-              ​
               Button
             </button>
           </li>
@@ -34,7 +33,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantFlat colorBrand"
               type="button"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -57,7 +55,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantFlat colorBrand"
               type="button"
             >
-              ​
               Button
               <svg
                 aria-hidden="true"
@@ -87,7 +84,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeMedium variantFlat colorBrand"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -105,7 +101,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeSmall variantFlat colorBrand"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -133,7 +128,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorBrand"
               type="button"
             >
-              ​
               Button
             </button>
           </li>
@@ -142,7 +136,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorBrand"
               type="button"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -165,7 +158,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorBrand"
               type="button"
             >
-              ​
               Button
               <svg
                 aria-hidden="true"
@@ -195,7 +187,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeMedium variantOutline colorBrand"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -213,7 +204,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeSmall variantOutline colorBrand"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -241,7 +231,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorNeutral"
               type="button"
             >
-              ​
               Button
             </button>
           </li>
@@ -250,7 +239,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorNeutral"
               type="button"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -273,7 +261,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantOutline colorNeutral"
               type="button"
             >
-              ​
               Button
               <svg
                 aria-hidden="true"
@@ -303,7 +290,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeMedium variantOutline colorNeutral"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -321,7 +307,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
             class="button sizeSmall variantOutline colorNeutral"
             type="button"
           >
-            ​
             Button
           </button>
         </div>
@@ -349,7 +334,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantPlain colorBrand"
               type="button"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -370,7 +354,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantPlain colorBrand"
               type="button"
             >
-              ​
               Button
               <svg
                 aria-hidden="true"
@@ -392,7 +375,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeLarge variantPlain colorBrand"
               type="button"
             >
-              ​
               <svg
                 class="mx-[-0.4em] svgIcon"
                 fill="currentColor"
@@ -425,7 +407,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeMedium variantPlain colorBrand"
               type="button"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -446,7 +427,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeMedium variantPlain colorBrand"
               type="button"
             >
-              ​
               Button
               <svg
                 aria-hidden="true"
@@ -466,7 +446,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
               class="button sizeMedium variantPlain colorBrand"
               type="button"
             >
-              ​
               <svg
                 class="mx-[-0.55em] svgIcon"
                 fill="currentColor"
@@ -501,7 +480,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           class="button variantLink colorBrand"
           type="button"
         >
-          ​
           Button
         </button>
       </li>
@@ -510,7 +488,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           class="button variantLink colorBrand"
           type="button"
         >
-          ​
           Button
           <svg
             class="ml-1 svgIcon"
@@ -549,7 +526,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantFlat colorAlert"
           type="button"
         >
-          ​
           Button
         </button>
       </li>
@@ -558,7 +534,6 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantFlat colorAlert"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -584,7 +559,6 @@ exports[`<Button /> Default story renders snapshot 1`] = `
   class="button sizeLarge variantFlat colorBrand"
   type="button"
 >
-  ​
   Button
 </button>
 `;
@@ -606,7 +580,6 @@ exports[`<Button /> LinkRecommendedVariants story renders snapshot 1`] = `
       class="button variantLink colorBrand"
       type="button"
     >
-      ​
       Button
     </button>
   </li>
@@ -615,7 +588,6 @@ exports[`<Button /> LinkRecommendedVariants story renders snapshot 1`] = `
       class="button variantLink colorBrand"
       type="button"
     >
-      ​
       Button
       <svg
         class="ml-1 svgIcon"
@@ -652,7 +624,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantPlain colorBrand"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -673,7 +644,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantPlain colorBrand"
           type="button"
         >
-          ​
           Button
           <svg
             aria-hidden="true"
@@ -695,7 +665,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantPlain colorBrand"
           type="button"
         >
-          ​
           <svg
             class="mx-[-0.4em] svgIcon"
             fill="currentColor"
@@ -728,7 +697,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeMedium variantPlain colorBrand"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -749,7 +717,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeMedium variantPlain colorBrand"
           type="button"
         >
-          ​
           Button
           <svg
             aria-hidden="true"
@@ -769,7 +736,6 @@ exports[`<Button /> PlainRecommendedVariants story renders snapshot 1`] = `
           class="button sizeMedium variantPlain colorBrand"
           type="button"
         >
-          ​
           <svg
             class="mx-[-0.55em] svgIcon"
             fill="currentColor"
@@ -807,7 +773,6 @@ exports[`<Button /> PrimaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantFlat colorBrand"
           type="button"
         >
-          ​
           Button
         </button>
       </li>
@@ -816,7 +781,6 @@ exports[`<Button /> PrimaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantFlat colorBrand"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -839,7 +803,6 @@ exports[`<Button /> PrimaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantFlat colorBrand"
           type="button"
         >
-          ​
           Button
           <svg
             aria-hidden="true"
@@ -869,7 +832,6 @@ exports[`<Button /> PrimaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeMedium variantFlat colorBrand"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -887,7 +849,6 @@ exports[`<Button /> PrimaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeSmall variantFlat colorBrand"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -911,7 +872,6 @@ exports[`<Button /> SecondaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorBrand"
           type="button"
         >
-          ​
           Button
         </button>
       </li>
@@ -920,7 +880,6 @@ exports[`<Button /> SecondaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorBrand"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -943,7 +902,6 @@ exports[`<Button /> SecondaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorBrand"
           type="button"
         >
-          ​
           Button
           <svg
             aria-hidden="true"
@@ -973,7 +931,6 @@ exports[`<Button /> SecondaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeMedium variantOutline colorBrand"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -991,7 +948,6 @@ exports[`<Button /> SecondaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeSmall variantOutline colorBrand"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -1015,7 +971,6 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorNeutral"
           type="button"
         >
-          ​
           Button
         </button>
       </li>
@@ -1024,7 +979,6 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorNeutral"
           type="button"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -1047,7 +1001,6 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
           class="button sizeLarge variantOutline colorNeutral"
           type="button"
         >
-          ​
           Button
           <svg
             aria-hidden="true"
@@ -1077,7 +1030,6 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeMedium variantOutline colorNeutral"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -1095,7 +1047,6 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         class="button sizeSmall variantOutline colorNeutral"
         type="button"
       >
-        ​
         Button
       </button>
     </div>
@@ -1109,7 +1060,6 @@ exports[`<Button /> passes class names down properly 1`] = `
   data-testid="example-class-name"
   type="button"
 >
-  ​
   Button with example className
 </button>
 `;
@@ -1120,7 +1070,6 @@ exports[`<Button /> passes test ids down properly 1`] = `
   data-testid="example-test-id"
   type="button"
 >
-  ​
   Button with data-testid
 </button>
 `;

--- a/packages/components/src/ClickableStyle/ClickableStyle.tsx
+++ b/packages/components/src/ClickableStyle/ClickableStyle.tsx
@@ -79,8 +79,6 @@ const ClickableStyle = React.forwardRef(
         ref={ref}
         {...rest}
       >
-        {/* No width space to ensure height of contents */}
-        {"\u200B"}
         {children}
       </Component>
     );

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -24,7 +24,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantFlat colorBrand"
             >
-              ​
               Link
             </a>
           </li>
@@ -32,7 +31,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantFlat colorBrand"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -54,7 +52,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantFlat colorBrand"
             >
-              ​
               Link
               <svg
                 aria-hidden="true"
@@ -83,7 +80,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeMedium variantFlat colorBrand"
           >
-            ​
             Link
           </a>
         </div>
@@ -100,7 +96,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeSmall variantFlat colorBrand"
           >
-            ​
             Link
           </a>
         </div>
@@ -127,7 +122,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorBrand"
             >
-              ​
               Link
             </a>
           </li>
@@ -135,7 +129,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorBrand"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -157,7 +150,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorBrand"
             >
-              ​
               Link
               <svg
                 aria-hidden="true"
@@ -186,7 +178,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeMedium variantOutline colorBrand"
           >
-            ​
             Link
           </a>
         </div>
@@ -203,7 +194,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeSmall variantOutline colorBrand"
           >
-            ​
             Link
           </a>
         </div>
@@ -230,7 +220,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorNeutral"
             >
-              ​
               Link
             </a>
           </li>
@@ -238,7 +227,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorNeutral"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -260,7 +248,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantOutline colorNeutral"
             >
-              ​
               Link
               <svg
                 aria-hidden="true"
@@ -289,7 +276,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeMedium variantOutline colorNeutral"
           >
-            ​
             Link
           </a>
         </div>
@@ -306,7 +292,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
           <a
             class="button sizeSmall variantOutline colorNeutral"
           >
-            ​
             Link
           </a>
         </div>
@@ -333,7 +318,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantPlain colorBrand"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -353,7 +337,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantPlain colorBrand"
             >
-              ​
               Link
               <svg
                 aria-hidden="true"
@@ -374,7 +357,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeLarge variantPlain colorBrand"
             >
-              ​
               <svg
                 class="mx-[-0.4em] svgIcon"
                 fill="currentColor"
@@ -406,7 +388,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeMedium variantPlain colorBrand"
             >
-              ​
               <svg
                 aria-hidden="true"
                 class="arrowBackIcon svgIcon"
@@ -426,7 +407,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeMedium variantPlain colorBrand"
             >
-              ​
               Link
               <svg
                 aria-hidden="true"
@@ -445,7 +425,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
             <a
               class="button sizeMedium variantPlain colorBrand"
             >
-              ​
               <svg
                 class="mx-[-0.55em] svgIcon"
                 fill="currentColor"
@@ -479,7 +458,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button variantLink colorBrand"
         >
-          ​
           Link
         </a>
       </li>
@@ -487,7 +465,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button variantLink colorBrand"
         >
-          ​
           Link
           <svg
             class="ml-1 svgIcon"
@@ -525,7 +502,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantFlat colorAlert"
         >
-          ​
           Link
         </a>
       </li>
@@ -533,7 +509,6 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantFlat colorAlert"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -559,7 +534,6 @@ exports[`<Link /> Default story renders snapshot 1`] = `
   class="button variantLink colorBrand"
   href=""
 >
-  ​
   Link
 </a>
 `;
@@ -580,7 +554,6 @@ exports[`<Link /> LinkRecommendedVariants story renders snapshot 1`] = `
     <a
       class="button variantLink colorBrand"
     >
-      ​
       Link
     </a>
   </li>
@@ -588,7 +561,6 @@ exports[`<Link /> LinkRecommendedVariants story renders snapshot 1`] = `
     <a
       class="button variantLink colorBrand"
     >
-      ​
       Link
       <svg
         class="ml-1 svgIcon"
@@ -624,7 +596,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantPlain colorBrand"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -644,7 +615,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantPlain colorBrand"
         >
-          ​
           Link
           <svg
             aria-hidden="true"
@@ -665,7 +635,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantPlain colorBrand"
         >
-          ​
           <svg
             class="mx-[-0.4em] svgIcon"
             fill="currentColor"
@@ -697,7 +666,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeMedium variantPlain colorBrand"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -717,7 +685,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeMedium variantPlain colorBrand"
         >
-          ​
           Link
           <svg
             aria-hidden="true"
@@ -736,7 +703,6 @@ exports[`<Link /> PlainRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeMedium variantPlain colorBrand"
         >
-          ​
           <svg
             class="mx-[-0.55em] svgIcon"
             fill="currentColor"
@@ -773,7 +739,6 @@ exports[`<Link /> PrimaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantFlat colorBrand"
         >
-          ​
           Link
         </a>
       </li>
@@ -781,7 +746,6 @@ exports[`<Link /> PrimaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantFlat colorBrand"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -803,7 +767,6 @@ exports[`<Link /> PrimaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantFlat colorBrand"
         >
-          ​
           Link
           <svg
             aria-hidden="true"
@@ -832,7 +795,6 @@ exports[`<Link /> PrimaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeMedium variantFlat colorBrand"
       >
-        ​
         Link
       </a>
     </div>
@@ -849,7 +811,6 @@ exports[`<Link /> PrimaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeSmall variantFlat colorBrand"
       >
-        ​
         Link
       </a>
     </div>
@@ -872,7 +833,6 @@ exports[`<Link /> SecondaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorBrand"
         >
-          ​
           Link
         </a>
       </li>
@@ -880,7 +840,6 @@ exports[`<Link /> SecondaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorBrand"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -902,7 +861,6 @@ exports[`<Link /> SecondaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorBrand"
         >
-          ​
           Link
           <svg
             aria-hidden="true"
@@ -931,7 +889,6 @@ exports[`<Link /> SecondaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeMedium variantOutline colorBrand"
       >
-        ​
         Link
       </a>
     </div>
@@ -948,7 +905,6 @@ exports[`<Link /> SecondaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeSmall variantOutline colorBrand"
       >
-        ​
         Link
       </a>
     </div>
@@ -971,7 +927,6 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorNeutral"
         >
-          ​
           Link
         </a>
       </li>
@@ -979,7 +934,6 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorNeutral"
         >
-          ​
           <svg
             aria-hidden="true"
             class="arrowBackIcon svgIcon"
@@ -1001,7 +955,6 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
         <a
           class="button sizeLarge variantOutline colorNeutral"
         >
-          ​
           Link
           <svg
             aria-hidden="true"
@@ -1030,7 +983,6 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeMedium variantOutline colorNeutral"
       >
-        ​
         Link
       </a>
     </div>
@@ -1047,7 +999,6 @@ exports[`<Link /> TertiaryRecommendedVariants story renders snapshot 1`] = `
       <a
         class="button sizeSmall variantOutline colorNeutral"
       >
-        ​
         Link
       </a>
     </div>
@@ -1064,7 +1015,6 @@ exports[`<Link /> linkInBody story renders snapshot 1`] = `
     class="button variantLink colorBrand"
     href=""
   >
-    ​
     Link
   </a>
    and shows that the link should adhere to its appearance
@@ -1080,7 +1030,6 @@ exports[`<Link /> linkInHeading story renders snapshot 1`] = `
     class="button variantLink colorBrand"
     href=""
   >
-    ​
     Link
   </a>
    and shows that the link should adhere to its appearance
@@ -1092,7 +1041,6 @@ exports[`<Link /> passes class names down properly 1`] = `
   class="exampleClassName button variantLink colorBrand"
   data-testid="example-class-name"
 >
-  ​
   Link with example className
 </a>
 `;
@@ -1102,7 +1050,6 @@ exports[`<Link /> passes test ids down properly 1`] = `
   class="button variantLink colorBrand"
   data-testid="example-test-id"
 >
-  ​
   Link with data-testid
 </a>
 `;


### PR DESCRIPTION
### Summary:
We have an empty space in the `ClickableStyle`, `Button`, and `Link` children. The comment says it's there to ensure the height of the button. We added `height` to the button styles a while back, to make sure icons don't expand the buttons and make them too tall, so we don't really need this anymore.

Strangely, the buttons are slightly *taller* after this change. According to the styles, the height is the same, but it's rendering very slightly taller. It's pretty subtle on an individual button.

<img width="1440" alt="before and after snapshots of the button stories in chromatic" src="https://user-images.githubusercontent.com/7761701/142081362-f940450a-20a7-48a3-99ca-4bcd657055e4.png">

### Test Plan:
Verify there are no significant changes in the chromatic snapshots.