### PR TITLE
chore(banner, toast): use mixins to share variant colors between messaging components

### DIFF
--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -129,64 +129,37 @@
 
 /**
  * Banner neutral
- * 1) The thick left border matches the icon color
  */
 .banner--neutral {
-  --border-light-color: var(--eds-theme-color-border-neutral-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-neutral-subtle); /* 1 */
-
-  background: var(--eds-theme-color-background-neutral-subtle);
-  color: var(--eds-theme-color-text-neutral-default);
+  @mixin messagingNeutral;
 }
 
 /**
  * Banner success
- * 1) The thick left border matches the icon color
  */
 .banner--success {
-  /* TODO: move these styles to mixins or tokens so the Toast can reuse them */
-  --border-light-color: var(--eds-theme-color-border-utility-success-default);
-  --border-dark-color: var(--eds-theme-color-icon-utility-success); /* 1 */
-
-  background: var(--eds-theme-color-background-utility-success);
-  color: var(--eds-theme-color-text-utility-success);
+  @mixin messagingSuccess;
 }
 
 /**
  * Banner warning
- * 1) The thick left border matches the icon color
  */
 .banner--warning {
-  --border-light-color: var(--eds-theme-color-border-utility-warning-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-utility-warning); /* 1 */
-
-  background: var(--eds-theme-color-background-utility-warning);
-  color: var(--eds-theme-color-text-utility-warning);
+  @mixin messagingWarning;
 }
 
 /**
  * Banner alert
- * 1) The thick left border matches the icon color
  */
 .banner--alert {
-  /* TODO: move these styles to mixins or tokens so the Toast can reuse them */
-  --border-light-color: var(--eds-theme-color-border-utility-error-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-utility-error); /* 1 */
-
-  background: var(--eds-theme-color-background-utility-error);
-  color: var(--eds-theme-color-text-utility-error);
+  @mixin messagingAlert;
 }
 
 /**
  * Banner brand
- * 1) The thick left border matches the icon color
  */
 .banner--brand {
-  --border-light-color: var(--eds-theme-color-border-brand-primary-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-brand-primary); /* 1 */
-
-  background: var(--eds-theme-color-background-brand-primary-default);
-  color: var(--eds-theme-color-text-brand-primary);
+  @mixin messagingBrand;
 }
 
 /*------------------------------------*\

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -27,21 +27,18 @@
   border-left-width: var(--eds-border-width-lg); /* 3 */
   border-radius: var(--eds-size-half);
 
+  border-color: var(--border-light-color);
+  border-left-color: var(--border-dark-color);
+
   box-shadow: var(--eds-box-shadow-sm);
 }
 
 .toast--success {
-  color: var(--eds-theme-color-text-utility-success);
-  background-color: var(--eds-theme-color-background-utility-success);
-  border-color: var(--eds-theme-color-border-utility-success-default);
-  border-left-color: var(--eds-theme-color-border-utility-success-strong);
+  @mixin messagingSuccess;
 }
 
 .toast--alert {
-  color: var(--eds-theme-color-text-utility-error);
-  background-color: var(--eds-theme-color-background-utility-error);
-  border-color: var(--eds-theme-color-border-utility-error-default);
-  border-left-color: var(--eds-theme-color-border-utility-error-strong);
+  @mixin messagingAlert;
 }
 
 /**

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -9,6 +9,7 @@
  * 2) Container for the toast content, to provide background styling
  * 3) The thick left border operates as a foreground band of color, 
  *    so foreground rather than border is used
+ * 4) The border CSS variables are defined in the messaging mixins
  */
 .toast {
   width: 100%;
@@ -27,8 +28,8 @@
   border-left-width: var(--eds-border-width-lg); /* 3 */
   border-radius: var(--eds-size-half);
 
-  border-color: var(--border-light-color);
-  border-left-color: var(--border-dark-color);
+  border-color: var(--border-light-color); /* 4 */
+  border-left-color: var(--border-dark-color); /* 4 */
 
   box-shadow: var(--eds-box-shadow-sm);
 }

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -140,3 +140,43 @@
   border: 0 !important;
   clip: rect(1px, 1px, 1px, 1px) !important;
 }
+
+@define-mixin messagingBrand {
+  --border-light-color: var(--eds-theme-color-border-brand-primary-subtle);
+  --border-dark-color: var(--eds-theme-color-icon-brand-primary);
+
+  background: var(--eds-theme-color-background-brand-primary-default);
+  color: var(--eds-theme-color-text-brand-primary);
+}
+
+@define-mixin messagingNeutral {
+  --border-light-color: var(--eds-theme-color-border-neutral-subtle);
+  --border-dark-color: var(--eds-theme-color-icon-neutral-subtle);
+
+  background: var(--eds-theme-color-background-neutral-subtle);
+  color: var(--eds-theme-color-text-neutral-default);
+}
+
+@define-mixin messagingSuccess {
+  --border-light-color: var(--eds-theme-color-border-utility-success-default);
+  --border-dark-color: var(--eds-theme-color-icon-utility-success);
+
+  background: var(--eds-theme-color-background-utility-success);
+  color: var(--eds-theme-color-text-utility-success);
+}
+
+@define-mixin messagingWarning {
+  --border-light-color: var(--eds-theme-color-border-utility-warning-subtle);
+  --border-dark-color: var(--eds-theme-color-icon-utility-warning);
+
+  background: var(--eds-theme-color-background-utility-warning);
+  color: var(--eds-theme-color-text-utility-warning);
+}
+
+@define-mixin messagingAlert {
+  --border-light-color: var(--eds-theme-color-border-utility-error-subtle);
+  --border-dark-color: var(--eds-theme-color-icon-utility-error);
+
+  background: var(--eds-theme-color-background-utility-error);
+  color: var(--eds-theme-color-text-utility-error);
+}


### PR DESCRIPTION
### Summary:
The `Banner` and `Toast` have overlapping styles, and there are a couple more components in the UI Kit like them. This PR adds mixins to reuse the color-related styles (text, background, and border colors) for the 5 possible variants for messaging components. This will help us keep them in sync so it's easier to maintain and keep them consistent. (This PR does have a slight change to the component styles because it causes the `Toast` to now use the exact same tokens as the `Banner`.)

One thing to note is that the `Toast` only supports 2 of these variants, so it's possible this is overkill and the complexity isn't worth the deduplication in this case. I'm more inclined to add this because it could be reused in other future messaging components.

UI Kit: https://www.figma.com/file/P9VPyI821gLq832tuU2WeY/UI-Kit-Master-(Core)?node-id=2525%3A662

### Test Plan:
Verify there are no changes to the `Banner` or `Toast` stories (in storybook and chromatic) aside from the left border for the `Toast` being a little darker and the other borders for the `Toast` being a little lighter.