### PR TITLE
feat(icons): add InfoRounded

### DIFF
--- a/packages/components/src/Icons/InfoRounded.tsx
+++ b/packages/components/src/Icons/InfoRounded.tsx
@@ -1,0 +1,6 @@
+import React from "react";
+import createSvgIcon from "../SvgIcon/utils/createSvgIcon";
+
+export default createSvgIcon(
+  <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 15c-.55 0-1-.45-1-1v-4c0-.55.45-1 1-1s1 .45 1 1v4c0 .55-.45 1-1 1zm1-8h-2V7h2v2z" />,
+);

--- a/packages/components/src/Icons/index.ts
+++ b/packages/components/src/Icons/index.ts
@@ -54,6 +54,7 @@ export { default as ForumRoundedIcon } from "./ForumRounded";
 export { default as GestureRoundedIcon } from "./GestureRounded";
 export { default as HelpRoundedIcon } from "./HelpRounded";
 export { default as HomeRoundedIcon } from "./HomeRounded";
+export { default as InfoRoundedIcon } from "./InfoRounded";
 export { default as LibraryBooksRoundedIcon } from "./LibraryBooksRounded";
 export { default as LinkRoundedIcon } from "./LinkRounded";
 export { default as LocalLibraryRoundedIcon } from "./LocalLibraryRounded";


### PR DESCRIPTION
### Summary:
Needed for some tooltip designs.

### Test Plan:
<img width="154" alt="Screen Shot 2021-12-01 at 5 46 13 PM" src="https://user-images.githubusercontent.com/15840841/144326575-f36df280-a68d-466d-a499-1aa03ab533fd.png">

it's a bit different from the stickersheet design but I see that the "master" component was deleted so need to check with Sean if that's still the intended look 🤔  easy to change if so
<img width="164" alt="Screen Shot 2021-12-01 at 5 50 40 PM" src="https://user-images.githubusercontent.com/15840841/144326884-6d8b6a58-609d-4d66-b292-a68cce765e37.png">
 