### PR TITLE
chore(form-group): add display names to components

### DIFF
--- a/packages/components/src/FormGroup/FormGroup.tsx
+++ b/packages/components/src/FormGroup/FormGroup.tsx
@@ -58,7 +58,7 @@ type ItemsProps = {
 /**
  * Helper sub-component for styling the title at the top of the component.
  */
-const Title = ({
+const Title: React.FC<TitleProps> = ({
   children,
   as: Component = "legend",
   className,
@@ -75,7 +75,11 @@ const Title = ({
 /**
  * Helper sub-component for styling the form elements in the component.
  */
-const Items = ({ children, as: Component = "div", className }: ItemsProps) => {
+const Items: React.FC<ItemsProps> = ({
+  children,
+  as: Component = "div",
+  className,
+}: ItemsProps) => {
   return (
     <Component className={clsx(className, styles.items)}>{children}</Component>
   );
@@ -103,5 +107,9 @@ function FormGroup({
 
 FormGroup.Title = Title;
 FormGroup.Items = Items;
+
+FormGroup.displayName = "FormGroup";
+FormGroup.Title.displayName = "FormGroup.Title";
+FormGroup.Items.displayName = "FormGroup.Items";
 
 export default FormGroup;

--- a/packages/components/src/FormGroup/FormGroup.tsx
+++ b/packages/components/src/FormGroup/FormGroup.tsx
@@ -62,7 +62,7 @@ const Title: React.FC<TitleProps> = ({
   children,
   as: Component = "legend",
   className,
-}: TitleProps) => {
+}) => {
   return (
     <Component className={clsx(className, styles.title)}>
       <Text size="sm" weight="bold">
@@ -79,7 +79,7 @@ const Items: React.FC<ItemsProps> = ({
   children,
   as: Component = "div",
   className,
-}: ItemsProps) => {
+}) => {
   return (
     <Component className={clsx(className, styles.items)}>{children}</Component>
   );


### PR DESCRIPTION
### Summary:
The `FormGroup` component has 2 subcomponents: `Form.Title` and `Form.Items`. But in the `code` feature of the docs tab in storybook, these components are shown as just `Title` and `Items`, which makes it little confusing for devs trying to import and use the component. The solution is to add display names for all three (`FormGroup`, `FormGroup.Title`, and `FormGroup.Items`).

Similar PR for the `Banner` component: https://github.com/chanzuckerberg/edu-design-system/pull/734

### Screenshots
#### Before
<img width="1000" alt="FormGroup component in storybook, before this change" src="https://user-images.githubusercontent.com/7761701/151609270-9143f891-bf22-417b-a027-72f10c0631ce.png">

#### After
<img width="1000" alt="FormGroup component in storybook, after this change" src="https://user-images.githubusercontent.com/7761701/151609294-71e35d27-3818-48a0-af58-100b4dbb124e.png">

### Test Plan:
Manually tested in storybook.