### PR TITLE
chore(dropdown): use key instead of id in options

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.spec.tsx
+++ b/packages/components/src/Dropdown/Dropdown.spec.tsx
@@ -11,15 +11,15 @@ const OpenByDefaultComponent = composeStory(OpenByDefault, stories.default);
 
 const exampleOptions = [
   {
-    id: "option1",
+    key: "1",
     label: "Option 1",
   },
   {
-    id: "option2",
+    key: "2",
     label: "Option 2",
   },
   {
-    id: "option3",
+    key: "3",
     label: "Option 3",
   },
 ];
@@ -51,7 +51,7 @@ describe("<Dropdown />", () => {
 
         <Dropdown.Options>
           {exampleOptions.map((option) => (
-            <Dropdown.Option key={option.id} value={option}>
+            <Dropdown.Option key={option.key} value={option}>
               {option.label}
             </Dropdown.Option>
           ))}
@@ -76,7 +76,7 @@ describe("<Dropdown />", () => {
 
         <Dropdown.Options>
           {exampleOptions.map((option) => (
-            <Dropdown.Option key={option.id} value={option}>
+            <Dropdown.Option key={option.key} value={option}>
               {option.label}
             </Dropdown.Option>
           ))}
@@ -150,7 +150,7 @@ describe("<Dropdown />", () => {
 
         <Dropdown.Options>
           {exampleOptions.map((option) => (
-            <Dropdown.Option key={option.id} value={option}>
+            <Dropdown.Option key={option.key} value={option}>
               {option.label}
             </Dropdown.Option>
           ))}

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -17,15 +17,15 @@ type Props = {
 
 const exampleOptions = [
   {
-    id: "1",
+    key: "1",
     label: "Dogs",
   },
   {
-    id: "2",
+    key: "2",
     label: "Cats",
   },
   {
-    id: "3",
+    key: "3",
     label: "Birds",
   },
 ];
@@ -66,7 +66,7 @@ function InteractiveExampleUsingChildren(props: Props) {
         <Dropdown.Button>{selectedOption?.label || "Select"}</Dropdown.Button>
         <Dropdown.Options>
           {exampleOptions.map((option) => (
-            <Dropdown.Option key={option.id} value={option}>
+            <Dropdown.Option key={option.key} value={option}>
               {option.label}
             </Dropdown.Option>
           ))}
@@ -114,7 +114,7 @@ function InteractiveExampleUsingFunctionChildren() {
             </Dropdown.Button>
             <Dropdown.Options>
               {exampleOptions.map((option) => (
-                <Dropdown.Option key={option.id} value={option}>
+                <Dropdown.Option key={option.key} value={option}>
                   {option.label}
                 </Dropdown.Option>
               ))}

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -5,8 +5,6 @@ import DropdownButton from "../DropdownButton";
 import CheckRoundedIcon from "../Icons/CheckRounded";
 import styles from "./Dropdown.module.css";
 
-type Option = { id: string; label: string };
-
 type ListboxProps = ComponentProps<typeof Listbox>;
 type DropdownProps = ListboxProps & {
   /**
@@ -42,7 +40,10 @@ type DropdownProps = ListboxProps & {
    * If you pass in `options`, we expect `labelText` (or `aria-label`),
    * and `buttonText` props as well and no `children`.
    */
-  options?: Array<Option>;
+  options?: Array<{
+    key: string | number;
+    label: string;
+  }>;
   /**
    * Optional className for additional styling.
    */
@@ -137,15 +138,15 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * ```
  * const options = [
  *   {
- *     id: 'option1',
+ *     key: 'option1',
  *     label: 'Option 1',
  *   },
  *   {
- *     id: 'option2',
+ *     key: 'option2',
  *     label: 'Option 2',
  *   },
  *   {
- *     id: 'option3',
+ *     key: 'option3',
  *     label: 'Option 3',
  *   },
  * ];
@@ -228,11 +229,14 @@ function Dropdown(props: DropdownProps) {
 
   const optionsList = options && (
     <DropdownOptions>
-      {options.map((option) => (
-        <DropdownOption key={option.id} value={option}>
-          {option.label}
-        </DropdownOption>
-      ))}
+      {options.map((option) => {
+        const { label, ...rest } = option;
+        return (
+          <DropdownOption value={option} {...rest} key={option.key}>
+            {label}
+          </DropdownOption>
+        );
+      })}
     </DropdownOptions>
   );
 


### PR DESCRIPTION
### Summary:
While working on migrating the existing `Dropdown` usage in `traject` to use the new eds component, I realized that the types for the `options` prop is inconsistent with the actual usage. In the stories, we were using `id`, but they're using `key` in the app. Changing the component to be consistent with actual usage will make it easier to use this prop.

### Test Plan:
I published an alpha build (0.8.1-alpha.1), updated `traject` locally to use that build, updated an example dropdown (`PDSearchBar`), and verified the conversion from using `<Dropdown.Options>` to `options` was smooth.