### PR TITLE
docs(code guidelines): revert change re: state

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -357,41 +357,7 @@ export const ComponentName = ({ children }: { children: ReactNode }) => {
 Interactive components likely require defining necessary [state and lifecycle](https://reactjs.org/docs/state-and-lifecycle.html) functions in addition to defining any other necessary variables and functions.
 
 #### useState()
-
-For simple state variables, define a `State` interface that holds the key/value pairs.
-
-```tsx
-interface State {
-  isActive?: boolean;
-}
-
-```
-
-For complex state objects, extract nested properties into their own interfaces. Use enums where needed.
-
-```tsx
-interface State {
-  userData: UserData | null;
-}
-
-interface UserData {
-  userId: number;
-  role: Roles;
-  userName: string;
-}
-
-enum Roles {
-  ANONYMOUS = "Anonymous",
-  AUTHENTICATED = "Authenticated",
-}
-
-```
-
-In either case, apply the `State` type via a generic:
-
-```tsx
-const [state, setState] = useState<State>('initial value');
-```
+When using the `useState()` hook, TypeScript will infer the correct type from the initial value. If explicit typing of a variable in state is necessary and a hard-coded initial value is not set, you can use a prop as the initial value.
 
 #### useEffect()
 `useEffect()` hooks do not require any typing. TypeScript expects them to either return nothing or a Destructor-typed function (a function that cleans up any side effects and returns void.)


### PR DESCRIPTION
### Summary:
This PR proposes removing the section in CODE_GUIDELINES that was recently added re: the typing of state. Rather than refactor components that aren't broken, I amended the `useState()` section to suggest the pattern of initializing state with a prop when explicit typing is necessary (and allowing TypeScript's type inference to handle the rest of the cases.)

### Test Plan:
Confirm that the suggested patterns conform with best practices.
