### PR TITLE
feat: use 'error' instead of 'alert' for red variants

### DIFF
--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -149,10 +149,10 @@
 }
 
 /**
- * Banner alert
+ * Banner error
  */
-.banner--alert {
-  @mixin messagingAlert;
+.banner--error {
+  @mixin messagingError;
 }
 
 /**

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -62,10 +62,10 @@ export const Warning: StoryObj<Args> = {
   },
 };
 
-export const Alert: StoryObj<Args> = {
+export const Error: StoryObj<Args> = {
   ...Brand,
   args: {
-    variant: 'alert',
+    variant: 'error',
   },
 };
 
@@ -114,11 +114,11 @@ export const WarningWithAction: StoryObj<Args> = {
   },
 };
 
-export const AlertWithAction: StoryObj<Args> = {
-  ...Alert,
+export const ErrorWithAction: StoryObj<Args> = {
+  ...Error,
   args: {
     action: action,
-    variant: 'alert',
+    variant: 'error',
   },
 };
 
@@ -153,10 +153,10 @@ export const WarningDismissable: StoryObj<Args> = {
   },
 };
 
-export const AlertDismissable: StoryObj<Args> = {
+export const ErrorDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
-    variant: 'alert',
+    variant: 'error',
     dismissable: true,
   },
 };

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -62,9 +62,9 @@ export interface Props {
    * - **neutral** - results in a gray banner
    * - **success** - results in a green banner
    * - **warning** - results in a yellow banner
-   * - **alert** - results in a red banner
+   * - **error** - results in a red banner
    */
-  variant?: 'brand' | 'neutral' | 'success' | 'warning' | 'alert';
+  variant?: 'brand' | 'neutral' | 'success' | 'warning' | 'error';
 }
 
 const variantToIconAssetsMap: {
@@ -89,9 +89,9 @@ const variantToIconAssetsMap: {
     name: 'warning',
     title: 'warning',
   },
-  alert: {
+  error: {
     name: 'dangerous',
-    title: 'alert',
+    title: 'error',
   },
 };
 
@@ -158,7 +158,7 @@ export const Banner = ({
     // Variants
     variant === 'neutral' && styles['banner--neutral'],
     variant === 'brand' && styles['banner--brand'],
-    variant === 'alert' && styles['banner--alert'],
+    variant === 'error' && styles['banner--error'],
     variant === 'warning' && styles['banner--warning'],
     variant === 'success' && styles['banner--success'],
     // Other options

--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -42,7 +42,7 @@
 /**
  * Color variants
  */
-.heading--alert {
+.heading--error {
   color: var(--eds-theme-color-text-utility-error);
 }
 .heading--base {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -3,7 +3,7 @@ import React, { forwardRef } from 'react';
 import styles from './Heading.module.css';
 
 export const VARIANTS = [
-  'alert',
+  'error',
   'base',
   'brand',
   'inherit',

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -363,9 +363,9 @@ exports[`<Heading /> Variants story renders snapshot 1`] = `
     class="variant--white"
   >
     <h1
-      class="heading heading--size-h1 heading--alert"
+      class="heading heading--size-h1 heading--error"
     >
-      alert
+      error
     </h1>
     <h1
       class="heading heading--size-h1 heading--base"
@@ -407,9 +407,9 @@ exports[`<Heading /> Variants story renders snapshot 1`] = `
     class="variant--light"
   >
     <h1
-      class="heading heading--size-h1 heading--alert"
+      class="heading heading--size-h1 heading--error"
     >
-      alert
+      error
     </h1>
     <h1
       class="heading heading--size-h1 heading--base"
@@ -451,9 +451,9 @@ exports[`<Heading /> Variants story renders snapshot 1`] = `
     class="variant--dark"
   >
     <h1
-      class="heading heading--size-h1 heading--alert"
+      class="heading heading--size-h1 heading--error"
     >
-      alert
+      error
     </h1>
     <h1
       class="heading heading--size-h1 heading--base"

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -34,7 +34,7 @@
 /**
  * Variant
  */
-.text--alert {
+.text--error {
   color: var(--eds-theme-color-text-utility-error);
 }
 .text--base {

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -19,7 +19,7 @@ export default {
 };
 
 const variants = [
-  'alert',
+  'error',
   'base',
   'brand',
   'inherit',
@@ -144,7 +144,7 @@ export const BodyVariantSuccessBold: StoryObj<Args> = {
 
 export const TextVariantInherit: StoryObj<Args> = {
   render: (args) => (
-    <Text size="body" variant="alert">
+    <Text size="body" variant="error">
       This text surrounds the <Text as="span" {...args} /> and shows it should
       inherit variant from the parent
     </Text>

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import styles from './Text.module.css';
 export type Size = 'body' | 'sm' | 'md' | 'lg' | 'xs' | 'caption' | 'overline';
 
 export type Variant =
-  | 'alert'
+  | 'error'
   | 'base'
   | 'brand'
   | 'inherit'

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -66,7 +66,7 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
 
 exports[`<Text /> TextVariantInherit story renders snapshot 1`] = `
 <p
-  class="text text--body text--alert"
+  class="text text--body text--error"
 >
   This text surrounds the 
   <span

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -38,8 +38,8 @@
   @mixin messagingSuccess;
 }
 
-.toast--alert {
-  @mixin messagingAlert;
+.toast--error {
+  @mixin messagingError;
 }
 
 /**

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -19,9 +19,9 @@ export const Success: StoryObj<Args> = {
   },
 };
 
-export const Alert: StoryObj<Args> = {
+export const Error: StoryObj<Args> = {
   args: {
-    variant: 'alert',
+    variant: 'error',
   },
 };
 

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -4,7 +4,7 @@ import styles from './Toast.module.css';
 import Button from '../Button';
 import Icon from '../Icon';
 
-export type Variant = 'success' | 'alert';
+export type Variant = 'success' | 'error';
 
 export type Props = {
   /**
@@ -47,7 +47,7 @@ export const Toast = ({
     className,
     styles['toast'],
     variant === 'success' && styles['toast--success'],
-    variant === 'alert' && styles['toast--alert'],
+    variant === 'error' && styles['toast--error'],
   );
   return (
     <div className={componentClassName} {...other}>

--- a/src/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Toast /> Alert story renders snapshot 1`] = `
+exports[`<Toast /> Error story renders snapshot 1`] = `
 <div
-  class="toast toast--alert"
+  class="toast toast--error"
 >
   <div
     class="toast__content"
@@ -19,7 +19,7 @@ exports[`<Toast /> Alert story renders snapshot 1`] = `
       <title
         id="mock-id"
       >
-        alert
+        error
       </title>
       <use
         xlink:href="test-file-stub#warning"

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -173,7 +173,7 @@
   color: var(--eds-theme-color-text-utility-warning);
 }
 
-@define-mixin messagingAlert {
+@define-mixin messagingError {
   --border-light-color: var(--eds-theme-color-border-utility-error-subtle);
   --border-dark-color: var(--eds-theme-color-icon-utility-error);
 


### PR DESCRIPTION
### Summary:
I noticed we're sometimes using the word "error" for red variants and sometimes using "alert" (but mostly using "error"). Design confirmed that we should be using "error" everywhere. This PR updates the `Banner`, `Toast`, `Text`, and `Heading` components to use "error".

### Test Plan:
Verify there are no changes to these components in storybook aside from the story name changes.