### PR TITLE
Add `SvgIcon` props to `Icon`

### DIFF
--- a/.storybook/components/IconGrid/IconGrid.js
+++ b/.storybook/components/IconGrid/IconGrid.js
@@ -1,23 +1,18 @@
 import React from 'react';
 import { Icon } from '../../../src/components/Icon/Icon';
+import { ALL_ICONS } from '../../../src/util/allIcons';
 import './IconGrid.css';
-
-// eslint-disable-next-line no-undef
-const ALL_ICONS = require
-  .context('../../../src/icons', false, /\.svg$/)
-  .keys()
-  .map((path) => ({ name: path.match(/([\w\s-]*)\.svg$/)[1] }));
 
 class IconGrid extends React.Component {
   render() {
     return (
       <div>
         <ul className="icon-grid">
-          {ALL_ICONS.map(function (item, index) {
+          {ALL_ICONS.map((name, index) => {
             return (
               <li className="icon-grid__item" key={`icon-grid-item-${index}`}>
-                <Icon name={item.name} />
-                <span className="icon-grid__text">{item.name}</span>
+                <Icon name={name} />
+                <span className="icon-grid__text">{name}</span>
               </li>
             );
           })}

--- a/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.tsx
@@ -122,7 +122,8 @@ export const AccordionPanel = ({
           <Icon
             className={styles['accordion-panel__icon']}
             name="expand-more"
-          ></Icon>
+            purpose="decorative"
+          />
         </button>
       </dt>
       <dd

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -85,6 +85,7 @@ export const Banner = ({
           name={iconName}
           title={iconTitle}
           className={styles['banner__icon']}
+          purpose="informative"
         />
       )}
       <div className={styles['banner__body']}>{children}</div>

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -31,8 +31,7 @@ export const BreadcrumbsItem = ({ className, text, href, ...other }: Props) => {
       <Icon
         className={styles['breadcrumbs__icon']}
         name="chevron-right"
-        aria-hidden={true}
-        focusable={false}
+        purpose="decorative"
       />
     </li>
   );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -121,16 +121,14 @@ export const Button = React.forwardRef(
       <>
         {loading && (
           <Icon
-            aria-hidden="true"
-            focusable={false}
+            purpose="decorative"
             name="spinner"
             className={styles['button__icon']}
           />
         )}
         {!loading && iconName && (
           <Icon
-            aria-hidden="true"
-            focusable={false}
+            purpose="decorative"
             name={iconName}
             className={styles['button__icon']}
           />

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -59,6 +59,7 @@ export const FieldNote = ({
         <Icon
           className={styles['field-note__icon']}
           title="error"
+          purpose="informative"
           name={isError && 'cancel'}
         />
       )}

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -265,7 +265,7 @@ export const FileUploadField = ({
   function renderFileListIconOrRemoveButton(file) {
     switch (statusLabel) {
       case 'success':
-        return <Icon name="caret-down" />;
+        return <Icon name="caret-down" purpose="decorative" />;
       case 'uploading':
         return (
           <LoadingIndicator

--- a/src/components/Icon/Icon.module.css
+++ b/src/components/Icon/Icon.module.css
@@ -8,9 +8,17 @@
  * 1) Small graphic that represents functionality
  */
 .icon {
-  display: block;
-  height: var(--eds-size-2);
-  width: var(--eds-size-2);
+  display: inline-block;
+  /**
+   * Size Priority:
+   * 1: --icon-size, passed through props
+   * 2: --icon-size-default, determined by context (text, button, pill)
+   * default: 1em, same size as surrounding text
+   *
+   * Inspired by https://www.youtube.com/watch?v=EDyiaDJJu-4
+   */
+   width: var(--icon-size, var(--icon-size-default, 1em));
+   height: var(--icon-size, var(--icon-size-default, 1em));
 
   /**
    * Icon within text passage
@@ -19,21 +27,19 @@
   .text-passage & {
     display: inline; /* 1 */
   }
-
-  /**
-   * Icon within small text passage
-   * 1) Sets icon to smaller height and width to match font size
-   */
-  .text-passage--sm & {
-    height: 12px; /* 1 */
-    width: 12px; /* 1 */
-  }
 }
 
 /**
-   * Inverted icon
-   * 1) Sets icon to smaller height and width to match font size
-   */
+ * Inverted icon
+ */
 .icon--inverted {
   fill: var(--eds-theme-color-body-foreground-inverted);
+}
+
+/**
+ * Full-width icon
+ * 1) A block icon fills 100% of the width of its container
+ */
+.icon--full-width {
+  display: block
 }

--- a/src/components/Icon/Icon.module.css
+++ b/src/components/Icon/Icon.module.css
@@ -30,13 +30,6 @@
 }
 
 /**
- * Inverted icon
- */
-.icon--inverted {
-  fill: var(--eds-theme-color-body-foreground-inverted);
-}
-
-/**
  * Full-width icon
  * 1) A block icon fills 100% of the width of its container
  */

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,20 +1,20 @@
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
-import { Icon, Props } from './Icon';
+import { Icon, IconProps } from './Icon';
 
 export default {
   title: 'Atoms/Icons/Icon',
   component: Icon,
 } as Meta;
 
-const Template: Story<Props> = (args) => <Icon {...args} />;
+const Template: Story<IconProps> = (args) => <Icon {...args} />;
 
 export const Default = Template.bind({});
 Default.args = { name: 'close' };
 
 export const Inverted = () => (
   <div className="u-padding-sm" style={{ background: '#000000' }}>
-    <Icon inverted={true} name="close" />
+    <Icon inverted={true} name="close" purpose="decorative" />
   </div>
 );

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,20 +1,114 @@
-import { Story, Meta } from '@storybook/react';
+import type { StoryObj } from '@storybook/react';
 import React from 'react';
-
 import { Icon, IconProps } from './Icon';
+import * as ColorTokens from '../../tokens-dist/colors';
+import { ALL_ICONS } from '../../util/allIcons';
+import Text from '../Text';
 
 export default {
   title: 'Atoms/Icons/Icon',
   component: Icon,
-} as Meta;
+  argTypes: {
+    name: {
+      control: {
+        type: 'select',
+        options: ALL_ICONS,
+      },
+    },
+    color: {
+      control: {
+        type: 'select',
+        options: ['currentColor', ...Object.keys(ColorTokens)],
+      },
+    },
+  },
+};
 
-const Template: Story<IconProps> = (args) => <Icon {...args} />;
+export const Default: StoryObj<IconProps> = {
+  render: ({ name, color, ...rest }) => {
+    const computedColor = color && ColorTokens[color];
+    return <Icon {...rest} name={name} color={computedColor} />;
+  },
+  args: {
+    name: 'close',
+    purpose: 'decorative' as const,
+  },
+};
 
-export const Default = Template.bind({});
-Default.args = { name: 'close' };
+export const Medium: StoryObj<IconProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    size: '2em',
+  },
+};
+
+export const Large: StoryObj<IconProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    size: '4em',
+  },
+};
+
+export const FullScreen: StoryObj<IconProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    size: '100vh',
+  },
+  parameters: {
+    axe: {
+      disabledRules: ['scrollable-region-focusable'],
+    },
+  },
+};
+
+export const CustomColor: StoryObj<IconProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    color: ColorTokens.EdsColorBrandGrape500,
+    size: '2em',
+  },
+};
 
 export const Inverted = () => (
   <div className="u-padding-sm" style={{ background: '#000000' }}>
     <Icon inverted={true} name="close" purpose="decorative" />
   </div>
 );
+
+export const InText: StoryObj<IconProps> = {
+  render: (args) => {
+    return (
+      <Text as="p">
+        The svg icon defaults to the surrounding text size (
+        <Icon
+          {...args}
+          name="account-circle"
+          purpose="informative"
+          title="icon with 1em line height"
+        />
+        , 1em), but often looks better with the line height (
+        <Icon
+          {...args}
+          name="account-circle"
+          purpose="informative"
+          title="icon with 2em line height"
+          size="2em"
+        />
+        , 2em) which is harder to determine. Take a look at the icons available
+        in{' '}
+        <a
+          href="https://material-ui.com/components/material-icons/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          https://material-ui.com/components/material-icons/
+        </a>
+        , currently we only support the filled icons.
+      </Text>
+    );
+  },
+};

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -68,16 +68,10 @@ export const CustomColor: StoryObj<IconProps> = {
   ...Default,
   args: {
     ...Default.args,
-    color: ColorTokens.EdsColorBrandGrape500,
+    color: 'EdsColorBrandGrape500',
     size: '2em',
   },
 };
-
-export const Inverted = () => (
-  <div className="u-padding-sm" style={{ background: '#000000' }}>
-    <Icon inverted={true} name="close" purpose="decorative" />
-  </div>
-);
 
 export const InText: StoryObj<IconProps> = {
   render: (args) => {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -5,68 +5,149 @@ import svg4everybody from 'svg4everybody';
 import styles from './Icon.module.css';
 import icons from '../../icons/spritemap/spritemap.svg';
 
-export interface Props {
+interface IconPropsBase {
   /**
    * CSS class names that can be appended to the component.
    */
   className?: string;
   /**
-   * Declares whether the icon is focusable or not for accessibility
+   * Either a fragment of svg elements (g, path, circle, etc.), or a single
+   * svg element. Useful for creating specific icon components.
+   *
+   * @example
+   * function CircleIcon(props: IconProps) {
+   *   return (
+   *     <Icon {...props}>
+   *       <circle cx="50" cy="50" r="50" />
+   *     </Icon>
+   *   )
+   * }
    */
-  focusable?: boolean;
+  children?: React.ReactNode;
+  /**
+   * The SVG Color, expects a valid css color (hex, rgb, etc.).
+   * Recommendation: if `currentColor` isn't sufficient, use color tokens from
+   * @chanzuckerberg/eds/lib/tokens/colors.ts
+   */
+  color?: string;
+  /**
+   * If true, the element will be displayed as a block, otherwise
+   * default is inline like images
+   */
+  fullWidth?: boolean;
   /**
    * ID used so the svg can read the title of the SVG icon to the user when accessibility is needed
    */
-  id?: any;
-  /**
-   * Name of icon to reference in icon sprite
-   */
-  name?: string;
+  id?: string;
   /**
    * Inverted variant for dark backgrounds
+   *
+   * TODO: investigate if needed
    */
   inverted?: boolean;
   /**
-   * SVG title which serves as alt text for the SVG.
+   * Name of icon to reference in icon sprite
+   *
+   * TODO: add typing of possible icon names
    */
-  title?: string;
+  name?: string;
+  /**
+   * Width/Height string (px, rem, em, vh, etc.)
+   * Recommendation: use "EdsFontSize" tokens from
+   * @chanzuckerberg/eds/lib/tokens/variables.json
+   */
+  size?: string;
+}
+
+interface InformativeIconProps extends IconPropsBase {
+  /**
+   * The role of the icon.
+   *
+   * Use "informative" when the icon **_does_** provide additional meaning to other text on the
+   * page. You'll be required to pass in a title to label the icon.
+   */
+  purpose: 'informative';
+  title: string;
+}
+
+interface DecorativeIconProps extends IconPropsBase {
+  /**
+   * The role of the icon.
+   *
+   * Use "decorative" when the icon **_does not_** provide any additional context or meaning to
+   * associated text. Basically the icon is for show and people don't need it to understand what's
+   * on the page.
+   */
+  purpose: 'decorative';
+}
+
+export type IconProps = DecorativeIconProps | InformativeIconProps;
+
+interface SvgStyle extends React.CSSProperties {
+  '--icon-size'?: string;
 }
 
 /**
- * Primary UI component for user interaction
+ * Render arbitrary SVG path data while enforcing good accessibility practices.
+ *
+ * If you're looking for specific icon files, look in the `src/icons` directory.
  */
-export const Icon = ({
-  className,
-  name,
-  focusable = false,
-  id,
-  inverted,
-  title,
-  ...other
-}: Props) => {
-  const [idVar, setId] = useState();
+export const Icon = (props: IconProps) => {
+  const {
+    children,
+    className,
+    color = 'currentColor',
+    name,
+    fullWidth = false,
+    id,
+    inverted,
+    purpose,
+    size,
+  } = props;
+  const [idVar, setId] = useState('');
 
   useEffect(() => {
     setId(id || nanoid());
-    svg4everybody(); //Required to get IE to render icon sprites
+    svg4everybody(); // Required to get IE to render icon sprites
   }, [id]);
 
   const componentClassName = clsx(
     styles['icon'],
     className,
     inverted && styles['icon--inverted'],
+    fullWidth && styles['icon--full-width'],
   );
-  return (
-    <svg
-      aria-hidden={!title}
-      aria-labelledby={title && idVar}
-      className={componentClassName}
-      focusable={focusable}
-      role={title && 'img'}
-      {...other}
-    >
-      {title && <title id={idVar}>{title}</title>}
-      <use xlinkHref={`${icons}#${name}`} />
-    </svg>
-  );
+  const style: SvgStyle = {
+    '--icon-size': size,
+  };
+
+  const svgCommonProps = {
+    className: componentClassName,
+    fill: color,
+    height: size,
+    /**
+     * height/width html properties are overriden by the defaults applied in CSS module
+     */
+    style,
+    width: size,
+    xmlns: 'http://www.w3.org/2000/svg',
+  };
+  // allow passing custom SVGs to render, otherwise
+  // load from the spritemap of EDS icons
+  const svgToUse = children || <use xlinkHref={`${icons}#${name}`} />;
+
+  if (purpose === 'informative') {
+    return (
+      <svg {...svgCommonProps} role="img">
+        <title id={idVar}>{props.title}</title>
+        {svgToUse}
+      </svg>
+    );
+  } else {
+    return (
+      <svg {...svgCommonProps} aria-hidden>
+        {svgToUse}
+      </svg>
+    );
+  }
 };

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { nanoid } from 'nanoid';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, ReactNode, CSSProperties } from 'react';
 import svg4everybody from 'svg4everybody';
 import styles from './Icon.module.css';
 import icons from '../../icons/spritemap/spritemap.svg';
@@ -23,7 +23,7 @@ interface IconPropsBase {
    *   )
    * }
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /**
    * The SVG Color, expects a valid css color (hex, rgb, etc.).
    * Recommendation: if `currentColor` isn't sufficient, use color tokens from
@@ -39,12 +39,6 @@ interface IconPropsBase {
    * ID used so the svg can read the title of the SVG icon to the user when accessibility is needed
    */
   id?: string;
-  /**
-   * Inverted variant for dark backgrounds
-   *
-   * TODO: investigate if needed
-   */
-  inverted?: boolean;
   /**
    * Name of icon to reference in icon sprite
    *
@@ -83,7 +77,7 @@ interface DecorativeIconProps extends IconPropsBase {
 
 export type IconProps = DecorativeIconProps | InformativeIconProps;
 
-interface SvgStyle extends React.CSSProperties {
+interface SvgStyle extends CSSProperties {
   '--icon-size'?: string;
 }
 
@@ -100,7 +94,6 @@ export const Icon = (props: IconProps) => {
     name,
     fullWidth = false,
     id,
-    inverted,
     purpose,
     size,
   } = props;
@@ -114,7 +107,6 @@ export const Icon = (props: IconProps) => {
   const componentClassName = clsx(
     styles['icon'],
     className,
-    inverted && styles['icon--inverted'],
     fullWidth && styles['icon--full-width'],
   );
   const style: SvgStyle = {
@@ -134,19 +126,19 @@ export const Icon = (props: IconProps) => {
   };
   // allow passing custom SVGs to render, otherwise
   // load from the spritemap of EDS icons
-  const svgToUse = children || <use xlinkHref={`${icons}#${name}`} />;
+  const computedSvg = children || <use xlinkHref={`${icons}#${name}`} />;
 
   if (purpose === 'informative') {
     return (
       <svg {...svgCommonProps} role="img">
         <title id={idVar}>{props.title}</title>
-        {svgToUse}
+        {computedSvg}
       </svg>
     );
   } else {
     return (
       <svg {...svgCommonProps} aria-hidden>
-        {svgToUse}
+        {computedSvg}
       </svg>
     );
   }

--- a/src/components/LinkListItem/LinkListItem.tsx
+++ b/src/components/LinkListItem/LinkListItem.tsx
@@ -73,7 +73,7 @@ export const LinkListItem = ({
       >
         {iconPosition === 'before' && (
           <Icon
-            aria-hidden="true"
+            purpose="decorative"
             name={iconName}
             className={styles['link-list__icon']}
           />
@@ -91,7 +91,7 @@ export const LinkListItem = ({
 
         {iconPosition === 'after' && (
           <Icon
-            aria-hidden="true"
+            purpose="decorative"
             name={iconName}
             className={styles['link-list__icon']}
           />

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -272,16 +272,19 @@ export const ListDetail = ({
                       <Icon
                         className={styles['list-detail__icon']}
                         name="check-circle"
+                        purpose="decorative"
                       />
                     ) : itemVariant === 'warning' ? (
                       <Icon
                         className={styles['list-detail__icon']}
                         name="error"
+                        purpose="decorative"
                       />
                     ) : itemVariant === 'error' ? (
                       <Icon
                         className={styles['list-detail__icon']}
                         name="cancel"
+                        purpose="decorative"
                       />
                     ) : itemVariant === 'number' ? (
                       <span className={styles['list-detail__number']}>

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -18,7 +18,7 @@ export const LoadingIndicator = ({ className, ...other }: Props) => {
   return (
     <div className={componentClassName} {...other}>
       <Icon
-        aria-hidden="true"
+        purpose="decorative"
         name="spinner"
         className={styles['loading-indicator__icon']}
       />

--- a/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -52,7 +52,11 @@ export const PrimaryNavItem = React.forwardRef<HTMLLIElement, Props>(
     return (
       <li className={componentClassName} {...other} ref={ref}>
         <TagName className={styles['primary-nav__link']} href={href}>
-          <Icon className={styles['primary-nav__icon']} name={iconName} />
+          <Icon
+            className={styles['primary-nav__icon']}
+            name={iconName}
+            purpose="decorative"
+          />
           <span className={styles['primary-nav__text']}>{text}</span>
         </TagName>
       </li>

--- a/src/components/SelectField/SelectField.tsx
+++ b/src/components/SelectField/SelectField.tsx
@@ -185,7 +185,11 @@ export const SelectField = ({
           onChange={(e) => handleOnChange(e)}
           {...other}
         />
-        <Icon name="expand-more" className={styles['select-field__icon']} />
+        <Icon
+          name="expand-more"
+          className={styles['select-field__icon']}
+          purpose="decorative"
+        />
       </div>
       {fieldNote && (
         <FieldNote

--- a/src/components/TagsItem/TagsItem.tsx
+++ b/src/components/TagsItem/TagsItem.tsx
@@ -55,7 +55,12 @@ export const TagsItem = ({
         >
           <span className={styles['tags__text']}>{text}</span>
           {dismissible && (
-            <Icon className={styles['tags__icon']} name="close" title="Close" />
+            <Icon
+              className={styles['tags__icon']}
+              name="close"
+              title="Close"
+              purpose="informative"
+            />
           )}
         </button>
       </li>

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -236,7 +236,11 @@ export const TextField = ({
           </div>
         )}
         {iconName && (
-          <Icon className={styles['text-field__icon']} name={iconName} />
+          <Icon
+            className={styles['text-field__icon']}
+            name={iconName}
+            purpose="decorative"
+          />
         )}
       </div>
       {fieldNote && (

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -223,7 +223,11 @@ export const TextareaField = ({
           </Button>
         )}
         {iconName && (
-          <Icon className={styles['textarea-field__icon']} name={iconName} />
+          <Icon
+            className={styles['textarea-field__icon']}
+            name={iconName}
+            purpose="decorative"
+          />
         )}
       </div>
       {fieldNote && (

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -74,6 +74,7 @@ export const Toast = ({
           name={iconName}
           title={iconTitle}
           className={styles['toast__icon']}
+          purpose="informative"
         />
       )}
       <div className={styles['toast__body']}>{children}</div>

--- a/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -84,8 +84,7 @@ export const UtilityNavItem = React.forwardRef<HTMLLIElement, Props>(
           <span className={styles['utility-nav__text']}>{text}</span>
           {children && (
             <Icon
-              aria-hidden="true"
-              focusable={false}
+              purpose="decorative"
               name="expand-more"
               className={styles['utility-nav__icon']}
             />

--- a/src/design-tokens/css/base/media.css
+++ b/src/design-tokens/css/base/media.css
@@ -10,3 +10,10 @@ img {
   max-width: 100%;
   height: auto;
 }
+
+/**
+ * Align SVG elements to be vertically centered by default
+ */
+svg {
+  vertical-align: middle;
+}

--- a/src/util/allIcons.ts
+++ b/src/util/allIcons.ts
@@ -1,0 +1,4 @@
+export const ALL_ICONS: Array<string> = require
+  .context('../icons', false, /\.svg$/)
+  .keys()
+  .map((path) => path.match(/([\w\s-]*)\.svg$/)[1]);


### PR DESCRIPTION
### Summary:
[ch187509]

- Adds props from `SvgIcon` to `Icon` component
- Updates existing callsites
- Adds extra stories from EDS

**To handle later** (aka I tried but it took too much time & wanted to timebox it):
- Making `ALL_ICONS` a union type for the Icon `name` prop to read from
- Adding snapshot tests (there's an error rn because the stories read from `ALL_ICONS`, and jest doesn't like `require.context`)
https://app.shortcut.com/czi-edu/story/191277/make-icon-name-prop-a-union-of-available-icon-types

### Test Plan:
- No type errors
- See visual changes in Chromatic
- Make sure Icon Docs page controls work
![Screen Shot 2022-04-04 at 6 59 41 PM](https://user-images.githubusercontent.com/15840841/161646096-fa39d2e0-786f-41a4-9dec-a95e0acdfe0b.png)
 