### PR TITLE
chore(clickable-style): give plain button hover style a border

### DIFF
--- a/packages/components/src/ClickableStyle/ClickableStyle.module.css
+++ b/packages/components/src/ClickableStyle/ClickableStyle.module.css
@@ -196,7 +196,7 @@
 
 .variantPlain {
   color: var(--link-color);
-  border: var(--plain-background-color);
+  border-color: var(--plain-background-color);
   background-color: var(--plain-background-color);
 
   &:hover,
@@ -204,14 +204,19 @@
   &:focus,
   &.stateFocus {
     color: var(--primary-color);
+    border-color: var(--primary-color);
   }
 
   &:active,
   &.stateActive {
     @apply text-white;
+
+    border-color: var(--plain-background-color);
   }
 
   &:disabled {
+    @apply border-transparent;
+
     color: var(--primary-color);
   }
 }


### PR DESCRIPTION
### Summary:
Ticket: https://app.shortcut.com/czi-edu/story/176514/revisit-hover-background-color-on-plain-variant

There's been some back and forth about the "plain" `Button` variant's hover style. The button has a very light background color, which looks great on white, but it kind of disappears into the light gray background that is commonly used in LP.

![example of plain variant button on a gray background with the hover style visible](https://user-images.githubusercontent.com/7761701/146241888-7ed659d9-f416-49d5-8edb-c99a6fdac278.png)

I talked to Sean and we decided to add a 2px border on the hover style (so it kind of turns into an "outline" variant button but it still has the light background color). I think the hope is that one day we may no longer have these gray backgrounds, but I don't think that day is going to come anytime soon. If it does, we can consider dropping the outline.

### Test Plan:
Navigate to `http://localhost:6008/?path=/story/button--all-variants`,
verify the hover and focus states are updated to have a border that matches the text color,
verify the other states are unchanged,
and specifically make sure that the disabled and active states don't now have a border that's a different color than the background.

### Screenshots
#### Before
<img width="1234" alt="all variants story in storybook, before this change" src="https://user-images.githubusercontent.com/7761701/146242404-2e9baa6b-e69f-407d-9743-0e102e926128.png">

#### After
<img width="1234" alt="all variants story in storybook, after this change" src="https://user-images.githubusercontent.com/7761701/146242425-4282e373-9710-4623-b12c-9a5c617a7a8f.png">
