### PR TITLE
docs(close-button): clean up component docstring

### DIFF
--- a/packages/components/src/common/CloseButton/CloseButton.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.tsx
@@ -29,10 +29,7 @@ type CloseButtonProps = {
 };
 
 /**
- * Generic close button. Currently only used for notification banners and toasts.
- *
- * Consumers need to set the --close-hover-color variable in their styles
- * in order for the hover state to work correctly.
+ * Generic close button.
  */
 const CloseButton = ({
   className,


### PR DESCRIPTION
### Summary:
I changed up the `CloseButton` but I didn't update the docstring, which is now incorrect. This PR just updates the docstring based on the changes made in https://github.com/chanzuckerberg/edu-design-system/pull/721

### Test Plan:
n/a