### PR TITLE
chore(link): add fake href, stop navigating away in stories

### DIFF
--- a/packages/components/src/Link/Link.spec.tsx
+++ b/packages/components/src/Link/Link.spec.tsx
@@ -25,7 +25,7 @@ describe("<Link />", () => {
   it("forwards refs", () => {
     const ref = React.createRef<HTMLAnchorElement>();
     render(
-      <Link href="www.example.com" ref={ref}>
+      <Link href="https://go.czi.team/eds" ref={ref}>
         Hi
       </Link>,
     );

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -33,7 +33,7 @@ export default {
     children: "Link",
     variant: "link" as const,
     color: "brand" as const,
-    href: "www.example.com",
+    href: "https://go.czi.team/eds",
     onClick: (event: React.MouseEvent<HTMLElement>) => {
       // Allows the user to click the links for testing without being navigated away.
       event.preventDefault();

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -33,7 +33,11 @@ export default {
     children: "Link",
     variant: "link" as const,
     color: "brand" as const,
-    href: "",
+    href: "www.example.com",
+    onClick: (event: React.MouseEvent<HTMLElement>) => {
+      // Allows the user to click the links for testing without being navigated away.
+      event.preventDefault();
+    },
   },
 };
 

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -532,7 +532,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
 exports[`<Link /> Default story renders snapshot 1`] = `
 <a
   class="button variantLink colorBrand"
-  href="www.example.com"
+  href="https://go.czi.team/eds"
 >
   Link
 </a>
@@ -553,7 +553,7 @@ exports[`<Link /> LinkInBody story renders snapshot 1`] = `
   This text surrounds the 
   <a
     class="button variantLink colorBrand"
-    href="www.example.com"
+    href="https://go.czi.team/eds"
   >
     Link
   </a>
@@ -568,7 +568,7 @@ exports[`<Link /> LinkInHeading story renders snapshot 1`] = `
   This text surrounds the 
   <a
     class="button variantLink colorBrand"
-    href="www.example.com"
+    href="https://go.czi.team/eds"
   >
     Link
   </a>
@@ -1040,7 +1040,7 @@ exports[`<Link /> passes class names down properly 1`] = `
 <a
   class="exampleClassName button variantLink colorBrand"
   data-testid="example-class-name"
-  href="www.example.com"
+  href="https://go.czi.team/eds"
 >
   Link
 </a>
@@ -1050,7 +1050,7 @@ exports[`<Link /> passes test ids down properly 1`] = `
 <a
   class="button variantLink colorBrand"
   data-testid="example-test-id"
-  href="www.example.com"
+  href="https://go.czi.team/eds"
 >
   Link
 </a>

--- a/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
+++ b/packages/components/src/Link/__snapshots__/Link.spec.tsx.snap
@@ -532,7 +532,7 @@ exports[`<Link /> AllRecommendedVariants story renders snapshot 1`] = `
 exports[`<Link /> Default story renders snapshot 1`] = `
 <a
   class="button variantLink colorBrand"
-  href=""
+  href="www.example.com"
 >
   Link
 </a>
@@ -553,7 +553,7 @@ exports[`<Link /> LinkInBody story renders snapshot 1`] = `
   This text surrounds the 
   <a
     class="button variantLink colorBrand"
-    href=""
+    href="www.example.com"
   >
     Link
   </a>
@@ -568,7 +568,7 @@ exports[`<Link /> LinkInHeading story renders snapshot 1`] = `
   This text surrounds the 
   <a
     class="button variantLink colorBrand"
-    href=""
+    href="www.example.com"
   >
     Link
   </a>
@@ -1040,7 +1040,7 @@ exports[`<Link /> passes class names down properly 1`] = `
 <a
   class="exampleClassName button variantLink colorBrand"
   data-testid="example-class-name"
-  href=""
+  href="www.example.com"
 >
   Link
 </a>
@@ -1050,7 +1050,7 @@ exports[`<Link /> passes test ids down properly 1`] = `
 <a
   class="button variantLink colorBrand"
   data-testid="example-test-id"
-  href=""
+  href="www.example.com"
 >
   Link
 </a>

--- a/packages/components/src/storyUtils/clickableStyleUtils.tsx
+++ b/packages/components/src/storyUtils/clickableStyleUtils.tsx
@@ -298,7 +298,7 @@ const getVariantWithStates = (
                     variant={variant}
                     state={state}
                     disabled={state === "disabled"}
-                    href={tag === "a" ? "www.example.com" : undefined}
+                    href={tag === "a" ? "https://go.czi.team/eds" : undefined}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {
                       // Allows the user to click the links for testing without being navigated away.
                       event.preventDefault();

--- a/packages/components/src/storyUtils/clickableStyleUtils.tsx
+++ b/packages/components/src/storyUtils/clickableStyleUtils.tsx
@@ -298,7 +298,11 @@ const getVariantWithStates = (
                     variant={variant}
                     state={state}
                     disabled={state === "disabled"}
-                    href={tag === "a" ? "" : undefined}
+                    href={tag === "a" ? "www.example.com" : undefined}
+                    onClick={(event: React.MouseEvent<HTMLElement>) => {
+                      // Allows the user to click the links for testing without being navigated away.
+                      event.preventDefault();
+                    }}
                   >
                     {buttonChildren}
                     {icon}


### PR DESCRIPTION
### Summary:
We have some `Link` stories that have an `href` that's just an empty string. When you click on those links, you're navigated to a different page that just has that story, which makes it kind of annoying to test the click interaction on these things.

This PR upgrades the `href` value to an actual example URL and also adds an `onClick` handler to stop the page navigation.

Please note that this only affects the top 3 stories (default, in body text, in a heading) and the big grids at the bottom (all variants) because I'm only updating the stories that already had an `href`. The other stories would be a little more work and repetition, and I don't think we need this for every single story. A couple is enough.

### Test Plan:
Navigate to `http://localhost:6008/?path=/docs/link--default`,
test clicking all the links in the stories,
and verify the top 3 and the big grids at bottom show a pointer cursor and focus the link on click but don't navigate you to another page.