### PR TITLE
RFC: Auto-generate story titles

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ["../src", "../docs"],
+  stories: ["../docs", "../src"],
   addons: [
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",

--- a/packages/components/.storybook/manager.js
+++ b/packages/components/.storybook/manager.js
@@ -1,0 +1,11 @@
+import { addons } from "@storybook/addons"; // eslint-disable-line import/no-extraneous-dependencies
+
+addons.setConfig({
+  sidebar: {
+    // Show top-level directories (under components/src) as directories instead of separate
+    // sections. It's a little nicer seeing them as directories instead of their own sections.
+    // We only need this when auto-generating story titles. If we supply our own titles, we should
+    // delete this config.
+    showRoots: false,
+  },
+});

--- a/packages/components/src/Banner/Banner.stories.tsx
+++ b/packages/components/src/Banner/Banner.stories.tsx
@@ -5,7 +5,6 @@ import Heading from "../Heading";
 import Banner from "./Banner";
 
 export default {
-  title: "Banner",
   component: Banner,
   argTypes: {
     elevation: {

--- a/packages/components/src/Button/button.stories.tsx
+++ b/packages/components/src/Button/button.stories.tsx
@@ -13,7 +13,6 @@ import {
 import Button from "./button";
 
 export default {
-  title: "Button",
   component: Button,
   argTypes: {
     children: {

--- a/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.stories.tsx
@@ -4,7 +4,6 @@ import Button from "../Button";
 import ButtonGroup from "./ButtonGroup";
 
 export default {
-  title: "ButtonGroup",
   component: ButtonGroup,
   args: {
     spacing: "1x" as const,

--- a/packages/components/src/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/Checkbox/Checkbox.stories.tsx
@@ -8,7 +8,6 @@ const defaultArgs = {
 };
 
 export default {
-  title: "Checkbox",
   component: Checkbox,
   args: defaultArgs,
   argTypes: {

--- a/packages/components/src/CloseButton/CloseButton.stories.tsx
+++ b/packages/components/src/CloseButton/CloseButton.stories.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import CloseButton from "./CloseButton";
 
 export default {
-  title: "CloseButton",
   component: CloseButton,
   args: {
     color: "brand",

--- a/packages/components/src/DropdownButton/DropdownButton.stories.tsx
+++ b/packages/components/src/DropdownButton/DropdownButton.stories.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import DropdownButton from "./DropdownButton";
 
 export default {
-  title: "DropdownButton",
   component: DropdownButton,
 };
 

--- a/packages/components/src/FormGroup/FormGroup.stories.tsx
+++ b/packages/components/src/FormGroup/FormGroup.stories.tsx
@@ -4,7 +4,6 @@ import Checkbox from "../Checkbox";
 import FormGroup from "./FormGroup";
 
 export default {
-  title: "FormGroup",
   component: FormGroup,
 };
 

--- a/packages/components/src/Heading/Heading.stories.tsx
+++ b/packages/components/src/Heading/Heading.stories.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import Heading from "./Heading";
 
 export default {
-  title: "Heading",
   component: Heading,
 };
 

--- a/packages/components/src/Link/Link.stories.tsx
+++ b/packages/components/src/Link/Link.stories.tsx
@@ -14,7 +14,6 @@ import {
 import Link from "./Link";
 
 export default {
-  title: "Link",
   component: Link,
   argTypes: {
     children: {

--- a/packages/components/src/SvgIcon/SvgIcon.stories.tsx
+++ b/packages/components/src/SvgIcon/SvgIcon.stories.tsx
@@ -7,7 +7,6 @@ import SvgIcon from "./SvgIcon";
 import styles from "./SvgIcon.stories.module.css";
 
 export default {
-  title: "SvgIcon",
   component: SvgIcon,
 
   argTypes: {

--- a/packages/components/src/Tag/Tag.stories.tsx
+++ b/packages/components/src/Tag/Tag.stories.tsx
@@ -10,7 +10,6 @@ import styles from "./Tag.stories.module.css";
 const colorOptions = Object.keys(stylesByColor) as Color[];
 
 export default {
-  title: "Tag",
   component: Tag,
 
   argTypes: {

--- a/packages/components/src/Text/Text.stories.tsx
+++ b/packages/components/src/Text/Text.stories.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import Text from "./Text";
 
 export default {
-  title: "Text",
   component: Text,
   argTypes: {
     children: {

--- a/packages/components/src/Toast/Toast.stories.tsx
+++ b/packages/components/src/Toast/Toast.stories.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import Toast from "./Toast";
 
 export default {
-  title: "Toast",
   component: Toast,
   argTypes: { onDismiss: { action: "dismissed" } },
   args: {

--- a/packages/components/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/Tooltip/Tooltip.stories.tsx
@@ -18,7 +18,6 @@ const defaultArgs = {
 };
 
 export default {
-  title: "Tooltip",
   component: Tooltip,
   args: defaultArgs,
 } as Meta<Args>;

--- a/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.stories.tsx
+++ b/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.stories.tsx
@@ -12,7 +12,6 @@ import styles from "./NotificationIcon.stories.module.css";
 const variants = Object.keys(variantToIconAssetsMap) as NotificationVariant[];
 
 export default {
-  title: "common/Notifications/NotificationIcon",
   component: NotificationIcon,
 };
 

--- a/plop-templates/Component/Component.stories.tsx.hbs
+++ b/plop-templates/Component/Component.stories.tsx.hbs
@@ -3,7 +3,6 @@ import React from "react";
 import {{pascalCase name}} from "./{{pascalCase name}}";
 
 export default {
-  title: "{{pascalCase name}}",
   component: {{pascalCase name}},
   args: {
     children: "Hello world =^_^=",


### PR DESCRIPTION
As of Storybook 6.4, Storybook can auto-generate story titles for us.

Is this a good idea for us? It means less work for us, and letting the library take care of things it can handle on its own. Having said that, writing titles isn't exactly the most challenging thing.

For example, if we just leave off the `title` from a story file

```diff
export default {
-  title: 'Button',
  component: Button,
}
```

storybook will infer it from the filesystem.

See the results of this, before (manual titles) on the left and after (generated titles) on the right:
<img width="2304" alt="storybook titles" src="https://user-images.githubusercontent.com/2503289/151242237-ab9b6ae7-236b-4236-876a-724713306355.png">

Note that
1. I changed the config so that the typography and tokens docs came first. This isn't related to generating the titles, but felt right.
2. We're now getting an extra level of nesting for each component. Instead of
    ```
    Button
    ┣━ foo
    ┗━ bar
    ```
    this will have
    ```
    📁 Button
    ┗━ Button
       ┣━ foo
       ┗━ bar
    ```
    This happens because the auto-generated titles are getting basically `Directory / ComponentName / all the stories`.

Number 2 could be weird, and let me know if it's too weird.
