### PR TITLE
docs(clickable-style, button, link): add argTypes to stories

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -7,6 +7,40 @@ import Icon from '../Icon';
 export default {
   title: 'Molecules/Buttons/Button',
   component: Button,
+  args: {
+    children: 'Button',
+    variant: 'primary',
+    status: 'brand',
+    fullWidth: false,
+    size: 'lg',
+    loading: false,
+  },
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'icon', 'link'],
+      },
+    },
+    status: {
+      control: {
+        type: 'select',
+        options: ['brand', 'neutral', 'success', 'warning', 'error'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['sm', 'md', 'lg'],
+      },
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
+    loading: {
+      control: 'boolean',
+    },
+  },
 } as Meta;
 
 type Args = React.ComponentProps<typeof Button>;
@@ -14,10 +48,9 @@ type Args = React.ComponentProps<typeof Button>;
 const Template: Story<Args> = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
-Primary.args = { children: 'Button' };
 
 export const PrimaryDisabled = Template.bind({});
-PrimaryDisabled.args = { children: 'Button', disabled: true };
+PrimaryDisabled.args = { disabled: true };
 
 export const PrimaryLeftIcon = Template.bind({});
 PrimaryLeftIcon.args = {
@@ -40,17 +73,16 @@ PrimaryRightIcon.args = {
 };
 
 export const PrimaryMedium = Template.bind({});
-PrimaryMedium.args = { children: 'Button', size: 'md' };
+PrimaryMedium.args = { size: 'md' };
 
 export const PrimarySmall = Template.bind({});
-PrimarySmall.args = { children: 'Button', size: 'sm' };
+PrimarySmall.args = { size: 'sm' };
 
 export const Secondary = Template.bind({});
-Secondary.args = { children: 'Button', variant: 'secondary' };
+Secondary.args = { variant: 'secondary' };
 
 export const SecondaryDisabled = Template.bind({});
 SecondaryDisabled.args = {
-  children: 'Button',
   variant: 'secondary',
   disabled: true,
 };
@@ -78,10 +110,10 @@ SecondaryRightIcon.args = {
 };
 
 export const SecondaryMedium = Template.bind({});
-SecondaryMedium.args = { children: 'Button', variant: 'secondary', size: 'md' };
+SecondaryMedium.args = { variant: 'secondary', size: 'md' };
 
 export const SecondarySmall = Template.bind({});
-SecondarySmall.args = { children: 'Button', variant: 'secondary', size: 'sm' };
+SecondarySmall.args = { variant: 'secondary', size: 'sm' };
 
 export const Tertiary = Template.bind({});
 Tertiary.args = {
@@ -92,7 +124,6 @@ Tertiary.args = {
 
 export const SecondaryNeutralDisabled = Template.bind({});
 SecondaryNeutralDisabled.args = {
-  children: 'Button',
   variant: 'secondary',
   status: 'neutral',
   disabled: true,
@@ -124,7 +155,6 @@ SecondaryNeutralRightIcon.args = {
 
 export const SecondaryNeutralMedium = Template.bind({});
 SecondaryNeutralMedium.args = {
-  children: 'Button',
   variant: 'secondary',
   status: 'neutral',
   size: 'md',
@@ -132,7 +162,6 @@ SecondaryNeutralMedium.args = {
 
 export const SecondaryNeutralSmall = Template.bind({});
 SecondaryNeutralSmall.args = {
-  children: 'Button',
   variant: 'secondary',
   status: 'neutral',
   size: 'sm',
@@ -210,10 +239,10 @@ IconButtonIconOnlySmall.args = {
 };
 
 export const Link = Template.bind({});
-Link.args = { children: 'Button', variant: 'link' };
+Link.args = { variant: 'link' };
 
 export const LinkDisabled = Template.bind({});
-LinkDisabled.args = { children: 'Button', variant: 'link', disabled: true };
+LinkDisabled.args = { variant: 'link', disabled: true };
 
 export const LinkRightIcon = Template.bind({});
 LinkRightIcon.args = {
@@ -250,32 +279,28 @@ PrimaryErrorLeftIcon.args = {
 };
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { children: 'Button', fullWidth: true };
+FullWidth.args = { fullWidth: true };
 
 export const Loading = Template.bind({});
 Loading.args = {
-  children: 'Button',
   loading: true,
   disabled: true,
 };
 
 export const SecondarySuccess = Template.bind({});
 SecondarySuccess.args = {
-  children: 'Button',
   status: 'success',
   variant: 'secondary',
 };
 
 export const SecondaryWarning = Template.bind({});
 SecondaryWarning.args = {
-  children: 'Button',
   status: 'warning',
   variant: 'secondary',
 };
 
 export const SecondaryError = Template.bind({});
 SecondaryError.args = {
-  children: 'Button',
   status: 'error',
   variant: 'secondary',
 };
@@ -330,28 +355,24 @@ IconError.args = {
 
 export const LinkNeutral = Template.bind({});
 LinkNeutral.args = {
-  children: 'Button',
   status: 'neutral',
   variant: 'link',
 };
 
 export const LinkSuccess = Template.bind({});
 LinkSuccess.args = {
-  children: 'Button',
   status: 'success',
   variant: 'link',
 };
 
 export const LinkWarning = Template.bind({});
 LinkWarning.args = {
-  children: 'Button',
   status: 'warning',
   variant: 'link',
 };
 
 export const LinkError = Template.bind({});
 LinkError.args = {
-  children: 'Button',
   status: 'error',
   variant: 'link',
 };

--- a/src/components/ClickableStyle/ClickableStyle.stories.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.stories.tsx
@@ -9,6 +9,33 @@ export default {
   component: ClickableStyle,
   args: {
     children: 'Clickable Style',
+    variant: 'primary',
+    status: 'brand',
+    fullWidth: false,
+    size: 'lg',
+  },
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'icon', 'link'],
+      },
+    },
+    status: {
+      control: {
+        type: 'select',
+        options: ['brand', 'neutral', 'success', 'warning', 'error'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['sm', 'md', 'lg'],
+      },
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
   },
 } as Meta;
 
@@ -19,7 +46,6 @@ const Template: Story<Args> = (args: Args) => (
 );
 
 export const Primary = Template.bind({});
-Primary.args = { children: 'Clickable Style' };
 
 export const PrimaryLeftIcon = Template.bind({});
 PrimaryLeftIcon.args = {
@@ -42,13 +68,13 @@ PrimaryRightIcon.args = {
 };
 
 export const PrimaryMedium = Template.bind({});
-PrimaryMedium.args = { children: 'Clickable Style', size: 'md' };
+PrimaryMedium.args = { size: 'md' };
 
 export const PrimarySmall = Template.bind({});
-PrimarySmall.args = { children: 'Clickable Style', size: 'sm' };
+PrimarySmall.args = { size: 'sm' };
 
 export const Secondary = Template.bind({});
-Secondary.args = { children: 'Clickable Style', variant: 'secondary' };
+Secondary.args = { variant: 'secondary' };
 
 export const SecondaryLeftIcon = Template.bind({});
 SecondaryLeftIcon.args = {
@@ -74,14 +100,12 @@ SecondaryRightIcon.args = {
 
 export const SecondaryMedium = Template.bind({});
 SecondaryMedium.args = {
-  children: 'Clickable Style',
   variant: 'secondary',
   size: 'md',
 };
 
 export const SecondarySmall = Template.bind({});
 SecondarySmall.args = {
-  children: 'Clickable Style',
   variant: 'secondary',
   size: 'sm',
 };
@@ -119,7 +143,6 @@ SecondaryNeutralRightIcon.args = {
 
 export const SecondaryNeutralMedium = Template.bind({});
 SecondaryNeutralMedium.args = {
-  children: 'Clickable Style',
   variant: 'secondary',
   status: 'neutral',
   size: 'md',
@@ -127,7 +150,6 @@ SecondaryNeutralMedium.args = {
 
 export const SecondaryNeutralSmall = Template.bind({});
 SecondaryNeutralSmall.args = {
-  children: 'Clickable Style',
   variant: 'secondary',
   status: 'neutral',
   size: 'sm',
@@ -193,7 +215,7 @@ IconClickableStyleIconOnlySmall.args = {
 };
 
 export const Link = Template.bind({});
-Link.args = { children: 'Clickable Style', variant: 'link' };
+Link.args = { variant: 'link' };
 
 export const LinkRightIcon = Template.bind({});
 LinkRightIcon.args = {
@@ -230,25 +252,22 @@ PrimaryErrorLeftIcon.args = {
 };
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { children: 'Clickable Style', fullWidth: true };
+FullWidth.args = { fullWidth: true };
 
 export const SecondarySuccess = Template.bind({});
 SecondarySuccess.args = {
-  children: 'Clickable Style',
   status: 'success',
   variant: 'secondary',
 };
 
 export const SecondaryWarning = Template.bind({});
 SecondaryWarning.args = {
-  children: 'Clickable Style',
   status: 'warning',
   variant: 'secondary',
 };
 
 export const SecondaryError = Template.bind({});
 SecondaryError.args = {
-  children: 'Clickable Style',
   status: 'error',
   variant: 'secondary',
 };
@@ -303,28 +322,24 @@ IconError.args = {
 
 export const LinkNeutral = Template.bind({});
 LinkNeutral.args = {
-  children: 'Clickable Style',
   status: 'neutral',
   variant: 'link',
 };
 
 export const LinkSuccess = Template.bind({});
 LinkSuccess.args = {
-  children: 'Clickable Style',
   status: 'success',
   variant: 'link',
 };
 
 export const LinkWarning = Template.bind({});
 LinkWarning.args = {
-  children: 'Clickable Style',
   status: 'warning',
   variant: 'link',
 };
 
 export const LinkError = Template.bind({});
 LinkError.args = {
-  children: 'Clickable Style',
   status: 'error',
   variant: 'link',
 };

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -7,6 +7,36 @@ import Icon from '../Icon';
 export default {
   title: 'Molecules/Buttons/Link',
   component: Link,
+  args: {
+    children: 'Link',
+    variant: 'primary',
+    status: 'brand',
+    fullWidth: false,
+    size: 'lg',
+  },
+  argTypes: {
+    variant: {
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'icon', 'link'],
+      },
+    },
+    status: {
+      control: {
+        type: 'select',
+        options: ['brand', 'neutral', 'success', 'warning', 'error'],
+      },
+    },
+    size: {
+      control: {
+        type: 'select',
+        options: ['sm', 'md', 'lg'],
+      },
+    },
+    fullWidth: {
+      control: 'boolean',
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (
@@ -19,7 +49,7 @@ const Template: Story<Props> = (args) => (
 );
 
 export const Default = Template.bind({});
-Default.args = { children: 'Link', variant: 'link' };
+Default.args = { variant: 'link' };
 
 export const LinkRightIcon = Template.bind({});
 LinkRightIcon.args = {
@@ -37,7 +67,7 @@ LinkRightIcon.args = {
 };
 
 export const Primary = Template.bind({});
-Primary.args = { children: 'Link', variant: 'primary' };
+Primary.args = { variant: 'primary' };
 
 export const PrimaryLeftIcon = Template.bind({});
 PrimaryLeftIcon.args = {
@@ -62,13 +92,13 @@ PrimaryRightIcon.args = {
 };
 
 export const PrimaryMedium = Template.bind({});
-PrimaryMedium.args = { children: 'Link', size: 'md', variant: 'primary' };
+PrimaryMedium.args = { size: 'md', variant: 'primary' };
 
 export const PrimarySmall = Template.bind({});
-PrimarySmall.args = { children: 'Link', size: 'sm', variant: 'primary' };
+PrimarySmall.args = { size: 'sm', variant: 'primary' };
 
 export const Secondary = Template.bind({});
-Secondary.args = { children: 'Link', variant: 'secondary' };
+Secondary.args = { variant: 'secondary' };
 
 export const SecondaryLeftIcon = Template.bind({});
 SecondaryLeftIcon.args = {
@@ -94,14 +124,12 @@ SecondaryRightIcon.args = {
 
 export const SecondaryMedium = Template.bind({});
 SecondaryMedium.args = {
-  children: 'Link',
   variant: 'secondary',
   size: 'md',
 };
 
 export const SecondarySmall = Template.bind({});
 SecondarySmall.args = {
-  children: 'Link',
   variant: 'secondary',
   size: 'sm',
 };
@@ -139,7 +167,6 @@ SecondaryNeutralRightIcon.args = {
 
 export const SecondaryNeutralMedium = Template.bind({});
 SecondaryNeutralMedium.args = {
-  children: 'Link',
   variant: 'secondary',
   status: 'neutral',
   size: 'md',
@@ -147,7 +174,6 @@ SecondaryNeutralMedium.args = {
 
 export const SecondaryNeutralSmall = Template.bind({});
 SecondaryNeutralSmall.args = {
-  children: 'Link',
   variant: 'secondary',
   status: 'neutral',
   size: 'sm',
@@ -232,25 +258,22 @@ PrimaryErrorLeftIcon.args = {
 };
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { children: 'Link', fullWidth: true, variant: 'primary' };
+FullWidth.args = { fullWidth: true, variant: 'primary' };
 
 export const SecondarySuccess = Template.bind({});
 SecondarySuccess.args = {
-  children: 'Link',
   status: 'success',
   variant: 'secondary',
 };
 
 export const SecondaryWarning = Template.bind({});
 SecondaryWarning.args = {
-  children: 'Link',
   status: 'warning',
   variant: 'secondary',
 };
 
 export const SecondaryError = Template.bind({});
 SecondaryError.args = {
-  children: 'Link',
   status: 'error',
   variant: 'secondary',
 };
@@ -305,28 +328,24 @@ IconError.args = {
 
 export const LinkNeutral = Template.bind({});
 LinkNeutral.args = {
-  children: 'Link',
   status: 'neutral',
   variant: 'link',
 };
 
 export const LinkSuccess = Template.bind({});
 LinkSuccess.args = {
-  children: 'Link',
   status: 'success',
   variant: 'link',
 };
 
 export const LinkWarning = Template.bind({});
 LinkWarning.args = {
-  children: 'Link',
   status: 'warning',
   variant: 'link',
 };
 
 export const LinkError = Template.bind({});
 LinkError.args = {
-  children: 'Link',
   status: 'error',
   variant: 'link',
 };


### PR DESCRIPTION
### Summary:
I'm having a bit of trouble with the `ClickableStyle`/`Button`/`Link` stories because the props aren't showing up by default. I don't want to get stuck in the weeds on this component anymore than I already have, so this PR just adds `argTypes` to the stories to get the docs working in storybook. (Unfortunately, we don't get the prop comments, which I really like, but, oh well.) I can make a backlog ticket to look into this further if we think it's worth coming back for.

### Screenshots
#### Before this change
<img width="1481" alt="button component in storybook before this change" src="https://user-images.githubusercontent.com/7761701/163852245-310d1613-69f9-456a-9935-fb3e1a0c238d.png">

#### After this change
<img width="1481" alt="button component in storybook after this change" src="https://user-images.githubusercontent.com/7761701/163852228-4ca2f9a8-e07a-446b-a43c-80fea020e2d9.png">

### Test Plan:
Verify the `ClickableStyle`, `Button`, and `Link` components now have their main configurable props listed on the docs tab in storybook and you can click around in them to change the component styling.