### PR TITLE
chore(toast): use plain button instead of CloseButton

### DIFF
--- a/packages/components/src/Toast/Toast.tsx
+++ b/packages/components/src/Toast/Toast.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import React from "react";
-import CloseButton from "../CloseButton";
+import Button from "../Button";
+import CloseRoundedIcon from "../Icons/CloseRounded";
 import Text from "../Text";
 import colorStyles from "../common/Notifications/Notification.module.css";
 import NotificationIcon from "../common/Notifications/NotificationIcon";
@@ -61,7 +62,15 @@ export default function Toast({
           {children}
         </Text>
       </div>
-      {onDismiss && <CloseButton color={color} onClose={onDismiss} />}
+      {onDismiss && (
+        <Button color={color} onClick={onDismiss} variant="plain">
+          <CloseRoundedIcon
+            purpose="informative"
+            size={"2rem"}
+            title={"dismiss message"}
+          />
+        </Button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Summary:
The `CloseButton` is kind of a snowflake because it has a hover effect for the icon button that we don't use anywhere else. I talked to Sean and we're good to remove it to make the close buttons consistent with our other icon buttons. But before we can delete the component, we need to update the locations using it.

This PR updates the `Toast` component to use a plain `Button` instead of the customized `CloseButton`. The placement of the icon is a little different than before, but we paired on it and decided this is fine for now.

### Test Plan:
Tested in storybook.

https://user-images.githubusercontent.com/7761701/161343986-affc8360-0251-4fb7-8b24-f15baea6e6b1.mp4


