### PR TITLE
feat(button): use new button tokens, update storybook

### DIFF
--- a/.storybook/data/tokens.json
+++ b/.storybook/data/tokens.json
@@ -207,7 +207,7 @@
   "eds-theme-color-button-tertiary-border": "#707070",
   "eds-theme-color-button-tertiary-border-hover": "#707070",
   "eds-theme-color-button-tertiary-border-active": "#21272D",
-  "eds-theme-color-button-tertiary-text": "#6B65E2",
+  "eds-theme-color-button-tertiary-text": "#707070",
   "eds-theme-color-button-tertiary-text-hover": "#ffffff",
   "eds-theme-color-button-tertiary-text-active": "#ffffff",
   "eds-theme-color-button-icon-background": "rgba(0, 0, 0, 0)",

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -11,6 +11,7 @@
  * 4) Adds a gap between children to automatically handle spacing between icons and text
  */
 .button {
+  @mixin eds-theme-typography-button-label;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -18,28 +19,11 @@
   gap: 0.75rem; /* 4 */
   border-width: var(--eds-theme-border-width);
   border-style: solid;
-  border-color: var(--eds-theme-color-primary-border);
   border-radius: var(--eds-theme-border-radius);
-  color: var(--eds-theme-color-primary-foreground);
-  background-color: transparent;
   cursor: pointer;
   transition: all var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
-  /* TODO: make default color prop in Icon inherit or something? */
-  svg {
-    fill: currentColor;
-  }
-
-  &:hover {
-    color: var(--eds-theme-color-primary-foreground-hover);
-    border-color: var(--eds-theme-color-primary-border-hover);
-  }
-
   &:focus {
-    background-color: transparent;
-  }
-
-  &:focus-visible {
     @mixin focus;
   }
 
@@ -47,13 +31,8 @@
    * Disabled buttons
    */
    &:disabled,
-   &:disabled:hover,
-   &:disabled:focus {
-    background: transparent;
-    border-color: var(--eds-theme-color-disabled-border);
-    color: var(--eds-theme-color-disabled-foreground);
+   &:disabled:hover {
     cursor: not-allowed;
-    transform: none;
   }
 }
 
@@ -63,25 +42,28 @@
  *    the most important action of a page.
  */
 .button--primary {
-  border-color: var(--eds-theme-color-primary-border);
-  background-color: var(--eds-theme-color-primary-background);
-  color: var(--eds-theme-color-body-foreground-inverted);
+  border-color: var(--eds-theme-color-button-primary-border);
+  background-color: var(--eds-theme-color-button-primary-background);
+  color: var(--eds-theme-color-button-primary-text);
 
   &:hover,
   &:focus {
-    background-color: var(--eds-theme-color-primary-background-hover);
-    color: var(--eds-theme-color-body-foreground-inverted);
+    border-color: var(--eds-theme-color-button-primary-border-hover);
+    background-color: var(--eds-theme-color-button-primary-background-hover);
+    color: var(--eds-theme-color-button-primary-text-hover);
   }
 
-  &:focus-visible {
-    @mixin focus;
+  &:active {
+    border-color: var(--eds-theme-color-button-primary-border-active);
+    background-color: var(--eds-theme-color-button-primary-background-active);
+    color: var(--eds-theme-color-button-primary-text-active);
   }
 
   &:disabled,
   &:disabled:hover {
-    background-color: var(--eds-theme-color-disabled-background);
-    border-color: var(--eds-theme-color-disabled-border);
-    color: var(--eds-theme-color-disabled-foreground);
+    border-color: var(--eds-theme-color-border-disabled);
+    background-color: var(--eds-theme-color-background-disabled);
+    color: var(--eds-theme-color-button-primary-text);
   }
 }
 
@@ -90,25 +72,28 @@
  * 1) Medium prominence button used for less important actions
  */
 .button--secondary {
-  border-color: var(--eds-theme-color-primary-border);
-  background-color: var(--eds-theme-color-primary-background);
-  color: var(--eds-theme-color-body-foreground-inverted);
+  border-color: var(--eds-theme-color-button-secondary-border);
+  background-color: var(--eds-theme-color-button-secondary-background);
+  color: var(--eds-theme-color-button-secondary-text);
 
   &:hover,
   &:focus {
-    background-color: var(--eds-theme-color-primary-background-hover);
-    color: var(--eds-theme-color-body-foreground-inverted);
+    border-color: var(--eds-theme-color-button-secondary-border-hover);
+    background-color: var(--eds-theme-color-button-secondary-background-hover);
+    color: var(--eds-theme-color-button-secondary-text-hover);
   }
 
-  &:focus-visible {
-    @mixin focus;
+  &:active {
+    border-color: var(--eds-theme-color-button-secondary-border-active);
+    background-color: var(--eds-theme-color-button-secondary-background-active);
+    color: var(--eds-theme-color-button-secondary-text-active);
   }
 
   &:disabled,
   &:disabled:hover {
-    background-color: var(--eds-theme-color-disabled-background);
-    border-color: var(--eds-theme-color-disabled-border);
-    color: var(--eds-theme-color-disabled-foreground);
+    border-color: var(--eds-theme-color-border-disabled);
+    background-color: transparent;
+    color: var(--eds-theme-color-text-disabled);
   }
 }
 
@@ -117,25 +102,28 @@
  * 1) Least prominent button used for least important actions on the page
  */
 .button--tertiary {
-  border-color: var(--eds-theme-color-primary-border);
-  background-color: var(--eds-theme-color-primary-background);
-  color: var(--eds-theme-color-body-foreground-inverted);
+  border-color: var(--eds-theme-color-button-tertiary-border);
+  background-color: var(--eds-theme-color-button-tertiary-background);
+  color: var(--eds-theme-color-button-tertiary-text);
 
   &:hover,
   &:focus {
-    background-color: var(--eds-theme-color-primary-background-hover);
-    color: var(--eds-theme-color-body-foreground-inverted);
+    border-color: var(--eds-theme-color-button-tertiary-border-hover);
+    background-color: var(--eds-theme-color-button-tertiary-background-hover);
+    color: var(--eds-theme-color-button-tertiary-text-hover);
   }
 
-  &:focus-visible {
-    @mixin focus;
+  &:active {
+    border-color: var(--eds-theme-color-button-tertiary-border-active);
+    background-color: var(--eds-theme-color-button-tertiary-background-active);
+    color: var(--eds-theme-color-button-tertiary-text-active);
   }
 
   &:disabled,
   &:disabled:hover {
-    background-color: var(--eds-theme-color-disabled-background);
-    border-color: var(--eds-theme-color-disabled-border);
-    color: var(--eds-theme-color-disabled-foreground);
+    border-color: var(--eds-theme-color-border-disabled);
+    background-color: var(--eds-theme-color-button-tertiary-background);
+    color: var(--eds-theme-color-text-disabled);
   }
 }
 
@@ -145,16 +133,15 @@
  */
 .button--link {
   @mixin textLink;
-  align-items: flex-start;
+
   padding: 0;
   border: 0;
-  border-radius: 0;
   text-align: left;
   background-color: transparent;
 
-  &:hover,
-  &:focus {
-    background-color: transparent;
+  &:disabled,
+  &:disabled:hover {
+    color: var(--eds-theme-color-text-disabled);
   }
 }
 
@@ -164,14 +151,28 @@
  * 2) Use for Close "X" buttons, tooltip icons, and other
  */
 .button--icon {
-  background-color: transparent;
-  border: 0;
-  padding: 0;
+  border-color: var(--eds-theme-color-button-icon-border);
+  background-color: var(--eds-theme-color-button-icon-background);
+  color: var(--eds-theme-color-button-icon-text);
 
   &:hover,
   &:focus {
-    color: var(--eds-theme-color-primary-foreground-hover);
-    background-color: transparent;
+    border-color: var(--eds-theme-color-button-icon-border-hover);
+    background-color: var(--eds-theme-color-button-icon-background-hover);
+    color: var(--eds-theme-color-button-icon-text-hover);
+  }
+
+  &:active {
+    border-color: var(--eds-theme-color-button-icon-border-active);
+    background-color: var(--eds-theme-color-button-icon-background-active);
+    color: var(--eds-theme-color-button-icon-text-active);
+  }
+
+  &:disabled,
+  &:disabled:hover {
+    border-color: var(--eds-theme-color-button-icon-border);
+    background-color: var(--eds-theme-color-button-icon-background);
+    color: var(--eds-theme-color-text-disabled);
   }
 }
 
@@ -181,25 +182,28 @@
  * 2) Use for destructive actions like deleting a user's account, deleting a course, etc
  */
 .button--destructive {
-  border-color: var(--eds-theme-color-primary-border);
-  background-color: var(--eds-theme-color-primary-background);
-  color: var(--eds-theme-color-body-foreground-inverted);
+  border-color: var(--eds-theme-color-button-destructive-border);
+  background-color: var(--eds-theme-color-button-destructive-background);
+  color: var(--eds-theme-color-button-destructive-text);
 
   &:hover,
   &:focus {
-    background-color: var(--eds-theme-color-primary-background-hover);
-    color: var(--eds-theme-color-body-foreground-inverted);
+    border-color: var(--eds-theme-color-button-destructive-border-hover);
+    background-color: var(--eds-theme-color-button-destructive-background-hover);
+    color: var(--eds-theme-color-button-destructive-text-hover);
   }
 
-  &:focus-visible {
-    @mixin focus;
+  &:active {
+    border-color: var(--eds-theme-color-button-destructive-border-active);
+    background-color: var(--eds-theme-color-button-destructive-background-active);
+    color: var(--eds-theme-color-button-destructive-text-active);
   }
 
   &:disabled,
   &:disabled:hover {
-    background-color: var(--eds-theme-color-disabled-background);
-    border-color: var(--eds-theme-color-disabled-border);
-    color: var(--eds-theme-color-disabled-foreground);
+    border-color: var(--eds-theme-color-border-disabled);
+    background-color: var(--eds-theme-color-background-disabled);
+    color: var(--eds-theme-color-button-destructive-text);
   }
 }
 
@@ -209,7 +213,6 @@
  *    cause the button height to expand
  */
 .button--sm {
-  @mixin eds-theme-typography-button-label;
   height: var(--eds-size-3); /* 1 */
   padding-left: var(--eds-size-half);
   padding-right: var(--eds-size-half);
@@ -221,7 +224,6 @@
  *    cause the button height to expand
  */
 .button--md {
-  @mixin eds-theme-typography-button-label;
   height: var(--eds-size-4); /* 1 */
   padding-left: var(--eds-size-2);
   padding-right: var(--eds-size-2);
@@ -233,7 +235,6 @@
  *    cause the button height to expand
  */
 .button--lg {
-  @mixin eds-theme-typography-button-label;
   height: var(--eds-size-5); /* 1 */
   padding-left: var(--eds-size-2);
   padding-right: var(--eds-size-2);

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -11,74 +11,233 @@ export default {
 
 const Template: Story<Props> = (args) => <Button {...args} />;
 
-export const Default = Template.bind({});
-Default.args = { children: 'Button' };
-
-export const DefaultWithIconBefore = Template.bind({});
-DefaultWithIconBefore.args = {
-  children: (
-    <>
-      <Icon purpose="decorative" name="chevron-left" />
-      Button
-    </>
-  ),
-};
-
-export const DefaultWithIconAfter = Template.bind({});
-DefaultWithIconAfter.args = {
-  children: (
-    <>
-      Button
-      <Icon purpose="decorative" name="chevron-right" />
-    </>
-  ),
-};
-
-export const DefaultDisabled = Template.bind({});
-DefaultDisabled.args = { children: 'Button', disabled: true };
-
-export const Primary = Template.bind({});
-Primary.args = { variant: 'primary', children: 'Primary Button' };
+export const PrimaryNoIcon = Template.bind({});
+PrimaryNoIcon.args = { children: 'Button' };
 
 export const PrimaryDisabled = Template.bind({});
-PrimaryDisabled.args = {
-  variant: 'primary',
-  children: 'Primary Button',
+PrimaryDisabled.args = { children: 'Button', disabled: true };
+
+export const PrimaryLeftIcon = Template.bind({});
+PrimaryLeftIcon.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+};
+
+export const PrimaryRightIcon = Template.bind({});
+PrimaryRightIcon.args = {
+  children: (
+    <>
+      Button
+      <Icon purpose="decorative" name="arrow-forward" />
+    </>
+  ),
+};
+
+export const PrimaryMedium = Template.bind({});
+PrimaryMedium.args = { children: 'Button', size: 'md' };
+
+export const PrimarySmall = Template.bind({});
+PrimarySmall.args = { children: 'Button', size: 'sm' };
+
+export const SecondaryNoIcon = Template.bind({});
+SecondaryNoIcon.args = { children: 'Button', variant: 'secondary' };
+
+export const SecondaryDisabled = Template.bind({});
+SecondaryDisabled.args = {
+  children: 'Button',
+  variant: 'secondary',
   disabled: true,
 };
 
-export const BareIcon = Template.bind({});
-BareIcon.args = {
-  variant: 'icon',
-  children: <Icon purpose="informative" title="Close" name="close" />,
+export const SecondaryLeftIcon = Template.bind({});
+SecondaryLeftIcon.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'secondary',
 };
 
-export const TextLink = Template.bind({});
-TextLink.args = { variant: 'link', children: 'Text Link Button' };
+export const SecondaryRightIcon = Template.bind({});
+SecondaryRightIcon.args = {
+  children: (
+    <>
+      Button
+      <Icon purpose="decorative" name="arrow-forward" />
+    </>
+  ),
+  variant: 'secondary',
+};
 
-export const UtilityError = Template.bind({});
-UtilityError.args = { variant: 'error', children: 'Button' };
+export const SecondaryMedium = Template.bind({});
+SecondaryMedium.args = { children: 'Button', variant: 'secondary', size: 'md' };
 
-export const Medium = Template.bind({});
-Medium.args = { size: 'md', children: 'Medium Button' };
+export const SecondarySmall = Template.bind({});
+SecondarySmall.args = { children: 'Button', variant: 'secondary', size: 'sm' };
 
-export const Small = Template.bind({});
-Small.args = { size: 'sm', children: 'Small Button' };
+export const TeritaryNoIcon = Template.bind({});
+TeritaryNoIcon.args = { children: 'Button', variant: 'tertiary' };
+
+export const TeritaryDisabled = Template.bind({});
+TeritaryDisabled.args = {
+  children: 'Button',
+  variant: 'tertiary',
+  disabled: true,
+};
+
+export const TeritaryLeftIcon = Template.bind({});
+TeritaryLeftIcon.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'tertiary',
+};
+
+export const TeritaryRightIcon = Template.bind({});
+TeritaryRightIcon.args = {
+  children: (
+    <>
+      Button
+      <Icon purpose="decorative" name="arrow-forward" />
+    </>
+  ),
+  variant: 'tertiary',
+};
+
+export const TeritaryMedium = Template.bind({});
+TeritaryMedium.args = { children: 'Button', variant: 'tertiary', size: 'md' };
+
+export const TeritarySmall = Template.bind({});
+TeritarySmall.args = { children: 'Button', variant: 'tertiary', size: 'sm' };
+
+export const IconButtonLeftIcon = Template.bind({});
+IconButtonLeftIcon.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'icon',
+};
+
+export const IconButtonDisabled = Template.bind({});
+IconButtonDisabled.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'icon',
+  disabled: true,
+};
+
+export const IconButtonRightIcon = Template.bind({});
+IconButtonRightIcon.args = {
+  children: (
+    <>
+      Button
+      <Icon purpose="decorative" name="arrow-forward" />
+    </>
+  ),
+  variant: 'icon',
+};
+
+export const IconButtonIconOnly = Template.bind({});
+IconButtonIconOnly.args = {
+  children: <Icon purpose="informative" title="go back" name="arrow-back" />,
+  variant: 'icon',
+};
+
+export const IconButtonLeftIconSmall = Template.bind({});
+IconButtonLeftIconSmall.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'icon',
+  size: 'sm',
+};
+
+export const IconButtonRightIconSmall = Template.bind({});
+IconButtonRightIconSmall.args = {
+  children: (
+    <>
+      Button
+      <Icon purpose="decorative" name="arrow-forward" />
+    </>
+  ),
+  variant: 'icon',
+  size: 'sm',
+};
+
+export const IconButtonIconOnlySmall = Template.bind({});
+IconButtonIconOnlySmall.args = {
+  children: <Icon purpose="informative" title="go back" name="arrow-back" />,
+  variant: 'icon',
+  size: 'sm',
+};
+
+export const LinkNoIcon = Template.bind({});
+LinkNoIcon.args = { children: 'Button', variant: 'link' };
+
+export const LinkDisabled = Template.bind({});
+LinkDisabled.args = { children: 'Button', variant: 'link', disabled: true };
+
+export const LinkRightIcon = Template.bind({});
+LinkRightIcon.args = {
+  children: (
+    <>
+      Button
+      <Icon
+        purpose="informative"
+        title="opens in a new tab"
+        name="open-in-new"
+      />
+    </>
+  ),
+  variant: 'link',
+};
+
+export const DestructiveNoIcon = Template.bind({});
+DestructiveNoIcon.args = { children: 'Button', variant: 'destructive' };
+
+export const DestructiveDisabled = Template.bind({});
+DestructiveDisabled.args = {
+  children: 'Button',
+  variant: 'destructive',
+  disabled: true,
+};
+
+export const DestructiveLeftIcon = Template.bind({});
+DestructiveLeftIcon.args = {
+  children: (
+    <>
+      <Icon purpose="decorative" name="arrow-back" />
+      Button
+    </>
+  ),
+  variant: 'destructive',
+};
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { fullWidth: true, children: 'Button' };
+FullWidth.args = { children: 'Button', fullWidth: true };
 
 export const Loading = Template.bind({});
 Loading.args = {
+  children: 'Button',
   loading: true,
   disabled: true,
-  children: 'Loading Button',
-};
-
-export const PrimaryLoading = Template.bind({});
-PrimaryLoading.args = {
-  variant: 'primary',
-  loading: true,
-  disabled: true,
-  children: 'Primary Loading Button',
 };

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -11,8 +11,8 @@ export default {
 
 const Template: Story<Props> = (args) => <Button {...args} />;
 
-export const PrimaryNoIcon = Template.bind({});
-PrimaryNoIcon.args = { children: 'Button' };
+export const Primary = Template.bind({});
+Primary.args = { children: 'Button' };
 
 export const PrimaryDisabled = Template.bind({});
 PrimaryDisabled.args = { children: 'Button', disabled: true };
@@ -43,8 +43,8 @@ PrimaryMedium.args = { children: 'Button', size: 'md' };
 export const PrimarySmall = Template.bind({});
 PrimarySmall.args = { children: 'Button', size: 'sm' };
 
-export const SecondaryNoIcon = Template.bind({});
-SecondaryNoIcon.args = { children: 'Button', variant: 'secondary' };
+export const Secondary = Template.bind({});
+Secondary.args = { children: 'Button', variant: 'secondary' };
 
 export const SecondaryDisabled = Template.bind({});
 SecondaryDisabled.args = {
@@ -81,8 +81,8 @@ SecondaryMedium.args = { children: 'Button', variant: 'secondary', size: 'md' };
 export const SecondarySmall = Template.bind({});
 SecondarySmall.args = { children: 'Button', variant: 'secondary', size: 'sm' };
 
-export const TeritaryNoIcon = Template.bind({});
-TeritaryNoIcon.args = { children: 'Button', variant: 'tertiary' };
+export const Teritary = Template.bind({});
+Teritary.args = { children: 'Button', variant: 'tertiary' };
 
 export const TeritaryDisabled = Template.bind({});
 TeritaryDisabled.args = {
@@ -190,8 +190,8 @@ IconButtonIconOnlySmall.args = {
   size: 'sm',
 };
 
-export const LinkNoIcon = Template.bind({});
-LinkNoIcon.args = { children: 'Button', variant: 'link' };
+export const Link = Template.bind({});
+Link.args = { children: 'Button', variant: 'link' };
 
 export const LinkDisabled = Template.bind({});
 LinkDisabled.args = { children: 'Button', variant: 'link', disabled: true };
@@ -211,8 +211,8 @@ LinkRightIcon.args = {
   variant: 'link',
 };
 
-export const DestructiveNoIcon = Template.bind({});
-DestructiveNoIcon.args = { children: 'Button', variant: 'destructive' };
+export const Destructive = Template.bind({});
+Destructive.args = { children: 'Button', variant: 'destructive' };
 
 export const DestructiveDisabled = Template.bind({});
 DestructiveDisabled.args = {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -79,7 +79,7 @@ export const Button = React.forwardRef(
       size = 'lg',
       children,
       type,
-      variant,
+      variant = 'primary',
       ...other
     }: Props,
     ref,

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-5"
-      class="button trigger--spacing-bottom trigger--spacing-left button--lg"
+      class="button trigger--spacing-bottom trigger--spacing-left button--lg button--primary"
     >
       Tooltip trigger
     </button>
@@ -58,7 +58,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-2"
-      class="button trigger--spacing button--lg"
+      class="button trigger--spacing button--lg button--primary"
     >
       Tooltip trigger
     </button>
@@ -115,7 +115,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
       </p>
       <button
         aria-describedby="tippy-8"
-        class="button trigger--spacing button--lg"
+        class="button trigger--spacing button--lg button--primary"
       >
         Hover here to see tooltip after clicking somewhere outside.
       </button>
@@ -169,7 +169,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-3"
-      class="button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--lg"
+      class="button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--lg button--primary"
     >
       Tooltip trigger
     </button>
@@ -222,7 +222,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-1"
-      class="button trigger--spacing button--lg"
+      class="button trigger--spacing button--lg button--primary"
     >
       Tooltip trigger
     </button>
@@ -275,7 +275,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-7"
-      class="button trigger--spacing-top button--lg"
+      class="button trigger--spacing-top button--lg button--primary"
     >
       Tooltip trigger with longer text to test placement
     </button>
@@ -328,7 +328,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-6"
-      class="button trigger--spacing button--lg"
+      class="button trigger--spacing button--lg button--primary"
     >
       Tooltip trigger
     </button>
@@ -379,7 +379,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-4"
-      class="button trigger--spacing-top trigger--spacing-left button--lg"
+      class="button trigger--spacing-top trigger--spacing-left button--lg button--primary"
     >
       Tooltip trigger
     </button>

--- a/src/components/UtilityNav/UtilityNav.module.css
+++ b/src/components/UtilityNav/UtilityNav.module.css
@@ -56,7 +56,6 @@
   gap: var(--eds-size-2-and-half);
   white-space: nowrap;
   @mixin TextLinkInverted;
-  text-decoration: none;
   appearance: none;
   border: none;
   background: none;

--- a/src/components/UtilityNav/UtilityNav.module.css
+++ b/src/components/UtilityNav/UtilityNav.module.css
@@ -56,6 +56,7 @@
   gap: var(--eds-size-2-and-half);
   white-space: nowrap;
   @mixin TextLinkInverted;
+  text-decoration: none;
   appearance: none;
   border: none;
   background: none;

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -24,7 +24,6 @@
 }
 
 @define-mixin TextLinkInverted {
-  
   @mixin eds-theme-typography-body-text-md;
   color: var(--eds-theme-color-link-foreground-inverted);
 

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -7,20 +7,24 @@
 }
 
 @define-mixin textLink {
+  /* TODO: inherit size */
   @mixin eds-theme-typography-body-text-md;
-  color: var(--eds-theme-color-link-foreground);
+  /* TODO: underline change on hover */
   text-decoration: underline;
+  color: var(--eds-theme-color-text-link-strong);
 
-  &:hover {
-    color: var(--eds-theme-color-link-foreground-hover);
+  &:hover,
+  &:focus {
+    color: var(--eds-theme-color-text-link-strong-hover);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 }
 
 @define-mixin TextLinkInverted {
+  
   @mixin eds-theme-typography-body-text-md;
   color: var(--eds-theme-color-link-foreground-inverted);
 

--- a/src/design-tokens/tier-3-component/buttons.json
+++ b/src/design-tokens/tier-3-component/buttons.json
@@ -98,7 +98,7 @@
             },
             "text": {
               "@": {
-                "value": "{eds.color.brand.grape.600}"
+                "value": "{eds.color.neutral.600}"
               },
               "hover": {
                 "value": "{eds.color.neutral.white}"

--- a/src/tokens-dist/_scss_variables.scss
+++ b/src/tokens-dist/_scss_variables.scss
@@ -207,7 +207,7 @@ $eds-theme-color-button-tertiary-background-active: #21272D !default;
 $eds-theme-color-button-tertiary-border: #707070 !default;
 $eds-theme-color-button-tertiary-border-hover: #707070 !default;
 $eds-theme-color-button-tertiary-border-active: #21272D !default;
-$eds-theme-color-button-tertiary-text: #6B65E2 !default;
+$eds-theme-color-button-tertiary-text: #707070 !default;
 $eds-theme-color-button-tertiary-text-hover: #ffffff !default;
 $eds-theme-color-button-tertiary-text-active: #ffffff !default;
 $eds-theme-color-button-icon-background: rgba(0, 0, 0, 0) !default;

--- a/src/tokens-dist/variables-nested.json
+++ b/src/tokens-dist/variables-nested.json
@@ -393,7 +393,7 @@
               "active": "#21272D"
             },
             "text": {
-              "@": "#6B65E2",
+              "@": "#707070",
               "hover": "#ffffff",
               "active": "#ffffff"
             }

--- a/src/tokens-dist/variables.css
+++ b/src/tokens-dist/variables.css
@@ -207,7 +207,7 @@
   --eds-theme-color-button-tertiary-border: #707070;
   --eds-theme-color-button-tertiary-border-hover: #707070;
   --eds-theme-color-button-tertiary-border-active: #21272D;
-  --eds-theme-color-button-tertiary-text: #6B65E2;
+  --eds-theme-color-button-tertiary-text: #707070;
   --eds-theme-color-button-tertiary-text-hover: #ffffff;
   --eds-theme-color-button-tertiary-text-active: #ffffff;
   --eds-theme-color-button-icon-background: rgba(0, 0, 0, 0);


### PR DESCRIPTION
### Summary:
I previously updated the variants in the `Button` component to match the new color tokens. This PR updates the `Button` styles to use those tokens. I also updated the stories to match the UI Kit, so it's now very close to the figma representation of the component. There's a little more work to do, mostly around sizing (icon size in the button, link text size, space between link text and icon), so I left a couple of todo comments.

### Test Plan:
Verify the button stories and styles now mostly match the UI Kit in figma, and make sure the hover/focus states look right (especially be sure to verify the disabled buttons don't change color or anything on hover/click).