### PR TITLE
docs: list docs/ stories first

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -1,5 +1,5 @@
 module.exports = {
-  stories: ["../src", "../docs"],
+  stories: ["../docs", "../src"],
   addons: [
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",


### PR DESCRIPTION
### Summary:
https://github.com/chanzuckerberg/edu-design-system/pull/813/files#r793032073 reminded me of this -- we should show the `docs/` pages first so they aren't buried under the components

### Test Plan:
confirmed Tokens & Typography story pages are now shown first:
<img width="223" alt="Screen Shot 2022-02-09 at 4 04 55 PM" src="https://user-images.githubusercontent.com/15840841/153289960-bf41b5b5-59e2-46d6-8d50-ca7b1c8f7c89.png">

