### PR TITLE
Exit Chromatic once the build is uploaded

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,15 @@ jobs:
         # `--storybook-build-dir` which prevents Chromatic's Storybook build and uses a pre-built Storybook
         # and `--only-changed` which enables Chromatic TurboSnap
         # https://github.com/chromaui/chromatic-cli/issues/403
-        # Once fixed, Storybook build should be its own step for modularity
+        # Once fixed, Storybook build can be its own step for modularity
       - name: Build Storybook and Publish to Chromatic
-        run: yarn workspace @chanzuckerberg/eds-components chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --output-dir storybook-static --exit-zero-on-changes --skip 'dependabot/**'
+        run: |
+          yarn workspace @chanzuckerberg/eds-components chromatic \
+            --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} \
+            --output-dir storybook-static \
+            --exit-zero-on-changes \
+            --exit-once-uploaded \
+            --skip 'dependabot/**'
       - name: Run Accessibility Tests 💛
         run: yarn workspace @chanzuckerberg/eds-components run storybook:axeOnly
 


### PR DESCRIPTION
Exit Chromatic's build step once the Storybook build is uploaded.

Previously this would wait until the build was uploaded AND Chromatic finished processing the build. But there's no reason for the job to wait for all the processing, since the UI Tests step won't be green until that processing is complete (and any diffs are approved).

Making this change should make the build a little more resilient. Long-running Chromatic processing times can still be an issue, but at least they won't cause the upload job to time out.