### PR TITLE
chore(list detail): adding variants

### DIFF
--- a/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
@@ -10,5 +10,5 @@ export default {
 
 const Template: Story<Props> = (args) => <ProjectOverview {...args} />;
 
-export const Default = Template.bind({});
-Default.args = {};
+export const StudentView = Template.bind({});
+StudentView.args = {};

--- a/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
@@ -12,8 +12,3 @@ const Template: Story<Props> = (args) => <ProjectOverview {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {};
-
-export const Sequence = Template.bind({});
-Sequence.args = {
-  listVariant: 'sequence'
-}

--- a/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
@@ -10,5 +10,10 @@ export default {
 
 const Template: Story<Props> = (args) => <ProjectOverview {...args} />;
 
-export const StudentView = Template.bind({});
-StudentView.args = {};
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Sequence = Template.bind({});
+Sequence.args = {
+  listVariant: 'sequence'
+}

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -1,98 +1,133 @@
 import React from 'react';
 
-import { PageHeader, TextPassage, ListDetail, ListDetailPanel, Breadcrumbs, BreadcrumbsItem, Button, Hr } from '../../../src';
+import {
+  PageHeader,
+  TextPassage,
+  ListDetail,
+  ListDetailPanel,
+  Breadcrumbs,
+  BreadcrumbsItem,
+  Button,
+  Hr,
+} from '../../../src';
 
 import { PageShell } from '../../recipes/PageShell/PageShell';
 
-export const ProjectOverview: React.FC = () => (
-  <PageShell>
-    <Breadcrumbs>
-    <BreadcrumbsItem text="My Courses" href="#" />
-    <BreadcrumbsItem text="Disciplinary Science 7" />
-  </Breadcrumbs>
-    <PageHeader 
-    title="Feudal Honor Codes and Values"
-    right={
-      <Button text="View plan" variant="bare" iconPosition="after" iconName="arrow-narrow-right" />
-    }
-     />
-     <ListDetail>
-	  <ListDetailPanel title="Overview" variant="success">
-    <div>List Detail Component</div>
-        <div className="fpo">Heading</div>
-        <div className="fpo">Text Passage large</div>
-        <div className="fpo">See more component (truncated text)</div>
-        <div className="fpo">Heading</div>
-        <div className="fpo">List component (Could include numbers/Q for question)</div>
-        <Hr />
-        <div className="fpo">
-          <div>Section title with image in front (Power Focus Areas)</div>
-          <div className="fpo">Tooltip (up for discussion)</div>
-          <div className="fpo">Hoverable/Linkable Card Recipe (naming TBD)</div>
-        </div>
-        <div className="fpo">
-          <div>Section title with image in front (Additional Focus Areas)</div>
+export interface Props {
+  /*
+   * Variant
+   * 1) Argument that gets passed to ListDetail Component for stylistic variant
+   */
+  listVariant?: 'sequence';
+}
+
+export const ProjectOverview: React.FC<Props> = ({...args}) => {
+  return (
+    <PageShell>
+      <Breadcrumbs>
+        <BreadcrumbsItem text="My Courses" href="#" />
+        <BreadcrumbsItem text="Disciplinary Science 7" />
+      </Breadcrumbs>
+      <PageHeader
+        title="Feudal Honor Codes and Values"
+        right={
+          <Button
+            text="View plan"
+            variant="bare"
+            iconPosition="after"
+            iconName="arrow-narrow-right"
+          />
+        }
+      />
+      <ListDetail variant={args.listVariant}>
+        <ListDetailPanel title="Overview" variant="success">
+          <div>List Detail Component</div>
+          <div className="fpo">Heading</div>
+          <div className="fpo">Text Passage large</div>
+          <div className="fpo">See more component (truncated text)</div>
+          <div className="fpo">Heading</div>
           <div className="fpo">
-            <div>Hoverable/Linkable Card Recipe (naming TBD)</div>
-            <div className="fpo">Badge? Status badge?</div>
+            List component (Could include numbers/Q for question)
+          </div>
+          <Hr />
+          <div className="fpo">
+            <div>Section title with image in front (Power Focus Areas)</div>
+            <div className="fpo">Tooltip (up for discussion)</div>
+            <div className="fpo">
+              Hoverable/Linkable Card Recipe (naming TBD)
+            </div>
           </div>
           <div className="fpo">
-            <div>Hoverable/Linkable Card Recipe (naming TBD)</div>
-            <div className="fpo">Badge? Status badge?</div>
+            <div>
+              Section title with image in front (Additional Focus Areas)
+            </div>
+            <div className="fpo">
+              <div>Hoverable/Linkable Card Recipe (naming TBD)</div>
+              <div className="fpo">Badge? Status badge?</div>
+            </div>
+            <div className="fpo">
+              <div>Hoverable/Linkable Card Recipe (naming TBD)</div>
+              <div className="fpo">Badge? Status badge?</div>
+            </div>
           </div>
-        </div>
-        <div className="fpo">
-          <div>Cognitive skills (smaller section title than ones above)</div>
-          <div className="fpo">Text passage with links?</div>
-        </div>
-	  </ListDetailPanel>
-  
-	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan and Wars of 5th Century" variant="warning">
-		<TextPassage>
-		  <h3>ListDetailPanel 2</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-  
-	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan" variant="error">
-		<TextPassage>
-		  <h3>ListDetailPanel 3</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-    <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
-		<TextPassage>
-		  <h3>ListDetailPanel 4</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-    <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
-		<TextPassage>
-		  <h3>ListDetailPanel 5</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-	</ListDetail>
-  
-  </PageShell>
-);
+          <div className="fpo">
+            <div>Cognitive skills (smaller section title than ones above)</div>
+            <div className="fpo">Text passage with links?</div>
+          </div>
+        </ListDetailPanel>
+
+        <ListDetailPanel
+          title="Expectations of Samuri in Feudal Japan and Wars of 5th Century"
+          variant="warning"
+        >
+          <TextPassage>
+            <h3>ListDetailPanel 2</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex{' '}
+            </p>
+          </TextPassage>
+        </ListDetailPanel>
+
+        <ListDetailPanel
+          title="Expectations of Samuri in Feudal Japan"
+          variant="error"
+        >
+          <TextPassage>
+            <h3>ListDetailPanel 3</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex{' '}
+            </p>
+          </TextPassage>
+        </ListDetailPanel>
+        <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
+          <TextPassage>
+            <h3>ListDetailPanel 4</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex{' '}
+            </p>
+          </TextPassage>
+        </ListDetailPanel>
+        <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
+          <TextPassage>
+            <h3>ListDetailPanel 5</h3>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
+              enim ad minim veniam, quis nostrud exercitation ullamco laboris
+              nisi ut aliquip ex{' '}
+            </p>
+          </TextPassage>
+        </ListDetailPanel>
+      </ListDetail>
+    </PageShell>
+  );
+};

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -18,7 +18,7 @@ export interface Props {
    * Variant
    * 1) Argument that gets passed to ListDetail Component for stylistic variant
    */
-  listVariant?: 'sequence';
+  listVariant?: 'ordered';
 }
 
 export const ProjectOverview: React.FC<Props> = ({...args}) => {

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -105,7 +105,7 @@ export const ProjectOverview: React.FC<Props> = ({...args}) => {
             </p>
           </TextPassage>
         </ListDetailPanel>
-        <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
+        <ListDetailPanel title="Expectations of Samuri in Feudal Japan" variant="number">
           <TextPassage>
             <h3>ListDetailPanel 4</h3>
             <p>

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -47,7 +47,7 @@ export const ProjectOverview: React.FC = () => (
         </div>
 	  </ListDetailPanel>
   
-	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan and Wars of 5th Century">
+	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan and Wars of 5th Century" variant="warning">
 		<TextPassage>
 		  <h3>ListDetailPanel 2</h3>
 		  <p>
@@ -59,7 +59,7 @@ export const ProjectOverview: React.FC = () => (
 		</TextPassage>
 	  </ListDetailPanel>
   
-	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan">
+	  <ListDetailPanel title="Expectations of Samuri in Feudal Japan" variant="error">
 		<TextPassage>
 		  <h3>ListDetailPanel 3</h3>
 		  <p>

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -21,7 +21,7 @@ export interface Props {
   listVariant?: 'ordered';
 }
 
-export const ProjectOverview: React.FC<Props> = ({...args}) => {
+export const ProjectOverview: React.FC<Props> = ({ ...args }) => {
   return (
     <PageShell>
       <Breadcrumbs>
@@ -39,7 +39,7 @@ export const ProjectOverview: React.FC<Props> = ({...args}) => {
           />
         }
       />
-      <ListDetail variant={args.listVariant}>
+      <ListDetail variant="ordered">
         <ListDetailPanel title="Overview" variant="success">
           <div>List Detail Component</div>
           <div className="fpo">Heading</div>
@@ -105,7 +105,10 @@ export const ProjectOverview: React.FC<Props> = ({...args}) => {
             </p>
           </TextPassage>
         </ListDetailPanel>
-        <ListDetailPanel title="Expectations of Samuri in Feudal Japan" variant="number">
+        <ListDetailPanel
+          title="Expectations of Samuri in Feudal Japan"
+          variant="number"
+        >
           <TextPassage>
             <h3>ListDetailPanel 4</h3>
             <p>

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -137,7 +137,7 @@
 
 .list-detail__link-left:not(.list-detail__link-hidden) {
   /**
-   * Before pseudoelement bullet
+   * Before pseudoelement bullet (for non-number variant items)
    * 1) Set to 9px to center the border
    */
   &:before {
@@ -165,27 +165,20 @@
   }
 }
 
-.list-detail__link-hidden {
-  &:before {
-    content: '';
-    margin-right: var(--eds-size-2);
-    display: inline-block;
-    top: var(--eds-size-1);
-    height: 0;
-    width: 9px;
-    visibility: hidden;
-  }
-}
+/**
+* List detail number
+* 1) Used on list items using number variant
+*/
 .list-detail__number {
-  position: absolute;
-  left: -4px;
-  width: 1.25rem;
-  height: 1.25rem;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
   border: 1px solid var(--eds-theme-color-neutral-subtle-border);
-  padding-left: 5px;
-  line-height: 1.5;
+  margin-right: 9px;
+  padding: 3px 6px;
   font-size: 12px;
+  margin-left: -4px;
+
 }
 
 /**

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -76,16 +76,18 @@
   position: relative;
   flex-shrink: 0; /* 1 */
   padding-bottom: var(--eds-size-4);
+}
 
-  /**
+/**
   * List detail item after
-  * 1) Line between items that shouldn't link out unliike the bullet
+  * 1) When list variant is 'sequence', add a line between items that shouldn't link out unliike the bullet
   */
+.list-detail__list--sequence .list-detail__item {
   &:after {
     content: '';
     position: absolute;
     top: 1.5rem;
-    left: .25rem;
+    left: 0.25rem;
     width: 0.0625rem;
     height: 70%;
     background: var(--eds-theme-color-neutral-subtle-background);
@@ -93,21 +95,20 @@
   }
 
   /**
-  * Last list detail item
-  */
+    * Last list detail item
+    */
   &:last-child {
     padding-bottom: 0;
 
     /**
-    * List list detail item after
-    * 1) Don't add a line between items
-    */
+      * List list detail item after
+      * 1) Don't add a line between items
+      */
     &:after {
       content: none;
     }
   }
 }
-
 /**
  * List detail link
  */
@@ -156,7 +157,7 @@
   * List detail item variants
   * 1) Remove the bullet since the icon will take its place
   */
-  li[class*="list-detail__item--"] & {
+  li[class*='list-detail__item--'] & {
     &:before {
       content: none;
     }
@@ -181,12 +182,12 @@
   */
   .list-detail__item--success & {
     fill: var(--eds-theme-color-utility-success-foreground);
-  }/**
+  } /**
   * List detail icon within warning list detail item
   */
   .list-detail__item--warning & {
     fill: var(--eds-theme-color-utility-warning-foreground);
-  }/**
+  } /**
   * List detail icon within error list detail item
   */
   .list-detail__item--error & {

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -78,9 +78,9 @@
 
 /**
   * List detail item after
-  * 1) When list variant is 'sequence', add a line between items that shouldn't link out unliike the bullet
+  * 1) When list variant is 'ordered', add a line between items that shouldn't link out unliike the bullet
   */
-.list-detail__list--sequence .list-detail__item {
+.list-detail__list--ordered .list-detail__item {
   &:after {
     content: '';
     position: absolute;

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -135,7 +135,7 @@
   }
 }
 
-.list-detail__link-left {
+.list-detail__link-left:not(.list-detail__link-hidden) {
   /**
    * Before pseudoelement bullet
    * 1) Set to 9px to center the border
@@ -153,6 +153,7 @@
     border-radius: 50%;
   }
 
+
   /**
   * List detail item variants
   * 1) Remove the bullet since the icon will take its place
@@ -162,6 +163,29 @@
       content: none;
     }
   }
+}
+
+.list-detail__link-hidden {
+  &:before {
+    content: '';
+    margin-right: var(--eds-size-2);
+    display: inline-block;
+    top: var(--eds-size-1);
+    height: 0;
+    width: 9px;
+    visibility: hidden;
+  }
+}
+.list-detail__number {
+  position: absolute;
+  left: -4px;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 1px solid var(--eds-theme-color-neutral-subtle-border);
+  padding-left: 5px;
+  line-height: 1.5;
+  font-size: 12px;
 }
 
 /**

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -153,7 +153,6 @@
     border-radius: 50%;
   }
 
-
   /**
   * List detail item variants
   * 1) Remove the bullet since the icon will take its place
@@ -170,15 +169,17 @@
 * 1) Used on list items using number variant
 */
 .list-detail__number {
-  width: 8px;
-  height: 8px;
+  position: relative;
+  left: -4px;
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
   border: 1px solid var(--eds-theme-color-neutral-subtle-border);
   margin-right: 9px;
-  padding: 3px 6px;
+  padding: 4px 8px;
   font-size: 12px;
   margin-left: -4px;
-
+  background: var(--eds-color-neutral-white); /* 1*/
 }
 
 /**
@@ -187,9 +188,9 @@
 */
 .list-detail__icon {
   position: relative;
-  left: -5px;
-  height: var(--eds-size-2-and-half);
-  width: var(--eds-size-2-and-half);
+  left: -7px;
+  height: var(--eds-size-3);
+  width: var(--eds-size-3);
   margin-right: var(--eds-size-half);
   background: var(--eds-color-neutral-white); /* 1*/
   z-index: var(--eds-z-index-100);

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -1,7 +1,7 @@
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\
-    #TABS
+    #List Detail
 \*------------------------------------*/
 
 /**
@@ -88,7 +88,7 @@
     left: .25rem;
     width: 0.0625rem;
     height: 70%;
-    background: var(--eds-color-neutral-200);
+    background: var(--eds-theme-color-neutral-subtle-background);
     border-radius: 50%;
   }
 
@@ -148,7 +148,7 @@
     top: var(--eds-size-1);
     height: 9px; /* 1 */
     width: 9px; /* 1 */
-    background: var(--eds-theme-color-neutral-md-background);
+    background: var(--eds-theme-color-neutral-subtle-background);
     border-radius: 50%;
   }
 

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -27,11 +27,10 @@
 .list-detail__header {
   width: 100%;
   position: relative;
-  padding: var(--eds-size-2);
+  padding: var(--eds-size-4) var(--eds-size-2);
 
   @media all and (min-width: $eds-bp-lg) {
-    padding-right: var(--eds-size-4);
-    padding-left: var(--eds-size-6);
+    padding: var(--eds-size-5);
     width: 20rem;
   }
 }
@@ -46,8 +45,7 @@
 
   @media all and (min-width: $eds-bp-lg) {
     flex: 1; /* 1 */
-    padding-right: var(--eds-size-8);
-    padding-left: var(--eds-size-8);
+    padding: var(--eds-size-5) var(--eds-size-8);
     box-shadow: -6px 0px 10px -2px var(--eds-theme-color-neutral-subtle-border); /* 1 */
   }
 }
@@ -64,7 +62,7 @@
 
   @media all and (min-width: $eds-bp-lg) {
     position: sticky;
-    top: var(--eds-size-2);
+    top: var(--eds-size-5);
   }
 }
 

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -85,8 +85,8 @@
     content: '';
     position: absolute;
     top: var(--eds-size-1-and-half);
-    left: 4px;
-    width: 1px;
+    left: .25rem;
+    width: 0.0625rem;
     height: 100%;
     background: var(--eds-theme-color-neutral-md-background);
     border-radius: 50%;
@@ -153,12 +153,12 @@
   }
 
   /**
-  * Success list detail item
+  * List detail item variants
   * 1) Remove the bullet since the icon will take its place
   */
-  .list-detail__item--success & {
+  li[class*="list-detail__item--"] & {
     &:before {
-      content: none; /* 1 */
+      content: none;
     }
   }
 }
@@ -181,5 +181,15 @@
   */
   .list-detail__item--success & {
     fill: var(--eds-theme-color-utility-success-foreground);
+  }/**
+  * List detail icon within warning list detail item
+  */
+  .list-detail__item--warning & {
+    fill: var(--eds-theme-color-utility-warning-foreground);
+  }/**
+  * List detail icon within error list detail item
+  */
+  .list-detail__item--error & {
+    fill: var(--eds-theme-color-utility-error-foreground);
   }
 }

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -84,11 +84,11 @@
   &:after {
     content: '';
     position: absolute;
-    top: var(--eds-size-1-and-half);
+    top: 1.5rem;
     left: .25rem;
     width: 0.0625rem;
-    height: 100%;
-    background: var(--eds-theme-color-neutral-md-background);
+    height: 70%;
+    background: var(--eds-color-neutral-200);
     border-radius: 50%;
   }
 

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -1,55 +1,71 @@
-
-import React from 'react';
 import { Story, Meta } from '@storybook/react';
+import React from 'react';
 
 import { ListDetail, Props } from './ListDetail';
 import { ListDetailPanel } from '../ListDetailPanel/ListDetailPanel';
 import { TextPassage } from '../TextPassage/TextPassage';
 
 export default {
-	title: 'Example/ListDetail',
-	component: ListDetail,
+  title: 'Example/ListDetail',
+  component: ListDetail,
 } as Meta;
 
 const Template: Story<Props> = (args) => (
-	<ListDetail {...args}>
-	  <ListDetailPanel title="ListDetailPanel 1">
-		<TextPassage>
-		  <h3>ListDetailPanel 1</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-  
-	  <ListDetailPanel title="ListDetailPanel 2">
-		<TextPassage>
-		  <h3>ListDetailPanel 2</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-  
-	  <ListDetailPanel title="ListDetailPanel 3">
-		<TextPassage>
-		  <h3>ListDetailPanel 3</h3>
-		  <p>
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-			eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-			minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-			aliquip ex{' '}
-		  </p>
-		</TextPassage>
-	  </ListDetailPanel>
-	</ListDetail>
-  );
-  
-  export const Default = Template.bind({});
-  Default.args = {};
+  <ListDetail {...args}>
+    <ListDetailPanel title="ListDetailPanel 1" variant="number">
+      <TextPassage>
+        <h3>ListDetailPanel 1</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+
+    <ListDetailPanel title="ListDetailPanel 2" variant="error">
+      <TextPassage>
+        <h3>ListDetailPanel 2</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+
+    <ListDetailPanel title="ListDetailPanel 3" variant="success">
+      <TextPassage>
+        <h3>ListDetailPanel 3</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+
+    <ListDetailPanel title="ListDetailPanel 4">
+      <TextPassage>
+        <h3>ListDetailPanel 3</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+  </ListDetail>
+);
+
+export const Default = Template.bind({});
+Default.args = {};
+
+export const Ordered = Template.bind({});
+Ordered.args = {
+  variant: 'ordered',
+};

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -219,7 +219,12 @@ export const ListDetail: React.FC<Props> = ({
               <li
                 className={clsx(styles['list-detail__item'], {
                   [styles['eds-is-active']]: isActive,
-				  [styles['list-detail__item--success']] : tab.props.variant === 'success'
+                  [styles['list-detail__item--success']]:
+                    tab.props.variant === 'success',
+                  [styles['list-detail__item--warning']]:
+                    tab.props.variant === 'warning',
+                  [styles['list-detail__item--error']]:
+                    tab.props.variant === 'error',
                 })}
                 key={'list-detail-item-' + i}
                 role="presentation"
@@ -241,11 +246,26 @@ export const ListDetail: React.FC<Props> = ({
                   ref={listDetailItemRefs[i]}
                   aria-label={tab.props.ariaLabel}
                 >
-					<div className={styles['list-detail__link-left']}>
-				  	{tab.props.variant === 'success' &&
-					<Icon className={styles['list-detail__icon']} name="check-circle" />
-					  }
-					</div>
+                  <div className={styles['list-detail__link-left']}>
+                    {tab.props.variant === 'success' ? (
+                      <Icon
+                        className={styles['list-detail__icon']}
+                        name="check-circle"
+                      />
+                    ) : tab.props.variant === 'warning' ? (
+                      <Icon
+                        className={styles['list-detail__icon']}
+                        name="exclamation-circle"
+                      />
+                    ) : tab.props.variant === 'error' ? (
+                      <Icon
+                        className={styles['list-detail__icon']}
+                        name="x-circle"
+                      />
+                    ) : (
+                      ''
+                    )}
+                  </div>
                   {tab.props.title}
                 </a>
               </li>

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -62,9 +62,9 @@ export interface Props {
   overflow?: 'inverted';
   /**
    * Stylistic variations:
-   * - **sequence** bullets can be replaced with icons; vertical line connects each item to indicate sequence
+   * - **ordered** uses a ordered list <ul> instead of the default unordered list <ul>, and allows for icons, bullets, or numbers
    */
-  variant?: 'sequence' | null;
+  variant?: 'ordered';
   /**
    * List detail item tab name
    */
@@ -215,15 +215,15 @@ export const ListDetail = ({
       return child;
     },
   );
-
+  const TagName = variant === 'ordered' ? 'ol' : 'ul';
   const componentClassName = clsx(styles['list-detail'], className, {});
 
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['list-detail__header']}>
-        <ul
+        <TagName
           className={clsx(styles['list-detail__list'], {
-            [styles['list-detail__list--sequence']]: variant === 'sequence',
+            [styles['list-detail__list--ordered']]: variant === 'ordered',
           })}
           role="tablist"
         >
@@ -289,7 +289,7 @@ export const ListDetail = ({
               </li>
             );
           })}
-        </ul>
+        </TagName>
       </div>
       <div className={styles['list-detail__body']}>
         {childrenWithProps[activeIndexState]}

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -260,7 +260,9 @@ export const ListDetail = ({
                   ref={listDetailItemRefs[i]}
                   aria-label={tab.props.ariaLabel}
                 >
-                  <div className={styles['list-detail__link-left']}>
+                  <div className={clsx(styles['list-detail__link-left'], {
+                    [styles['list-detail__link-hidden']]: itemVariant === 'number'
+                  })}>
                     {itemVariant === 'success' ? (
                       <Icon
                         className={styles['list-detail__icon']}
@@ -276,6 +278,8 @@ export const ListDetail = ({
                         className={styles['list-detail__icon']}
                         name="x-circle"
                       />
+                    ) : itemVariant === 'number' ? (
+                      <span className={styles['list-detail__number']}>{i + 1}</span>
                     ) : (
                       ''
                     )}

--- a/src/components/ListDetailPanel/ListDetailPanel.tsx
+++ b/src/components/ListDetailPanel/ListDetailPanel.tsx
@@ -28,8 +28,9 @@ export interface Props {
    * - **success** - results in a green list detail item and add icon
    * - **warning** - results in a yellow list detail item and add icon
    * - **error** - results in a red list detail item and adds icon
+   * - **number** - results in an indexed number in place of icon
    */
-   variant?: 'success' | 'warning' | 'error';
+   variant?: 'success' | 'warning' | 'error' | 'number';
 }
 
 /**


### PR DESCRIPTION
### Summary:
Shortcut: https://app.shortcut.com/czi-edu/story/189947/list-detail-component-sequence-variant

This PR adds a 'sequence' variant to the List Detail Component; sequence variant adds icons for 'success', 'warning' and 'error' and a vertical line to the list detail component's unordered list;

NOTES:
- The colors need to be replaced
- The line between list elements has vert space above and below it, but there is irregularity when the text in adjacent list elements are varying heights (see screenshot below)
- I fought the linter and the linter won. I'm open to suggestions on how to refactor those CSS selectors (src/components/ListDetail/ListDetail.module.css:107, 161)

![Screen Shot 2022-03-24 at 10 59 06 PM](https://user-images.githubusercontent.com/24812780/160051675-67007fa5-a691-4738-aa8e-ed253ef8418e.png)

