### PR TITLE
chore(close-button): add hover color, aria-label prop, and default prop vals

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -107,7 +107,7 @@ export default function Banner({
           className={styles.dismiss}
           color={color}
           onClose={onDismiss}
-          size="28px"
+          size="1.75rem"
         />
       )}
 

--- a/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -53,18 +53,18 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorAlert"
 >
   <button
-    class="close dismiss button variantLink colorAlert"
+    class="button dismiss colorAlert button variantLink colorAlert"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -168,18 +168,18 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
-    class="close dismiss button variantLink colorBrand"
+    class="button dismiss colorBrand button variantLink colorBrand"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -235,18 +235,18 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
-    class="close dismiss button variantLink colorBrand"
+    class="button dismiss colorBrand button variantLink colorBrand"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -402,18 +402,18 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorNeutral"
 >
   <button
-    class="close dismiss button variantLink colorNeutral"
+    class="button dismiss colorNeutral button variantLink colorNeutral"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -591,18 +591,18 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorSuccess"
 >
   <button
-    class="close dismiss button variantLink colorSuccess"
+    class="button dismiss colorSuccess button variantLink colorSuccess"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -702,18 +702,18 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
   class="bannerDialog dismissable colorBrand"
 >
   <button
-    class="close dismiss button variantLink colorBrand"
+    class="button dismiss colorBrand button variantLink colorBrand"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -769,18 +769,18 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
   class="bannerDialog dismissable colorBrand"
 >
   <button
-    class="close dismiss button variantLink colorBrand"
+    class="button dismiss colorBrand button variantLink colorBrand"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
@@ -992,18 +992,18 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorWarning"
 >
   <button
-    class="close dismiss button variantLink colorWarning"
+    class="button dismiss colorWarning button variantLink colorWarning"
     type="button"
   >
     ​
     <svg
       class="svgIcon"
       fill="currentColor"
-      height="28px"
+      height="1.75rem"
       role="img"
-      style="--svg-icon-size: 28px;"
+      style="--svg-icon-size: 1.75rem;"
       viewBox="0 0 24 24"
-      width="28px"
+      width="1.75rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>

--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -57,9 +57,7 @@ export default function Toast({
           {children}
         </Text>
       </div>
-      {onDismiss && (
-        <CloseButton color={color} onClose={onDismiss} size="32px" />
-      )}
+      {onDismiss && <CloseButton color={color} onClose={onDismiss} />}
     </div>
   );
 }

--- a/packages/components/src/common/CloseButton/CloseButton.module.css
+++ b/packages/components/src/common/CloseButton/CloseButton.module.css
@@ -2,7 +2,7 @@
   @apply w-12 h-12 justify-center rounded-full;
 }
 
-/* The hover transition is inherited from the Button component */
+/* The hover transition is inherited from the ClickableStyle component */
 .button:hover {
   @apply text-white;
 

--- a/packages/components/src/common/CloseButton/CloseButton.module.css
+++ b/packages/components/src/common/CloseButton/CloseButton.module.css
@@ -10,26 +10,21 @@
 }
 
 .colorBrand {
-  @apply text-brand-700;
   --close-hover-color: var(--eds-color-brand-600);
 }
 
 .colorNeutral {
-  @apply text-neutral-700;
   --close-hover-color: var(--eds-color-neutral-600);
 }
 
 .colorSuccess {
-  @apply text-success-700;
   --close-hover-color: var(--eds-color-success-600);
 }
 
 .colorWarning {
-  @apply text-warning-700;
   --close-hover-color: var(--eds-color-warning-600);
 }
 
 .colorAlert {
-  @apply text-alert-700;
   --close-hover-color: var(--eds-color-alert-600);
 }

--- a/packages/components/src/common/CloseButton/CloseButton.module.css
+++ b/packages/components/src/common/CloseButton/CloseButton.module.css
@@ -1,11 +1,35 @@
-.close {
+.button {
   @apply w-12 h-12 justify-center rounded-full;
 }
 
-.close:hover {
-  /* The hover transition is inherited from the Button component */
+/* The hover transition is inherited from the Button component */
+.button:hover {
   @apply text-white;
 
-  /* --close-hover-color variable should be set in the consumer's styles */
   background-color: var(--close-hover-color);
+}
+
+.colorBrand {
+  @apply text-brand-700;
+  --close-hover-color: var(--eds-color-brand-600);
+}
+
+.colorNeutral {
+  @apply text-neutral-700;
+  --close-hover-color: var(--eds-color-neutral-600);
+}
+
+.colorSuccess {
+  @apply text-success-700;
+  --close-hover-color: var(--eds-color-success-600);
+}
+
+.colorWarning {
+  @apply text-warning-700;
+  --close-hover-color: var(--eds-color-warning-600);
+}
+
+.colorAlert {
+  @apply text-alert-700;
+  --close-hover-color: var(--eds-color-alert-600);
 }

--- a/packages/components/src/common/CloseButton/CloseButton.stories.module.css
+++ b/packages/components/src/common/CloseButton/CloseButton.stories.module.css
@@ -1,3 +1,0 @@
-.dismiss {
-  --close-hover-color: var(--eds-color-black);
-}

--- a/packages/components/src/common/CloseButton/CloseButton.stories.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.stories.tsx
@@ -1,7 +1,6 @@
 import { Story } from "@storybook/react/types-6-0";
 import React from "react";
 import CloseButton from "./CloseButton";
-import styles from "./CloseButton.stories.module.css";
 
 export default {
   title: "common/CloseButton",
@@ -10,14 +9,9 @@ export default {
 
 type Args = React.ComponentProps<typeof CloseButton>;
 
-const Template: Story<Args> = (args) => (
-  <div className={styles.dismiss}>
-    <CloseButton {...args} className={styles.dismiss} />
-  </div>
-);
+const Template: Story<Args> = (args) => <CloseButton {...args} />;
 
 const defaultArgs = {
-  size: "2rem",
   color: "brand" as const,
 };
 
@@ -29,11 +23,23 @@ Default.args = {
 export const SmallerSize = Template.bind(null);
 SmallerSize.args = {
   ...defaultArgs,
-  size: "28px",
+  size: "1rem",
 };
 
 export const DifferentColor = Template.bind(null);
 DifferentColor.args = {
   ...defaultArgs,
   color: "alert" as const,
+};
+
+export const CustomAriaLabel = Template.bind(null);
+CustomAriaLabel.args = {
+  ...defaultArgs,
+  "aria-label": "close modal",
+};
+CustomAriaLabel.parameters = {
+  chromatic: {
+    // This story is just for jest snapshot tests.
+    disableSnapshot: true,
+  },
 };

--- a/packages/components/src/common/CloseButton/CloseButton.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.tsx
@@ -2,25 +2,27 @@ import clsx from "clsx";
 import React from "react";
 import Button from "../../Button";
 import CloseRoundedIcon from "../../Icons/CloseRounded";
-import { NotificationVariant } from "../Notifications/NotificationIcon";
 import styles from "./CloseButton.module.css";
 
+export type Variant = "brand" | "neutral" | "success" | "warning" | "alert";
+
 type CloseButtonProps = {
-  className?: string;
   /**
-   * The default color of the icon. Does not effect hover state.
+   * The color theme of the icon. Also affects the hover state.
    */
-  color: NotificationVariant;
-  onClose: () => void;
+  color: Variant;
   /**
-   * Size of the icon. Does not button size. The button is larger than the
+   * Size of the icon. Does not affect actual button size. The button is larger than the
    * icon to ensure the hit box is large enough (for accessibility).
    *
    * The string should be some number + px, rem, em, vh, etc. Ex: 2rem.
    * Recommendation: use "EdsSizeLineHeight" tokens from
    * @chanzuckerberg/eds-tokens/json/variables.json
    */
-  size: string;
+  size?: string;
+  "aria-label"?: string;
+  onClose: () => void;
+  className?: string;
 };
 
 /**
@@ -29,14 +31,31 @@ type CloseButtonProps = {
  * Consumers need to set the --close-hover-color variable in their styles
  * in order for the hover state to work correctly.
  */
-const CloseButton = ({ className, color, onClose, size }: CloseButtonProps) => (
+const CloseButton = ({
+  className,
+  color = "neutral",
+  onClose,
+  size = "2rem",
+  "aria-label": ariaLabel = "close",
+  ...rest
+}: CloseButtonProps) => (
   <Button
-    className={clsx(styles.close, className)}
+    className={clsx(
+      styles.button,
+      className,
+      // Color props
+      color === "brand" && styles.colorBrand,
+      color === "neutral" && styles.colorNeutral,
+      color === "success" && styles.colorSuccess,
+      color === "warning" && styles.colorWarning,
+      color === "alert" && styles.colorAlert,
+    )}
     color={color}
     onClick={onClose}
     variant="link"
+    {...rest}
   >
-    <CloseRoundedIcon purpose="informative" size={size} title="close" />
+    <CloseRoundedIcon purpose="informative" size={size} title={ariaLabel} />
   </Button>
 );
 

--- a/packages/components/src/common/CloseButton/CloseButton.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.tsx
@@ -20,6 +20,9 @@ type CloseButtonProps = {
    * @chanzuckerberg/eds-tokens/json/variables.json
    */
   size?: string;
+  /**
+   * Custom aria-label. If undefined, "close" will be used.
+   */
   "aria-label"?: string;
   onClose: () => void;
   className?: string;

--- a/packages/components/src/common/Notifications/Notification.module.css
+++ b/packages/components/src/common/Notifications/Notification.module.css
@@ -2,33 +2,28 @@
   @apply text-brand-700 bg-brand-100;
   --border-light-color: var(--eds-color-brand-200);
   --border-dark-color: var(--eds-color-brand-500);
-  --close-hover-color: var(--eds-color-brand-600);
 }
 
 .colorNeutral {
   @apply text-neutral-700 bg-neutral-100;
   --border-light-color: var(--eds-color-neutral-200);
   --border-dark-color: var(--eds-color-neutral-500);
-  --close-hover-color: var(--eds-color-neutral-600);
 }
 
 .colorSuccess {
   @apply text-success-700 bg-success-100;
   --border-light-color: var(--eds-color-success-200);
   --border-dark-color: var(--eds-color-success-500);
-  --close-hover-color: var(--eds-color-success-600);
 }
 
 .colorWarning {
   @apply text-warning-700 bg-warning-100;
   --border-light-color: var(--eds-color-warning-200);
   --border-dark-color: var(--eds-color-warning-500);
-  --close-hover-color: var(--eds-color-warning-600);
 }
 
 .colorAlert {
   @apply text-alert-700 bg-alert-100;
   --border-light-color: var(--eds-color-alert-200);
   --border-dark-color: var(--eds-color-alert-500);
-  --close-hover-color: var(--eds-color-alert-600);
 }


### PR DESCRIPTION
### Summary:
The `CloseButton` component was only really intended to be used in the `Banner` and `Toast` components, but I'm using the `CloseButton` in the `Modal` component in `traject`, and I noticed a few things I wanted to change:
- having to add your own hover color is annoying and not intuitive
- you can't add a custom aria label
- you can't pass other attributes like `data-testid` down to the button
- there are no default `size` and `color` values (I like the be able to plug the component in, verify it works with the default values, and then customize it to meet my needs)

This PR attempts to address these issues.

I'm also wondering if we should pull the `CloseButton` out of `common` or not.

### Test Plan:
Verify the close button hover state is unchanged in the `Banner` and `Toast` components in storybook,
and verify no changes are registered in the chromatic snapshots (except to the sizes are different in the `CloseButton` stories).