### PR TITLE
chore: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    # dependabot does not work with yarn v2, disabling for now
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore
       include: scope
@@ -12,7 +13,8 @@ updates:
     directory: "/packages/tokens"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    # dependabot does not work with yarn v2, disabling for now
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore
       include: scope
@@ -20,7 +22,8 @@ updates:
     directory: "/packages/components"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    # dependabot does not work with yarn v2, disabling for now
+    open-pull-requests-limit: 0
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
### Summary:
https://app.shortcut.com/czi-edu/story/183913/figure-out-what-to-do-with-dependabot

All dependabot version update PRs fail the build ([example](https://github.com/chanzuckerberg/edu-design-system/runs/5314913517?check_suite_focus=true)) because [dependabot does not support yarn v2](https://github.com/dependabot/dependabot-core/issues/2030)

this turns off the PRs (which we did, and then un-did awhile ago)

### Test Plan:
not sure how to test, I followed https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates#disabling-dependabot-version-updates