### PR TITLE
feat: add NotificationIcon

### DIFF
--- a/src/components/Utilities/NotificationIcon/NotificationIcon.module.css
+++ b/src/components/Utilities/NotificationIcon/NotificationIcon.module.css
@@ -1,0 +1,48 @@
+/*------------------------------------*\
+    # NOTIFICATION ICON
+\*------------------------------------*/
+
+/* TODO(Icon): update styles to use Icon component props after Icon component is done */
+
+/**
+ * Notification icon
+ */
+.notification-icon {
+  width: var(--eds-size-2-and-half);
+  height: var(--eds-size-2-and-half);
+}
+
+/**
+ * Brand notification icon
+ */
+.notification-icon--brand {
+  fill: var(--eds-color-brand-blue-500);
+}
+
+/**
+ * Neutral notification icon
+ */
+.notification-icon--neutral {
+  fill: var(--eds-color-neutral-500);
+}
+
+/**
+ * Success notification icon
+ */
+.notification-icon--success {
+  fill: var(--eds-color-other-green-500);
+}
+
+/**
+ * Warning notification icon
+ */
+.notification-icon--warning {
+  fill: var(--eds-color-other-orange-500);
+}
+
+/**
+ * Alert notification icon
+ */
+.notification-icon--alert {
+  fill: var(--eds-color-other-red-500);
+}

--- a/src/components/Utilities/NotificationIcon/NotificationIcon.stories.module.css
+++ b/src/components/Utilities/NotificationIcon/NotificationIcon.stories.module.css
@@ -1,0 +1,3 @@
+.variant {
+  margin-bottom: 1rem;
+}

--- a/src/components/Utilities/NotificationIcon/NotificationIcon.stories.tsx
+++ b/src/components/Utilities/NotificationIcon/NotificationIcon.stories.tsx
@@ -1,0 +1,36 @@
+/**
+ * TODO(Banner): Remove these stories when Banner is done because those tests will cover this
+ * component and we don't want this one in storybook since it's not intended to be used outside
+ * of the Banner and Toast.
+ */
+import { StoryObj } from '@storybook/react';
+import * as React from 'react';
+import NotificationIcon, {
+  NotificationVariant,
+  variantToIconAssetsMap,
+} from './NotificationIcon';
+import styles from './NotificationIcon.stories.module.css';
+
+// todo (Andrew): look into getting rid of the `as` cast. The `stylesByColor` object's keys are
+// members of Color. Can TypeScript understand that?
+const variants = Object.keys(variantToIconAssetsMap) as NotificationVariant[];
+
+export default {
+  title: 'Molecules/Messaging/NotificationIcon',
+  component: NotificationIcon,
+};
+
+type Args = React.ComponentProps<typeof NotificationIcon>;
+
+export const ColorVariants: StoryObj<Args> = {
+  render: (args) => (
+    <>
+      {variants.map((variant) => (
+        <div className={styles.variant} key={variant}>
+          {variant}
+          <NotificationIcon {...args} variant={variant} />
+        </div>
+      ))}
+    </>
+  ),
+};

--- a/src/components/Utilities/NotificationIcon/NotificationIcon.tsx
+++ b/src/components/Utilities/NotificationIcon/NotificationIcon.tsx
@@ -1,0 +1,80 @@
+import clsx from 'clsx';
+import * as React from 'react';
+
+import styles from './NotificationIcon.module.css';
+import { Icon } from '../../Icon/Icon';
+
+export type NotificationVariant =
+  | 'brand'
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'alert';
+
+type Props = {
+  /**
+   * Stylistic variations for the NotificationIcon type.
+   * - **brand** - results in a purple check-circle icon
+   * - **neutral** - results in a gray information-circle icon
+   * - **success** - results in a green check-circle icon
+   * - **warning** - results in a yellow exclamation-circle icon
+   * - **alert** - results in a red x-circle icon
+   */
+  variant: NotificationVariant;
+};
+
+// TODO(Icon): Update to use the icons from figma after the Icon component is done:
+//             https://github.com/chanzuckerberg/edu-design-system/blob/main/packages/components/src/common/Notifications/NotificationIcon/NotificationIcon.tsx#L25
+
+export const variantToIconAssetsMap = {
+  brand: {
+    name: 'check-circle',
+    title: 'attention',
+  },
+  neutral: {
+    name: 'information-circle',
+    title: 'notice',
+  },
+  success: {
+    name: 'check-circle',
+    title: 'success',
+  },
+  warning: {
+    name: 'exclamation-circle',
+    title: 'warning',
+  },
+  alert: {
+    name: 'x-circle',
+    title: 'alert',
+  },
+};
+
+/**
+ * An icon that appears in notifcation components (ie Banner and Toast).
+ * This icon communicates the tone of the notification through its image,
+ * color, and title text.
+ */
+export const NotificationIcon = ({ variant }: Props) => {
+  const iconAssets = variantToIconAssetsMap[variant];
+
+  const componentClassName = clsx(
+    // Base styles
+    styles['notification-icon'],
+    // Variants
+    variant === 'neutral' && styles['notification-icon--neutral'],
+    variant === 'brand' && styles['notification-icon--brand'],
+    variant === 'alert' && styles['notification-icon--alert'],
+    variant === 'warning' && styles['notification-icon--warning'],
+    variant === 'success' && styles['notification-icon--success'],
+  );
+
+  return (
+    <Icon
+      className={componentClassName}
+      name={iconAssets.name}
+      title={iconAssets.title}
+    />
+  );
+};
+
+export default NotificationIcon;

--- a/src/components/Utilities/NotificationIcon/index.ts
+++ b/src/components/Utilities/NotificationIcon/index.ts
@@ -1,0 +1,2 @@
+export { default } from './NotificationIcon';
+export type { NotificationVariant } from './NotificationIcon';


### PR DESCRIPTION
### Summary:
Ticket: https://app.shortcut.com/czi-edu/story/187520/move-notificationicon-to-new-architecture
NotificationIcon on `main`: https://github.com/chanzuckerberg/edu-design-system/tree/main/packages/components/src/common/Notifications/NotificationIcon

This adds the `NotificationIcon` that will be used in the `Banner` and `Toast` components. This PR is very similar to https://github.com/chanzuckerberg/edu-design-system/pull/900

Outstanding issues:
- Lots of TODO comments again for the `Icon` component because I'm adding the styles with CSS whereas before we were passing down props and the `Icon` was handling it
- No test file because jest doesn't like [some syntax in the `Icon` component code](https://github.com/chanzuckerberg/edu-design-system/blob/next/src/components/Icon/Icon.tsx#L67)
- I'm still not sure how we're supposed to handle using color tokens that aren't being used in a `theme` yet. The `Banner`, `Toast`, `CloseButton`, and `NotificationIcon` are designed to go together, so I'm thinking I'll make a new theme tokens file and list them all out in there.
- Also, we're probably going to reuse that variant type across some of these components. We used to export it from this component and use it in other places, but I feel like it should be in its own file instead of in a component because the `CloseButton` uses the same type as well and it doesn't rely on this component.

### Test Plan:
Manually tested in storybook. I currently have this component in `Molecules/Messaging`, but since it's a util component and not intended to be consumed externally, I'm planning to remove the `.stories` file when it's been integrated into the `Banner` and `Toast`.

<img width="1086" alt="notification icon in storybook" src="https://user-images.githubusercontent.com/7761701/159078340-c4b3c563-6c4e-4515-8f4c-4d8611e6f97b.png">