### PR TITLE
docs(read-me): change yarn generateFlowtypes to yarn generateFlowTypes

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -59,7 +59,7 @@ and then use them in your React components
 For any component, run
 
 ```bash
-yarn generateFlowtypes <Component>
+yarn generateFlowTypes <Component>
 ```
 
 to get automatically generated flowtypes.


### PR DESCRIPTION
### Summary:
Fixing a typo?

### Test Plan:
- Ran `yarn generateFlowTypes DropdownButton`; verified that worked.
- Tried `yarn generateFlowtypes DropdownButton`; verified that did not work.
- Previewed the read me file; verified it said `yarn generateFlowTypes <Component>`.