### PR TITLE
chore(dropdown-button): wrap children in span

### DIFF
--- a/packages/components/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.tsx
@@ -52,7 +52,7 @@ export default function ButtonGroup({
         orientation === "vertical" && styles.vertical,
       )}
     >
-      <>{children}</>
+      {children}
     </div>
   );
 }

--- a/packages/components/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.tsx
@@ -52,7 +52,7 @@ export default function ButtonGroup({
         orientation === "vertical" && styles.vertical,
       )}
     >
-      {children}
+      <>{children}</>
     </div>
   );
 }

--- a/packages/components/src/DropdownButton/DropdownButton.tsx
+++ b/packages/components/src/DropdownButton/DropdownButton.tsx
@@ -19,6 +19,8 @@ const DropdownButton = forwardRef<HTMLButtonElement, Props>(
         ref={ref}
         {...rest}
       >
+        {/* Wrapping span ensures that `children` and icon will be correctly pushed to
+            either side of the button even if `children` contains more than one element. */}
         <span>{children}</span>
         <ExpandMoreRoundedIcon purpose="decorative" size="1.25rem" />
       </button>

--- a/packages/components/src/DropdownButton/DropdownButton.tsx
+++ b/packages/components/src/DropdownButton/DropdownButton.tsx
@@ -19,7 +19,7 @@ const DropdownButton = forwardRef<HTMLButtonElement, Props>(
         ref={ref}
         {...rest}
       >
-        {children}
+        <span>{children}</span>
         <ExpandMoreRoundedIcon purpose="decorative" size="1.25rem" />
       </button>
     );

--- a/packages/components/src/DropdownButton/__snapshots__/DropdownButton.spec.ts.snap
+++ b/packages/components/src/DropdownButton/__snapshots__/DropdownButton.spec.ts.snap
@@ -4,7 +4,9 @@ exports[`<DropdownButton /> Default story renders snapshot 1`] = `
 <button
   class="dropdownButton"
 >
-  Dropdown button
+  <span>
+    Dropdown button
+  </span>
   <svg
     aria-hidden="true"
     class="svgIcon"


### PR DESCRIPTION
### Summary:
Part of https://app.shortcut.com/czi-edu/story/169970/dropdown-api-improvements

Wrapping the `DropdownButton` children in a `<span>` in case label contains more than just text

### Test Plan:
Verify the `<span>` is showing up in the snapshot file for the `DropdownButton` component.