### PR TITLE
chore: remove --only-changed from chromatic github action

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
     "build:styles": "postcss \"src/**/*.css\" --dir lib/ --base src/ --verbose",
     "build:watch": "yarn run build:js --watch",
     "build:storybook": "build-storybook -o storybook-static",
-    "chromatic": "chromatic --only-changed",
+    "chromatic": "chromatic",
     "deploy:docs": "storybook-to-ghpages --ci",
     "prepack": "yarn run build",
     "storybook": "start-storybook -p 6008",

--- a/packages/components/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.tsx
@@ -52,7 +52,7 @@ export default function ButtonGroup({
         orientation === "vertical" && styles.vertical,
       )}
     >
-      <>{children}</>
+      {children}
     </div>
   );
 }

--- a/packages/components/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.tsx
@@ -52,7 +52,7 @@ export default function ButtonGroup({
         orientation === "vertical" && styles.vertical,
       )}
     >
-      {children}
+      <>{children}</>
     </div>
   );
 }


### PR DESCRIPTION
### Summary:
After making a very small change in a component in https://github.com/chanzuckerberg/edu-design-system/pull/832, I hit a chromatic build issue involving our chromatic version and Turbosnap. To unblock development, we can downgrade chromatic or remove the `--only-changed` flag from the chromatic script. We are opting to do the latter.

### Test plan:
Make a change in some component (like adding a fragment or wrapping span or something),
then run `yarn workspace @chanzuckerberg/eds-components chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --output-dir storybook-static --exit-zero-on-changes --skip 'dependabot/**'` (replacing `${{ secrets.CHROMATIC_PROJECT_TOKEN }}` with the actual token, which can be found in chromatic),
and verify you don't get an error.