### PR TITLE
test(tooltip): disable snapshot for long button text

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -120,7 +120,7 @@ export const LongButtonText: StoryObj<Args> = {
   },
   parameters: {
     // Is flaky on chromatic, disabling for now
-    chromatic: { delay: 300 },
+    chromatic: { disableSnapshot: true },
   },
 };
 


### PR DESCRIPTION
### Summary:
There's a flaky tooltip snapshot that keeps showing up in the chromatic changes. @jinlee93 added a delay to this test, which we had hoped would fix this, but I'm still seeing it sometimes. We could increase the delay, but now I'm also wondering what we even gain from this snapshot because it doesn't even show the tooltip. So this PR disables the chromatic snapshot for this story, but I'm also open to increasing the delay if people think that would be better.

https://www.chromatic.com/test?appId=61313967cde49b003ae2a860&id=6258e75b6814fe003a4828d2
<img width="1351" alt="the long button text tooltip story in chromatic" src="https://user-images.githubusercontent.com/7761701/163596244-ec0a1520-1447-422d-b492-35fcc84312f2.png">

### Test Plan:
Verify this snapshot is missing in chromatic.