### PR TITLE
chore(popover-example): remove unused variables

### DIFF
--- a/src/components/Popover/PopoverExample.tsx
+++ b/src/components/Popover/PopoverExample.tsx
@@ -1,4 +1,3 @@
-import { relative } from 'path/posix';
 import clsx from 'clsx';
 import React, {
   ReactNode,
@@ -15,7 +14,6 @@ import { NotificationList } from '../NotificationList/NotificationList';
 import { NotificationListItem } from '../NotificationListItem/NotificationListItem';
 import { PopoverBody } from '../PopoverBody/PopoverBody';
 import { PopoverHeader } from '../PopoverHeader/PopoverHeader';
-import { TextPassage } from '../TextPassage/TextPassage';
 
 export interface Props {
   /**
@@ -36,7 +34,6 @@ export interface Props {
  * Primary UI component for user interaction
  */
 export const PopoverExample: React.FC<Props> = ({
-  children,
   className,
   position,
   ...other


### PR DESCRIPTION
### Summary:
I'm seeing some type errors because of some unused imports in the `PopoverExample` component, and I also noticed an unused variable from a prop deconstruction, so I'm removing them in this PR so get the tests passing in a different PR.

### Test Plan:
`yarn types` returns no errors.