### PR TITLE
docs(banner): add example to docstring

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -49,6 +49,22 @@ export type BannerProps = {
 
 /**
  * A banner used to provide and highlight information to a user or ask for a decision or action.
+ *
+ * ```tsx
+ * <Banner
+ *   onDismiss={handleDismiss}
+ *   textContent={
+ *     <>
+ *       <Banner.Title>{bannerTitle}</Banner.Title>
+ *       <Banner.Message>{bannerMessage}</Banner.Message>
+ *     </>
+ *   }
+ * />
+ * ```
+ *
+ * Please note the code snippets under each Banner story on storybook are misleading
+ * because they use <BannerTitle> and <BannerMessage> when they are actually called
+ * <Banner.Title> and <Banner.Message>.
  */
 export default function Banner({
   className,

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -63,8 +63,8 @@ export type BannerProps = {
  * ```
  *
  * Please note the code snippets under each Banner story on storybook are misleading
- * because they use <BannerTitle> and <BannerMessage> when they are actually called
- * <Banner.Title> and <Banner.Message>.
+ * because they use `<BannerTitle>` and `<BannerMessage>` when they are actually called
+ * `<Banner.Title>` and `<Banner.Message>`.
  */
 export default function Banner({
   className,

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -50,6 +50,8 @@ export type BannerProps = {
 /**
  * A banner used to provide and highlight information to a user or ask for a decision or action.
  *
+ * Example usage:
+ *
  * ```tsx
  * <Banner
  *   onDismiss={handleDismiss}

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -61,10 +61,6 @@ export type BannerProps = {
  *   }
  * />
  * ```
- *
- * Please note the code snippets under each Banner story on storybook are misleading
- * because they use `<BannerTitle>` and `<BannerMessage>` when they are actually called
- * `<Banner.Title>` and `<Banner.Message>`.
  */
 export default function Banner({
   className,


### PR DESCRIPTION
### Summary:
#### Updated summary:
This PR updates the `Banner` docstring to have a code example. It was originally for clarifying something confusing about the code snippets under the stories, but that was fixed in Alternative to https://github.com/chanzuckerberg/edu-design-system/pull/734

#### Original summary:
Alternative to https://github.com/chanzuckerberg/edu-design-system/pull/734

The code snippets for the `Banner` stories in storybook are a little misleading because they show the subcomponents as being called `BannerTitle` and `BannerMessage`, but when you use them in the code, you refer to them as `Banner.Title` and `Banner.Message`.

This PR updates the `Banner` docstring to have a code example that uses the right names and also points out that the code snippets are wrong.

### Screenshots
#### Before
<img width="1262" alt="Banner component in storybook, before this change" src="https://user-images.githubusercontent.com/7761701/144144811-66e62179-798d-43d1-be60-e437fb0293f5.png">

#### After
<img width="1253" alt="Banner component in storybook, after this change" src="https://user-images.githubusercontent.com/7761701/144915724-bdf74ac4-74bd-4118-9837-d4fd410e094b.png">

### Test Plan:
Check out the `Banner` in storybook and verify the new docstring is present and makes sense.