### PR TITLE
chore: add grid styling to checkbox long labels story

### DIFF
--- a/src/components/Checkbox/Checkbox.stories.module.css
+++ b/src/components/Checkbox/Checkbox.stories.module.css
@@ -1,0 +1,14 @@
+/*------------------------------------*\
+    #CHECKBOX STORIES
+\*------------------------------------*/
+
+/**
+ * Display grid to constrain widths of long labels.
+ * Used to show that the CheckboxInput centers with the first line of the label text.
+ */
+.longlabels--grid {
+  width: 20rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--eds-size-2);
+}

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Checkbox } from './Checkbox';
+import styles from './Checkbox.stories.module.css';
 import CheckboxInput from '../CheckboxInput';
 import CheckboxLabel from '../CheckboxLabel';
 
@@ -119,12 +120,12 @@ export const LongLabels = {
     const label = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
 
     return (
-      <>
+      <div className={styles['longlabels--grid']}>
         <Checkbox label={label} />
         <Checkbox label={label} size="small" />
         <Checkbox label={label} disabled />
         <Checkbox label={label} disabled size="small" />
-      </>
+      </div>
     );
   },
   parameters: {

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -615,190 +615,194 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
   style="margin: 0.25rem;"
 >
   <div
-    class="checkbox"
+    class="longlabels--grid"
   >
-    <span
-      class="input__wrapper"
+    <div
+      class="checkbox"
     >
-      <input
-        class="checkbox__input"
-        data-bootstrap-override="checkbox"
-        id="18"
-        style="--checkbox-svg-size: 1.25rem;"
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        height="1.25rem"
-        viewBox="0 0 20 20"
-        width="1.25rem"
+      <span
+        class="input__wrapper"
       >
-        <rect
-          class="checkmark__outline"
-          fill="none"
-          height="18"
-          rx="3"
-          stroke="currentColor"
-          stroke-width="2"
-          width="18"
-          x="1"
-          y="1"
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
+          id="18"
+          style="--checkbox-svg-size: 1.25rem;"
+          type="checkbox"
         />
-        <path
-          class="checkmark__content"
-          d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
-          fill="none"
-        />
-      </svg>
-    </span>
-    <label
-      class="label label--md"
-      data-bootstrap-override="label"
-      for="18"
-      style="--checkbox-svg-size: 1.25rem;"
-    >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit
-    </label>
-  </div>
-  <div
-    class="checkbox"
-  >
-    <span
-      class="input__wrapper"
-    >
-      <input
-        class="checkbox__input"
-        data-bootstrap-override="checkbox"
-        id="19"
+        <svg
+          aria-hidden="true"
+          height="1.25rem"
+          viewBox="0 0 20 20"
+          width="1.25rem"
+        >
+          <rect
+            class="checkmark__outline"
+            fill="none"
+            height="18"
+            rx="3"
+            stroke="currentColor"
+            stroke-width="2"
+            width="18"
+            x="1"
+            y="1"
+          />
+          <path
+            class="checkmark__content"
+            d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--md"
+        data-bootstrap-override="label"
+        for="18"
         style="--checkbox-svg-size: 1.25rem;"
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        height="1.25rem"
-        viewBox="0 0 20 20"
-        width="1.25rem"
       >
-        <rect
-          class="checkmark__outline"
-          fill="none"
-          height="18"
-          rx="3"
-          stroke="currentColor"
-          stroke-width="2"
-          width="18"
-          x="1"
-          y="1"
-        />
-        <path
-          class="checkmark__content"
-          d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
-          fill="none"
-        />
-      </svg>
-    </span>
-    <label
-      class="label label--sm"
-      data-bootstrap-override="label"
-      for="19"
-      style="--checkbox-svg-size: 1.25rem;"
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      </label>
+    </div>
+    <div
+      class="checkbox"
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit
-    </label>
-  </div>
-  <div
-    class="checkbox"
-  >
-    <span
-      class="input__wrapper input__wrapper--disabled"
-    >
-      <input
-        class="checkbox__input"
-        data-bootstrap-override="checkbox"
-        disabled=""
-        id="20"
+      <span
+        class="input__wrapper"
+      >
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
+          id="19"
+          style="--checkbox-svg-size: 1.25rem;"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          height="1.25rem"
+          viewBox="0 0 20 20"
+          width="1.25rem"
+        >
+          <rect
+            class="checkmark__outline"
+            fill="none"
+            height="18"
+            rx="3"
+            stroke="currentColor"
+            stroke-width="2"
+            width="18"
+            x="1"
+            y="1"
+          />
+          <path
+            class="checkmark__content"
+            d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--sm"
+        data-bootstrap-override="label"
+        for="19"
         style="--checkbox-svg-size: 1.25rem;"
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        height="1.25rem"
-        viewBox="0 0 20 20"
-        width="1.25rem"
       >
-        <rect
-          class="checkmark__outline"
-          fill="none"
-          height="18"
-          rx="3"
-          stroke="currentColor"
-          stroke-width="2"
-          width="18"
-          x="1"
-          y="1"
-        />
-        <path
-          class="checkmark__content"
-          d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
-          fill="none"
-        />
-      </svg>
-    </span>
-    <label
-      class="label label--md label--disabled"
-      data-bootstrap-override="label"
-      for="20"
-      style="--checkbox-svg-size: 1.25rem;"
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      </label>
+    </div>
+    <div
+      class="checkbox"
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit
-    </label>
-  </div>
-  <div
-    class="checkbox"
-  >
-    <span
-      class="input__wrapper input__wrapper--disabled"
-    >
-      <input
-        class="checkbox__input"
-        data-bootstrap-override="checkbox"
-        disabled=""
-        id="21"
+      <span
+        class="input__wrapper input__wrapper--disabled"
+      >
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
+          disabled=""
+          id="20"
+          style="--checkbox-svg-size: 1.25rem;"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          height="1.25rem"
+          viewBox="0 0 20 20"
+          width="1.25rem"
+        >
+          <rect
+            class="checkmark__outline"
+            fill="none"
+            height="18"
+            rx="3"
+            stroke="currentColor"
+            stroke-width="2"
+            width="18"
+            x="1"
+            y="1"
+          />
+          <path
+            class="checkmark__content"
+            d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--md label--disabled"
+        data-bootstrap-override="label"
+        for="20"
         style="--checkbox-svg-size: 1.25rem;"
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        height="1.25rem"
-        viewBox="0 0 20 20"
-        width="1.25rem"
       >
-        <rect
-          class="checkmark__outline"
-          fill="none"
-          height="18"
-          rx="3"
-          stroke="currentColor"
-          stroke-width="2"
-          width="18"
-          x="1"
-          y="1"
-        />
-        <path
-          class="checkmark__content"
-          d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
-          fill="none"
-        />
-      </svg>
-    </span>
-    <label
-      class="label label--sm label--disabled"
-      data-bootstrap-override="label"
-      for="21"
-      style="--checkbox-svg-size: 1.25rem;"
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      </label>
+    </div>
+    <div
+      class="checkbox"
     >
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit
-    </label>
+      <span
+        class="input__wrapper input__wrapper--disabled"
+      >
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
+          disabled=""
+          id="21"
+          style="--checkbox-svg-size: 1.25rem;"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          height="1.25rem"
+          viewBox="0 0 20 20"
+          width="1.25rem"
+        >
+          <rect
+            class="checkmark__outline"
+            fill="none"
+            height="18"
+            rx="3"
+            stroke="currentColor"
+            stroke-width="2"
+            width="18"
+            x="1"
+            y="1"
+          />
+          <path
+            class="checkmark__content"
+            d="M15.5605 5.2094C15.447 5.12571 15.3181 5.06522 15.1811 5.03137C15.0442 4.99752 14.902 4.99099 14.7625 5.01214C14.6231 5.0333 14.4892 5.08172 14.3684 5.15465C14.2477 5.22758 14.1425 5.32359 14.0589 5.43718L8.96703 12.3478L5.72917 9.7572C5.50592 9.58618 5.22455 9.50943 4.94539 9.54341C4.66622 9.57738 4.41148 9.71937 4.23576 9.93893C4.06004 10.1585 3.97733 10.4382 4.00536 10.718C4.03339 10.9978 4.16993 11.2555 4.38572 11.4359L8.49687 14.7244C8.61048 14.8133 8.74065 14.8786 8.87979 14.9166C9.01893 14.9546 9.16424 14.9645 9.30724 14.9457C9.45024 14.9269 9.58805 14.8798 9.71264 14.8071C9.83723 14.7344 9.94609 14.6377 10.0329 14.5225L15.7917 6.71187C15.8753 6.59806 15.9356 6.4689 15.9691 6.33178C16.0027 6.19465 16.009 6.05225 15.9875 5.91272C15.966 5.77318 15.9173 5.63925 15.844 5.51857C15.7707 5.39789 15.6744 5.29283 15.5605 5.2094Z"
+            fill="none"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--sm label--disabled"
+        data-bootstrap-override="label"
+        for="21"
+        style="--checkbox-svg-size: 1.25rem;"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit
+      </label>
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
### Summary:
- This was accidentally removed from original merged move checkbox pr
- Reintroduces grid to show that label wraps while `CheckboxInput` centers with first line of label
### Test Plan:
- `CheckboxInput` centers with first line of label in Storybook/Chromatic

![image](https://user-images.githubusercontent.com/86632227/162496512-4b1aa580-6dd6-4aca-8a8d-7342ca5a2b3a.png)
