### PR TITLE
Remove build matrix for Node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,17 +5,12 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install Dependencies ⬆️
@@ -32,17 +27,12 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install Dependencies ⬆️
@@ -53,11 +43,6 @@ jobs:
 
   storybook:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -77,20 +62,15 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
-
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 16.x
           cache: 'yarn'
 
       - name: Install Dependencies ⬆️


### PR DESCRIPTION
### Summary:

Remove build matrix for Node versions.

Testing this repo on different versions of Node isn't meaningful. The Node version isn't the thing that will make these tests fail or pass. More relevant would be something like operating system.

This PR simplifies things a bit, and has the side benefit of meaning things like #767 don't have to update the branch protection rules to get required checks working right.

If/when approved, I'll update the branch protection rules and the 14.x checks will no longer show up as required.

### Test Plan:

- CI
