### PR TITLE
[RFC] feat(banner): style links and buttons in Banner

### DIFF
--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -57,6 +57,10 @@
 
 .banner__textContent {
   gap: var(--eds-size-1);
+
+  a {
+    color: inherit;
+  }
 }
 
 .banner__action {
@@ -131,6 +135,7 @@
 /**
  * Banner neutral
  * 1) The thick left border matches the icon color
+ * 2) Links inside the Banner get their color from the banner variant styles
  */
 .banner--neutral {
   --border-light-color: var(--eds-theme-color-border-neutral-subtle);
@@ -138,11 +143,17 @@
 
   background: var(--eds-theme-color-background-neutral-subtle);
   color: var(--eds-theme-color-text-neutral-default);
+
+  a:hover,
+  a:focus {
+    color: var(--eds-theme-color-text-link-default-hover); /* 2 */
+  }
 }
 
 /**
  * Banner success
  * 1) The thick left border matches the icon color
+ * 2) Links inside the Banner get their color from the banner variant styles
  */
 .banner--success {
   /* TODO: move these styles to mixins or tokens so the Toast can reuse them */
@@ -151,11 +162,17 @@
 
   background: var(--eds-theme-color-background-utility-success);
   color: var(--eds-theme-color-text-utility-success);
+
+  a:hover,
+  a:focus {
+    color: var(--eds-color-other-mint-800); /* 2 */
+  }
 }
 
 /**
  * Banner warning
  * 1) The thick left border matches the icon color
+ * 2) Links inside the Banner get their color from the banner variant styles
  */
 .banner--warning {
   --border-light-color: var(--eds-theme-color-border-utility-warning-subtle);
@@ -163,11 +180,17 @@
 
   background: var(--eds-theme-color-background-utility-warning);
   color: var(--eds-theme-color-text-utility-warning);
+
+  a:hover,
+  a:focus {
+    color: var(--eds-color-other-orange-800); /* 2 */
+  }
 }
 
 /**
  * Banner alert
  * 1) The thick left border matches the icon color
+ * 2) Links inside the Banner get their color from the banner variant styles
  */
 .banner--alert {
   /* TODO: move these styles to mixins or tokens so the Toast can reuse them */
@@ -176,11 +199,17 @@
 
   background: var(--eds-theme-color-background-utility-error);
   color: var(--eds-theme-color-text-utility-error);
+
+  a:hover,
+  a:focus {
+    color: var(--eds-color-other-ruby-800); /* 2 */
+  }
 }
 
 /**
  * Banner brand
  * 1) The thick left border matches the icon color
+ * 2) Links inside the Banner get their color from the banner variant styles
  */
 .banner--brand {
   --border-light-color: var(--eds-theme-color-border-brand-primary-subtle);
@@ -188,4 +217,69 @@
 
   background: var(--eds-theme-color-background-brand-primary-default);
   color: var(--eds-theme-color-text-brand-primary);
+
+  a:hover,
+  a:focus {
+    color: var(--eds-color-brand-grape-800); /* 2 */
+  }
+}
+
+/*------------------------------------*\
+    # ACTION STYLES
+\*------------------------------------*/
+
+.banner__action > * {
+  /* TODO: move to mixin */
+  @mixin eds-theme-typography-button-label;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0; /* 3 */
+  gap: 0.75rem; /* 4 */
+  border-width: var(--eds-theme-border-width);
+  border-style: solid;
+  border-radius: var(--eds-theme-border-radius);
+  cursor: pointer;
+  transition: all var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  &:focus {
+    @mixin focus;
+  }
+
+  &:disabled,
+  &:disabled:hover {
+    cursor: not-allowed;
+    border-color: var(--eds-theme-color-border-disabled);
+    background-color: transparent;
+    color: var(--eds-theme-color-text-disabled);
+  }
+
+  svg {
+    --icon-size-default: 2em; /* 5 */
+  }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.banner--success .banner__action > * {
+  /* TODO: move these colors to tokens */
+  border-color: var(--eds-color-other-mint-700);
+  background-color: transparent;
+  color: var(--eds-color-other-mint-700);
+
+  &:hover,
+  &:focus {
+    border-color: var(--eds-color-other-mint-700);
+    background-color: var(--eds-color-other-mint-700);
+    color: white;
+  }
+
+  &:active {
+    border-color: var(--eds-color-other-mint-800);
+    background-color: var(--eds-color-other-mint-800);
+    color: white;
+  }
 }


### PR DESCRIPTION
### Summary:
When we revamped the `Button` props, we slimmed down the potential variants to only purple and gray buttons. All the orange, red, and green buttons were removed because they're only used in the `Banner` and `Toast` components.

Since they were removed from the main `Button` component, we're going to need to get a little creative for using them in messaging components. This PR presents one possible direction. It's very rough, so you're going to have to use your imagination a bit.

Keep in mind that the variants we specifically need are:
- link variants in the banner text block
- outline buttons in the "action" prop
- icon buttons for the close button

Possible directions:
1) The styles are baked into the `Banner` CSS. We'll need some of the base `Button` styles, so those can be moved to mixins and reused here. (This is the direction shown in this PR.)
  - Pros: devs just pass in links and buttons and the styles are taken care of.
  - Cons: it's pretty messy, and it may be confusing that they pass in a purple or gray button/link and then the colors are overridden. Devs may waste time trying to figure out where to get these colored buttons from, not realizing that the component takes care of this for them. 
2) A new component (called something like `MessagingButton` because it will also be used in the `Toast component`). It would work like the old `Button` in that it can create all three variants and colors.
  - Pros: all the styles will be contained in this other component, it will be easy to reuse between the `Banner` and `Toast`, and it will be fairly intuitive because it's similar to the old version of the `Button`.
  - Cons: we're going to have to deal with the colors/variants API again (which may be especially confusing now because the main `Button` works very differently), and we're going to have to support rendering `button` and `a` tags because we don't actually know what the "action" functionality will be.
3) Change the "action" prop from being a react node to being an object that accepts attributes of the button, and we put the button together ourselves (it would look something like `actionProps={children: "Button children", onClick={() => console.log("clicked")!} `).
  - Pros: The API makes a little more sense because they're not passing in a purple or gray button and having the styles overridden – we can specify that we're going to create a button that matches the banner variant.
  - Cons: We're still going to have to handle the styling in some way, either by having a separate component or baking the styles into the `Banner`, and this especially doesn't help us when it comes to the close button or links in the text block.
4) Bring back the color x shape spread in a different component that the `Button` and `Link` rely on (possibly taking the place of `ClickableStyle` or be another component that `ClickableStyle` wraps, see https://github.com/chanzuckerberg/edu-design-system/pull/962 for what `ClickableStyle` is). The `Button` would still only produce the variants it does now (it's API wouldn't change), but there would be another component that only the "Messaging" components use. I'm thinking this would combine with option # 3 so devs wouldn't actually use this component.
  - Pros: effectively pushes the styles into another component to reduce messiness, and that component could be reused across all of these locations to reduce duplication
  - Cons: links would still need to baked into the messaging component styles though unless we do want to give devs access to this component which kind of defeats the purpose of reducing the variant options in `Button`, and the token to styles mapping would be really strange for the primary, secondary, tertiary, etc variants (we might want to just drop that token structure and have a set of button tokens that just includes the full color x shape spread)

Thoughts? Sorry if this is confusing; I feel like it requires a bit of context on the button variants and current tokens structures to understand why this is so complicated.

### Banner images (for reference on which buttons/links we need)
Figma: https://www.figma.com/file/P9VPyI821gLq832tuU2WeY/UI-Kit-Master-(Core)?node-id=3049%3A9285
<img width="599" alt="the banner component in figma" src="https://user-images.githubusercontent.com/7761701/163426298-f0d72d09-cbd1-4d2d-ba7e-fe5b3ce66c22.png">

Just FYI I did specifically ask design if we could get away with using the gray or purple outline buttons in the banner, but they were very clear that's not an option.

### Button variants
These are the variants that the `Button` component now supports. You used to be able to get any color and shape combo from this component, but it now only produces the variants used in the product outline of the `Banner` and `Toast` components.

<img width="186" alt="new-variants" src="https://user-images.githubusercontent.com/7761701/163428583-880cabd0-215d-4de8-8906-51440c7a4d34.png">

### Test Plan:
Chromatic and storybook.