### PR TITLE
chore(banner): use plain button instead of CloseButton

### DIFF
--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -1,7 +1,8 @@
 import clsx from "clsx";
 import React from "react";
-import CloseButton from "../CloseButton";
+import Button from "../Button";
 import Heading, { HeadingElement } from "../Heading";
+import CloseRoundedIcon from "../Icons/CloseRounded";
 import Text from "../Text";
 import colorStyles from "../common/Notifications/Notification.module.css";
 import NotificationIcon, {
@@ -96,12 +97,19 @@ export default function Banner({
       )}
     >
       {onDismiss && (
-        <CloseButton
+        <Button
           className={styles.dismiss}
           color={color}
-          onClose={onDismiss}
-          size="1.75rem"
-        />
+          onClick={onDismiss}
+          variant="plain"
+          size="large"
+        >
+          <CloseRoundedIcon
+            purpose="informative"
+            size={"1.75rem"}
+            title={"dismiss banner"}
+          />
+        </Button>
       )}
 
       <NotificationIcon variant={color} />

--- a/packages/components/src/Banner/Banner.tsx
+++ b/packages/components/src/Banner/Banner.tsx
@@ -102,7 +102,6 @@ export default function Banner({
           color={color}
           onClick={onDismiss}
           variant="plain"
-          size="large"
         >
           <CloseRoundedIcon
             purpose="informative"

--- a/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
+++ b/packages/components/src/Banner/__snapshots__/Banner.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorAlert"
 >
   <button
-    class="button dismiss colorAlert button variantLink colorAlert"
+    class="dismiss button sizeLarge variantPlain colorAlert"
     type="button"
   >
     <svg
@@ -67,7 +67,7 @@ exports[`<Banner /> AlertDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -167,7 +167,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
-    class="button dismiss colorBrand button variantLink colorBrand"
+    class="dismiss button sizeLarge variantPlain colorBrand"
     type="button"
   >
     <svg
@@ -181,7 +181,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -233,7 +233,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorBrand"
 >
   <button
-    class="button dismiss colorBrand button variantLink colorBrand"
+    class="dismiss button sizeLarge variantPlain colorBrand"
     type="button"
   >
     <svg
@@ -247,7 +247,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -398,7 +398,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorNeutral"
 >
   <button
-    class="button dismiss colorNeutral button variantLink colorNeutral"
+    class="dismiss button sizeLarge variantPlain colorNeutral"
     type="button"
   >
     <svg
@@ -412,7 +412,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -586,7 +586,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorSuccess"
 >
   <button
-    class="button dismiss colorSuccess button variantLink colorSuccess"
+    class="dismiss button sizeLarge variantPlain colorSuccess"
     type="button"
   >
     <svg
@@ -600,7 +600,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -696,7 +696,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
   class="bannerDialog dismissable colorBrand"
 >
   <button
-    class="button dismiss colorBrand button variantLink colorBrand"
+    class="dismiss button sizeLarge variantPlain colorBrand"
     type="button"
   >
     <svg
@@ -710,7 +710,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -762,7 +762,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
   class="bannerDialog dismissable colorBrand"
 >
   <button
-    class="button dismiss colorBrand button variantLink colorBrand"
+    class="dismiss button sizeLarge variantPlain colorBrand"
     type="button"
   >
     <svg
@@ -776,7 +776,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"
@@ -982,7 +982,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   class="bannerDialog horizontal dismissable colorWarning"
 >
   <button
-    class="button dismiss colorWarning button variantLink colorWarning"
+    class="dismiss button sizeLarge variantPlain colorWarning"
     type="button"
   >
     <svg
@@ -996,7 +996,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title>
-        close
+        dismiss banner
       </title>
       <path
         d="M18.3 5.71a.9959.9959 0 00-1.41 0L12 10.59 7.11 5.7a.9959.9959 0 00-1.41 0c-.39.39-.39 1.02 0 1.41L10.59 12 5.7 16.89c-.39.39-.39 1.02 0 1.41.39.39 1.02.39 1.41 0L12 13.41l4.89 4.89c.39.39 1.02.39 1.41 0 .39-.39.39-1.02 0-1.41L13.41 12l4.89-4.89c.38-.38.38-1.02 0-1.4z"


### PR DESCRIPTION
### Summary:
The `CloseButton` is kind of a snowflake because it has a hover effect for the icon button that we don't use anywhere else. I talked to Sean and we're good to remove it to make the close buttons consistent with our other icon buttons. But before we can delete the component, we need to update the locations using it.

This PR updates the `Banner` component to use a plain `Button` instead of the customized `CloseButton`. The placement of the icon is a little different than before, but we paired on it and decided this is fine for now.

### Test Plan:
Tested in storybook.

https://user-images.githubusercontent.com/7761701/161342193-d8d57a08-abde-41ff-9aca-2ff9186cba39.mp4
