### PR TITLE
chore: replace flaky image url with a cuter image url

### DIFF
--- a/src/components/MediaBlock/MediaBlock.stories.tsx
+++ b/src/components/MediaBlock/MediaBlock.stories.tsx
@@ -26,13 +26,15 @@ const Template: Story<Props> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  imgSrc: 'https://placehold.it/600x400',
+  // eslint-disable-next-line @chanzuckerberg/stories/no-ext-resources-in-stories
+  imgSrc: 'https://st1.latestly.com/wp-content/uploads/2021/08/31-6.jpg',
   imgAlt: 'placeholder image',
 };
 
 export const Reversed = Template.bind({});
 Reversed.args = {
   variant: 'reversed',
-  imgSrc: 'https://placehold.it/600x400',
+  // eslint-disable-next-line @chanzuckerberg/stories/no-ext-resources-in-stories
+  imgSrc: 'https://st1.latestly.com/wp-content/uploads/2021/08/31-6.jpg',
   imgAlt: 'placeholder image',
 };

--- a/src/components/StackedBlock/StackedBlock.stories.tsx
+++ b/src/components/StackedBlock/StackedBlock.stories.tsx
@@ -18,7 +18,11 @@ export default {
 const Template: Story<Props> = (args) => (
   <StackedBlock>
     <StackedBlockHeader>
-      <img src="https://placehold.it/600x400" alt="placeholder" />
+      <img
+        // eslint-disable-next-line @chanzuckerberg/stories/no-ext-resources-in-stories
+        src="https://st1.latestly.com/wp-content/uploads/2021/08/31-6.jpg"
+        alt="placeholder"
+      />
     </StackedBlockHeader>
     <StackedBlockBody>
       <Heading className="u-margin-bottom-md" as="h3">


### PR DESCRIPTION
### Summary:
The `MediaBlock` and `StackedBlock` stories have been flaky in chromatic because they're linking to an image that doesn't exist (`https://placehold.it/600x400` takes forever and eventually just loads an error page), so sometimes we get no image and sometimes we get a broken image icon. We shouldn't link to external images anyway because it can cause flakiness, but in this case it's really obvious why this particular image is flaky, so I'm just replacing it with an actual image url for now.

### Test Plan:
Check out the `MediaBlock` and `StackedBlock` stories in storybook and verify they are now 1000% cuter.

<img width="881" alt="default media block story in storybook which has a photo of two kittens being super cute" src="https://user-images.githubusercontent.com/7761701/161841720-88304474-6552-4a1c-8892-4a439578b164.png">
<img width="1335" alt="reserved media block story in storybook which has a photo of two kittens being super cute" src="https://user-images.githubusercontent.com/7761701/161841738-ca000f38-313e-46db-894d-f4044d10d15c.png">
<img width="1335" alt="stacked block story in storybook which has a photo of two kittens being super cute" src="https://user-images.githubusercontent.com/7761701/161841742-2d996ae4-21b4-4ca5-b35c-21669922f2d8.png">