### PR TITLE
chore(button, link): make dark background stories gray instead

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -12,3 +12,18 @@ export const decorators = [
     </div>
   ),
 ];
+
+export const parameters = {
+  backgrounds: {
+    values: [
+      {
+        name: "gray",
+        value: "#f3f3f3",
+      },
+      {
+        name: "dark",
+        value: "#21272D", // eds-color-neutral-700
+      },
+    ],
+  },
+};

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -8,7 +8,7 @@ import {
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
   getAllVariantsWithStates,
-  getLargeVariantsOnDarkBackgroundWithStates,
+  getLargeVariantsWithStates,
 } from "../storyUtils/clickableStyleUtils";
 import Button from "./button";
 
@@ -79,12 +79,12 @@ export const AllVariants = {
   parameters: gridParameters,
 };
 
-export const LargeVariantsOnDarkBackground = {
-  render: () => getLargeVariantsOnDarkBackgroundWithStates("button", "Button"),
+export const LargeVariantsOnGrayBackground = {
+  render: () => getLargeVariantsWithStates("button", "Button"),
   parameters: {
     ...gridParameters,
     backgrounds: {
-      default: "dark",
+      default: "gray",
     },
   },
 };

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -9,7 +9,7 @@ import {
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
   getAllVariantsWithStates,
-  getLargeVariantsOnDarkBackgroundWithStates,
+  getLargeVariantsWithStates,
 } from "../storyUtils/clickableStyleUtils";
 import Link from "./Link";
 
@@ -104,12 +104,12 @@ export const AllVariants = {
   parameters: gridParameters,
 };
 
-export const LargeVariantsOnDarkBackground = {
-  render: () => getLargeVariantsOnDarkBackgroundWithStates("a", "Link"),
+export const LargeVariantsOnGrayBackground = {
+  render: () => getLargeVariantsWithStates("a", "Link"),
   parameters: {
     ...gridParameters,
     backgrounds: {
-      default: "dark",
+      default: "gray",
     },
   },
 };

--- a/packages/components/src/storyUtils/clickableStyleUtils.tsx
+++ b/packages/components/src/storyUtils/clickableStyleUtils.tsx
@@ -263,7 +263,6 @@ const buttonStates = [...linkStates, "disabled"] as const;
 const getVariantWithStates = (
   tag: "button" | "a",
   variant: ClickableStyleProps<"button">["variant"],
-  headingColor: "white" | "neutral",
   buttonChildren: "Button" | "Link",
   size?: ClickableStyleProps<"button">["size"],
 ) => {
@@ -274,7 +273,7 @@ const getVariantWithStates = (
 
   return (
     <React.Fragment key={variant}>
-      <Heading size="h2" color={headingColor}>
+      <Heading size="h2">
         {variant}
         {size && ` - ${size}`}
       </Heading>
@@ -283,9 +282,7 @@ const getVariantWithStates = (
           {states.map((state) => (
             <tr key={state}>
               <th scope="row">
-                <Text size="body" color={headingColor}>
-                  {state}
-                </Text>
+                <Text size="body">{state}</Text>
               </th>
               {colors.map((color) => (
                 <td key={color} className="p-2">
@@ -322,26 +319,26 @@ export const getAllVariantsWithStates = (
   buttonChildren: "Button" | "Link",
 ) => (
   <ul>
-    <li>{getVariantWithStates(tag, "link", "neutral", buttonChildren)}</li>
+    <li>{getVariantWithStates(tag, "link", buttonChildren)}</li>
     {sizes.map((size) => (
       <li key={size}>
         {variants.map((variant) =>
-          getVariantWithStates(tag, variant, "neutral", buttonChildren, size),
+          getVariantWithStates(tag, variant, buttonChildren, size),
         )}
       </li>
     ))}
   </ul>
 );
 
-export const getLargeVariantsOnDarkBackgroundWithStates = (
+export const getLargeVariantsWithStates = (
   tag: "button" | "a",
   buttonChildren: "Button" | "Link",
 ) => (
   <ul>
-    <li>{getVariantWithStates(tag, "link", "white", buttonChildren)}</li>
+    <li>{getVariantWithStates(tag, "link", buttonChildren)}</li>
     {variants.map((variant) => (
       <li key={variant}>
-        {getVariantWithStates(tag, variant, "white", buttonChildren, "large")}
+        {getVariantWithStates(tag, variant, buttonChildren, "large")}
       </li>
     ))}
   </ul>


### PR DESCRIPTION
### Summary:
The `Button` and `Link` components both have a story that shows all of the variants of the component in one size (large) on a dark background. The reason we added these stories was to make the opacity of the buttons clear – specifically it's obvious when looking at these buttons that the outline variant has a transparent background (which there was some confusion around before). I used the standard "dark" background that comes with storybook because that accomplished the goal.

What I would like to do with this PR is change those stories to use the same gray that LP uses. This way, the stories will still communicate the opacity of the buttons but it will also help us see how well the buttons are working on this gray, which is very common in LP. I think the hope is that one day those gray backgrounds will be removed, but, for now, we have to live with it and these buttons are going to be living on it.

I also added a dark background that uses one of the EDS colors because I imagine it will still come in handy, but now it'll be consistent with the design system.

### Test Plan:
Navigate to `http://localhost:6008/?path=/story/button--large-variants-on-gray-background&globals=backgrounds.value:transparent` and `http://localhost:6008/?path=/story/link--large-variants-on-gray-background&globals=backgrounds.value:transparent`,
verify the background is now LP gray with dark text headings and labels,
verify you can still pick a dark background from the toolbar,
and verify all the other stories still have white backgrounds.

### Screenshots:
#### Before
![The Link component's large variants on dark background, before this change](https://user-images.githubusercontent.com/7761701/146255256-72db5279-8847-43f6-a614-11358a4cd5e8.png)

#### After
![The Link component's large variants on gray background, after this change](https://user-images.githubusercontent.com/7761701/146255265-d88fbf7b-2a05-48a7-b97d-9f36417f9a0b.png)
