### PR TITLE
chore(dropdown): remove optionsWidth

### DIFF
--- a/packages/components/src/Dropdown/Dropdown.module.css
+++ b/packages/components/src/Dropdown/Dropdown.module.css
@@ -2,6 +2,14 @@
   @apply relative bg-white;
 }
 
+.compact {
+  @apply w-min;
+}
+
+.compact > button {
+  @apply p-1;
+}
+
 .label {
   @apply text-sm text-neutral-500 font-bold mb-1;
 }
@@ -11,7 +19,15 @@
 }
 
 .options {
-  @apply w-full absolute bg-white mt-2 py-2 rounded shadow-2 z-10;
+  @apply absolute bg-white mt-2 py-2 rounded shadow-2 z-10;
+}
+
+.optionsFullWidth {
+  @apply w-full;
+}
+
+.optionsAlignRight {
+  @apply right-0;
 }
 
 .option {

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -15,26 +15,25 @@ type Props = {
   labelComponent?: React.ReactNode;
   compact?: boolean;
   optionsAlign?: OptionsAlignType;
-  optionsWidth?: string;
 };
 
 const exampleOptions = [
   {
     key: "1",
-    label: "Dogs",
+    label: "a",
   },
   {
     key: "2",
-    label: "Cats",
+    label: "abcde",
   },
   {
     key: "3",
-    label: "Birds",
+    label: "abcdefghij",
   },
 ];
 
 function InteractiveExampleUsingSeparateProps(props: Props) {
-  const { compact, optionsAlign, optionsWidth } = props;
+  const { compact, optionsAlign } = props;
 
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
@@ -49,7 +48,6 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
         onChange={setSelectedOption}
         options={exampleOptions}
         optionsAlign={optionsAlign}
-        optionsWidth={optionsWidth}
         value={selectedOption}
         {...props}
       />
@@ -58,7 +56,7 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
-  const { compact, optionsWidth } = props;
+  const { compact } = props;
 
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
@@ -71,7 +69,6 @@ function InteractiveExampleUsingChildren(props: Props) {
         compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
-        optionsWidth={optionsWidth}
         value={selectedOption}
       >
         {props.labelComponent}
@@ -155,7 +152,6 @@ export const Compact: StoryObj = {
     <InteractiveExampleUsingSeparateProps
       aria-label="Favorite Animal"
       compact
-      optionsWidth="w-96"
     />
   ),
 };
@@ -166,16 +162,6 @@ export const CompactWithOptionsRightAligned: StoryObj = {
       aria-label="Favorite Animal"
       compact
       optionsAlign="right"
-      optionsWidth="w-96"
-    />
-  ),
-};
-
-export const SeparateButtonAndMenuWidth: StoryObj = {
-  render: () => (
-    <InteractiveExampleUsingSeparateProps
-      aria-label="Favorite Animal"
-      optionsWidth="w-96"
     />
   ),
 };
@@ -196,11 +182,7 @@ export const UsingChildrenPropAndNoVisibleLabel: StoryObj = {
 
 export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      compact
-      optionsWidth="w-96"
-    />
+    <InteractiveExampleUsingChildren aria-label="Favorite Animal" compact />
   ),
 };
 
@@ -217,8 +199,7 @@ export const OpenByDefault: StoryObj = {
     // Open the dropdown.
     const dropdownButton = await canvas.findByRole("button");
     dropdownButton.click();
-    // Select the best option.
-    const bestOption = await canvas.findByText("Cats");
+    const bestOption = await canvas.findByText("a");
     bestOption.click();
     // Reopen the dropdown; selecting an option closed it.
     dropdownButton.click();

--- a/packages/components/src/Dropdown/Dropdown.stories.tsx
+++ b/packages/components/src/Dropdown/Dropdown.stories.tsx
@@ -2,7 +2,7 @@ import { StoryObj } from "@storybook/react";
 import { within } from "@storybook/testing-library";
 import React from "react";
 import FilterListRoundedIcon from "../Icons/FilterListRounded";
-import Dropdown from "./Dropdown";
+import Dropdown, { OptionsAlignType } from "./Dropdown";
 
 export default {
   title: "Dropdown",
@@ -13,6 +13,9 @@ type Props = {
   labelText?: string;
   "aria-label"?: string;
   labelComponent?: React.ReactNode;
+  compact?: boolean;
+  optionsAlign?: OptionsAlignType;
+  optionsWidth?: string;
 };
 
 const exampleOptions = [
@@ -31,17 +34,22 @@ const exampleOptions = [
 ];
 
 function InteractiveExampleUsingSeparateProps(props: Props) {
+  const { compact, optionsAlign, optionsWidth } = props;
+
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
 
   return (
-    <div className="h-48">
+    <div className={`h-48${optionsAlign === "right" ? " pl-96" : ""}`}>
       <Dropdown
         buttonText={selectedOption?.label || "Select"}
-        className="w-60"
+        className={compact ? "" : "w-60"}
+        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
         options={exampleOptions}
+        optionsAlign={optionsAlign}
+        optionsWidth={optionsWidth}
         value={selectedOption}
         {...props}
       />
@@ -50,6 +58,8 @@ function InteractiveExampleUsingSeparateProps(props: Props) {
 }
 
 function InteractiveExampleUsingChildren(props: Props) {
+  const { compact, optionsWidth } = props;
+
   const [selectedOption, setSelectedOption] =
     React.useState<typeof exampleOptions[0]>();
 
@@ -57,9 +67,11 @@ function InteractiveExampleUsingChildren(props: Props) {
     <div className="h-48">
       <Dropdown
         aria-label={props["aria-label"]}
-        className="w-60"
+        className={compact ? "" : "w-60"}
+        compact={compact}
         data-testid="dropdown"
         onChange={setSelectedOption}
+        optionsWidth={optionsWidth}
         value={selectedOption}
       >
         {props.labelComponent}
@@ -138,6 +150,36 @@ export const DefaultWithoutVisibleLabel: StoryObj = {
   ),
 };
 
+export const Compact: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      compact
+      optionsWidth="w-96"
+    />
+  ),
+};
+
+export const CompactWithOptionsRightAligned: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      compact
+      optionsAlign="right"
+      optionsWidth="w-96"
+    />
+  ),
+};
+
+export const SeparateButtonAndMenuWidth: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingSeparateProps
+      aria-label="Favorite Animal"
+      optionsWidth="w-96"
+    />
+  ),
+};
+
 export const UsingChildrenProp: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren
@@ -149,6 +191,16 @@ export const UsingChildrenProp: StoryObj = {
 export const UsingChildrenPropAndNoVisibleLabel: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
+  ),
+};
+
+export const CompactUsingChildrenPropAndNoVisibleLabel: StoryObj = {
+  render: () => (
+    <InteractiveExampleUsingChildren
+      aria-label="Favorite Animal"
+      compact
+      optionsWidth="w-96"
+    />
   ),
 };
 

--- a/packages/components/src/Dropdown/Dropdown.tsx
+++ b/packages/components/src/Dropdown/Dropdown.tsx
@@ -58,8 +58,7 @@ type DropdownProps = ListboxProps & {
   /**
    * Render dropdown button that is only as wide as the content.
    *
-   * When defining compact dropdown need to provide optionsWidth to
-   * define width of options menu, and optionally provide optionsAlign
+   * When defining compact dropdown need to optionally provide optionsAlign
    * if desired to right align to dropdow button.
    */
   compact?: boolean;
@@ -67,11 +66,6 @@ type DropdownProps = ListboxProps & {
    * Align dropdown menu to the left (default) or right of dropdown button
    */
   optionsAlign?: OptionsAlignType;
-  /**
-   * Render dropdown menu with width (specify using tailwind utility string)
-   * independent of dropdown button width
-   */
-  optionsWidth?: string;
 };
 
 type RenderProp<Arg> = (arg: Arg) => ReactNode;
@@ -190,7 +184,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  * );
  * ```
  *
- * For compact dropdown button, add compact and optionsWidth props to
+ * For compact dropdown button, add compact prop to
  * <Dropdown>.
  *
  * Examples:
@@ -202,7 +196,6 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     aria-label="Options"
  *     compact
  *     optionsAlign="right"
- *     optionsWidth="w-96"
  *   >
  *     <Dropdown.Options>
  *       <Dropdown.Option>Option 1</Dropdown.Option>
@@ -224,14 +217,13 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     compact
  *     options={options}
  *     optionsAlign="right"
- *     optionsWidth="w-96"
  *   />
  * );
  * ```
  *
  * For dropdown that differs in button and options menu width, style <Dropdown>
- * with className for the button with and provide optionsWidth for the options
- * menu width.
+ * with className for the button with and provide optionsAlign for the options
+ * menu alignment.
  *
  * Example:
  *
@@ -247,7 +239,6 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *     compact
  *     options={options}
  *     optionsAlign="right"
- *     optionsWidth="w-96"
  *   />
  * );
  * ```
@@ -262,7 +253,6 @@ function Dropdown(props: DropdownProps) {
     "aria-label": ariaLabel,
     compact,
     optionsAlign,
-    optionsWidth,
     ...rest
   } = props;
 
@@ -296,7 +286,7 @@ function Dropdown(props: DropdownProps) {
 
   if (typeof children === "function") {
     return (
-      <DropdownContext.Provider value={{ optionsAlign, optionsWidth }}>
+      <DropdownContext.Provider value={{ optionsAlign, compact }}>
         <Listbox
           {...sharedProps}
           // We prefer to pass the aria-label in via an invisible DropdownLabel, but we can't
@@ -319,10 +309,7 @@ function Dropdown(props: DropdownProps) {
   const trigger = buttonText && <DropdownTrigger>{buttonText}</DropdownTrigger>;
 
   const optionsList = options && (
-    <DropdownOptions
-    // optionsAlign={optionsAlign}
-    // optionsWidth={optionsWidth}
-    >
+    <DropdownOptions>
       {options.map((option) => {
         const { label, ...rest } = option;
         return (
@@ -346,7 +333,7 @@ function Dropdown(props: DropdownProps) {
   const contextValue = Object.assign(
     {},
     optionsAlign ? { optionsAlign } : null,
-    optionsWidth ? { optionsWidth } : null,
+    compact ? { compact } : null,
   );
 
   return (
@@ -358,7 +345,7 @@ function Dropdown(props: DropdownProps) {
 
 const DropdownContext = React.createContext<{
   optionsAlign?: OptionsAlignType;
-  optionsWidth?: string;
+  compact?: boolean;
 }>({});
 
 const DropdownLabel = (props: { className?: string; children: ReactNode }) => {
@@ -396,14 +383,14 @@ const DropdownOptions = function (
   props: PropsWithRenderProp<{ open: boolean }>,
 ) {
   const { className, ...rest } = props;
-  const { optionsAlign, optionsWidth } = useContext(DropdownContext);
+  const { optionsAlign, compact } = useContext(DropdownContext);
 
   return (
     <Listbox.Options
       className={clsx(
         styles.options,
         className,
-        optionsWidth || styles.optionsFullWidth,
+        !compact && styles.optionsFullWidth,
         optionsAlign === "right" && styles.optionsAlignRight,
       )}
       {...rest}

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -41,7 +41,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-13"
     aria-orientation="vertical"
-    class="options w-96"
+    class="options"
     id="headlessui-listbox-options-15"
     role="listbox"
     tabindex="0"
@@ -55,7 +55,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -67,7 +67,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -79,7 +79,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -93,17 +93,17 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
 >
   <label
     class="label srOnly"
-    id="headlessui-listbox-label-43"
+    id="headlessui-listbox-label-37"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-45"
+    aria-controls="headlessui-listbox-options-39"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-43 headlessui-listbox-button-44"
+    aria-labelledby="headlessui-listbox-label-37 headlessui-listbox-button-38"
     class="dropdownButton"
-    id="headlessui-listbox-button-44"
+    id="headlessui-listbox-button-38"
     type="button"
   >
     <span>
@@ -125,47 +125,47 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-label-43"
+    aria-labelledby="headlessui-listbox-label-37"
     aria-orientation="vertical"
-    class="options w-96"
-    id="headlessui-listbox-options-45"
+    class="options"
+    id="headlessui-listbox-options-39"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-46"
+      id="headlessui-listbox-option-40"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-47"
+      id="headlessui-listbox-option-41"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-48"
+      id="headlessui-listbox-option-42"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -213,7 +213,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
   <ul
     aria-labelledby="headlessui-listbox-label-19"
     aria-orientation="vertical"
-    class="options w-96 optionsAlignRight"
+    class="options optionsAlignRight"
     id="headlessui-listbox-options-21"
     role="listbox"
     tabindex="0"
@@ -227,7 +227,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -239,7 +239,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -251,7 +251,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -313,7 +313,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -325,7 +325,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -337,7 +337,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -399,7 +399,7 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -411,7 +411,7 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -423,20 +423,20 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
 </div>
 `;
 
-exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
+exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
   data-testid="dropdown"
 >
   <label
-    class="label srOnly"
+    class="label"
     id="headlessui-listbox-label-25"
   >
     Favorite Animal
@@ -471,7 +471,7 @@ exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-25"
     aria-orientation="vertical"
-    class="options w-96"
+    class="options optionsFullWidth"
     id="headlessui-listbox-options-27"
     role="listbox"
     tabindex="0"
@@ -485,7 +485,7 @@ exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -497,7 +497,7 @@ exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -509,20 +509,20 @@ exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
 </div>
 `;
 
-exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
+exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
   data-testid="dropdown"
 >
   <label
-    class="label"
+    class="label srOnly"
     id="headlessui-listbox-label-31"
   >
     Favorite Animal
@@ -571,7 +571,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
@@ -583,7 +583,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
@@ -595,93 +595,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
       <span
         class="optionContent"
       >
-        Birds
-      </span>
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`] = `
-<div
-  class="dropdown w-60"
-  data-testid="dropdown"
->
-  <label
-    class="label srOnly"
-    id="headlessui-listbox-label-37"
-  >
-    Favorite Animal
-  </label>
-  <button
-    aria-controls="headlessui-listbox-options-39"
-    aria-expanded="true"
-    aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-37 headlessui-listbox-button-38"
-    class="dropdownButton"
-    id="headlessui-listbox-button-38"
-    type="button"
-  >
-    <span>
-      Select
-    </span>
-    <svg
-      aria-hidden="true"
-      class="svgIcon"
-      fill="currentColor"
-      height="1.25rem"
-      style="--svg-icon-size: 1.25rem;"
-      viewBox="0 0 24 24"
-      width="1.25rem"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-      />
-    </svg>
-  </button>
-  <ul
-    aria-labelledby="headlessui-listbox-label-37"
-    aria-orientation="vertical"
-    class="options optionsFullWidth"
-    id="headlessui-listbox-options-39"
-    role="listbox"
-    tabindex="0"
-  >
-    <li
-      class="option"
-      id="headlessui-listbox-option-40"
-      role="option"
-      tabindex="-1"
-    >
-      <span
-        class="optionContent"
-      >
-        Dogs
-      </span>
-    </li>
-    <li
-      class="option"
-      id="headlessui-listbox-option-41"
-      role="option"
-      tabindex="-1"
-    >
-      <span
-        class="optionContent"
-      >
-        Cats
-      </span>
-    </li>
-    <li
-      class="option"
-      id="headlessui-listbox-option-42"
-      role="option"
-      tabindex="-1"
-    >
-      <span
-        class="optionContent"
-      >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -695,11 +609,11 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-50"
+    aria-controls="headlessui-listbox-options-44"
     aria-expanded="true"
     aria-haspopup="true"
     class="p-4 rounded-md border border-neutral-300"
-    id="headlessui-listbox-button-49"
+    id="headlessui-listbox-button-43"
     type="button"
   >
     Select
@@ -716,47 +630,47 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-button-49"
+    aria-labelledby="headlessui-listbox-button-43"
     aria-orientation="vertical"
     class="options optionsFullWidth"
-    id="headlessui-listbox-options-50"
+    id="headlessui-listbox-options-44"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-51"
+      id="headlessui-listbox-option-45"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Dogs
+        a
       </span>
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-52"
+      id="headlessui-listbox-option-46"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Cats
+        abcde
       </span>
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-53"
+      id="headlessui-listbox-option-47"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Birds
+        abcdefghij
       </span>
     </li>
   </ul>
@@ -770,21 +684,21 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
 >
   <label
     class="label"
-    id="headlessui-listbox-label-54"
+    id="headlessui-listbox-label-48"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-56"
+    aria-controls="headlessui-listbox-options-50"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-54 headlessui-listbox-button-55"
+    aria-labelledby="headlessui-listbox-label-48 headlessui-listbox-button-49"
     class="dropdownButton"
-    id="headlessui-listbox-button-55"
+    id="headlessui-listbox-button-49"
     type="button"
   >
     <span>
-      Cats
+      a
     </span>
     <svg
       aria-hidden="true"
@@ -802,30 +716,18 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     </svg>
   </button>
   <ul
-    aria-activedescendant="headlessui-listbox-option-61"
-    aria-labelledby="headlessui-listbox-label-54"
+    aria-activedescendant="headlessui-listbox-option-54"
+    aria-labelledby="headlessui-listbox-label-48"
     aria-orientation="vertical"
     class="options optionsFullWidth"
-    id="headlessui-listbox-options-56"
+    id="headlessui-listbox-options-50"
     role="listbox"
     tabindex="0"
   >
     <li
-      class="option"
-      id="headlessui-listbox-option-60"
-      role="option"
-      tabindex="-1"
-    >
-      <span
-        class="optionContent"
-      >
-        Dogs
-      </span>
-    </li>
-    <li
       aria-selected="true"
       class="option optionActive optionSelected"
-      id="headlessui-listbox-option-61"
+      id="headlessui-listbox-option-54"
       role="option"
       tabindex="-1"
     >
@@ -850,19 +752,31 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
       <span
         class="optionContent"
       >
-        Cats
+        a
       </span>
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-62"
+      id="headlessui-listbox-option-55"
       role="option"
       tabindex="-1"
     >
       <span
         class="optionContent"
       >
-        Birds
+        abcde
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-56"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        abcdefghij
       </span>
     </li>
   </ul>

--- a/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
+++ b/packages/components/src/Dropdown/__snapshots__/Dropdown.spec.tsx.snap
@@ -1,5 +1,263 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Dropdown /> Compact story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-13"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-15"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
+    class="dropdownButton"
+    id="headlessui-listbox-button-14"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-13"
+    aria-orientation="vertical"
+    class="options w-96"
+    id="headlessui-listbox-options-15"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-16"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-17"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-18"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-43"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-45"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-43 headlessui-listbox-button-44"
+    class="dropdownButton"
+    id="headlessui-listbox-button-44"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-43"
+    aria-orientation="vertical"
+    class="options w-96"
+    id="headlessui-listbox-options-45"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-46"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-47"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-48"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] = `
+<div
+  class="dropdown compact"
+  data-testid="dropdown"
+>
+  <label
+    class="label srOnly"
+    id="headlessui-listbox-label-19"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-21"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
+    class="dropdownButton"
+    id="headlessui-listbox-button-20"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-19"
+    aria-orientation="vertical"
+    class="options w-96 optionsAlignRight"
+    id="headlessui-listbox-options-21"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-22"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-23"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-24"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`<Dropdown /> Default story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
@@ -41,7 +299,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-1"
     aria-orientation="vertical"
-    class="options"
+    class="options optionsFullWidth"
     id="headlessui-listbox-options-3"
     role="listbox"
     tabindex="0"
@@ -127,7 +385,7 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
   <ul
     aria-labelledby="headlessui-listbox-label-7"
     aria-orientation="vertical"
-    class="options"
+    class="options optionsFullWidth"
     id="headlessui-listbox-options-9"
     role="listbox"
     tabindex="0"
@@ -172,24 +430,24 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
+exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
 <div
   class="dropdown w-60"
   data-testid="dropdown"
 >
   <label
-    class="label"
-    id="headlessui-listbox-label-13"
+    class="label srOnly"
+    id="headlessui-listbox-label-25"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-15"
+    aria-controls="headlessui-listbox-options-27"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
+    aria-labelledby="headlessui-listbox-label-25 headlessui-listbox-button-26"
     class="dropdownButton"
-    id="headlessui-listbox-button-14"
+    id="headlessui-listbox-button-26"
     type="button"
   >
     <span>
@@ -211,16 +469,16 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-label-13"
+    aria-labelledby="headlessui-listbox-label-25"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-15"
+    class="options w-96"
+    id="headlessui-listbox-options-27"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-16"
+      id="headlessui-listbox-option-28"
       role="option"
       tabindex="-1"
     >
@@ -232,7 +490,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-17"
+      id="headlessui-listbox-option-29"
       role="option"
       tabindex="-1"
     >
@@ -244,7 +502,93 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-18"
+      id="headlessui-listbox-option-30"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Birds
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
+<div
+  class="dropdown w-60"
+  data-testid="dropdown"
+>
+  <label
+    class="label"
+    id="headlessui-listbox-label-31"
+  >
+    Favorite Animal
+  </label>
+  <button
+    aria-controls="headlessui-listbox-options-33"
+    aria-expanded="true"
+    aria-haspopup="true"
+    aria-labelledby="headlessui-listbox-label-31 headlessui-listbox-button-32"
+    class="dropdownButton"
+    id="headlessui-listbox-button-32"
+    type="button"
+  >
+    <span>
+      Select
+    </span>
+    <svg
+      aria-hidden="true"
+      class="svgIcon"
+      fill="currentColor"
+      height="1.25rem"
+      style="--svg-icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+  <ul
+    aria-labelledby="headlessui-listbox-label-31"
+    aria-orientation="vertical"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-33"
+    role="listbox"
+    tabindex="0"
+  >
+    <li
+      class="option"
+      id="headlessui-listbox-option-34"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Dogs
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-35"
+      role="option"
+      tabindex="-1"
+    >
+      <span
+        class="optionContent"
+      >
+        Cats
+      </span>
+    </li>
+    <li
+      class="option"
+      id="headlessui-listbox-option-36"
       role="option"
       tabindex="-1"
     >
@@ -265,17 +609,17 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
 >
   <label
     class="label srOnly"
-    id="headlessui-listbox-label-19"
+    id="headlessui-listbox-label-37"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-21"
+    aria-controls="headlessui-listbox-options-39"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
+    aria-labelledby="headlessui-listbox-label-37 headlessui-listbox-button-38"
     class="dropdownButton"
-    id="headlessui-listbox-button-20"
+    id="headlessui-listbox-button-38"
     type="button"
   >
     <span>
@@ -297,16 +641,16 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-label-19"
+    aria-labelledby="headlessui-listbox-label-37"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-21"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-39"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-22"
+      id="headlessui-listbox-option-40"
       role="option"
       tabindex="-1"
     >
@@ -318,7 +662,7 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-23"
+      id="headlessui-listbox-option-41"
       role="option"
       tabindex="-1"
     >
@@ -330,7 +674,7 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-24"
+      id="headlessui-listbox-option-42"
       role="option"
       tabindex="-1"
     >
@@ -351,11 +695,11 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-26"
+    aria-controls="headlessui-listbox-options-50"
     aria-expanded="true"
     aria-haspopup="true"
     class="p-4 rounded-md border border-neutral-300"
-    id="headlessui-listbox-button-25"
+    id="headlessui-listbox-button-49"
     type="button"
   >
     Select
@@ -372,16 +716,16 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </svg>
   </button>
   <ul
-    aria-labelledby="headlessui-listbox-button-25"
+    aria-labelledby="headlessui-listbox-button-49"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-26"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-50"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-27"
+      id="headlessui-listbox-option-51"
       role="option"
       tabindex="-1"
     >
@@ -393,7 +737,7 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-28"
+      id="headlessui-listbox-option-52"
       role="option"
       tabindex="-1"
     >
@@ -405,7 +749,7 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-29"
+      id="headlessui-listbox-option-53"
       role="option"
       tabindex="-1"
     >
@@ -426,17 +770,17 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
 >
   <label
     class="label"
-    id="headlessui-listbox-label-30"
+    id="headlessui-listbox-label-54"
   >
     Favorite Animal
   </label>
   <button
-    aria-controls="headlessui-listbox-options-32"
+    aria-controls="headlessui-listbox-options-56"
     aria-expanded="true"
     aria-haspopup="true"
-    aria-labelledby="headlessui-listbox-label-30 headlessui-listbox-button-31"
+    aria-labelledby="headlessui-listbox-label-54 headlessui-listbox-button-55"
     class="dropdownButton"
-    id="headlessui-listbox-button-31"
+    id="headlessui-listbox-button-55"
     type="button"
   >
     <span>
@@ -458,17 +802,17 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     </svg>
   </button>
   <ul
-    aria-activedescendant="headlessui-listbox-option-37"
-    aria-labelledby="headlessui-listbox-label-30"
+    aria-activedescendant="headlessui-listbox-option-61"
+    aria-labelledby="headlessui-listbox-label-54"
     aria-orientation="vertical"
-    class="options"
-    id="headlessui-listbox-options-32"
+    class="options optionsFullWidth"
+    id="headlessui-listbox-options-56"
     role="listbox"
     tabindex="0"
   >
     <li
       class="option"
-      id="headlessui-listbox-option-36"
+      id="headlessui-listbox-option-60"
       role="option"
       tabindex="-1"
     >
@@ -481,7 +825,7 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     <li
       aria-selected="true"
       class="option optionActive optionSelected"
-      id="headlessui-listbox-option-37"
+      id="headlessui-listbox-option-61"
       role="option"
       tabindex="-1"
     >
@@ -511,7 +855,7 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
     </li>
     <li
       class="option"
-      id="headlessui-listbox-option-38"
+      id="headlessui-listbox-option-62"
       role="option"
       tabindex="-1"
     >


### PR DESCRIPTION
### Summary:
Just a test PR to see if we can get away with not using a specified width for the options menu when using a compact dropdown button. The changes to the options list in `.stories` is just to make it easier to verify that the options menu width is working as expected.

![Screen Shot 2022-03-28 at 3 33 34 PM](https://user-images.githubusercontent.com/7761701/160498507-57925c7b-d1a5-426d-806b-6747d8e9c20b.png)

### Test Plan:
