### PR TITLE
feat(button): remove icon props

### DIFF
--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -13,6 +13,7 @@ import {
   Section,
   Card,
   CardBody,
+  Icon,
 } from '../../../src';
 import utilityStyles from '../../../src/components/Utilities/Spacing.module.css';
 
@@ -28,12 +29,13 @@ export const ProjectOverview = () => {
       <PageHeader
         title="Feudal Honor Codes and Values"
         right={
-          <Button
-            variant="bare"
-            iconPosition="after"
-            iconName="arrow-narrow-right"
-          >
+          <Button variant="bare">
             View plan
+            <Icon
+              aria-hidden="true"
+              focusable={false}
+              name="arrow-narrow-right"
+            />
           </Button>
         }
       />

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -31,11 +31,7 @@ export const ProjectOverview = () => {
         right={
           <Button variant="bare">
             View plan
-            <Icon
-              aria-hidden="true"
-              focusable={false}
-              name="arrow-narrow-right"
-            />
+            <Icon purpose="decorative" name="arrow-narrow-right" />
           </Button>
         }
       />

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -9,6 +9,7 @@ import {
   NavContainer,
   Button,
   AvatarBlock,
+  Icon,
 } from '../../../src';
 
 export interface Props {
@@ -44,11 +45,15 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
         className={styles['global-header__menu-button']}
         variant="bare"
         aria-label={isActive ? 'Close' : 'Menu'}
-        iconPosition="before"
-        iconName={isActive ? 'close' : 'menu'}
         inverted={true}
         onClick={toggleMenu}
-      />
+      >
+        <Icon
+          aria-hidden="true"
+          focusable={false}
+          name={isActive ? 'x' : 'menu'}
+        />
+      </Button>
 
       <NavContainer
         isActive={isActive}

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -48,7 +48,7 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
         onClick={toggleMenu}
       >
         <Icon
-          purpose="decorative"
+          purpose="informative"
           name={isActive ? 'close' : 'menu'}
           title={isActive ? 'Close' : 'Menu'}
         />

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -49,7 +49,7 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
       >
         <Icon
           purpose="decorative"
-          name={isActive ? 'x' : 'menu'}
+          name={isActive ? 'close' : 'menu'}
           title={isActive ? 'Close' : 'Menu'}
         />
       </Button>

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -44,11 +44,14 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
       <Button
         className={styles['global-header__menu-button']}
         variant="bare"
-        aria-label={isActive ? 'Close' : 'Menu'}
         inverted={true}
         onClick={toggleMenu}
       >
-        <Icon purpose="decorative" name={isActive ? 'x' : 'menu'} />
+        <Icon
+          purpose="decorative"
+          name={isActive ? 'x' : 'menu'}
+          title={isActive ? 'Close' : 'Menu'}
+        />
       </Button>
 
       <NavContainer

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -48,11 +48,7 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
         inverted={true}
         onClick={toggleMenu}
       >
-        <Icon
-          aria-hidden="true"
-          focusable={false}
-          name={isActive ? 'x' : 'menu'}
-        />
+        <Icon purpose="decorative" name={isActive ? 'x' : 'menu'} />
       </Button>
 
       <NavContainer

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -29,7 +29,7 @@ From there, call EDS components in your React application and pass in the desire
   onClick={...}
 >
   Submit
-  <Icon name="chevron-right" aria-hidden="true" focusable={false} />
+  <Icon name="chevron-right" purpose="decorative" />
 </Button>
 ```
 

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -5,6 +5,7 @@ This codebase contains all the components, [recipes](https://bradfrost.com/blog/
 ## Working with components
 
 ### Using components
+
 TODO: define this process
 
 Using EDS components in your React application involves first installing the EDS package as a dependency:
@@ -25,11 +26,10 @@ From there, call EDS components in your React application and pass in the desire
 ```jsx
 <Button
   variant="primary"
-  iconName="chevron-right"
-  iconPosition="after"
   onClick={...}
 >
   Submit
+  <Icon name="chevron-right" aria-hidden="true" focusable={false} />
 </Button>
 ```
 

--- a/docs/ICONS.md
+++ b/docs/ICONS.md
@@ -12,10 +12,14 @@ There are several ways to use EDS icons in an application. The first and most di
 
 View the "Icon Grid" story in Storybook for a visualization of all available icons to pass into the `name` prop.
 
-The second way involves components that bake the `Icon` component into the internals of a component, such as `Button`. For these components, use the `iconName` prop (and perhaps also the `iconPosition` prop) like so:
+The second way involves components that bake the `Icon` component into the internals of a component, such as `LinkListItem`. For these components, use the `iconName` prop (and perhaps also the `iconPosition` prop) like so:
 
 ```jsx
-<Button iconName="magnifying-glass" iconPosition="after">Search</Button>
+<LinkListItem
+  iconName="magnifying-glass"
+  iconPosition="after"
+  text="Link List Item 1"
+/>
 ```
 
 ---

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -95,10 +95,14 @@ export const Banner = ({
           className={styles['banner__close-btn']}
           variant="bare"
           aria-label={closeButtonText}
-          iconName="close"
-          iconPosition="after"
           onClick={(e: any) => onDismiss(e)}
-        />
+        >
+          <Icon
+            name="x"
+            title={closeButtonText}
+            className={styles['banner__icon']}
+          />
+        </Button>
       )}
     </div>
   );

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -97,7 +97,7 @@ export const Banner = ({
           onClick={(e: any) => onDismiss(e)}
         >
           <Icon
-            name="x"
+            name="close"
             title={closeButtonText}
             className={styles['banner__icon']}
             purpose="informative"

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -94,7 +94,6 @@ export const Banner = ({
         <Button
           className={styles['banner__close-btn']}
           variant="bare"
-          aria-label={closeButtonText}
           onClick={(e: any) => onDismiss(e)}
         >
           <Icon

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -101,6 +101,7 @@ export const Banner = ({
             name="x"
             title={closeButtonText}
             className={styles['banner__icon']}
+            purpose="informative"
           />
         </Button>
       )}

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -8,12 +8,14 @@
  * 1) Button or link that has functionality to it
  * 2) Defaults to primary button
  * 3) Margin 0 added becuase Safari has margin on the button
+ * 4) Adds a gap between children to automatically handle spacing between icons and text
  */
 .button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   margin: 0; /* 3 */
+  gap: 0.75rem; /* 4 */
   border-width: var(--eds-theme-border-width);
   border-style: solid;
   border-color: var(--eds-theme-color-primary-border);
@@ -22,6 +24,11 @@
   background-color: transparent;
   cursor: pointer;
   transition: all var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  /* TODO: make default color prop in Icon inherit or something? */
+  svg {
+    fill: currentColor;
+  }
 
   &:hover {
     color: var(--eds-theme-color-primary-foreground-hover);
@@ -230,44 +237,15 @@
 }
 
 /**
- * Button children before icon spacing
- * 1) Controls the spacing between the button children
- *    and the icon that comes _before_ button children
- */
-.button__icon + .button__children {
-  margin-left: var(--eds-size-1); /* 1 */
-
-  .button--sm & {
-    margin-left: var(--eds-size-half);
-  }
-}
-
-/**
- * Button after icon spacing
- * 1) Controls the spacing between the button children
- *    and the icon that comes _after_ button children
- */
-.button__children + .button__icon {
-  margin-left: var(--eds-size-1); /* 1 */
-
-  /**
-   * Button icon after button children within a link variant button
-   */
-  .button--link & {
-    margin-left: var(--eds-size-half);
-  }
-
-  .button--sm & {
-    margin-left: var(--eds-size-half);
-  }
-}
-
-/**
  * Loading icon rotiation style
  */
 .button.eds-is-loading > .button__icon {
-  animation: rotateIcon 2s linear infinite; /* 1 */
+  animation: rotateIcon 2s linear infinite;
   overflow: visible;
+
+  @media screen and (prefers-reduced-motion) {
+    animation: none;
+  }
 }
 
 /**

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -229,17 +229,11 @@
 }
 
 /**
- * Button Icon
+ * Loading icon rotiation style
  * 1) Set SVG icon fill to the current text color
  */
-.button__icon {
+.button__icon-loading {
   fill: currentColor; /* 1 */
-}
-
-/**
- * Loading icon rotiation style
- */
-.button.eds-is-loading > .button__icon {
   animation: rotateIcon 2s linear infinite;
   overflow: visible;
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -67,14 +67,14 @@ PrimaryInverted.args = {
 export const BareIcon = Template.bind({});
 BareIcon.args = {
   variant: 'bare',
-  children: <Icon purpose="informative" title="Close" name="x" />,
+  children: <Icon purpose="informative" title="Close" name="close" />,
 };
 
 export const BareIconInverted = InvertedTemplate.bind({});
 BareIconInverted.args = {
   inverted: true,
   variant: 'bare',
-  children: <Icon purpose="informative" title="Close" name="x" />,
+  children: <Icon purpose="informative" title="Close" name="close" />,
 };
 
 export const TextLink = Template.bind({});

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
 import { Button, Props } from './Button';
+import Icon from '../Icon';
 
 export default {
   title: 'Molecules/Buttons/Button',
@@ -22,16 +23,22 @@ Default.args = { children: 'Button' };
 
 export const DefaultWithIconBefore = Template.bind({});
 DefaultWithIconBefore.args = {
-  children: 'Button',
-  iconPosition: 'before',
-  iconName: 'chevron-left',
+  children: (
+    <>
+      <Icon aria-hidden="true" focusable={false} name="chevron-left" />
+      Button
+    </>
+  ),
 };
 
 export const DefaultWithIconAfter = Template.bind({});
 DefaultWithIconAfter.args = {
-  children: 'Button',
-  iconPosition: 'after',
-  iconName: 'chevron-right',
+  children: (
+    <>
+      Button
+      <Icon aria-hidden="true" focusable={false} name="chevron-right" />
+    </>
+  ),
 };
 
 export const DefaultDisabled = Template.bind({});
@@ -61,8 +68,7 @@ export const BareIcon = Template.bind({});
 BareIcon.args = {
   variant: 'bare',
   'aria-label': 'Close',
-  iconName: 'close',
-  iconPosition: 'before',
+  children: <Icon aria-hidden="true" focusable={false} name="x" />,
 };
 
 export const BareIconInverted = InvertedTemplate.bind({});
@@ -70,8 +76,7 @@ BareIconInverted.args = {
   inverted: true,
   variant: 'bare',
   'aria-label': 'Close',
-  iconName: 'close',
-  iconPosition: 'before',
+  children: <Icon aria-hidden="true" focusable={false} name="x" />,
 };
 
 export const TextLink = Template.bind({});

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -25,7 +25,7 @@ export const DefaultWithIconBefore = Template.bind({});
 DefaultWithIconBefore.args = {
   children: (
     <>
-      <Icon aria-hidden="true" focusable={false} name="chevron-left" />
+      <Icon purpose="decorative" name="chevron-left" />
       Button
     </>
   ),
@@ -36,7 +36,7 @@ DefaultWithIconAfter.args = {
   children: (
     <>
       Button
-      <Icon aria-hidden="true" focusable={false} name="chevron-right" />
+      <Icon purpose="decorative" name="chevron-right" />
     </>
   ),
 };
@@ -67,16 +67,14 @@ PrimaryInverted.args = {
 export const BareIcon = Template.bind({});
 BareIcon.args = {
   variant: 'bare',
-  'aria-label': 'Close',
-  children: <Icon aria-hidden="true" focusable={false} name="x" />,
+  children: <Icon purpose="informative" title="Close" name="x" />,
 };
 
 export const BareIconInverted = InvertedTemplate.bind({});
 BareIconInverted.args = {
   inverted: true,
   variant: 'bare',
-  'aria-label': 'Close',
-  children: <Icon aria-hidden="true" focusable={false} name="x" />,
+  children: <Icon purpose="informative" title="Close" name="x" />,
 };
 
 export const TextLink = Template.bind({});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -29,16 +29,6 @@ export interface Props {
    */
   href?: string;
   /**
-   * Name of SVG icon (i.e. caret-down, minus, warning)
-   */
-  iconName?: string;
-  /**
-   * Determines position of icon relative to button children.
-   * - **before** places icon before button children
-   * - **after** places icon after button children
-   */
-  iconPosition?: 'before' | 'after';
-  /**
    * Button rendered on a dark backgorund
    */
   inverted?: boolean;
@@ -57,7 +47,7 @@ export interface Props {
   /**
    * The visible button children
    */
-  children?: string | ReactNode;
+  children: string | ReactNode;
   /**
    * Determines type of button
    * - **button** The button is a clickable button.
@@ -82,8 +72,6 @@ export const Button = React.forwardRef(
       forwardRef,
       fullWidth,
       href,
-      iconName,
-      iconPosition = 'before',
       inverted,
       loading,
       onClick,
@@ -117,25 +105,6 @@ export const Button = React.forwardRef(
     );
     const TagName = href ? 'a' : 'button';
 
-    const computedIcon = (
-      <>
-        {loading && (
-          <Icon
-            purpose="decorative"
-            name="spinner"
-            className={styles['button__icon']}
-          />
-        )}
-        {!loading && iconName && (
-          <Icon
-            purpose="decorative"
-            name={iconName}
-            className={styles['button__icon']}
-          />
-        )}
-      </>
-    );
-
     return (
       <TagName
         className={componentClassName}
@@ -147,13 +116,16 @@ export const Button = React.forwardRef(
         onClick={onClick}
         {...other}
       >
-        {iconPosition === 'before' && computedIcon}
-
-        {children && (
-          <span className={styles['button__children']}>{children}</span>
+        {loading && (
+          <Icon
+            aria-hidden="true"
+            focusable={false}
+            name="spinner"
+            className={styles['button__icon']}
+          />
         )}
 
-        {iconPosition === 'after' && computedIcon}
+        {children}
       </TagName>
     );
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -121,7 +121,7 @@ export const Button = React.forwardRef(
             aria-hidden="true"
             focusable={false}
             name="spinner"
-            className={styles['button__icon']}
+            className={styles['button__icon-loading']}
           />
         )}
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -118,8 +118,8 @@ export const Button = React.forwardRef(
       >
         {loading && (
           <Icon
-            aria-hidden="true"
-            focusable={false}
+            purpose="informative"
+            title="loading"
             name="spinner"
             className={styles['button__icon-loading']}
           />

--- a/src/components/Counter/Counter.stories.tsx
+++ b/src/components/Counter/Counter.stories.tsx
@@ -35,11 +35,7 @@ DefaultWithTooltip.args = {
     <Tooltip text="Some text to help with a form field">
       <Button variant="bare">
         Hover this button to trigger the tooltip
-        <Icon
-          name="question-mark-circle"
-          aria-hidden="true"
-          focusable={false}
-        />
+        <Icon name="question-mark-circle" purpose="decorative" />
       </Button>
     </Tooltip>
   ),

--- a/src/components/Counter/Counter.stories.tsx
+++ b/src/components/Counter/Counter.stories.tsx
@@ -2,6 +2,7 @@ import { Story, Meta } from '@storybook/react';
 import React from 'react';
 import { Counter, Props } from './Counter';
 import Button from '../Button';
+import Icon from '../Icon';
 import Tooltip from '../Tooltip';
 
 export default {
@@ -32,8 +33,13 @@ DefaultWithTooltip.args = {
   fieldNote: 'This is a counter field',
   labelAfter: (
     <Tooltip text="Some text to help with a form field">
-      <Button variant="bare" iconPosition="after" iconName="help">
+      <Button variant="bare">
         Hover this button to trigger the tooltip
+        <Icon
+          name="question-mark-circle"
+          aria-hidden="true"
+          focusable={false}
+        />
       </Button>
     </Tooltip>
   ),

--- a/src/components/Counter/Counter.stories.tsx
+++ b/src/components/Counter/Counter.stories.tsx
@@ -35,7 +35,7 @@ DefaultWithTooltip.args = {
     <Tooltip text="Some text to help with a form field">
       <Button variant="bare">
         Hover this button to trigger the tooltip
-        <Icon name="question-mark-circle" purpose="decorative" />
+        <Icon name="help" purpose="decorative" />
       </Button>
     </Tooltip>
   ),

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -172,7 +172,7 @@ export const Counter = ({
           disabled={disabled || (min !== undefined && count === min)}
           onClick={(e) => onDecrease(e)}
         >
-          <Icon name="minus" purpose="informative" title={minusButtonText} />
+          <Icon name="remove" purpose="informative" title={minusButtonText} />
         </Button>
         <TextInput
           className={styles['counter__input']}
@@ -195,7 +195,7 @@ export const Counter = ({
           disabled={disabled || (max !== undefined && count === max)}
           onClick={(e) => onIncrease(e)}
         >
-          <Icon name="plus" purpose="informative" title={plusButtonText} />
+          <Icon name="add" purpose="informative" title={plusButtonText} />
         </Button>
       </div>
       {fieldNote && (

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -4,6 +4,7 @@ import React, { ReactNode, useEffect, useState } from 'react';
 import styles from './Counter.module.css';
 import Button from '../Button';
 import FieldNote from '../FieldNote';
+import Icon from '../Icon';
 import Label from '../Label';
 import TextInput from '../TextInput';
 
@@ -168,12 +169,12 @@ export const Counter = ({
         <Button
           className={styles['counter__btn']}
           variant="bare"
-          iconPosition="after"
-          iconName="remove"
           aria-label={minusButtonText}
           disabled={disabled || (min !== undefined && count === min)}
           onClick={(e) => onDecrease(e)}
-        />
+        >
+          <Icon name="minus" aria-hidden="true" focusable={false} />
+        </Button>
         <TextInput
           className={styles['counter__input']}
           type="text"
@@ -192,12 +193,12 @@ export const Counter = ({
         <Button
           className={styles['counter__btn']}
           variant="bare"
-          iconPosition="after"
-          iconName="add"
           aria-label={plusButtonText}
           disabled={disabled || (max !== undefined && count === max)}
           onClick={(e) => onIncrease(e)}
-        />
+        >
+          <Icon name="plus" aria-hidden="true" focusable={false} />
+        </Button>
       </div>
       {fieldNote && (
         <FieldNote

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -169,11 +169,10 @@ export const Counter = ({
         <Button
           className={styles['counter__btn']}
           variant="bare"
-          aria-label={minusButtonText}
           disabled={disabled || (min !== undefined && count === min)}
           onClick={(e) => onDecrease(e)}
         >
-          <Icon name="minus" aria-hidden="true" focusable={false} />
+          <Icon name="minus" purpose="informative" title={minusButtonText} />
         </Button>
         <TextInput
           className={styles['counter__input']}
@@ -193,11 +192,10 @@ export const Counter = ({
         <Button
           className={styles['counter__btn']}
           variant="bare"
-          aria-label={plusButtonText}
           disabled={disabled || (max !== undefined && count === max)}
           onClick={(e) => onIncrease(e)}
         >
-          <Icon name="plus" aria-hidden="true" focusable={false} />
+          <Icon name="plus" purpose="informative" title={plusButtonText} />
         </Button>
       </div>
       {fieldNote && (

--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -45,11 +45,10 @@ export const DrawerHeader = ({
       {dismissible && (
         <Button
           className={styles['drawer__close-button']}
-          aria-label={closeButtonText}
           variant="bare"
           onClick={onClick}
         >
-          <Icon name="x" aria-hidden="true" focusable={false} />
+          <Icon name="x" purpose="informative" title={closeButtonText} />
         </Button>
       )}
     </header>

--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -48,7 +48,7 @@ export const DrawerHeader = ({
           variant="bare"
           onClick={onClick}
         >
-          <Icon name="x" purpose="informative" title={closeButtonText} />
+          <Icon name="close" purpose="informative" title={closeButtonText} />
         </Button>
       )}
     </header>

--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React, { MouseEventHandler, ReactNode } from 'react';
 import Button from '../Button';
 import styles from '../Drawer/Drawer.module.css';
+import Icon from '../Icon';
 
 export interface Props {
   /**
@@ -44,12 +45,12 @@ export const DrawerHeader = ({
       {dismissible && (
         <Button
           className={styles['drawer__close-button']}
-          iconPosition="before"
-          iconName="close"
           aria-label={closeButtonText}
           variant="bare"
           onClick={onClick}
-        />
+        >
+          <Icon name="x" aria-hidden="true" focusable={false} />
+        </Button>
       )}
     </header>
   );

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -276,13 +276,12 @@ export const FileUploadField = ({
       default:
         return (
           <Button
-            aria-label={removeFileButtonText}
             variant="bare"
             onClick={() => {
               onFileRemove(file.id);
             }}
           >
-            <Icon name="x" aria-hidden="true" focusable={false} />
+            <Icon name="x" purpose="informative" title={removeFileButtonText} />
           </Button>
         );
     }

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -276,14 +276,14 @@ export const FileUploadField = ({
       default:
         return (
           <Button
-            iconName="close"
-            iconPosition="before"
             aria-label={removeFileButtonText}
             variant="bare"
             onClick={() => {
               onFileRemove(file.id);
             }}
-          />
+          >
+            <Icon name="x" aria-hidden="true" focusable={false} />
+          </Button>
         );
     }
   }

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -281,7 +281,11 @@ export const FileUploadField = ({
               onFileRemove(file.id);
             }}
           >
-            <Icon name="x" purpose="informative" title={removeFileButtonText} />
+            <Icon
+              name="close"
+              purpose="informative"
+              title={removeFileButtonText}
+            />
           </Button>
         );
     }

--- a/src/components/ModalHeader/ModalHeader.tsx
+++ b/src/components/ModalHeader/ModalHeader.tsx
@@ -45,11 +45,10 @@ export const ModalHeader = ({
       {dismissible && (
         <Button
           className={styles['modal__close-button']}
-          aria-label={closeButtonText}
           variant="bare"
           onClick={onClick}
         >
-          <Icon name="x" aria-hidden="true" focusable={false} />
+          <Icon name="x" title={closeButtonText} purpose="informative" />
         </Button>
       )}
     </header>

--- a/src/components/ModalHeader/ModalHeader.tsx
+++ b/src/components/ModalHeader/ModalHeader.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { MouseEventHandler, ReactNode } from 'react';
 import Button from '../Button';
+import Icon from '../Icon';
 import styles from '../Modal/Modal.module.css';
 
 export interface Props {
@@ -44,12 +45,12 @@ export const ModalHeader = ({
       {dismissible && (
         <Button
           className={styles['modal__close-button']}
-          iconPosition="before"
-          iconName="close"
           aria-label={closeButtonText}
           variant="bare"
           onClick={onClick}
-        />
+        >
+          <Icon name="x" aria-hidden="true" focusable={false} />
+        </Button>
       )}
     </header>
   );

--- a/src/components/ModalHeader/ModalHeader.tsx
+++ b/src/components/ModalHeader/ModalHeader.tsx
@@ -48,7 +48,7 @@ export const ModalHeader = ({
           variant="bare"
           onClick={onClick}
         >
-          <Icon name="x" title={closeButtonText} purpose="informative" />
+          <Icon name="close" title={closeButtonText} purpose="informative" />
         </Button>
       )}
     </header>

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<Props> = (args) => (
     <ShowHide
       trigger={
         <Button type="button">
-          <Icon name="chevron-down" aria-hidden="true" focusable={false} />
+          <Icon name="chevron-down" aria-hidden="true" />
         </Button>
       }
       {...args}

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<Props> = (args) => (
     <ShowHide
       trigger={
         <Button type="button">
-          <Icon name="chevron-down" aria-hidden="true" />
+          <Icon name="chevron-down" purpose="decorative" />
         </Button>
       }
       {...args}

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<Props> = (args) => (
     <ShowHide
       trigger={
         <Button type="button">
-          <Icon name="chevron-down" purpose="decorative" />
+          <Icon name="expamd-more" purpose="decorative" />
         </Button>
       }
       {...args}

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -15,7 +15,7 @@ const Template: Story<Props> = (args) => (
     <ShowHide
       trigger={
         <Button type="button">
-          <Icon name="expamd-more" purpose="decorative" />
+          <Icon name="expand-more" purpose="decorative" />
         </Button>
       }
       {...args}

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { ShowHide, Props } from './ShowHide';
 import Button from '../Button';
+import Icon from '../Icon';
 
 export default {
   title: 'Molecules/Interactive/ShowHide',
@@ -13,7 +14,9 @@ const Template: Story<Props> = (args) => (
   <div style={{ margin: '10rem' }}>
     <ShowHide
       trigger={
-        <Button type="button" iconName="expand-more" iconPosition="after" />
+        <Button type="button">
+          <Icon name="chevron-down" aria-hidden="true" focusable={false} />
+        </Button>
       }
       {...args}
     >

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import React, { MouseEventHandler, ReactNode } from 'react';
 import Button from '../Button';
+import Icon from '../Icon';
 import styles from '../Table/Table.module.css';
 
 export interface Props {
@@ -82,13 +83,9 @@ export const TableHeaderCell = ({
       id={id}
       {...other}
     >
-      <Button
-        variant="table-header"
-        iconPosition="after"
-        iconName="arrow-narrow-down"
-        onClick={onClick}
-      >
+      <Button variant="table-header" onClick={onClick}>
         {children}
+        <Icon name="arrow-narrow-down" aria-hidden="true" focusable={false} />
       </Button>
     </th>
   );

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -84,7 +84,7 @@ export const TableHeaderCell = ({
     >
       <Button variant="table-header" onClick={onClick}>
         {text}
-        <Icon name="arrow-narrow-down" aria-hidden="true" focusable={false} />
+        <Icon name="arrow-narrow-down" purpose="decorative" />
       </Button>
     </th>
   );

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -51,7 +51,6 @@ export interface Props {
  * Primary UI component for user interaction
  */
 export const TableHeaderCell = ({
-  children,
   className,
   rowSpan,
   colSpan,
@@ -84,7 +83,7 @@ export const TableHeaderCell = ({
       {...other}
     >
       <Button variant="table-header" onClick={onClick}>
-        {children}
+        {text}
         <Icon name="arrow-narrow-down" aria-hidden="true" focusable={false} />
       </Button>
     </th>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -83,10 +83,9 @@ export const Toast = ({
         <Button
           className={styles['toast__close-btn']}
           variant="bare"
-          aria-label={closeButtonText}
           onClick={(e: any) => onDismiss(e)}
         >
-          <Icon name="x" aria-hidden="true" focusable={false} />
+          <Icon name="x" purpose="informative" title={closeButtonText} />
         </Button>
       )}
     </div>

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -84,10 +84,10 @@ export const Toast = ({
           className={styles['toast__close-btn']}
           variant="bare"
           aria-label={closeButtonText}
-          iconName="close"
-          iconPosition="after"
           onClick={(e: any) => onDismiss(e)}
-        />
+        >
+          <Icon name="x" aria-hidden="true" focusable={false} />
+        </Button>
       )}
     </div>
   );

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -85,7 +85,7 @@ export const Toast = ({
           variant="bare"
           onClick={(e: any) => onDismiss(e)}
         >
-          <Icon name="x" purpose="informative" title={closeButtonText} />
+          <Icon name="close" purpose="informative" title={closeButtonText} />
         </Button>
       )}
     </div>

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -7,11 +7,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
       aria-describedby="tippy-5"
       class="button trigger--spacing-bottom trigger--spacing-left button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div
@@ -64,11 +60,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
       aria-describedby="tippy-2"
       class="button trigger--spacing button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div
@@ -125,11 +117,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
         aria-describedby="tippy-8"
         class="button trigger--spacing button--lg"
       >
-        <span
-          class="button__children"
-        >
-          Hover here to see tooltip after clicking somewhere outside.
-        </span>
+        Hover here to see tooltip after clicking somewhere outside.
       </button>
     </div>
   </div>
@@ -183,11 +171,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
       aria-describedby="tippy-3"
       class="button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div
@@ -240,11 +224,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
       aria-describedby="tippy-1"
       class="button trigger--spacing button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div
@@ -297,11 +277,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
       aria-describedby="tippy-7"
       class="button trigger--spacing-top button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger with longer text to test placement
-      </span>
+      Tooltip trigger with longer text to test placement
     </button>
   </div>
   <div
@@ -354,11 +330,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
       aria-describedby="tippy-6"
       class="button trigger--spacing button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div
@@ -409,11 +381,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
       aria-describedby="tippy-4"
       class="button trigger--spacing-top trigger--spacing-left button--lg"
     >
-      <span
-        class="button__children"
-      >
-        Tooltip trigger
-      </span>
+      Tooltip trigger
     </button>
   </div>
   <div


### PR DESCRIPTION
### Summary:
On the CZI side, we've been discussing retaining the existing `Button` API where devs pass in an icon via `children` instead of the `iconName` and `iconPosition` props. This PR explores what that would look like.

Our reasoning is:
- we can get the spacing between icons and text with `gap`; we don't need to manually add margin to icons before and after the text
- this API feels much more intuitive and natural to us, and we feel confident the devs using the components would agree
- the other API felt especially weird to us when the button only contained an icon; you still had to pass in an `iconPosition` and it would add the margin on to one side, making it lop-sided; `gap` only adds the spacing when there's more than one child

The only downsides imo are:
- if the `children` text is broken up into multiple spans or something for some reason, that would need to be wrapped in another `span` to avoid weird spacing in the text (this seems pretty rare though)
- it was kinda nice that if there was an icon before the text and the `loading` prop was set to `true`, the loading spinner would automatically replace the icon to avoid a double icon (though I don't know if we really care about that)

For more context on the `loading` prop, we don't have that in the current EDS `Button` and I've only seen one or two places in the product that are using a loading spinner in a button like this, but I talked to Sean and we agreed this would be a nice paradigm to start using because it's so simple and consistent. We're planning to write up a little guidance on when to use it. So although it's not currently a thing in LP, we would like for it to become one.

### Test Plan:
Check out the buttons in storybook that have icons and verify they're mostly unchanged (the icon placement did shift a little).