### PR TITLE
chore: extend props for Text and Heading

### DIFF
--- a/packages/components/src/Heading/Heading.tsx
+++ b/packages/components/src/Heading/Heading.tsx
@@ -20,7 +20,7 @@ type Props = {
   spacing?: TypographyProps<HeadingElement>["spacing"];
   tabIndex?: number;
   weight?: TypographyProps<HeadingElement>["weight"];
-};
+} & React.HTMLAttributes<HTMLHeadingElement>;
 
 const Heading = forwardRef<HTMLElement, Props>(
   (

--- a/packages/components/src/Text/Text.tsx
+++ b/packages/components/src/Text/Text.tsx
@@ -16,7 +16,7 @@ type Props = {
   spacing?: TypographyProps<TextElement>["spacing"];
   tabIndex?: number;
   weight?: TypographyProps<TextElement>["weight"];
-};
+} & React.HTMLAttributes<HTMLElement>;
 
 const Text = forwardRef<HTMLElement, Props>(
   (


### PR DESCRIPTION
[sc-66248]

### Summary:
- extends Heading props to have html heading attributes
- extends Text props to have global html attributes

### Test Plan:
- no typescript complaints when html attributes exist

Previously:
![previousTextTyping](https://user-images.githubusercontent.com/86632227/150449306-6e053a60-0795-463a-be32-a07bf1c3031a.png)
![previousHeading](https://user-images.githubusercontent.com/86632227/150449340-24fee653-93b3-44ac-a02b-73bc5fdfcba8.png)

Now no errors:
![textTyping](https://user-images.githubusercontent.com/86632227/150449325-16cca1c4-dbb0-4922-a949-cd0200f18460.png)
![typedHeading](https://user-images.githubusercontent.com/86632227/150449335-ae8aef7c-d2be-4509-b164-f2c0479801c7.png)

