### PR TITLE
feat: introduce badges addon for storybook

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -5,6 +5,7 @@ module.exports = {
     "@storybook/addon-a11y",
     "storybook-css-modules-preset",
     "@storybook/addon-interactions",
+    "@geometricpanda/storybook-addon-badges",
     {
       name: "@storybook/addon-postcss",
       options: {

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -3,6 +3,10 @@ import "../src/styles/fonts.css";
 import "../src/styles/global.css";
 import "../src/styles/tailwindUtilities.css";
 
+import {
+  BADGE,
+  defaultBadgesConfig,
+} from "@geometricpanda/storybook-addon-badges";
 import React from "react";
 
 export const decorators = [
@@ -25,5 +29,27 @@ export const parameters = {
         value: "#21272D", // eds-color-neutral-700
       },
     ],
+  },
+  badgesConfig: {
+    deprecated: {
+      ...defaultBadgesConfig[BADGE.DEPRECATED],
+      tooltip: "This component is deprecated, please avoid using it.",
+    },
+    beta: {
+      ...defaultBadgesConfig[BADGE.BETA],
+      tooltip: {
+        title: "This is Beta",
+        desc: "Be ready to receive updates frequently and leave a feedback",
+        links: [
+          { title: "Read more", href: "http://path/to/your/docs" },
+          {
+            title: "Leave feedback",
+            onClick: () => {
+              alert("thanks for the feedback");
+            },
+          },
+        ],
+      },
+    },
   },
 };

--- a/packages/components/docs/badges-addon.stories.tsx
+++ b/packages/components/docs/badges-addon.stories.tsx
@@ -1,0 +1,15 @@
+import { BADGE } from "@geometricpanda/storybook-addon-badges";
+import { StoryObj } from "@storybook/react";
+import React from "react";
+
+const Example = () => <p>Example to show badges addon</p>;
+
+export default {
+  title: "BadgesAddon",
+  component: Example,
+  parameters: {
+    badges: [BADGE.STABLE, BADGE.DEPRECATED, BADGE.BETA],
+  },
+};
+
+export const Default: StoryObj = {};

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,6 +57,7 @@
   "devDependencies": {
     "@chanzuckerberg/axe-storybook-testing": "^5.0.0",
     "@chanzuckerberg/story-utils": "^3.0.4",
+    "@geometricpanda/storybook-addon-badges": "^0.2.1",
     "@storybook/addon-a11y": "^6.4.19",
     "@storybook/addon-essentials": "^6.4.19",
     "@storybook/addon-interactions": "^6.4.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,6 +1579,7 @@ __metadata:
     "@chanzuckerberg/axe-storybook-testing": ^5.0.0
     "@chanzuckerberg/eds-tokens": ^0.9.0
     "@chanzuckerberg/story-utils": ^3.0.4
+    "@geometricpanda/storybook-addon-badges": ^0.2.1
     "@headlessui/react": ^1.4.3
     "@storybook/addon-a11y": ^6.4.19
     "@storybook/addon-essentials": ^6.4.19
@@ -2056,6 +2057,22 @@ __metadata:
   version: 1.1.2
   resolution: "@gar/promisify@npm:1.1.2"
   checksum: d05081e0887a49c178b75ee3067bd6ee086f73c154d121b854fb2e044e8a89cb1cbb6de3a0dd93a519b80f0531fda68b099dd7256205f7fbb3490324342f2217
+  languageName: node
+  linkType: hard
+
+"@geometricpanda/storybook-addon-badges@npm:^0.2.1":
+  version: 0.2.1
+  resolution: "@geometricpanda/storybook-addon-badges@npm:0.2.1"
+  dependencies:
+    react: ^17.0.2
+    react-dom: ^17.0.2
+    react-is: ^17.0.2
+  peerDependencies:
+    "@storybook/addons": ^6.2.9
+    "@storybook/api": ^6.2.9
+    "@storybook/components": ^6.2.9
+    "@storybook/theming": ^6.2.9
+  checksum: a063d91beb9d5a55b26c7db80f3b0806b4d37d8359a722487a6cb510493a20e8b8fd1d45a5314fd80b5f4aaf0bbf556ca284bfa19b709dd353da3ec7b4e82553
   languageName: node
   linkType: hard
 
@@ -17946,6 +17963,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-dom@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react-dom@npm:17.0.2"
+  dependencies:
+    loose-envify: ^1.1.0
+    object-assign: ^4.1.1
+    scheduler: ^0.20.2
+  peerDependencies:
+    react: 17.0.2
+  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+  languageName: node
+  linkType: hard
+
 "react-draggable@npm:^4.4.3":
   version: 4.4.4
   resolution: "react-draggable@npm:4.4.4"
@@ -18144,6 +18174,16 @@ __metadata:
     object-assign: ^4.1.1
     prop-types: ^15.6.2
   checksum: 8484f3ecb13414526f2a7412190575fc134da785c02695eb92bb6028c930bfe1c238d7be2a125088fec663cc7cda0a3623373c46807cf2c281f49c34b79881ac
+  languageName: node
+  linkType: hard
+
+"react@npm:^17.0.2":
+  version: 17.0.2
+  resolution: "react@npm:17.0.2"
+  dependencies:
+    loose-envify: ^1.1.0
+    object-assign: ^4.1.1
+  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
   languageName: node
   linkType: hard
 
@@ -18985,6 +19025,16 @@ __metadata:
     loose-envify: ^1.1.0
     object-assign: ^4.1.1
   checksum: 73e185a59e2ff5aa3609f5b9cb97ddd376f89e1610579d29939d952411ca6eb7a24907a4ea4556569dacb931467a1a4a56d94fe809ef713aa76748642cd96a6c
+  languageName: node
+  linkType: hard
+
+"scheduler@npm:^0.20.2":
+  version: 0.20.2
+  resolution: "scheduler@npm:0.20.2"
+  dependencies:
+    loose-envify: ^1.1.0
+    object-assign: ^4.1.1
+  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary:
- This explores the badges addon for storybook 
![image](https://user-images.githubusercontent.com/86632227/158453545-5cf6669c-7418-4544-b84e-b9b1e5ad81ea.png)
- Can be configured to have simple or more complex tooltips
![image](https://user-images.githubusercontent.com/86632227/158453702-64d14b30-210e-44b9-9a64-f2f87f0366df.png)
![image](https://user-images.githubusercontent.com/86632227/158453758-8964063f-792d-47ff-b4d1-a3ea03984075.png)
- Badges can be configured (color, border, text, etc)
- https://storybook.js.org/addons/@geometricpanda/storybook-addon-badges

### Test Plan:
- Example [story](https://61313967cde49b003ae2a860-fcoxvnsxcz.chromatic.com/?path=/story/badgesaddon--default) to show usage, to be removed before merge?