### PR TITLE
docs(banner): fix display names for subcomponents

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -113,27 +113,37 @@ export default function Banner({
     </article>
   );
 }
+Banner.displayName = "Banner";
 
+type TitleProps = {
+  children?: React.ReactNode;
+  as: HeadingElement;
+};
 /**
  * This should import a Heading element type
  */
-Banner.Title = (props: { children?: React.ReactNode; as: HeadingElement }) => {
+const BannerTitle: React.FC<TitleProps> = (props: TitleProps) => {
   return props.children ? (
     <Heading as={props.as} color={"inherit"} size="h3">
       {props.children}
     </Heading>
   ) : null;
 };
+Banner.Title = BannerTitle;
 Banner.Title.displayName = "Banner.Title";
 
+type MessageProps = {
+  children?: React.ReactNode;
+};
 /**
  * This should import a Text element type
  */
-Banner.Message = (props: { children?: React.ReactNode }) => {
+const BannerMessage: React.FC<MessageProps> = (props: MessageProps) => {
   return props.children ? (
     <Text color={"inherit"} size="body">
       {props.children}
     </Text>
   ) : null;
 };
+Banner.Message = BannerMessage;
 Banner.Message.displayName = "Banner.Message";

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -48,31 +48,6 @@ export type BannerProps = {
 };
 
 /**
- * This should import a Heading element type
- */
-Banner.Title = function BannerTitle(props: {
-  children?: React.ReactNode;
-  as: HeadingElement;
-}) {
-  return props.children ? (
-    <Heading as={props.as} color={"inherit"} size="h3">
-      {props.children}
-    </Heading>
-  ) : null;
-};
-
-/**
- * This should import a Text element type
- */
-Banner.Message = function BannerMessage(props: { children?: React.ReactNode }) {
-  return props.children ? (
-    <Text color={"inherit"} size="body">
-      {props.children}
-    </Text>
-  ) : null;
-};
-
-/**
  * A banner used to provide and highlight information to a user or ask for a decision or action.
  */
 export default function Banner({
@@ -138,3 +113,27 @@ export default function Banner({
     </article>
   );
 }
+
+/**
+ * This should import a Heading element type
+ */
+Banner.Title = (props: { children?: React.ReactNode; as: HeadingElement }) => {
+  return props.children ? (
+    <Heading as={props.as} color={"inherit"} size="h3">
+      {props.children}
+    </Heading>
+  ) : null;
+};
+Banner.Title.displayName = "Banner.Title";
+
+/**
+ * This should import a Text element type
+ */
+Banner.Message = (props: { children?: React.ReactNode }) => {
+  return props.children ? (
+    <Text color={"inherit"} size="body">
+      {props.children}
+    </Text>
+  ) : null;
+};
+Banner.Message.displayName = "Banner.Message";


### PR DESCRIPTION
### Summary:
If you look at the `Banner` code snippets in storybook, it shows the subcomponents being called `BannerTitle` and `BannerMessage`. This is confusing because when you use them in your code, they're `Banner.Title` and `Banner.Message`. The component names in that snippet are coming from the `displayName` of the subcomponent, which are defined in `Banner` when they're first defined. We're taking these components and setting them to `Banner.Title` and `Banner.Message`, but that's not their names under the hood.

This PR adds display names for the `Banner` and its subcomponents so their names appear correctly in the code snippets on the docs page.

Alternatively, we could just update the docstring on the `Banner` with some example code that does use the right component names. https://github.com/chanzuckerberg/edu-design-system/pull/735

### Screenshots
#### Before
<img width="1230" alt="Banner in storybook, before this change" src="https://user-images.githubusercontent.com/7761701/144142404-2f43e438-75b2-48b3-84e7-3c3e28d6b2a0.png">

#### After
<img width="1238" alt="Banner in storybook, after this change" src="https://user-images.githubusercontent.com/7761701/144907923-2db364c6-09d8-4527-bf39-335cdab7a436.png">

### Test Plan:
Checkout the `Banner` in storybook,
look at the `code` feature on any of the stories,
and see that the example code says `Banner.Title` instead of `BannerTitle` and `Banner.Message` instead of `BannerMessage`.

Also verify Chromatic doesn't pick up any visual changes.