### PR TITLE
feat: add CloseButton

### DIFF
--- a/src/components/CloseButton/CloseButton.module.css
+++ b/src/components/CloseButton/CloseButton.module.css
@@ -1,0 +1,48 @@
+.close-button {
+  width: var(--eds-size-6);
+  height: var(--eds-size-6);
+  border-radius: 50%;
+
+  svg {
+    /* TODO(Icon): use size prop on Icon after that component is done */
+    height: var(--eds-size-4);
+    width: var(--eds-size-4);
+    /* TODO(Icon): use color prop on Icon after that component is done */
+    fill: var(--close-button-icon-color);
+  }
+
+  &:hover {
+    background-color: var(--close-button-icon-hover-color);
+  
+    /* TODO(Icon): fix after Icon component is done */
+    /* stylelint-disable-next-line max-nesting-depth */
+    svg {
+      fill: var(--eds-theme-color-neutral-bold-foreground-inverted);
+    }
+  }
+}
+
+.close-button--variant-brand {
+  --close-button-icon-color: var(--eds-color-brand-blue-700);
+  --close-button-icon-hover-color: var(--eds-theme-color-primary-foreground);
+}
+
+.close-button--variant-neutral {
+  --close-button-icon-color: var(--eds-theme-color-neutral-md-background-inverted);
+  --close-button-icon-hover-color: var(--eds-theme-color-neutral-md-foreground);
+}
+
+.close-button--variant-success {
+  --close-button-icon-color: var(--eds-theme-color-utility-success-foreground);
+  --close-button-icon-hover-color: var(--eds-color-other-green-600);
+}
+
+.close-button--variant-warning {
+  --close-button-icon-color: var(--eds-theme-color-utility-warning-foreground);
+  --close-button-icon-hover-color: var(--eds-color-other-orange-600);
+}
+
+.close-button--variant-alert {
+  --close-button-icon-color: var(--eds-theme-color-utility-error-foreground);
+  --close-button-icon-hover-color: var(--eds-color-other-red-600);
+}

--- a/src/components/CloseButton/CloseButton.stories.tsx
+++ b/src/components/CloseButton/CloseButton.stories.tsx
@@ -1,0 +1,64 @@
+import { StoryObj } from '@storybook/react';
+import React from 'react';
+import CloseButton from './CloseButton';
+
+export default {
+  title: 'Molecules/Buttons/CloseButton',
+  component: CloseButton,
+  args: {
+    color: 'brand',
+  },
+};
+
+type Args = React.ComponentProps<typeof CloseButton>;
+
+export const Default: StoryObj<Args> = {};
+
+export const Brand: StoryObj<Args> = {
+  ...Default,
+  args: {
+    variant: 'brand',
+  },
+};
+
+export const Success: StoryObj<Args> = {
+  ...Default,
+  args: {
+    variant: 'success',
+  },
+};
+
+export const Alert: StoryObj<Args> = {
+  ...Default,
+  args: {
+    variant: 'alert',
+  },
+};
+
+export const Warninig: StoryObj<Args> = {
+  ...Default,
+  args: {
+    variant: 'warning',
+  },
+};
+
+/* TODO(Icon): uncomment after Icon component is done */
+// export const SmallerSize: StoryObj<Args> = {
+//   ...Default,
+//   args: {
+//     iconSize: '1rem',
+//   },
+// };
+
+export const CustomAriaLabel: StoryObj<Args> = {
+  ...Default,
+  args: {
+    'aria-label': 'close modal',
+  },
+  parameters: {
+    chromatic: {
+      // This story is just for jest snapshot tests.
+      disableSnapshot: true,
+    },
+  },
+};

--- a/src/components/CloseButton/CloseButton.test.tsx
+++ b/src/components/CloseButton/CloseButton.test.tsx
@@ -1,0 +1,22 @@
+// import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import CloseButton from './CloseButton';
+// import * as CloseButtonStoryFile from './CloseButton.stories';
+
+describe('<CloseButton />', () => {
+  // TODO(Icon): uncomment this test and its imports above when Icon component is done
+  // generateSnapshots(CloseButtonStoryFile);
+
+  // TODO(Icon): Unskip this when the Icon component is done
+  it.skip('forwards refs', () => {
+    const ref = React.createRef<HTMLButtonElement>();
+    render(<CloseButton ref={ref} onClose={() => console.log('closing...')} />);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    ref.current!.focus();
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveFocus();
+  });
+});

--- a/src/components/CloseButton/CloseButton.tsx
+++ b/src/components/CloseButton/CloseButton.tsx
@@ -1,0 +1,76 @@
+import clsx from 'clsx';
+import React, { forwardRef } from 'react';
+import styles from './CloseButton.module.css';
+import { Button } from '../Button/Button';
+import { Icon } from '../Icon/Icon';
+
+type CloseButtonProps = {
+  /**
+   * Stylistic variations for the close button type.
+   * - **brand** - results in a blue background color on hover
+   * - **neutral** - results in a gray background color on hover
+   * - **success** - results in a green background color on hover
+   * - **warning** - results in an orange background color on hover
+   * - **alert** - results in a red background color on hover
+   */
+  variant?: 'brand' | 'neutral' | 'success' | 'warning' | 'alert';
+  // TODO(Icon): handle this when the Icon component is done
+  /**
+   * Size of the icon. Does not affect actual button size. The button is larger than the
+   * icon to ensure the hit box is large enough (for accessibility).
+   *
+   * The string should be some number + px, rem, em, vh, etc. Ex: 2rem.
+   * Recommendation: use "EdsSizeLineHeight" tokens from
+   * @chanzuckerberg/eds-tokens/json/variables.json
+   */
+  // iconSize?: string;
+  /**
+   * Custom aria-label. If undefined, "close" will be used.
+   */
+  'aria-label'?: string;
+  onClose: () => void;
+  className?: string;
+};
+
+/**
+ * ```ts
+ * import {CloseButton} from "@chanzuckerberg/eds-components";
+ * ```
+ *
+ * Generic close button.
+ */
+const CloseButton = forwardRef<HTMLButtonElement, CloseButtonProps>(
+  (
+    {
+      className,
+      variant = 'neutral',
+      onClose,
+      // TODO(Icon): handle this when the Icon component is done
+      // iconSize = '2rem',
+      'aria-label': ariaLabel = 'close',
+      ...rest
+    },
+    ref,
+  ) => (
+    <Button
+      className={clsx(
+        styles['close-button'],
+        className,
+        // Variants
+        variant === 'brand' && styles['close-button--variant-brand'],
+        variant === 'neutral' && styles['close-button--variant-neutral'],
+        variant === 'success' && styles['close-button--variant-success'],
+        variant === 'warning' && styles['close-button--variant-warning'],
+        variant === 'alert' && styles['close-button--variant-alert'],
+      )}
+      onClick={onClose}
+      variant="bare"
+      ref={ref}
+      text={<Icon name="x" title={ariaLabel} />}
+      {...rest}
+    />
+  ),
+);
+CloseButton.displayName = 'CloseButton';
+
+export default CloseButton;

--- a/src/components/CloseButton/index.ts
+++ b/src/components/CloseButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CloseButton';


### PR DESCRIPTION
### Summary:
Ticket: https://app.shortcut.com/czi-edu/story/187521/move-closebutton-to-new-architecture
Close button in `main`: https://github.com/chanzuckerberg/edu-design-system/tree/main/packages/components/src/CloseButton

Adding the `CloseButton`. This will be used by the `Banner` and `Toast` in EDS and the `Modal` in `traject` (which will eventually be moved into EDS as well).

Some outstanding issues:
- there's a whole bunch of TODOs in here because I'm handling styles with CSS that we were using `Icon` props for before
- also the tests are broken because jest doesn't like [some syntax in the `Icon` component code](https://github.com/chanzuckerberg/edu-design-system/blob/next/src/components/Icon/Icon.tsx#L67)
- I'm still not sure how we're supposed to handle using color tokens that aren't being used in a `theme` yet. The `Banner`, `Toast`, `CloseButton`, and `NotificationIcon` are designed to go together, so I'm thinking I'll make a new theme tokens file and list them all out in there.

### Test Plan:
Manually tested in storybook.

https://user-images.githubusercontent.com/7761701/159060263-0c212f95-cab9-49dd-8ed7-f61eb436a40e.mp4
