### PR TITLE
Enable icon snapshot tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,11 +6,10 @@ module.exports = {
   coverageDirectory: 'coverage',
   moduleNameMapper: {
     '\\.css$': 'identity-obj-proxy',
-    svg4everybody: 'identity-obj-proxy',
     'react-portal': 'identity-obj-proxy',
     shortid: 'identity-obj-proxy',
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
-      'identity-obj-proxy',
+      '<rootDir>/jest/mocks/fileMock.js',
   },
   preset: 'ts-jest',
   roots: ['<rootDir>/src'],

--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -1,6 +1,16 @@
 import '@testing-library/jest-dom';
 import { format } from 'util';
 
+// Globally mock svg4everybody. It's used to support IE in Icons
+// and throws errors when used in tests.
+jest.mock('svg4everybody');
+
+// nanoid generates unique string IDs; we mock out that randomness to ensure
+// consistent snapshots in tests.
+jest.mock('nanoid', () => {
+  return { nanoid: () => 'mock-id' };
+});
+
 /**
  * Ensure `console.error` calls throw an error in tests
  */

--- a/jest/mocks/fileMock.js
+++ b/jest/mocks/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/src/components/Icon/Icon.test.tsx
+++ b/src/components/Icon/Icon.test.tsx
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as IconStoryFile from './Icon.stories';
+
+describe('<Icon />', () => {
+  generateSnapshots(IconStoryFile);
+});

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -1,0 +1,130 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Icon /> CustomColor story renders snapshot 1`] = `
+<svg
+  aria-hidden="true"
+  class="icon"
+  fill="#8984E8"
+  height="2em"
+  style="--icon-size: 2em;"
+  width="2em"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <use
+    xlink:href="test-file-stub#close"
+  />
+</svg>
+`;
+
+exports[`<Icon /> Default story renders snapshot 1`] = `
+<svg
+  aria-hidden="true"
+  class="icon"
+  fill="currentColor"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <use
+    xlink:href="test-file-stub#close"
+  />
+</svg>
+`;
+
+exports[`<Icon /> FullScreen story renders snapshot 1`] = `
+<svg
+  aria-hidden="true"
+  class="icon"
+  fill="currentColor"
+  height="100vh"
+  style="--icon-size: 100vh;"
+  width="100vh"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <use
+    xlink:href="test-file-stub#close"
+  />
+</svg>
+`;
+
+exports[`<Icon /> InText story renders snapshot 1`] = `
+<p
+  class="text text--body"
+>
+  The svg icon defaults to the surrounding text size (
+  <svg
+    class="icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      icon with 1em line height
+    </title>
+    <use
+      xlink:href="test-file-stub#account-circle"
+    />
+  </svg>
+  , 1em), but often looks better with the line height (
+  <svg
+    class="icon"
+    fill="currentColor"
+    height="2em"
+    role="img"
+    style="--icon-size: 2em;"
+    width="2em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      icon with 2em line height
+    </title>
+    <use
+      xlink:href="test-file-stub#account-circle"
+    />
+  </svg>
+  , 2em) which is harder to determine. Take a look at the icons available in
+   
+  <a
+    href="https://material-ui.com/components/material-icons/"
+    rel="noreferrer"
+    target="_blank"
+  >
+    https://material-ui.com/components/material-icons/
+  </a>
+  , currently we only support the filled icons.
+</p>
+`;
+
+exports[`<Icon /> Large story renders snapshot 1`] = `
+<svg
+  aria-hidden="true"
+  class="icon"
+  fill="currentColor"
+  height="4em"
+  style="--icon-size: 4em;"
+  width="4em"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <use
+    xlink:href="test-file-stub#close"
+  />
+</svg>
+`;
+
+exports[`<Icon /> Medium story renders snapshot 1`] = `
+<svg
+  aria-hidden="true"
+  class="icon"
+  fill="currentColor"
+  height="2em"
+  style="--icon-size: 2em;"
+  width="2em"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <use
+    xlink:href="test-file-stub#close"
+  />
+</svg>
+`;

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -55,16 +55,10 @@ export const OutlineVariants: StoryObj<Args> = {
   ),
 };
 
-/**
- * Snap tests disabled due to TypeError in <Icon> but should be turned back on once fixed.
- */
 export const WithIcon: StoryObj<Args> = {
   ...Default,
   args: {
     icon: <Icon purpose="decorative" name="favorite" />,
-  },
-  parameters: {
-    snapshot: { skip: true },
   },
   render: (args) => (
     <div className={styles.tagList}>
@@ -88,9 +82,6 @@ export const WithLongTextAndIcon: StoryObj<Args> = {
   args: {
     text: 'This tag has a really long text message',
     icon: <Icon purpose="decorative" name="star" />,
-  },
-  parameters: {
-    snapshot: { skip: true },
   },
   render: (args) => (
     <div className={styles.tagList}>

--- a/src/components/Tag/__snapshots__/Tag.test.ts.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.ts.snap
@@ -133,3 +133,245 @@ exports[`<Tag /> OutlineVariants story renders snapshot 1`] = `
   </span>
 </div>
 `;
+
+exports[`<Tag /> WithIcon story renders snapshot 1`] = `
+<div
+  class="tagList"
+>
+  <span
+    class="tag tag--default tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      default
+    </span>
+  </span>
+  <span
+    class="tag tag--go tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      go
+    </span>
+  </span>
+  <span
+    class="tag tag--yield tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      yield
+    </span>
+  </span>
+  <span
+    class="tag tag--stop tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      stop
+    </span>
+  </span>
+  <span
+    class="tag tag--warning tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      warning
+    </span>
+  </span>
+  <span
+    class="tag tag--brand tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#favorite"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      brand
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
+<div
+  class="tagList"
+>
+  <span
+    class="tag tag--default tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+  <span
+    class="tag tag--go tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+  <span
+    class="tag tag--yield tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+  <span
+    class="tag tag--stop tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+  <span
+    class="tag tag--warning tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+  <span
+    class="tag tag--brand tag--outline text text--sm text--bold-weight"
+  >
+    <svg
+      aria-hidden="true"
+      class="icon"
+      fill="currentColor"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#star"
+      />
+    </svg>
+    <span
+      class="tag__body"
+    >
+      This tag has a really long text message
+    </span>
+  </span>
+</div>
+`;

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -13,22 +13,15 @@ export default {
 
 type Args = React.ComponentProps<typeof Toast>;
 
-// Snap tests have been disabled due to errors with Icon, should be re-enabled once fixed
 export const Success: StoryObj<Args> = {
   args: {
     variant: 'success',
-  },
-  parameters: {
-    snapshot: { skip: true },
   },
 };
 
 export const Alert: StoryObj<Args> = {
   args: {
     variant: 'alert',
-  },
-  parameters: {
-    snapshot: { skip: true },
   },
 };
 
@@ -39,8 +32,5 @@ export const NotDismissable: StoryObj<Args> = {
     // @ts-ignore onDismiss is not nullable, but this is needed to remove the arg from
     // storybook's actions addon
     onDismiss: null,
-  },
-  parameters: {
-    snapshot: { skip: true },
   },
 };

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as ToastStoryFile from './Toast.stories';
+
+describe('<Toast />', () => {
+  generateSnapshots(ToastStoryFile);
+});

--- a/src/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Toast /> Alert story renders snapshot 1`] = `
+<div
+  class="toast toast--alert"
+>
+  <div
+    class="toast__content"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        alert
+      </title>
+      <use
+        xlink:href="test-file-stub#warning"
+      />
+    </svg>
+    <p
+      class="toast__text"
+    >
+      You've got toast!
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
+<div
+  class="toast toast--success"
+>
+  <div
+    class="toast__content"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        success
+      </title>
+      <use
+        xlink:href="test-file-stub#check-circle"
+      />
+    </svg>
+    <p
+      class="toast__text"
+    >
+      You've got toast!
+    </p>
+  </div>
+</div>
+`;
+
+exports[`<Toast /> Success story renders snapshot 1`] = `
+<div
+  class="toast toast--success"
+>
+  <div
+    class="toast__content"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        success
+      </title>
+      <use
+        xlink:href="test-file-stub#check-circle"
+      />
+    </svg>
+    <p
+      class="toast__text"
+    >
+      You've got toast!
+    </p>
+  </div>
+</div>
+`;


### PR DESCRIPTION
### Summary:
[ch191630]

Turns out the error was mocking `svg` files & some specific modules correctly. This adds back `Icon`, `Toast`, and `Tag` snapshot tests 🎉 

### Test Plan:
- `yarn test` passes