### PR TITLE
Double size limit to 140kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
   "size-limit": [
     {
       "path": "packages/components/lib/**/*([a-zA-Z-_]).js",
-      "limit": "70KB",
+      "limit": "140KB",
       "name": "components",
       "webpack": false
     },
     {
       "path": "packages/components/lib/**/*([a-zA-Z-_]).css",
-      "limit": "70KB",
+      "limit": "140KB",
       "name": "styles",
       "webpack": false
     }


### PR DESCRIPTION
### Summary:

We're now over the 70kb size limit from the size-limit-action. This PR doubles it to 140kb, since it's expected that the package will keep getting bigger.

I'm not sure we should even use this action. But maybe it's nice to get the report on how much size increases per PR.

### Test Plan:

- CI