### PR TITLE
docs(dropdown): add import example to docstring

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -86,7 +86,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
 
 /**
  * ```ts
- * import {DropdownButton} from "@chanzuckerberg/eds-components";
+ * import {Dropdown} from "@chanzuckerberg/eds-components";
  * ```
  *
  * EDS Dropdown. Used to select one option from a list of options.

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -85,6 +85,10 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
 }
 
 /**
+ * ```ts
+ * import {DropdownButton} from "@chanzuckerberg/eds-components";
+ * ```
+ *
  * EDS Dropdown. Used to select one option from a list of options.
  *
  * Built on top of the Headless UI Listbox: https://headlessui.dev/react/listbox#basic-example


### PR DESCRIPTION
### Summary:
I missed this change to the `Dropdown` component when I copied the code into this codebase.

<img width="1446" alt="dropdown component in storybook with the import line in the docstring" src="https://user-images.githubusercontent.com/7761701/156060584-5604295b-9f4e-4183-9a46-cf678d113de3.png">

### Test Plan:
Verify the import example appears in storybook for the `Dropdown` component in the same way that it appears for other ones.