### PR TITLE
chore(close-button): add forwardRef, test file

### DIFF
--- a/packages/components/src/common/CloseButton/CloseButton.spec.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.spec.tsx
@@ -1,0 +1,20 @@
+import { generateSnapshots } from "@chanzuckerberg/story-utils";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import CloseButton from "./CloseButton";
+import * as CloseButtonStoryFile from "./CloseButton.stories";
+
+describe("<CloseButton />", () => {
+  generateSnapshots(CloseButtonStoryFile);
+
+  it("forwards refs", () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<CloseButton ref={ref} onClose={() => console.log("closing...")} />);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ref.current!.focus();
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveFocus();
+  });
+});

--- a/packages/components/src/common/CloseButton/CloseButton.tsx
+++ b/packages/components/src/common/CloseButton/CloseButton.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import React from "react";
+import React, { forwardRef } from "react";
 import Button from "../../Button";
 import CloseRoundedIcon from "../../Icons/CloseRounded";
 import styles from "./CloseButton.module.css";
@@ -10,7 +10,7 @@ type CloseButtonProps = {
   /**
    * The color theme of the icon. Also affects the hover state.
    */
-  color: Variant;
+  color?: Variant;
   /**
    * Size of the icon. Does not affect actual button size. The button is larger than the
    * icon to ensure the hit box is large enough (for accessibility).
@@ -31,32 +31,39 @@ type CloseButtonProps = {
 /**
  * Generic close button.
  */
-const CloseButton = ({
-  className,
-  color = "neutral",
-  onClose,
-  size = "2rem",
-  "aria-label": ariaLabel = "close",
-  ...rest
-}: CloseButtonProps) => (
-  <Button
-    className={clsx(
-      styles.button,
+const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
+  (
+    {
       className,
-      // Color props
-      color === "brand" && styles.colorBrand,
-      color === "neutral" && styles.colorNeutral,
-      color === "success" && styles.colorSuccess,
-      color === "warning" && styles.colorWarning,
-      color === "alert" && styles.colorAlert,
-    )}
-    color={color}
-    onClick={onClose}
-    variant="link"
-    {...rest}
-  >
-    <CloseRoundedIcon purpose="informative" size={size} title={ariaLabel} />
-  </Button>
+      color = "neutral",
+      onClose,
+      size = "2rem",
+      "aria-label": ariaLabel = "close",
+      ...rest
+    },
+    ref,
+  ) => (
+    <Button
+      className={clsx(
+        styles.button,
+        className,
+        // Color props
+        color === "brand" && styles.colorBrand,
+        color === "neutral" && styles.colorNeutral,
+        color === "success" && styles.colorSuccess,
+        color === "warning" && styles.colorWarning,
+        color === "alert" && styles.colorAlert,
+      )}
+      color={color}
+      onClick={onClose}
+      variant="link"
+      ref={ref}
+      {...rest}
+    >
+      <CloseRoundedIcon purpose="informative" size={size} title={ariaLabel} />
+    </Button>
+  ),
 );
+CloseButton.displayName = "CloseButton";
 
 export default CloseButton;

--- a/packages/components/src/common/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
+++ b/packages/components/src/common/CloseButton/__snapshots__/CloseButton.spec.tsx.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<CloseButton /> CustomAriaLabel story renders snapshot 1`] = `
+<button
+  class="button colorBrand button variantLink colorBrand"
+  type="button"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    height="2rem"
+    role="img"
+    style="--svg-icon-size: 2rem;"
+    viewBox="0 0 24 24"
+    width="2rem"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      close modal
+    </title>
+    <path
+      d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`<CloseButton /> Default story renders snapshot 1`] = `
+<button
+  class="button colorBrand button variantLink colorBrand"
+  type="button"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    height="2rem"
+    role="img"
+    style="--svg-icon-size: 2rem;"
+    viewBox="0 0 24 24"
+    width="2rem"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      close
+    </title>
+    <path
+      d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`<CloseButton /> DifferentColor story renders snapshot 1`] = `
+<button
+  class="button colorAlert button variantLink colorAlert"
+  type="button"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    height="2rem"
+    role="img"
+    style="--svg-icon-size: 2rem;"
+    viewBox="0 0 24 24"
+    width="2rem"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      close
+    </title>
+    <path
+      d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+    />
+  </svg>
+</button>
+`;
+
+exports[`<CloseButton /> SmallerSize story renders snapshot 1`] = `
+<button
+  class="button colorBrand button variantLink colorBrand"
+  type="button"
+>
+  <svg
+    class="svgIcon"
+    fill="currentColor"
+    height="1rem"
+    role="img"
+    style="--svg-icon-size: 1rem;"
+    viewBox="0 0 24 24"
+    width="1rem"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title>
+      close
+    </title>
+    <path
+      d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
+    />
+  </svg>
+</button>
+`;


### PR DESCRIPTION
### Summary:
Part of https://app.shortcut.com/czi-edu/story/176519/modal-follow-ups

While working on the `Modal` component in LP, I've been thinking about how multi-step modals will need to manually set focus on the first interactive element in the modal when the user moves to a different step. We set focus using refs, but the `CloseButton` doesn't actually support forwarding refs atm, so this PR adds that functionality.

I wanted to add a test to verify that the ref was properly being forwarded, and I realized I never added a spec file for this component (???), so I added that while I was in here.

Next up: I'm going to move the `CloseButton` out of `/common` since we now expect it will be used in LP outside of EDS components.

### Test Plan:
Verify automated tests pass.