### PR TITLE
feat(link): use default link color tokens in textLink mixin

### DIFF
--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -13,11 +13,11 @@
   text-transform: inherit;
 
   text-decoration: underline;
-  color: var(--eds-theme-color-text-link-strong);
+  color: var(--eds-theme-color-text-link);
 
   &:hover,
   &:focus {
-    color: var(--eds-theme-color-text-link-strong-hover);
+    color: var(--eds-theme-color-text-link-hover);
     text-decoration-thickness: 2px;
   }
 


### PR DESCRIPTION
### Summary:
This change was originally part of https://github.com/chanzuckerberg/edu-design-system/pull/968, which was closed because we're not going in that direction anymore.

This PR updates the `textLink` mixin to use the default link color tokens (instead of the "strong" ones). This does not affect the `ClickableStyle`, `Button`, or `Link` components; it only affects components that have text links but use the mixin instead of the component. (We may want to go back and use the component instead of the mixin in these places, but for now I think it's fine if they use the mixin.)

### Test Plan:
In storybook,
verify the "link" variant stories in the `Link` component are unchanged,
and verify the links in http://localhost:9009/?path=/docs/organisms-text-textpassage--default are now gray (and become a slightly darker gray on hover).