### PR TITLE
chore(templates): update plop templates

### DIFF
--- a/plop-templates/Page/Page.stories.tsx.hbs
+++ b/plop-templates/Page/Page.stories.tsx.hbs
@@ -2,15 +2,15 @@
 import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
-import { {{pascalCase name}}, Props } from './{{pascalCase name}}';
+import { {{pascalCase name}} } from './{{pascalCase name}}';
 
 export default {
 	title: 'Pages/{{pascalCase name}}',
 	component: {{pascalCase name}},
 } as Meta;
 
-const Template: Story<Props> = (args) => <{{pascalCase name}} {...args} />;
+const Template: Story = (args) => <{{pascalCase name}} {...args} />;
 
 export const Default = Template.bind({});
 Default.args = {
-};;
+};

--- a/plop-templates/Page/Page.tsx.hbs
+++ b/plop-templates/Page/Page.tsx.hbs
@@ -6,7 +6,7 @@ import {
 
 import { PageShell } from '../../recipes/PageShell/PageShell';
 
-export const {{pascalCase name}}: React.FC = () => (
+export const {{pascalCase name}} = () => (
   <PageShell>
     <PageHeader title="Page title" />
   </PageShell>

--- a/plop-templates/Page/index.ts.hbs
+++ b/plop-templates/Page/index.ts.hbs
@@ -1,0 +1,1 @@
+export { {{pascalCase name}} as default } from './{{pascalCase name}}'

--- a/plop-templates/Recipe/Recipe.tsx.hbs
+++ b/plop-templates/Recipe/Recipe.tsx.hbs
@@ -12,10 +12,10 @@ export interface Props {
 /**
  * Primary UI component for user interaction
  */
-export const {{pascalCase name}}: React.FC<Props> = ({
+export const {{pascalCase name}} = ({
 	className,
 	...other
-}) => {
+}: Props) => {
 	const componentClassName = clsx(styles['{{dashCase name}}'], className, {
 	});
 	return (

--- a/plop-templates/Recipe/index.ts.hbs
+++ b/plop-templates/Recipe/index.ts.hbs
@@ -1,0 +1,1 @@
+export { {{pascalCase name}} as default } from './{{pascalCase name}}'

--- a/plopfile.js
+++ b/plopfile.js
@@ -32,12 +32,17 @@ module.exports = (plop) => {
         templateFile: 'plop-templates/Component/Component.test.tsx.hbs',
       },
       {
+        type: 'add',
+        path: 'src/components/{{pascalCase name}}/index.ts',
+        templateFile: 'plop-templates/Component/index.ts.hbs',
+      },
+      {
         type: 'append',
         pattern: /;\n$/,
         separator: '',
         path: 'src/index.ts',
         template:
-          'export { {{pascalCase name}} } from "./components/{{pascalCase name}}/{{pascalCase name}}";',
+          'export { {{default as pascalCase name}} } from "./components/{{pascalCase name}}";',
       },
       // From https://github.com/bradfrost/czi-vanilla-storybook
       function sortIndex() {
@@ -86,6 +91,11 @@ module.exports = (plop) => {
         path: '.storybook/recipes/{{pascalCase name}}/{{pascalCase name}}.module.css',
         templateFile: 'plop-templates/Recipe/Recipe.module.css.hbs',
       },
+      {
+        type: 'add',
+        path: '.storybook/recipes/{{pascalCase name}}/index.ts',
+        templateFile: 'plop-templates/Recipe/index.ts.hbs',
+      },
     ],
   });
   plop.setGenerator('page', {
@@ -107,6 +117,11 @@ module.exports = (plop) => {
         type: 'add',
         path: '.storybook/pages/{{pascalCase name}}/{{pascalCase name}}.stories.tsx',
         templateFile: 'plop-templates/Page/Page.stories.tsx.hbs',
+      },
+      {
+        type: 'add',
+        path: '.storybook/pages/{{pascalCase name}}/index.ts',
+        templateFile: 'plop-templates/Page/index.ts.hbs',
       },
     ],
   });

--- a/plopfile.js
+++ b/plopfile.js
@@ -42,7 +42,7 @@ module.exports = (plop) => {
         separator: '',
         path: 'src/index.ts',
         template:
-          'export { {{default as pascalCase name}} } from "./components/{{pascalCase name}}";',
+          'export { default as {{pascalCase name}} } from "./components/{{pascalCase name}}";',
       },
       // From https://github.com/bradfrost/czi-vanilla-storybook
       function sortIndex() {


### PR DESCRIPTION
### Summary:
This PR contains changes to the plop templates that were missed in the initial pass. Specifically:

1. Add `index.ts` to the Page and Recipe templates to match established directory structure
2. Remove React.FC typing in Page and Recipe templates to match Component template

### Test Plan:
Run `yarn run plop`, `yarn run plop:page` and `yarn run plop:recipe` and confirm that all files are generated correctly with no errors. 

<img width="904" alt="Screen Shot 2022-04-05 at 8 36 47 AM" src="https://user-images.githubusercontent.com/24812780/161767559-675654fc-4ff0-4b26-b1a9-3e581030acd6.png">

