### PR TITLE
feat(dropdown): add compact button as option

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.module.css
+++ b/packages/components/src/Dropdown/Dropdown.module.css
@@ -2,6 +2,14 @@
   @apply relative bg-white;
 }
 
+.compact {
+  @apply w-min;
+}
+
+.compact > button {
+  @apply p-1;
+}
+
 .label {
   @apply text-sm text-neutral-500 font-bold mb-1;
 }
@@ -11,7 +19,15 @@
 }
 
 .options {
-  @apply w-full absolute bg-white mt-2 py-2 rounded shadow-2 z-10;
+  @apply absolute bg-white mt-2 py-2 rounded shadow-2 z-10;
+}
+
+.optionsFullWidth {
+  @apply w-full;
+}
+
+.optionsAlignRight {
+  @apply right-0;
 }
 
 .option {

--- a/packages/components/src/Dropdown/Dropdown.module.css
+++ b/packages/components/src/Dropdown/Dropdown.module.css
@@ -2,11 +2,11 @@
   @apply relative bg-white;
 }
 
-.compact {
+.compactDropdown {
   @apply w-min;
 }
 
-.compact > button {
+.compactDropdownButton {
   @apply p-1;
 }
 

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -14,7 +14,7 @@ type Props = {
   "aria-label"?: string;
   labelComponent?: React.ReactNode;
   optionsAlign?: OptionsAlignType;
-  optionsWidth?: string;
+  optionsClassName?: string;
   variant?: VariantType;
 };
 
@@ -34,7 +34,7 @@ const exampleOptions = [
 ];
 
 function InteractiveExampleUsingSeparateProps(props: Props) {
-  const { optionsAlign, optionsWidth, variant } = props;
+  const { optionsAlign, optionsClassName, variant } = props;
   const compact = variant === "compact";
 
   const [selectedOption, setSelectedOption] =
@@ -49,7 +49,7 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
         onChange={setSelectedOption}
         options={exampleOptions}
         optionsAlign={optionsAlign}
-        optionsWidth={optionsWidth}
+        optionsClassName={optionsClassName}
         value={selectedOption}
         variant={variant}
         {...props}
@@ -59,7 +59,7 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
-  const { optionsWidth, variant } = props;
+  const { optionsClassName, variant } = props;
   const compact = variant === "compact";
 
   const [selectedOption, setSelectedOption] =
@@ -72,7 +72,7 @@ function InteractiveExampleUsingChildren(props: Props) {
         className={compact ? "" : "w-60"}
         data-testid="dropdown"
         onChange={setSelectedOption}
-        optionsWidth={optionsWidth}
+        optionsClassName={optionsClassName}
         value={selectedOption}
         variant={variant}
       >
@@ -156,7 +156,7 @@ export const Compact: StoryObj = {
   render: () => (
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
-      optionsWidth="w-96"
+      optionsClassName="w-96"
       variant="compact"
     />
   ),
@@ -167,7 +167,7 @@ export const CompactWithOptionsRightAligned: StoryObj = {
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
       optionsAlign="right"
-      optionsWidth="w-96"
+      optionsClassName="w-96"
       variant="compact"
     />
   ),
@@ -177,7 +177,7 @@ export const SeparateButtonAndMenuWidth: StoryObj = {
   render: () => (
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
-      optionsWidth="w-96"
+      optionsClassName="w-96"
     />
   ),
 };
@@ -200,7 +200,7 @@ export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
-      optionsWidth="w-96"
+      optionsClassName="w-96"
       variant="compact"
     />
   ),

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { StoryObj } from "@storybook/react";
 import { within } from "@storybook/testing-library";
 import React from "react";
 import FilterListRoundedIcon from "../Icons/FilterListRounded";
-import Dropdown, { OptionsAlignType } from "./Dropdown";
+import Dropdown, { OptionsAlignType, VariantType } from "./Dropdown";
 
 export default {
   title: "Dropdown",
@@ -13,9 +13,9 @@ type Props = {
   labelText?: string;
   "aria-label"?: string;
   labelComponent?: React.ReactNode;
-  compact?: boolean;
   optionsAlign?: OptionsAlignType;
   optionsWidth?: string;
+  variant?: VariantType;
 };
 
 const exampleOptions = [
@@ -34,7 +34,8 @@ const exampleOptions = [
 ];
 
 function InteractiveExampleUsingSeparateProps(props: Props) {
-  const { compact, optionsAlign, optionsWidth } = props;
+  const { optionsAlign, optionsWidth, variant } = props;
+  const compact = variant === "compact";
 
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
@@ -44,13 +45,13 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
       <Dropdown
         buttonText={selectedOption?.label || "Select"}
         className={compact ? "" : "w-60"}
-        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
         options={exampleOptions}
         optionsAlign={optionsAlign}
         optionsWidth={optionsWidth}
         value={selectedOption}
+        variant={variant}
         {...props}
       />
     </div>
@@ -58,7 +59,8 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
-  const { compact, optionsWidth } = props;
+  const { optionsWidth, variant } = props;
+  const compact = variant === "compact";
 
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
@@ -68,11 +70,11 @@ function InteractiveExampleUsingChildren(props: Props) {
       <Dropdown
         aria-label={props["aria-label"]}
         className={compact ? "" : "w-60"}
-        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
         optionsWidth={optionsWidth}
         value={selectedOption}
+        variant={variant}
       >
         {props.labelComponent}
         <Dropdown.Button>{selectedOption?.label || "Select"}</Dropdown.Button>
@@ -154,8 +156,8 @@ export const Compact: StoryObj = {
   render: () => (
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
-      compact
       optionsWidth="w-96"
+      variant="compact"
     />
   ),
 };
@@ -164,9 +166,9 @@ export const CompactWithOptionsRightAligned: StoryObj = {
   render: () => (
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
-      compact
       optionsAlign="right"
       optionsWidth="w-96"
+      variant="compact"
     />
   ),
 };
@@ -198,8 +200,8 @@ export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
-      compact
       optionsWidth="w-96"
+      variant="compact"
     />
   ),
 };

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -41,7 +41,7 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
     React.useState<typeof exampleOptions[0]>();
 
   return (
-    <div className={`h-48${optionsAlign === "right" ? " pl-96" : ""}`}>
+    <div className={`h-48${optionsAlign === "right" ? " pl-8" : ""}`}>
       <Dropdown
         buttonText={selectedOption?.label || "Select"}
         className={compact ? "" : "w-60"}
@@ -59,7 +59,7 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
-  const { optionsClassName, variant } = props;
+  const { variant } = props;
   const compact = variant === "compact";
 
   const [selectedOption, setSelectedOption] =
@@ -72,7 +72,6 @@ function InteractiveExampleUsingChildren(props: Props) {
         className={compact ? "" : "w-60"}
         data-testid="dropdown"
         onChange={setSelectedOption}
-        optionsClassName={optionsClassName}
         value={selectedOption}
         variant={variant}
       >
@@ -156,7 +155,6 @@ export const Compact: StoryObj = {
   render: () => (
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
-      optionsClassName="w-96"
       variant="compact"
     />
   ),
@@ -167,7 +165,6 @@ export const CompactWithOptionsRightAligned: StoryObj = {
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
       optionsAlign="right"
-      optionsClassName="w-96"
       variant="compact"
     />
   ),
@@ -200,7 +197,6 @@ export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
-      optionsClassName="w-96"
       variant="compact"
     />
   ),

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { StoryObj } from "@storybook/react";
 import { within } from "@storybook/testing-library";
 import React from "react";
 import FilterListRoundedIcon from "../Icons/FilterListRounded";
-import Dropdown from "./Dropdown";
+import Dropdown, { OptionsAlignType } from "./Dropdown";
 
 export default {
   title: "Dropdown",
@@ -13,6 +13,9 @@ type Props = {
   labelText?: string;
   "aria-label"?: string;
   labelComponent?: React.ReactNode;
+  compact?: boolean;
+  optionsAlign?: OptionsAlignType;
+  optionsWidth?: string;
 };
 
 const exampleOptions = [
@@ -31,17 +34,22 @@ const exampleOptions = [
 ];
 
 function InteractiveExampleUsingSeparateProps(props: Props) {
+  const { compact, optionsAlign, optionsWidth } = props;
+
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
 
   return (
-    <div className="h-48">
+    <div className={`h-48${optionsAlign === "right" ? " pl-96" : ""}`}>
       <Dropdown
         buttonText={selectedOption?.label || "Select"}
-        className="w-60"
+        className={compact ? "" : "w-60"}
+        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
         options={exampleOptions}
+        optionsAlign={optionsAlign}
+        optionsWidth={optionsWidth}
         value={selectedOption}
         {...props}
       />
@@ -50,6 +58,8 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
+  const { compact, optionsWidth } = props;
+
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
 
@@ -57,9 +67,11 @@ function InteractiveExampleUsingChildren(props: Props) {
     <div className="h-48">
       <Dropdown
         aria-label={props["aria-label"]}
-        className="w-60"
+        className={compact ? "" : "w-60"}
+        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
+        optionsWidth={optionsWidth}
         value={selectedOption}
       >
         {props.labelComponent}
@@ -138,6 +150,36 @@ export const DefaultWithoutVisibleLabel: StoryObj = {
   ),
 };
 
+export const Compact: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      compact
+      optionsWidth="w-96"
+    />
+  ),
+};
+
+export const CompactWithOptionsRightAligned: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      compact
+      optionsAlign="right"
+      optionsWidth="w-96"
+    />
+  ),
+};
+
+export const SeparateButtonAndMenuWidth: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      optionsWidth="w-96"
+    />
+  ),
+};
+
 export const UsingChildrenProp: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren
@@ -149,6 +191,16 @@ export const UsingChildrenProp: StoryObj = {
 export const UsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
+  ),
+};
+
+export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingChildren
+      aria-label="Favorite Animal"
+      compact
+      optionsWidth="w-96"
+    />
   ),
 };
 

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -68,6 +68,9 @@ type DropdownProps = ListboxProps & {
   optionsAlign?: OptionsAlignType;
   /**
    * Optional className for additional options menu styling.
+   *
+   * When not using the compact variant, if optionsClassName is provided please
+   * include the width property to define the options menu width.
    */
   optionsClassName?: string;
 };

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -284,7 +284,7 @@ function Dropdown(props: DropdownProps) {
     className: clsx(
       styles.dropdown,
       className,
-      variant === "compact" && styles.compact,
+      variant === "compact" && styles.compactDropdown,
     ),
     // Provide a wrapping <div> element for the dropdown. This is needed so that any props
     // passed directly to this component have a corresponding DOM element to receive them.
@@ -374,6 +374,8 @@ const DropdownTrigger = function (
   props: PropsWithRenderProp<{ disabled: boolean; open: boolean }>,
 ) {
   const { children, className, ...rest } = props;
+  const { compact } = useContext(DropdownContext);
+
   return (
     <Listbox.Button
       // Render as a fragment instead of the default element. We're rendering our own element in
@@ -385,7 +387,11 @@ const DropdownTrigger = function (
       {typeof children === "function" ? (
         children
       ) : (
-        <DropdownButton className={className}>{children}</DropdownButton>
+        <DropdownButton
+          className={clsx(className, compact && styles.compactDropdownButton)}
+        >
+          {children}
+        </DropdownButton>
       )}
     </Listbox.Button>
   );

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ import CheckRoundedIcon from "../Icons/CheckRounded";
 import styles from "./Dropdown.module.css";
 
 export type OptionsAlignType = "left" | "right";
+export type VariantType = "compact" | "full";
 
 type ListboxProps = ComponentProps<typeof Listbox>;
 type DropdownProps = ListboxProps & {
@@ -56,15 +57,13 @@ type DropdownProps = ListboxProps & {
    */
   className?: string;
   /**
-   * Render dropdown button that is only as wide as the content.
+   * The style of the dropdown.
    *
-   * When defining compact dropdown need to provide optionsWidth to
-   * define width of options menu, and optionally provide optionsAlign
-   * if desired to right align to dropdow button.
+   * Compact renders dropdown button that is only as wide as the content.
    */
-  compact?: boolean;
+  variant?: VariantType;
   /**
-   * Align dropdown menu to the left (default) or right of dropdown button
+   * Align dropdown menu to the left (default) or right of dropdown button.
    */
   optionsAlign?: OptionsAlignType;
   /**
@@ -190,7 +189,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * );
  * ```
  *
- * For compact dropdown button, add compact and optionsWidth props to
+ * For compact variant, add variant="compact" and optionsWidth props to
  * <Dropdown>.
  *
  * Examples:
@@ -200,9 +199,9 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * return (
  *   <Dropdown
  *     aria-label="Options"
- *     compact
  *     optionsAlign="right"
  *     optionsWidth="w-96"
+ *     variant="compact"
  *   >
  *     <Dropdown.Options>
  *       <Dropdown.Option>Option 1</Dropdown.Option>
@@ -221,10 +220,10 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * return (
  *   <Dropdown
  *     aria-label="Options"
- *     compact
  *     options={options}
  *     optionsAlign="right"
  *     optionsWidth="w-96"
+ *     variant="compact"
  *   />
  * );
  * ```
@@ -244,10 +243,10 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *   <Dropdown
  *     aria-label="Options"
  *     className="w-60"
- *     compact
  *     options={options}
  *     optionsAlign="right"
  *     optionsWidth="w-96"
+ *     variant="compact"
  *   />
  * );
  * ```
@@ -255,12 +254,12 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
 function Dropdown(props: DropdownProps) {
   const {
     className,
+    variant,
     labelText,
     buttonText,
     options,
     children,
     "aria-label": ariaLabel,
-    compact,
     optionsAlign,
     optionsWidth,
     ...rest
@@ -286,7 +285,11 @@ function Dropdown(props: DropdownProps) {
   }
 
   const sharedProps = {
-    className: clsx(styles.dropdown, className, compact && styles.compact),
+    className: clsx(
+      styles.dropdown,
+      className,
+      variant === "compact" && styles.compact,
+    ),
     // Provide a wrapping <div> element for the dropdown. This is needed so that any props
     // passed directly to this component have a corresponding DOM element to receive them.
     // Otherwise we get an error.

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -287,7 +287,7 @@ function Dropdown(props: DropdownProps) {
     className: clsx(
       styles.dropdown,
       className,
-      variant === "compact" && styles.compactDropdown,
+      compact && styles.compactDropdown,
     ),
     // Provide a wrapping <div> element for the dropdown. This is needed so that any props
     // passed directly to this component have a corresponding DOM element to receive them.
@@ -296,11 +296,15 @@ function Dropdown(props: DropdownProps) {
     ...rest,
   };
 
+  const contextValue = Object.assign(
+    { compact },
+    optionsAlign ? { optionsAlign } : null,
+    optionsClassName ? { optionsClassName } : null,
+  );
+
   if (typeof children === "function") {
     return (
-      <DropdownContext.Provider
-        value={{ compact, optionsAlign, optionsClassName }}
-      >
+      <DropdownContext.Provider value={contextValue}>
         <Listbox
           {...sharedProps}
           // We prefer to pass the aria-label in via an invisible DropdownLabel, but we can't
@@ -342,12 +346,6 @@ function Dropdown(props: DropdownProps) {
       {optionsList}
       {children}
     </>
-  );
-
-  const contextValue = Object.assign(
-    { compact },
-    optionsAlign ? { optionsAlign } : null,
-    optionsClassName ? { optionsClassName } : null,
   );
 
   return (

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -67,10 +67,9 @@ type DropdownProps = ListboxProps & {
    */
   optionsAlign?: OptionsAlignType;
   /**
-   * Render dropdown menu with width (specify using tailwind utility string)
-   * independent of dropdown button width
+   * Optional className for additional options menu styling.
    */
-  optionsWidth?: string;
+  optionsClassName?: string;
 };
 
 type RenderProp<Arg> = (arg: Arg) => ReactNode;
@@ -189,8 +188,8 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * );
  * ```
  *
- * For compact variant, add variant="compact" and optionsWidth props to
- * <Dropdown>.
+ * For compact variant, add variant="compact" and optionsClassName to style
+ * options menu width.
  *
  * Examples:
  *
@@ -200,7 +199,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *   <Dropdown
  *     aria-label="Options"
  *     optionsAlign="right"
- *     optionsWidth="w-96"
+ *     optionsClassName="w-96"
  *     variant="compact"
  *   >
  *     <Dropdown.Options>
@@ -222,15 +221,14 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     aria-label="Options"
  *     options={options}
  *     optionsAlign="right"
- *     optionsWidth="w-96"
+ *     optionsClassName="w-96"
  *     variant="compact"
  *   />
  * );
  * ```
  *
- * For dropdown that differs in button and options menu width, style <Dropdown>
- * with className for the button with and provide optionsWidth for the options
- * menu width.
+ * For dropdown that differs in button and options menu width, style button
+ * width with className and options menu width with optionsClassName.
  *
  * Example:
  *
@@ -245,8 +243,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     className="w-60"
  *     options={options}
  *     optionsAlign="right"
- *     optionsWidth="w-96"
- *     variant="compact"
+ *     optionsClassName="w-96"
  *   />
  * );
  * ```
@@ -261,7 +258,7 @@ function Dropdown(props: DropdownProps) {
     children,
     "aria-label": ariaLabel,
     optionsAlign,
-    optionsWidth,
+    optionsClassName,
     ...rest
   } = props;
 
@@ -299,7 +296,7 @@ function Dropdown(props: DropdownProps) {
 
   if (typeof children === "function") {
     return (
-      <DropdownContext.Provider value={{ optionsAlign, optionsWidth }}>
+      <DropdownContext.Provider value={{ optionsAlign, optionsClassName }}>
         <Listbox
           {...sharedProps}
           // We prefer to pass the aria-label in via an invisible DropdownLabel, but we can't
@@ -322,10 +319,7 @@ function Dropdown(props: DropdownProps) {
   const trigger = buttonText && <DropdownTrigger>{buttonText}</DropdownTrigger>;
 
   const optionsList = options && (
-    <DropdownOptions
-    // optionsAlign={optionsAlign}
-    // optionsWidth={optionsWidth}
-    >
+    <DropdownOptions>
       {options.map((option) => {
         const { label, ...rest } = option;
         return (
@@ -349,7 +343,7 @@ function Dropdown(props: DropdownProps) {
   const contextValue = Object.assign(
     {},
     optionsAlign ? { optionsAlign } : null,
-    optionsWidth ? { optionsWidth } : null,
+    optionsClassName ? { optionsClassName } : null,
   );
 
   return (
@@ -361,7 +355,7 @@ function Dropdown(props: DropdownProps) {
 
 const DropdownContext = React.createContext<{
   optionsAlign?: OptionsAlignType;
-  optionsWidth?: string;
+  optionsClassName?: string;
 }>({});
 
 const DropdownLabel = (props: { className?: string; children: ReactNode }) => {
@@ -399,15 +393,15 @@ const DropdownOptions = function (
   props: PropsWithRenderProp<{ open: boolean }>,
 ) {
   const { className, ...rest } = props;
-  const { optionsAlign, optionsWidth } = useContext(DropdownContext);
+  const { optionsAlign, optionsClassName } = useContext(DropdownContext);
 
   return (
     <Listbox.Options
       className={clsx(
         styles.options,
         className,
-        optionsWidth || styles.optionsFullWidth,
         optionsAlign === "right" && styles.optionsAlignRight,
+        optionsClassName || styles.optionsFullWidth,
       )}
       {...rest}
     />

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -188,8 +188,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * );
  * ```
  *
- * For compact variant, add variant="compact" and optionsClassName to style
- * options menu width.
+ * For compact variant, add variant="compact" and optionally optionsAlign.
  *
  * Examples:
  *
@@ -199,7 +198,6 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *   <Dropdown
  *     aria-label="Options"
  *     optionsAlign="right"
- *     optionsClassName="w-96"
  *     variant="compact"
  *   >
  *     <Dropdown.Options>
@@ -221,7 +219,6 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     aria-label="Options"
  *     options={options}
  *     optionsAlign="right"
- *     optionsClassName="w-96"
  *     variant="compact"
  *   />
  * );
@@ -251,16 +248,18 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
 function Dropdown(props: DropdownProps) {
   const {
     className,
-    variant,
     labelText,
     buttonText,
     options,
     children,
     "aria-label": ariaLabel,
+    variant,
     optionsAlign,
     optionsClassName,
     ...rest
   } = props;
+
+  const compact = variant === "compact";
 
   if (process.env.NODE_ENV !== "production") {
     if (children && [labelText, buttonText, options].some((prop) => !!prop)) {
@@ -296,7 +295,9 @@ function Dropdown(props: DropdownProps) {
 
   if (typeof children === "function") {
     return (
-      <DropdownContext.Provider value={{ optionsAlign, optionsClassName }}>
+      <DropdownContext.Provider
+        value={{ compact, optionsAlign, optionsClassName }}
+      >
         <Listbox
           {...sharedProps}
           // We prefer to pass the aria-label in via an invisible DropdownLabel, but we can't
@@ -341,7 +342,7 @@ function Dropdown(props: DropdownProps) {
   );
 
   const contextValue = Object.assign(
-    {},
+    { compact },
     optionsAlign ? { optionsAlign } : null,
     optionsClassName ? { optionsClassName } : null,
   );
@@ -354,6 +355,7 @@ function Dropdown(props: DropdownProps) {
 }
 
 const DropdownContext = React.createContext<{
+  compact?: boolean;
   optionsAlign?: OptionsAlignType;
   optionsClassName?: string;
 }>({});
@@ -393,7 +395,8 @@ const DropdownOptions = function (
   props: PropsWithRenderProp<{ open: boolean }>,
 ) {
   const { className, ...rest } = props;
-  const { optionsAlign, optionsClassName } = useContext(DropdownContext);
+  const { compact, optionsAlign, optionsClassName } =
+    useContext(DropdownContext);
 
   return (
     <Listbox.Options
@@ -401,7 +404,7 @@ const DropdownOptions = function (
         styles.options,
         className,
         optionsAlign === "right" && styles.optionsAlignRight,
-        optionsClassName || styles.optionsFullWidth,
+        optionsClassName || (!compact && styles.optionsFullWidth),
       )}
       {...rest}
     />

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -41,7 +41,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-13"
     aria-orientation="vertical"
-    class="options w-96"
+    class="options"
     id="headlessui-listbox-options-15"
     role="listbox"
     tabindex="0"
@@ -127,7 +127,7 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
   <ul
     aria-labelledby="headlessui-listbox-label-43"
     aria-orientation="vertical"
-    class="options w-96"
+    class="options"
     id="headlessui-listbox-options-45"
     role="listbox"
     tabindex="0"
@@ -213,7 +213,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
   <ul
     aria-labelledby="headlessui-listbox-label-19"
     aria-orientation="vertical"
-    class="options optionsAlignRight w-96"
+    class="options optionsAlignRight"
     id="headlessui-listbox-options-21"
     role="listbox"
     tabindex="0"

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -1,5 +1,263 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Dropdown /> Compact story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-13"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-15"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
+    class="dropdownButton"
+    id="headlessui-listbox-button-14"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-13"
+    aria-orientation="vertical"
+    class="options w-96"
+    id="headlessui-listbox-options-15"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-16"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-17"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-18"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-43"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-45"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-43 headlessui-listbox-button-44"
+    class="dropdownButton"
+    id="headlessui-listbox-button-44"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-43"
+    aria-orientation="vertical"
+    class="options w-96"
+    id="headlessui-listbox-options-45"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-46"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-47"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-48"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-19"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-21"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
+    class="dropdownButton"
+    id="headlessui-listbox-button-20"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-19"
+    aria-orientation="vertical"
+    class="options w-96 optionsAlignRight"
+    id="headlessui-listbox-options-21"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-22"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-23"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-24"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
@@ -41,7 +299,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-1"
     aria-orientation="vertical"
-    class="options"
+    class="options optionsFullWidth"
     id="headlessui-listbox-options-3"
     role="listbox"
     tabindex="0"
@@ -127,7 +385,7 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-7"
     aria-orientation="vertical"
-    class="options"
+    class="options optionsFullWidth"
     id="headlessui-listbox-options-9"
     role="listbox"
     tabindex="0"
@@ -172,24 +430,24 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
+exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
   data-testid="dropdown"
 >
   <label
-    class="label"
-    id="headlessui-listbox-label-13"
+    class="label srOnly"
+    id="headlessui-listbox-label-25"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-15"
+    aria-controls="headlessui-listbox-options-27"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
+    aria-labelledby="headlessui-listbox-label-25 headlessui-listbox-button-26"
     class="dropdownButton"
-    id="headlessui-listbox-button-14"
+    id="headlessui-listbox-button-26"
     type="button"
   >
     <span>
@@ -211,16 +469,16 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-label-13"
+    aria-labelledby="headlessui-listbox-label-25"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-15"
+    class="options w-96"
+    id="headlessui-listbox-options-27"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-16"
+      id="headlessui-listbox-option-28"
       role="option"
       tabindex="-1"
     >
@@ -232,7 +490,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-17"
+      id="headlessui-listbox-option-29"
       role="option"
       tabindex="-1"
     >
@@ -244,7 +502,93 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-18"
+      id="headlessui-listbox-option-30"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
+<div
+  class="dropdown w-60"
+  data-testid="dropdown"
+>
+  <label
+    class="label"
+    id="headlessui-listbox-label-31"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-33"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-31 headlessui-listbox-button-32"
+    class="dropdownButton"
+    id="headlessui-listbox-button-32"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-31"
+    aria-orientation="vertical"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-33"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-34"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-35"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-36"
       role="option"
       tabindex="-1"
     >
@@ -265,17 +609,17 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
 >
   <label
     class="label srOnly"
-    id="headlessui-listbox-label-19"
+    id="headlessui-listbox-label-37"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-21"
+    aria-controls="headlessui-listbox-options-39"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
+    aria-labelledby="headlessui-listbox-label-37 headlessui-listbox-button-38"
     class="dropdownButton"
-    id="headlessui-listbox-button-20"
+    id="headlessui-listbox-button-38"
     type="button"
   >
     <span>
@@ -297,16 +641,16 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-label-19"
+    aria-labelledby="headlessui-listbox-label-37"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-21"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-39"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-22"
+      id="headlessui-listbox-option-40"
       role="option"
       tabindex="-1"
     >
@@ -318,7 +662,7 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-23"
+      id="headlessui-listbox-option-41"
       role="option"
       tabindex="-1"
     >
@@ -330,7 +674,7 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-24"
+      id="headlessui-listbox-option-42"
       role="option"
       tabindex="-1"
     >
@@ -351,11 +695,11 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-26"
+    aria-controls="headlessui-listbox-options-50"
     aria-expanded="true"
     aria-haspopup="true"
     class="p-4 rounded-md border border-neutral-300"
-    id="headlessui-listbox-button-25"
+    id="headlessui-listbox-button-49"
     type="button"
   >
     Select
@@ -372,16 +716,16 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-button-25"
+    aria-labelledby="headlessui-listbox-button-49"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-26"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-50"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-27"
+      id="headlessui-listbox-option-51"
       role="option"
       tabindex="-1"
     >
@@ -393,7 +737,7 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-28"
+      id="headlessui-listbox-option-52"
       role="option"
       tabindex="-1"
     >
@@ -405,7 +749,7 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-29"
+      id="headlessui-listbox-option-53"
       role="option"
       tabindex="-1"
     >
@@ -426,17 +770,17 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
 >
   <label
     class="label"
-    id="headlessui-listbox-label-30"
+    id="headlessui-listbox-label-54"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-32"
+    aria-controls="headlessui-listbox-options-56"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-30 headlessui-listbox-button-31"
+    aria-labelledby="headlessui-listbox-label-54 headlessui-listbox-button-55"
     class="dropdownButton"
-    id="headlessui-listbox-button-31"
+    id="headlessui-listbox-button-55"
     type="button"
   >
     <span>
@@ -458,17 +802,17 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     </svg>
   </button>
   <ul
-    aria-activedescendant="headlessui-listbox-option-37"
-    aria-labelledby="headlessui-listbox-label-30"
+    aria-activedescendant="headlessui-listbox-option-61"
+    aria-labelledby="headlessui-listbox-label-54"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-32"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-56"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-36"
+      id="headlessui-listbox-option-60"
       role="option"
       tabindex="-1"
     >
@@ -481,7 +825,7 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     <li
       aria-selected="true"
       class="option optionActive optionSelected"
-      id="headlessui-listbox-option-37"
+      id="headlessui-listbox-option-61"
       role="option"
       tabindex="-1"
     >
@@ -511,7 +855,7 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-38"
+      id="headlessui-listbox-option-62"
       role="option"
       tabindex="-1"
     >

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Dropdown /> Compact story renders snapshot 1`] = `
 <div
-  class="dropdown compact"
+  class="dropdown compactDropdown"
   data-testid="dropdown"
 >
   <label
@@ -16,7 +16,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
     aria-expanded="true"
     aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
-    class="dropdownButton"
+    class="dropdownButton compactDropdownButton"
     id="headlessui-listbox-button-14"
     type="button"
   >
@@ -88,7 +88,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
 
 exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders snapshot 1`] = `
 <div
-  class="dropdown compact"
+  class="dropdown compactDropdown"
   data-testid="dropdown"
 >
   <label
@@ -102,7 +102,7 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
     aria-expanded="true"
     aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-43 headlessui-listbox-button-44"
-    class="dropdownButton"
+    class="dropdownButton compactDropdownButton"
     id="headlessui-listbox-button-44"
     type="button"
   >
@@ -174,7 +174,7 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
 
 exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] = `
 <div
-  class="dropdown compact"
+  class="dropdown compactDropdown"
   data-testid="dropdown"
 >
   <label
@@ -188,7 +188,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
     aria-expanded="true"
     aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
-    class="dropdownButton"
+    class="dropdownButton compactDropdownButton"
     id="headlessui-listbox-button-20"
     type="button"
   >

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -213,7 +213,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
   <ul
     aria-labelledby="headlessui-listbox-label-19"
     aria-orientation="vertical"
-    class="options w-96 optionsAlignRight"
+    class="options optionsAlignRight w-96"
     id="headlessui-listbox-options-21"
     role="listbox"
     tabindex="0"


### PR DESCRIPTION
### Summary:

Addresses: https://app.shortcut.com/czi-edu/story/189746/notebook-c3-compact-mode-variant-for-eds-drop-down

This PR adds compact variant to EDS drop-down:

- Dropdown button is only as large as content requires
- Dropdown can have differing button width and options menu width
- Dropdown menu has wider width to accomodate
- Dropdown menu can be right aligned to the button

<img width="300" alt="Screen Shot 2022-03-19 at 6 43 49 PM" src="https://user-images.githubusercontent.com/40640760/159144484-9f5d2a77-d183-4936-9818-f42d56a48cfc.png">

Alternative approaches considered:
1. Using CSS var to defined and pass width
```
.compact > .options {
  width: var(--eds-dropdown-options-width);
}
```
2. Passing ref back to caller to style options menu width

### Test Plan:

See storybook for Dropdown component:
1. Compact
2. Compact With Options Right Aligned
3. Separate Button And Menu Width
4. Compact Using Children Prop And No Visible Label