### PR TITLE
test: use .test as extension instead of .spec

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
       "error",
       {
         "devDependencies": [
-          "src/**/*.{spec,test}.{ts,tsx}",
+          "src/**/*.test.{ts,tsx}",
           "src/**/*.stories.{ts,tsx}",
           "**/*.config.{js,ts}",
           "**/*.setup.{js,ts}",
@@ -61,7 +61,7 @@
       }
     },
     {
-      "files": ["*.spec.ts", "*.spec.tsx", "*.test.ts", "*.test.tsx", "**/test/**"],
+      "files": ["*.test.ts", "*.test.tsx", "**/test/**"],
       "plugins": ["jest"],
       "extends": ["plugin:jest/recommended"],
       "env": {

--- a/plop-templates/Component/Component.spec.tsx.hbs
+++ b/plop-templates/Component/Component.spec.tsx.hbs
@@ -1,6 +1,0 @@
-import * as {{pascalCase name}}StoryFile from "./{{pascalCase name}}.stories";
-import { generateSnapshots } from "@chanzuckerberg/story-utils";
-
-describe("<{{pascalCase name}} />", () => {
-  generateSnapshots({{pascalCase name}}StoryFile);
-});

--- a/plop-templates/Component/Component.test.tsx.hbs
+++ b/plop-templates/Component/Component.test.tsx.hbs
@@ -1,0 +1,6 @@
+import {generateSnapshots} from '@chanzuckerberg/story-utils';
+import * as stories from './{{pascalCase name}}.stories';
+
+describe('<{{pascalCase name}} />', () => {
+  generateSnapshots(stories);
+});

--- a/plopfile.js
+++ b/plopfile.js
@@ -28,8 +28,8 @@ module.exports = (plop) => {
       },
       {
         type: 'add',
-        path: 'src/components/{{pascalCase name}}/{{pascalCase name}}.spec.tsx',
-        templateFile: 'plop-templates/Component/Component.spec.tsx.hbs',
+        path: 'src/components/{{pascalCase name}}/{{pascalCase name}}.test.tsx',
+        templateFile: 'plop-templates/Component/Component.test.tsx.hbs',
       },
       {
         type: 'add',


### PR DESCRIPTION
### Summary:

Merging into `next` branch. Drops support for `.spec.ts` extension in favor of `.test.ts` going forward

### Test Plan:
- test file still linted correctly
- `plop` creates test file correctly