### PR TITLE
feat(button): removed inverted prop

### DIFF
--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -44,7 +44,6 @@ export const GlobalHeader = ({ className, ...other }: Props) => {
       <Button
         className={styles['global-header__menu-button']}
         variant="icon"
-        inverted={true}
         onClick={toggleMenu}
       >
         <Icon

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -62,10 +62,10 @@ BEM conventions result in an explicit (and yes, sometimes verbose) class string 
 
 Let's take a look at the following example:
 
-`.button--inverted`
+`.button--full-width`
 
 - `button` is the block name (“Block” being the “B” in BEM)
-- `--inverted` is a modifier, indicating a stylistic variation of the block (“Modifier” being the “M” in BEM)
+- `--full-width` is a modifier, indicating a stylistic variation of the block (“Modifier” being the “M” in BEM)
 
 Here's another example:
 

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -55,20 +55,6 @@
     cursor: not-allowed;
     transform: none;
   }
-
-  /**
-   * Inverted button
-   */
-  &.button--inverted {
-    border-color: var(--eds-theme-color-primary-border-inverted);
-    color: var(--eds-theme-color-primary-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      border-color: var(--eds-theme-color-primary-border-inverted-hover);
-      color: var(--eds-theme-color-primary-foreground-inverted-hover);
-    }
-  }
 }
 
 /**
@@ -97,20 +83,6 @@
     border-color: var(--eds-theme-color-disabled-border);
     color: var(--eds-theme-color-disabled-foreground);
   }
-
-  /**
-   * Inverted primary button
-   */
-  &.button--inverted {
-    background-color: var(--eds-theme-color-primary-background);
-    color: var(--eds-theme-color-body-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      background-color: var(--eds-theme-color-primary-background-hover);
-      color: var(--eds-theme-color-body-foreground-inverted);
-    }
-  }
 }
 
 /**
@@ -137,20 +109,6 @@
     background-color: var(--eds-theme-color-disabled-background);
     border-color: var(--eds-theme-color-disabled-border);
     color: var(--eds-theme-color-disabled-foreground);
-  }
-
-  /**
-   * Inverted secondary button
-   */
-  &.button--inverted {
-    background-color: var(--eds-theme-color-primary-background);
-    color: var(--eds-theme-color-body-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      background-color: var(--eds-theme-color-primary-background-hover);
-      color: var(--eds-theme-color-body-foreground-inverted);
-    }
   }
 }
 
@@ -179,20 +137,6 @@
     border-color: var(--eds-theme-color-disabled-border);
     color: var(--eds-theme-color-disabled-foreground);
   }
-
-  /**
-   * Inverted tertiary button
-   */
-  &.button--inverted {
-    background-color: var(--eds-theme-color-primary-background);
-    color: var(--eds-theme-color-body-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      background-color: var(--eds-theme-color-primary-background-hover);
-      color: var(--eds-theme-color-body-foreground-inverted);
-    }
-  }
 }
 
 /**
@@ -212,13 +156,6 @@
   &:focus {
     background-color: transparent;
   }
-
-  /**
-   * Inverted link button
-   */
-  &.button--inverted {
-    @mixin TextLinkInverted;
-  }
 }
 
 /**
@@ -235,19 +172,6 @@
   &:focus {
     color: var(--eds-theme-color-primary-foreground-hover);
     background-color: transparent;
-  }
-
-  /**
-   * Inverted icon button
-   */
-  &.button--inverted {
-    color: var(--eds-theme-color-primary-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      color: var(--eds-theme-color-primary-foreground-inverted-hover);
-      background-color: transparent;
-    }
   }
 }
 
@@ -276,20 +200,6 @@
     background-color: var(--eds-theme-color-disabled-background);
     border-color: var(--eds-theme-color-disabled-border);
     color: var(--eds-theme-color-disabled-foreground);
-  }
-
-  /**
-   * Inverted primary button
-   */
-  &.button--inverted {
-    background-color: var(--eds-theme-color-primary-background);
-    color: var(--eds-theme-color-body-foreground-inverted);
-    /* stylelint-disable-next-line max-nesting-depth */
-    &:hover,
-    &:focus {
-      background-color: var(--eds-theme-color-primary-background-hover);
-      color: var(--eds-theme-color-body-foreground-inverted);
-    }
   }
 }
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -11,13 +11,6 @@ export default {
 
 const Template: Story<Props> = (args) => <Button {...args} />;
 
-const InvertedTemplate: Story<Props> = (args) => (
-  <div style={{ padding: '1rem', backgroundColor: '#000' }}>
-    {' '}
-    <Button {...args} />
-  </div>
-);
-
 export const Default = Template.bind({});
 Default.args = { children: 'Button' };
 
@@ -44,9 +37,6 @@ DefaultWithIconAfter.args = {
 export const DefaultDisabled = Template.bind({});
 DefaultDisabled.args = { children: 'Button', disabled: true };
 
-export const DefaultInverted = InvertedTemplate.bind({});
-DefaultInverted.args = { inverted: true, children: 'Button' };
-
 export const Primary = Template.bind({});
 Primary.args = { variant: 'primary', children: 'Primary Button' };
 
@@ -57,35 +47,14 @@ PrimaryDisabled.args = {
   disabled: true,
 };
 
-export const PrimaryInverted = InvertedTemplate.bind({});
-PrimaryInverted.args = {
-  variant: 'primary',
-  inverted: true,
-  children: 'Primary Button',
-};
-
 export const BareIcon = Template.bind({});
 BareIcon.args = {
   variant: 'icon',
   children: <Icon purpose="informative" title="Close" name="close" />,
 };
 
-export const IconButtonInverted = InvertedTemplate.bind({});
-IconButtonInverted.args = {
-  inverted: true,
-  variant: 'icon',
-  children: <Icon purpose="informative" title="Close" name="close" />,
-};
-
 export const TextLink = Template.bind({});
 TextLink.args = { variant: 'link', children: 'Text Link Button' };
-
-export const TextLinkInverted = InvertedTemplate.bind({});
-TextLinkInverted.args = {
-  variant: 'link',
-  inverted: true,
-  children: 'Text Link Button',
-};
 
 export const UtilityError = Template.bind({});
 UtilityError.args = { variant: 'error', children: 'Button' };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -29,10 +29,6 @@ export interface Props {
    */
   href?: string;
   /**
-   * Button rendered on a dark backgorund
-   */
-  inverted?: boolean;
-  /**
    * Loading state passed down from higher level used to trigger loader and text change
    */
   loading?: boolean;
@@ -78,7 +74,6 @@ export const Button = React.forwardRef(
       forwardRef,
       fullWidth,
       href,
-      inverted,
       loading,
       onClick,
       size = 'lg',
@@ -107,7 +102,6 @@ export const Button = React.forwardRef(
       variant === 'link' && styles['button--link'],
       variant === 'destructive' && styles['button--destructive'],
       // Other options
-      inverted === true && styles['button--inverted'],
       fullWidth && styles['button--full-width'],
       loading && styles['eds-is-loading'],
     );


### PR DESCRIPTION
### Summary:
I talked to Sean about the `inverted` `Button` prop, and we decided to remove it. The reasoning is that:
- LP has no dark backgrounds (except the sidebar/header, which is unique and will need unique styling anyway)
- we have no plans to implement dark mode (maybe one day but it's not in the foreseeable future)

The inverted button tokens were also removed, so there's nothing for us to use in the styles anyway.

### Test Plan:
Verify there are no type errors and there is no change to the icons in the`GlobalHeader` recipe.