### PR TITLE
chore: deprecate dark tooltip

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { Meta, Story, StoryObj } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import clsx from 'clsx';
@@ -38,6 +39,9 @@ export const LightVariant: StoryObj<Args> = {};
 export const DarkVariant: StoryObj<Args> = {
   args: {
     variant: 'dark',
+  },
+  parameters: {
+    badges: [BADGE.DEPRECATED],
   },
 };
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -52,7 +52,10 @@ type TooltipProps = {
   /**
    * Whether the tooltip has a light or dark background.
    */
-  variant?: 'light' | 'dark';
+  variant?:
+    | 'light'
+    /** @deprecated */
+    | 'dark';
   /**
    * Whether the tooltip is always visible or always invisible.
    *
@@ -83,6 +86,9 @@ export const Tooltip = ({
   text,
   ...rest
 }: TooltipProps) => {
+  if (variant === 'dark' && process.env.NODE_ENV !== 'production') {
+    console.warn('Dark variant is deprecated.');
+  }
   // Hides tooltip when escape key is pressed, following:
   // https://atomiks.github.io/tippyjs/v6/plugins/#hideonesc
   const hideOnEsc: Plugin = {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -87,7 +87,9 @@ export const Tooltip = ({
   ...rest
 }: TooltipProps) => {
   if (variant === 'dark' && process.env.NODE_ENV !== 'production') {
-    console.warn('Dark variant is deprecated.');
+    console.warn(
+      'The dark variant is deprecated and will be removed in an upcoming release. Please use the default light variant instead.',
+    );
   }
   // Hides tooltip when escape key is pressed, following:
   // https://atomiks.github.io/tippyjs/v6/plugins/#hideonesc


### PR DESCRIPTION
[sc-189391]
### Summary:
- deprecates dark tooltip via:
  - tsdoc `@deprecated` flag (doesn't do anything with VSCode now, but hopefully will be better supported in future TS releases https://github.com/microsoft/tsdoc/issues/131)
  - `console.warn` in non prod
  - badge in storybook
### Test Plan:
- manual testing
  - storybook has badge
  - console warns
