### PR TITLE
chore(button): rename 'text' prop to 'children'

### DIFF
--- a/.storybook/pages/CoursesYear/CoursesYear.tsx
+++ b/.storybook/pages/CoursesYear/CoursesYear.tsx
@@ -10,7 +10,7 @@ export const CoursesYear: React.FC = () => (
       <Heading as="h2" size={4}>
         Get ready for your next mentoring check-in with Science Teacher.
       </Heading>
-      <Button variant="primary" text="Begin Pre-Work" />
+      <Button variant="primary">Begin Pre-Work</Button>
     </Panel>
     <Panel>
       <div className="fpo">Year calendar table</div>

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -32,11 +32,12 @@ export const ProjectOverview: React.FC<Props> = ({ ...args }) => {
         title="Feudal Honor Codes and Values"
         right={
           <Button
-            text="View plan"
             variant="bare"
             iconPosition="after"
             iconName="arrow-narrow-right"
-          />
+          >
+            View plan
+          </Button>
         }
       />
       <ListDetail variant="ordered">

--- a/.storybook/recipes/PageShell/PageShell.tsx
+++ b/.storybook/recipes/PageShell/PageShell.tsx
@@ -35,11 +35,12 @@ export const PageShell: React.FC<Props> = ({
     <body className={componentClassName}>
       <Button
         className={styles['page-shell__skip-link']}
-        text="Skip to content"
         href="#main-content"
         variant="primary"
         size="sm"
-      />
+      >
+        Skip to content
+      </Button>
       <Layout>
         <LayoutSection region="sidebar">
           <GlobalHeader />

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -291,7 +291,6 @@ The design system's component directory contains all of the design system's comp
 
 ### Imports
 
-
 The framework follows a specific ordering/clustering for importing modules into a component. This is enforced through the [`import/order` lint rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md).
 
 Here's an example:
@@ -339,6 +338,7 @@ export const ComponentName = ({
 This defines the component name and passes in all the `Props`.
 
 ### Children
+
 When a component uses `children` as a prop, use the type `React.ReactNode` unless context dictates otherwise, including `ReactNode` as a named import.
 
 ```tsx
@@ -356,16 +356,18 @@ export const ComponentName = ({ children }: { children: ReactNode }) => {
 Interactive components likely require defining necessary [state and lifecycle](https://reactjs.org/docs/state-and-lifecycle.html) functions in addition to defining any other necessary variables and functions.
 
 #### useState()
+
 When using the `useState()` hook, TypeScript will infer the correct type from the initial value. If explicit typing of a variable in state is necessary and a hard-coded initial value is not set, you can use a prop as the initial value.
 
 #### useEffect()
+
 `useEffect()` hooks do not require any typing. TypeScript expects them to either return nothing or a Destructor-typed function (a function that cleans up any side effects and returns void.)
 
 #### useRef()
-`useRef()` hooks access underlying DOM elements to perform imperative actions. The resulting `ref` object can either be *mutable* or *not mutable*. (If the value store in its' `.current` property may be changed, the ref needs to be `mutable`.) Explictly convey the intended mutability status of each `ref` by using either `React.MutableObject` and `React.RefObject`, in a generic type definition. 
+
+`useRef()` hooks access underlying DOM elements to perform imperative actions. The resulting `ref` object can either be _mutable_ or _not mutable_. (If the value store in its' `.current` property may be changed, the ref needs to be `mutable`.) Explictly convey the intended mutability status of each `ref` by using either `React.MutableObject` and `React.RefObject`, in a generic type definition.
 
 For consistency, include `MutableRefObject` and `RefObject` with your import statements.
-
 
 ```tsx
 import React, { useRef, MutableRefObject, RefObject } from 'react';
@@ -375,6 +377,7 @@ import React, { useRef, MutableRefObject, RefObject } from 'react';
 const ref = useRef() as MutableRefObject<HTMLInputElement>;
 
 ```
+
 ### Define `componentClassName`
 
 The last thing that appears above the `return` statement is the `componentClassName`, which defines the CSS block for the component in addition to any modifier CSS class names using the [`clsx` library](https://www.npmjs.com/package/clsx). CSS Modules' bracket syntax (e.g. `styles['my-component']`) is used to enable BEM conventions (which uses dashes).
@@ -390,9 +393,7 @@ const componentClassName = clsx(styles['my-component'], className, {
 Finally, the `return` statement contains the JSX markup for the component and applies the `componentClassName` to the outermost element to be rendered in the DOM.
 
 ```tsx
-return (
-  <div className={componentClassName} {...other} />
-);
+return <div className={componentClassName} {...other} />;
 ```
 
 ## Component Rules and Considerations
@@ -442,12 +443,13 @@ EDS adheres to the following API naming conventions:
 - `verticalAlign` should be used for vertically aligning content, and should include `top`, `middle`, `bottom` if needed.
 - The default option should be the one most commonly used in order to reduce friction for developers using the components.
 
-### Text, Labels, Titles
+### Text, Labels, Titles, and Children
 
 - Default to `text` for short strings of text, such as `<BreadCrumbsItem text="My Courses">` or `<Badge text="Overdue" />`.
 - For headings, default to `title`, such as `<PageHeader title="My Page Title">`.
 - Default to `description` for text that serves as a descriptor, such as `<PageHeader title="Project name" description="Brief overview of the project..." />`
 - For form-related components, use the semantic `label` or `legend` (e.g. `<TextField label="first name" />` and `<RadioField legend="Grade level">`).
+- `children` can be used for components that only have one main block of content being passed in (so there will be no confusion with other content props) and when it's safe for that content to be a `ReactNode`. (If it's important for the content to only come in the form of a string, use a different prop name, like `text`.)
 
 ### Tag name
 

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -444,7 +444,7 @@ EDS adheres to the following API naming conventions:
 
 ### Text, Labels, Titles
 
-- Default to `text` for short strings of text, such as `<Button text="Click here">` or `<Badge text="Overdue" />`.
+- Default to `text` for short strings of text, such as `<BreadCrumbsItem text="My Courses">` or `<Badge text="Overdue" />`.
 - For headings, default to `title`, such as `<PageHeader title="My Page Title">`.
 - Default to `description` for text that serves as a descriptor, such as `<PageHeader title="Project name" description="Brief overview of the project..." />`
 - For form-related components, use the semantic `label` or `legend` (e.g. `<TextField label="first name" />` and `<RadioField legend="Grade level">`).

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -27,9 +27,10 @@ From there, call EDS components in your React application and pass in the desire
   variant="primary"
   iconName="chevron-right"
   iconPosition="after"
-  text="Submit"
   onClick={...}
-/>
+>
+  Submit
+</Button>
 ```
 
 Each EDS component is documented in Storybook, which surfaces each component's API and provides copy-and-paste code snippets. If you have questions or are experiencing any issues when working with EDS's components, please [reach out for support](#) (TODO: provide support link) and the team will be happy to help.

--- a/docs/ICONS.md
+++ b/docs/ICONS.md
@@ -15,7 +15,7 @@ View the "Icon Grid" story in Storybook for a visualization of all available ico
 The second way involves components that bake the `Icon` component into the internals of a component, such as `Button`. For these components, use the `iconName` prop (and perhaps also the `iconPosition` prop) like so:
 
 ```jsx
-<Button text="Search" iconName="magnifying-glass" iconPosition="after">
+<Button iconName="magnifying-glass" iconPosition="after">Search</Button>
 ```
 
 ---

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -60,7 +60,7 @@ const WithActionTemplate: Story<Props> = (args) => (
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
       </p>
     </TextPassage>
-    <Button text="Banner action" />
+    <Button>Banner action</Button>
   </Banner>
 );
 

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -230,11 +230,11 @@
 }
 
 /**
- * Button text before icon spacing
- * 1) Controls the spacing between the button text
- *    and the icon that comes _before_ button text
+ * Button children before icon spacing
+ * 1) Controls the spacing between the button children
+ *    and the icon that comes _before_ button children
  */
-.button__icon + .button__text {
+.button__icon + .button__children {
   margin-left: var(--eds-size-1); /* 1 */
 
   .button--sm & {
@@ -244,14 +244,14 @@
 
 /**
  * Button after icon spacing
- * 1) Controls the spacing between the button text
- *    and the icon that comes _after_ button text
+ * 1) Controls the spacing between the button children
+ *    and the icon that comes _after_ button children
  */
-.button__text + .button__icon {
+.button__children + .button__icon {
   margin-left: var(--eds-size-1); /* 1 */
 
   /**
-   * Button icon after button text within a link variant button
+   * Button icon after button children within a link variant button
    */
   .button--link & {
     margin-left: var(--eds-size-half);

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -18,35 +18,35 @@ const InvertedTemplate: Story<Props> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = { text: 'Button' };
+Default.args = { children: 'Button' };
 
 export const DefaultWithIconBefore = Template.bind({});
 DefaultWithIconBefore.args = {
-  text: 'Button',
+  children: 'Button',
   iconPosition: 'before',
   iconName: 'chevron-left',
 };
 
 export const DefaultWithIconAfter = Template.bind({});
 DefaultWithIconAfter.args = {
-  text: 'Button',
+  children: 'Button',
   iconPosition: 'after',
   iconName: 'chevron-right',
 };
 
 export const DefaultDisabled = Template.bind({});
-DefaultDisabled.args = { text: 'Button', disabled: true };
+DefaultDisabled.args = { children: 'Button', disabled: true };
 
 export const DefaultInverted = InvertedTemplate.bind({});
-DefaultInverted.args = { inverted: true, text: 'Button' };
+DefaultInverted.args = { inverted: true, children: 'Button' };
 
 export const Primary = Template.bind({});
-Primary.args = { variant: 'primary', text: 'Primary Button' };
+Primary.args = { variant: 'primary', children: 'Primary Button' };
 
 export const PrimaryDisabled = Template.bind({});
 PrimaryDisabled.args = {
   variant: 'primary',
-  text: 'Primary Button',
+  children: 'Primary Button',
   disabled: true,
 };
 
@@ -54,7 +54,7 @@ export const PrimaryInverted = InvertedTemplate.bind({});
 PrimaryInverted.args = {
   variant: 'primary',
   inverted: true,
-  text: 'Primary Button',
+  children: 'Primary Button',
 };
 
 export const BareIcon = Template.bind({});
@@ -75,32 +75,32 @@ BareIconInverted.args = {
 };
 
 export const TextLink = Template.bind({});
-TextLink.args = { variant: 'link', text: 'Text Link Button' };
+TextLink.args = { variant: 'link', children: 'Text Link Button' };
 
 export const TextLinkInverted = InvertedTemplate.bind({});
 TextLinkInverted.args = {
   variant: 'link',
   inverted: true,
-  text: 'Text Link Button',
+  children: 'Text Link Button',
 };
 
 export const UtilityError = Template.bind({});
-UtilityError.args = { variant: 'error', text: 'Button' };
+UtilityError.args = { variant: 'error', children: 'Button' };
 
 export const Medium = Template.bind({});
-Medium.args = { size: 'md', text: 'Medium Button' };
+Medium.args = { size: 'md', children: 'Medium Button' };
 
 export const Small = Template.bind({});
-Small.args = { size: 'sm', text: 'Small Button' };
+Small.args = { size: 'sm', children: 'Small Button' };
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { fullWidth: true, text: 'Button' };
+FullWidth.args = { fullWidth: true, children: 'Button' };
 
 export const Loading = Template.bind({});
 Loading.args = {
   loading: true,
   disabled: true,
-  text: 'Loading Button',
+  children: 'Loading Button',
 };
 
 export const PrimaryLoading = Template.bind({});
@@ -108,5 +108,5 @@ PrimaryLoading.args = {
   variant: 'primary',
   loading: true,
   disabled: true,
-  text: 'Primary Loading Button',
+  children: 'Primary Loading Button',
 };

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -4,21 +4,21 @@ import React from 'react';
 import { Button } from './Button';
 
 test('renders the text in the button', () => {
-  render(<Button text="Click" />);
+  render(<Button>Click</Button>);
 
   expect(screen.getByRole('button')).toHaveTextContent('Click');
 });
 
 test('fires callback on click', () => {
   const onClick = jest.fn();
-  render(<Button text="Click" onClick={onClick} />);
+  render(<Button onClick={onClick}>Click</Button>);
 
   userEvent.click(screen.getByRole('button'));
   expect(onClick).toHaveBeenCalled();
 });
 
 test('renders as a link when provided href', () => {
-  render(<Button text="test link" href="/test-url" />);
+  render(<Button href="/test-url">test link</Button>);
 
   expect(screen.getByRole('link')).toBeDefined();
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,7 +5,7 @@ import Icon from '../Icon';
 export interface Props {
   /**
    * Visually hidden button text (but text is still accessible to assistive technology).
-   * This overrides `text`
+   * This overrides `children` for screen readers
    */
   'aria-label'?: string;
   /**
@@ -33,9 +33,9 @@ export interface Props {
    */
   iconName?: string;
   /**
-   * Determines position of icon relative to button text.
-   * - **before** places icon before button text
-   * - **after** places icon after button text
+   * Determines position of icon relative to button children.
+   * - **before** places icon before button children
+   * - **after** places icon after button children
    */
   iconPosition?: 'before' | 'after';
   /**
@@ -55,9 +55,9 @@ export interface Props {
    */
   size?: 'sm' | 'md' | 'lg';
   /**
-   * The visible button text
+   * The visible button children
    */
-  text?: string | ReactNode;
+  children?: string | ReactNode;
   /**
    * Determines type of button
    * - **button** The button is a clickable button.
@@ -88,7 +88,7 @@ export const Button = React.forwardRef(
       loading,
       onClick,
       size = 'lg',
-      text,
+      children,
       type,
       variant,
       ...other
@@ -151,7 +151,9 @@ export const Button = React.forwardRef(
       >
         {iconPosition === 'before' && computedIcon}
 
-        {text && <span className={styles['button__text']}>{text}</span>}
+        {children && (
+          <span className={styles['button__children']}>{children}</span>
+        )}
 
         {iconPosition === 'after' && computedIcon}
       </TagName>

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -10,8 +10,8 @@ export default {
 
 const Template: Story<Props> = (args) => (
   <ButtonGroup {...args}>
-    <Button variant="primary" text="Primary Button" />
-    <Button text="Secondary Button" />
+    <Button variant="primary">Primary Button</Button>
+    <Button>Secondary Button</Button>
   </ButtonGroup>
 );
 

--- a/src/components/Counter/Counter.stories.tsx
+++ b/src/components/Counter/Counter.stories.tsx
@@ -36,8 +36,9 @@ DefaultWithTooltip.args = {
         variant="bare"
         iconPosition="after"
         iconName="question-mark-circle"
-        text="Hover this button to trigger the tooltip"
-      />
+      >
+        Hover this button to trigger the tooltip
+      </Button>
     </Tooltip>
   ),
 };

--- a/src/components/Drawer/DrawerExample.tsx
+++ b/src/components/Drawer/DrawerExample.tsx
@@ -46,11 +46,9 @@ export const DrawerExample = ({ className, ...other }: Props) => {
       className={componentClassName}
       {...other}
     >
-      <Button
-        text="Open Drawer"
-        onClick={openDrawerExample}
-        ref={drawerButton}
-      />
+      <Button onClick={openDrawerExample} ref={drawerButton}>
+        Open Drawer
+      </Button>
 
       <Drawer
         dismissible={true}
@@ -69,8 +67,8 @@ export const DrawerExample = ({ className, ...other }: Props) => {
         </DrawerBody>
         <DrawerFooter>
           <ButtonGroup>
-            <Button variant="primary" text="Button" />
-            <Button text="Close Drawer" onClick={closeDrawerExample} />
+            <Button variant="primary">Button</Button>
+            <Button onClick={closeDrawerExample}>Close Drawer</Button>
           </ButtonGroup>
         </DrawerFooter>
       </Drawer>

--- a/src/components/InlineForm/InlineForm.tsx
+++ b/src/components/InlineForm/InlineForm.tsx
@@ -81,7 +81,7 @@ export const InlineForm = ({
         placeholder={placeholder}
       />
 
-      <Button variant="primary" text={buttonText} />
+      <Button variant="primary">{buttonText}</Button>
     </form>
   );
 };

--- a/src/components/Modal/ModalExample.tsx
+++ b/src/components/Modal/ModalExample.tsx
@@ -56,7 +56,9 @@ export const ModalExample = ({
       className={componentClassName}
       {...other}
     >
-      <Button text="Open Modal" onClick={openContinueModal} ref={modalButton} />
+      <Button onClick={openContinueModal} ref={modalButton}>
+        Open Modal
+      </Button>
 
       <Modal
         dismissible={true}
@@ -83,12 +85,10 @@ export const ModalExample = ({
         </ModalBody>
         <ModalFooter>
           <ButtonGroup align="right">
-            <Button
-              variant="primary"
-              text="Submit"
-              onClick={closeContinueModal}
-            />
-            <Button text="Close" onClick={closeContinueModal} />
+            <Button variant="primary" onClick={closeContinueModal}>
+              Submit
+            </Button>
+            <Button onClick={closeContinueModal}>Close</Button>
           </ButtonGroup>
         </ModalFooter>
       </Modal>

--- a/src/components/Popover/PopoverExample.tsx
+++ b/src/components/Popover/PopoverExample.tsx
@@ -71,7 +71,9 @@ export const PopoverExample: React.FC<Props> = ({
       className={componentClassName}
       {...other}
     >
-      <Button text="Open Popover" onClick={openPopover} ref={popoverButton} />
+      <Button onClick={openPopover} ref={popoverButton}>
+        Open Popover
+      </Button>
 
       <Popover
         position={position}
@@ -82,7 +84,11 @@ export const PopoverExample: React.FC<Props> = ({
         ariaDescribedBy="popover-description-1"
       >
         <PopoverHeader
-          titleAfter={<Button text="Mark All Seen" size="sm" variant="bare" />}
+          titleAfter={
+            <Button size="sm" variant="bare">
+              Mark All Seen
+            </Button>
+          }
         >
           <Heading id="popover-heading-1" as="h6">
             Notifications (4)

--- a/src/components/StackedBlock/StackedBlock.stories.tsx
+++ b/src/components/StackedBlock/StackedBlock.stories.tsx
@@ -33,8 +33,8 @@ const Template: Story<Props> = (args) => (
     </StackedBlockBody>
     <StackedBlockFooter>
       <ButtonGroup>
-        <Button variant="primary" text="Primary Button" />
-        <Button text="Secondary Button" />
+        <Button variant="primary">Primary Button</Button>
+        <Button>Secondary Button</Button>
       </ButtonGroup>
     </StackedBlockFooter>
   </StackedBlock>

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -84,11 +84,12 @@ export const TableHeaderCell = ({
     >
       <Button
         variant="table-header"
-        text={children}
         iconPosition="after"
         iconName="arrow-narrow-down"
         onClick={onClick}
-      />
+      >
+        {children}
+      </Button>
     </th>
   );
 };

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -55,7 +55,11 @@ export const InputWithin = () => {
     <div>
       <TextField
         type="text"
-        inputWithin={<Button variant="bare" size="sm" text="Button" />}
+        inputWithin={
+          <Button variant="bare" size="sm">
+            Button
+          </Button>
+        }
       />
     </div>
   );

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -214,12 +214,13 @@ export const TextareaField = ({
           <Button
             className={styles['textarea-field__button']}
             type="button"
-            text={fieldButtonText}
             aria-label={fieldButtonAriaLabel}
             variant="bare"
             size="sm"
             onClick={fieldButtonOnClick}
-          />
+          >
+            {fieldButtonText}
+          </Button>
         )}
         {iconName && (
           <Icon className={styles['textarea-field__icon']} name={iconName} />

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -17,10 +17,9 @@ const defaultArgs = {
     </span>
   ),
   children: (
-    <Button
-      className={clsx(styles['trigger--spacing'])}
-      text="Tooltip trigger"
-    />
+    <Button className={clsx(styles['trigger--spacing'])}>
+      Tooltip trigger
+    </Button>
   ),
   align: 'right',
   visible: true,
@@ -52,8 +51,9 @@ export const LeftPlacement: StoryObj<Args> = {
           styles['trigger--spacing-bottom'],
           styles['trigger--spacing-left-large'],
         )}
-        text="Tooltip trigger"
-      />
+      >
+        Tooltip trigger
+      </Button>
     ),
   },
 };
@@ -67,8 +67,9 @@ export const TopPlacement: StoryObj<Args> = {
           styles['trigger--spacing-top'],
           styles['trigger--spacing-left'],
         )}
-        text="Tooltip trigger"
-      />
+      >
+        Tooltip trigger
+      </Button>
     ),
   },
 };
@@ -82,8 +83,9 @@ export const BottomPlacement: StoryObj<Args> = {
           styles['trigger--spacing-bottom'],
           styles['trigger--spacing-left'],
         )}
-        text="Tooltip trigger"
-      />
+      >
+        Tooltip trigger
+      </Button>
     ),
   },
 };
@@ -107,10 +109,9 @@ export const LongText: StoryObj<Args> = {
 export const LongButtonText: StoryObj<Args> = {
   args: {
     children: (
-      <Button
-        className={clsx(styles['trigger--spacing-top'])}
-        text="Tooltip trigger with longer text to test placement"
-      />
+      <Button className={clsx(styles['trigger--spacing-top'])}>
+        Tooltip trigger with longer text to test placement
+      </Button>
     ),
   },
 };
@@ -119,10 +120,9 @@ export const Interactive: StoryObj<Args> = {
   args: {
     visible: undefined,
     children: (
-      <Button
-        className={clsx(styles['trigger--spacing'])}
-        text="Hover here to see tooltip after clicking somewhere outside."
-      />
+      <Button className={clsx(styles['trigger--spacing'])}>
+        Hover here to see tooltip after clicking somewhere outside.
+      </Button>
     ),
   },
   decorators: [

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
       class="button trigger--spacing-bottom trigger--spacing-left button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>
@@ -65,7 +65,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
       class="button trigger--spacing button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>
@@ -126,7 +126,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
         class="button trigger--spacing button--lg"
       >
         <span
-          class="button__text"
+          class="button__children"
         >
           Hover here to see tooltip after clicking somewhere outside.
         </span>
@@ -184,7 +184,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
       class="button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>
@@ -241,7 +241,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
       class="button trigger--spacing button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>
@@ -298,7 +298,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
       class="button trigger--spacing-top button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger with longer text to test placement
       </span>
@@ -355,7 +355,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
       class="button trigger--spacing button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>
@@ -410,7 +410,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
       class="button trigger--spacing-top trigger--spacing-left button--lg"
     >
       <span
-        class="button__text"
+        class="button__children"
       >
         Tooltip trigger
       </span>


### PR DESCRIPTION
### Summary:
Following up on our EDS eng sync conversation on 3/29, this PR renames the `text` prop in the `Button` component to `children` to be consistent with what the users of this design system expect.

### Test Plan:
Spot check storybook, especially the docs changes since automated tests won't catch typos in there.