### PR TITLE
chore(tooltip): add chromatic delay to stories

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,6 +30,9 @@ export default {
   title: 'Molecules/Messaging/Tooltip',
   component: Tooltip,
   args: defaultArgs,
+  parameters: {
+    chromatic: { delay: 900 },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Tooltip>;


### PR DESCRIPTION
### Summary:
The `Tooltip` stories have been flaky. I'm testing whether adding a delay helps or not.

### Test Plan:
Keep rebasing in changes and pushing it up to see if the tooltip stories are flaky in chromatic.