### PR TITLE
feat(clickable-style): make secondary variant default

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: Button,
   args: {
     children: 'Button',
-    variant: 'primary',
+    variant: 'secondary',
     status: 'brand',
     fullWidth: false,
     size: 'lg',
@@ -47,10 +47,17 @@ type Args = React.ComponentProps<typeof Button>;
 
 const Template: Story<Args> = (args) => <Button {...args} />;
 
+export const Default = Template.bind({});
+Default.args = { variant: 'secondary' };
+
 export const Primary = Template.bind({});
+Primary.args = { variant: 'primary' };
 
 export const PrimaryDisabled = Template.bind({});
-PrimaryDisabled.args = { disabled: true };
+PrimaryDisabled.args = {
+  disabled: true,
+  variant: 'primary',
+};
 
 export const PrimaryLeftIcon = Template.bind({});
 PrimaryLeftIcon.args = {
@@ -60,6 +67,7 @@ PrimaryLeftIcon.args = {
       Button
     </>
   ),
+  variant: 'primary',
 };
 
 export const PrimaryRightIcon = Template.bind({});
@@ -70,20 +78,17 @@ PrimaryRightIcon.args = {
       <Icon name="arrow-forward" purpose="decorative" />
     </>
   ),
+  variant: 'primary',
 };
 
 export const PrimaryMedium = Template.bind({});
-PrimaryMedium.args = { size: 'md' };
+PrimaryMedium.args = { size: 'md', variant: 'primary' };
 
 export const PrimarySmall = Template.bind({});
-PrimarySmall.args = { size: 'sm' };
-
-export const Secondary = Template.bind({});
-Secondary.args = { variant: 'secondary' };
+PrimarySmall.args = { size: 'sm', variant: 'primary' };
 
 export const SecondaryDisabled = Template.bind({});
 SecondaryDisabled.args = {
-  variant: 'secondary',
   disabled: true,
 };
 
@@ -95,7 +100,6 @@ SecondaryLeftIcon.args = {
       Button
     </>
   ),
-  variant: 'secondary',
 };
 
 export const SecondaryRightIcon = Template.bind({});
@@ -106,7 +110,6 @@ SecondaryRightIcon.args = {
       <Icon name="arrow-forward" purpose="decorative" />
     </>
   ),
-  variant: 'secondary',
 };
 
 export const SecondaryMedium = Template.bind({});
@@ -117,52 +120,45 @@ SecondarySmall.args = { variant: 'secondary', size: 'sm' };
 
 export const Tertiary = Template.bind({});
 Tertiary.args = {
-  children: 'Button',
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralDisabled = Template.bind({});
-SecondaryNeutralDisabled.args = {
-  variant: 'secondary',
+export const TertiaryDisabled = Template.bind({});
+TertiaryDisabled.args = {
   status: 'neutral',
   disabled: true,
 };
 
-export const SecondaryNeutralLeftIcon = Template.bind({});
-SecondaryNeutralLeftIcon.args = {
+export const TertiaryLeftIcon = Template.bind({});
+TertiaryLeftIcon.args = {
   children: (
     <>
       <Icon name="arrow-back" purpose="decorative" />
       Button
     </>
   ),
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralRightIcon = Template.bind({});
-SecondaryNeutralRightIcon.args = {
+export const TertiaryRightIcon = Template.bind({});
+TertiaryRightIcon.args = {
   children: (
     <>
       Button
       <Icon name="arrow-forward" purpose="decorative" />
     </>
   ),
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralMedium = Template.bind({});
-SecondaryNeutralMedium.args = {
-  variant: 'secondary',
+export const TertiaryMedium = Template.bind({});
+TertiaryMedium.args = {
   status: 'neutral',
   size: 'md',
 };
 
-export const SecondaryNeutralSmall = Template.bind({});
-SecondaryNeutralSmall.args = {
-  variant: 'secondary',
+export const TertiarySmall = Template.bind({});
+TertiarySmall.args = {
   status: 'neutral',
   size: 'sm',
 };
@@ -261,13 +257,12 @@ LinkRightIcon.args = {
 
 export const Destructive = Template.bind({});
 Destructive.args = {
-  children: 'Button',
   status: 'error',
   variant: 'primary',
 };
 
-export const PrimaryErrorLeftIcon = Template.bind({});
-PrimaryErrorLeftIcon.args = {
+export const DestructiveLeftIcon = Template.bind({});
+DestructiveLeftIcon.args = {
   children: (
     <>
       <Icon name="arrow-back" purpose="decorative" />
@@ -290,19 +285,16 @@ Loading.args = {
 export const SecondarySuccess = Template.bind({});
 SecondarySuccess.args = {
   status: 'success',
-  variant: 'secondary',
 };
 
 export const SecondaryWarning = Template.bind({});
 SecondaryWarning.args = {
   status: 'warning',
-  variant: 'secondary',
 };
 
 export const SecondaryError = Template.bind({});
 SecondaryError.args = {
   status: 'error',
-  variant: 'secondary',
 };
 
 export const IconNeutral = Template.bind({});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -48,7 +48,7 @@ export const Button = React.forwardRef<
       loading,
       size = 'lg',
       type = 'button',
-      variant = 'primary',
+      variant,
       ...other
     },
     ref,

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,8 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<Button /> Default story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`<Button /> Destructive story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`<Button /> DestructiveLeftIcon story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  type="button"
+>
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-back"
+    />
+  </svg>
+  Button
+</button>
+`;
+
 exports[`<Button /> FullWidth story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand clickable-style--full-width"
+  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width"
   type="button"
 >
   Button
@@ -310,7 +347,7 @@ exports[`<Button /> LinkWarning story renders snapshot 1`] = `
 
 exports[`<Button /> Loading story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary button--disabled eds-is-loading clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style button button--secondary button--disabled eds-is-loading clickable-style--lg clickable-style--secondary clickable-style--brand"
   disabled=""
   tabindex="-1"
   type="button"
@@ -353,34 +390,6 @@ exports[`<Button /> PrimaryDisabled story renders snapshot 1`] = `
   tabindex="-1"
   type="button"
 >
-  Button
-</button>
-`;
-
-exports[`<Button /> Destructive story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
-  type="button"
->
-  Button
-</button>
-`;
-
-exports[`<Button /> PrimaryErrorLeftIcon story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
-  type="button"
->
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-back"
-    />
-  </svg>
   Button
 </button>
 `;
@@ -441,15 +450,6 @@ exports[`<Button /> PrimarySmall story renders snapshot 1`] = `
 </button>
 `;
 
-exports[`<Button /> Secondary story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
-  type="button"
->
-  Button
-</button>
-`;
-
 exports[`<Button /> SecondaryDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--brand"
@@ -492,82 +492,6 @@ exports[`<Button /> SecondaryLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> SecondaryMedium story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--brand"
-  type="button"
->
-  Button
-</button>
-`;
-
-exports[`<Button /> Tertiary story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  type="button"
->
-  Button
-</button>
-`;
-
-exports[`<Button /> SecondaryNeutralDisabled story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  disabled=""
-  tabindex="-1"
-  type="button"
->
-  Button
-</button>
-`;
-
-exports[`<Button /> SecondaryNeutralLeftIcon story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  type="button"
->
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-back"
-    />
-  </svg>
-  Button
-</button>
-`;
-
-exports[`<Button /> SecondaryNeutralMedium story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--neutral"
-  type="button"
->
-  Button
-</button>
-`;
-
-exports[`<Button /> SecondaryNeutralRightIcon story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  type="button"
->
-  Button
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-forward"
-    />
-  </svg>
-</button>
-`;
-
-exports[`<Button /> SecondaryNeutralSmall story renders snapshot 1`] = `
-<button
-  class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--neutral"
   type="button"
 >
   Button
@@ -620,9 +544,85 @@ exports[`<Button /> SecondaryWarning story renders snapshot 1`] = `
 </button>
 `;
 
+exports[`<Button /> Tertiary story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`<Button /> TertiaryDisabled story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  disabled=""
+  tabindex="-1"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`<Button /> TertiaryLeftIcon story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  type="button"
+>
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-back"
+    />
+  </svg>
+  Button
+</button>
+`;
+
+exports[`<Button /> TertiaryMedium story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--neutral"
+  type="button"
+>
+  Button
+</button>
+`;
+
+exports[`<Button /> TertiaryRightIcon story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  type="button"
+>
+  Button
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-forward"
+    />
+  </svg>
+</button>
+`;
+
+exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
+<button
+  class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--neutral"
+  type="button"
+>
+  Button
+</button>
+`;
+
 exports[`<Button /> passes class names down properly 1`] = `
 <button
-  class="clickable-style button exampleClassName button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style button exampleClassName clickable-style--lg clickable-style--secondary clickable-style--brand"
   data-testid="example-class-name"
   type="button"
 >
@@ -632,7 +632,7 @@ exports[`<Button /> passes class names down properly 1`] = `
 
 exports[`<Button /> passes test ids down properly 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
   data-testid="example-test-id"
   type="button"
 >

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -11,8 +11,8 @@ export default {
     orientation: 'horizontal' as const,
     children: (
       <>
-        <Button>Button 1</Button>
-        <Button variant="secondary">Button 2</Button>
+        <Button variant="primary">Button 1</Button>
+        <Button>Button 2</Button>
       </>
     ),
   },
@@ -44,11 +44,11 @@ export const WithFiveButtons: StoryObj<Args> = {
   args: {
     children: (
       <>
-        <Button variant="secondary">Button 1</Button>
-        <Button variant="secondary">Button 2</Button>
-        <Button variant="secondary">Button 3</Button>
-        <Button variant="secondary">Button 4</Button>
-        <Button>Button 5</Button>
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button>Button 3</Button>
+        <Button>Button 4</Button>
+        <Button variant="primary">Button 5</Button>
       </>
     ),
   },

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
@@ -11,7 +11,7 @@ exports[`<ButtonGroup /> Default story renders snapshot 1`] = `
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 2
@@ -30,7 +30,7 @@ exports[`<ButtonGroup /> SpacingMax story renders snapshot 1`] = `
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 2
@@ -49,7 +49,7 @@ exports[`<ButtonGroup /> SpacingNone story renders snapshot 1`] = `
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 2
@@ -68,7 +68,7 @@ exports[`<ButtonGroup /> Vertical story renders snapshot 1`] = `
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 2
@@ -81,25 +81,25 @@ exports[`<ButtonGroup /> WithFiveButtons story renders snapshot 1`] = `
   class="button-group button-group--spacing-1x"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 2
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 3
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style button clickable-style--lg clickable-style--secondary clickable-style--brand"
     type="button"
   >
     Button 4

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -56,7 +56,7 @@ export const ClickableStyle = React.forwardRef(
       fullWidth,
       size = 'lg',
       status = 'brand',
-      variant = 'primary',
+      variant = 'secondary',
       ...other
     }: ClickableStyleProps<IComponent>,
     ref: React.ForwardedRef<HTMLElement>,

--- a/src/components/Drawer/DrawerExample.tsx
+++ b/src/components/Drawer/DrawerExample.tsx
@@ -46,7 +46,7 @@ export const DrawerExample = ({ className, ...other }: Props) => {
       style={{ padding: '1rem', minHeight: '500px' }}
       {...other}
     >
-      <Button onClick={openDrawerExample} ref={drawerButton}>
+      <Button onClick={openDrawerExample} ref={drawerButton} variant="primary">
         Open Drawer
       </Button>
 

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: Link,
   args: {
     children: 'Link',
-    variant: 'primary',
+    variant: 'secondary',
     status: 'brand',
     fullWidth: false,
     size: 'lg',
@@ -98,7 +98,6 @@ export const PrimarySmall = Template.bind({});
 PrimarySmall.args = { size: 'sm', variant: 'primary' };
 
 export const Secondary = Template.bind({});
-Secondary.args = { variant: 'secondary' };
 
 export const SecondaryLeftIcon = Template.bind({});
 SecondaryLeftIcon.args = {
@@ -108,7 +107,6 @@ SecondaryLeftIcon.args = {
       Link
     </>
   ),
-  variant: 'secondary',
 };
 
 export const SecondaryRightIcon = Template.bind({});
@@ -119,62 +117,53 @@ SecondaryRightIcon.args = {
       <Icon name="arrow-forward" purpose="decorative" />
     </>
   ),
-  variant: 'secondary',
 };
 
 export const SecondaryMedium = Template.bind({});
 SecondaryMedium.args = {
-  variant: 'secondary',
   size: 'md',
 };
 
 export const SecondarySmall = Template.bind({});
 SecondarySmall.args = {
-  variant: 'secondary',
   size: 'sm',
 };
 
 export const Tertiary = Template.bind({});
 Tertiary.args = {
-  children: 'Link',
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralLeftIcon = Template.bind({});
-SecondaryNeutralLeftIcon.args = {
+export const TertiaryLeftIcon = Template.bind({});
+TertiaryLeftIcon.args = {
   children: (
     <>
       <Icon name="arrow-back" purpose="decorative" />
       Link
     </>
   ),
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralRightIcon = Template.bind({});
-SecondaryNeutralRightIcon.args = {
+export const TertiaryRightIcon = Template.bind({});
+TertiaryRightIcon.args = {
   children: (
     <>
       Link
       <Icon name="arrow-forward" purpose="decorative" />
     </>
   ),
-  variant: 'secondary',
   status: 'neutral',
 };
 
-export const SecondaryNeutralMedium = Template.bind({});
-SecondaryNeutralMedium.args = {
-  variant: 'secondary',
+export const TertiaryMedium = Template.bind({});
+TertiaryMedium.args = {
   status: 'neutral',
   size: 'md',
 };
 
-export const SecondaryNeutralSmall = Template.bind({});
-SecondaryNeutralSmall.args = {
-  variant: 'secondary',
+export const TertiarySmall = Template.bind({});
+TertiarySmall.args = {
   status: 'neutral',
   size: 'sm',
 };
@@ -240,13 +229,12 @@ IconClickableStyleIconOnlySmall.args = {
 
 export const Destructive = Template.bind({});
 Destructive.args = {
-  children: 'Link',
   status: 'error',
   variant: 'primary',
 };
 
-export const PrimaryErrorLeftIcon = Template.bind({});
-PrimaryErrorLeftIcon.args = {
+export const DestructiveLeftIcon = Template.bind({});
+DestructiveLeftIcon.args = {
   children: (
     <>
       <Icon name="arrow-back" purpose="decorative" />
@@ -258,24 +246,21 @@ PrimaryErrorLeftIcon.args = {
 };
 
 export const FullWidth = Template.bind({});
-FullWidth.args = { fullWidth: true, variant: 'primary' };
+FullWidth.args = { fullWidth: true, variant: 'secondary' };
 
 export const SecondarySuccess = Template.bind({});
 SecondarySuccess.args = {
   status: 'success',
-  variant: 'secondary',
 };
 
 export const SecondaryWarning = Template.bind({});
 SecondaryWarning.args = {
   status: 'warning',
-  variant: 'secondary',
 };
 
 export const SecondaryError = Template.bind({});
 SecondaryError.args = {
   status: 'error',
-  variant: 'secondary',
 };
 
 export const IconNeutral = Template.bind({});

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -9,9 +9,37 @@ exports[`<Link /> Default story renders snapshot 1`] = `
 </a>
 `;
 
+exports[`<Link /> Destructive story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
+  href="/"
+>
+  Link
+</a>
+`;
+
+exports[`<Link /> DestructiveLeftIcon story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
+  href="/"
+>
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-back"
+    />
+  </svg>
+  Link
+</a>
+`;
+
 exports[`<Link /> FullWidth story renders snapshot 1`] = `
 <a
-  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand clickable-style--full-width"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width"
   href="/"
 >
   Link
@@ -285,34 +313,6 @@ exports[`<Link /> Primary story renders snapshot 1`] = `
 </a>
 `;
 
-exports[`<Link /> Destructive story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
-  href="/"
->
-  Link
-</a>
-`;
-
-exports[`<Link /> PrimaryErrorLeftIcon story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
-  href="/"
->
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-back"
-    />
-  </svg>
-  Link
-</a>
-`;
-
 exports[`<Link /> PrimaryLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand"
@@ -415,71 +415,6 @@ exports[`<Link /> SecondaryMedium story renders snapshot 1`] = `
 </a>
 `;
 
-exports[`<Link /> Tertiary story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  href="/"
->
-  Link
-</a>
-`;
-
-exports[`<Link /> SecondaryNeutralLeftIcon story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  href="/"
->
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-back"
-    />
-  </svg>
-  Link
-</a>
-`;
-
-exports[`<Link /> SecondaryNeutralMedium story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--md clickable-style--secondary clickable-style--neutral"
-  href="/"
->
-  Link
-</a>
-`;
-
-exports[`<Link /> SecondaryNeutralRightIcon story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
-  href="/"
->
-  Link
-  <svg
-    aria-hidden="true"
-    class="icon"
-    fill="currentColor"
-    xmlns="http://www.w3.org/2000/svg"
-  >
-    <use
-      xlink:href="test-file-stub#arrow-forward"
-    />
-  </svg>
-</a>
-`;
-
-exports[`<Link /> SecondaryNeutralSmall story renders snapshot 1`] = `
-<a
-  class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--neutral"
-  href="/"
->
-  Link
-</a>
-`;
-
 exports[`<Link /> SecondaryRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand"
@@ -520,6 +455,71 @@ exports[`<Link /> SecondarySuccess story renders snapshot 1`] = `
 exports[`<Link /> SecondaryWarning story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--warning"
+  href="/"
+>
+  Link
+</a>
+`;
+
+exports[`<Link /> Tertiary story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  href="/"
+>
+  Link
+</a>
+`;
+
+exports[`<Link /> TertiaryLeftIcon story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  href="/"
+>
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-back"
+    />
+  </svg>
+  Link
+</a>
+`;
+
+exports[`<Link /> TertiaryMedium story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--md clickable-style--secondary clickable-style--neutral"
+  href="/"
+>
+  Link
+</a>
+`;
+
+exports[`<Link /> TertiaryRightIcon story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  href="/"
+>
+  Link
+  <svg
+    aria-hidden="true"
+    class="icon"
+    fill="currentColor"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <use
+      xlink:href="test-file-stub#arrow-forward"
+    />
+  </svg>
+</a>
+`;
+
+exports[`<Link /> TertiarySmall story renders snapshot 1`] = `
+<a
+  class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--neutral"
   href="/"
 >
   Link

--- a/src/components/Modal/ModalExample.tsx
+++ b/src/components/Modal/ModalExample.tsx
@@ -56,7 +56,7 @@ export const ModalExample = ({
       style={{ padding: '1rem', minHeight: '500px' }}
       {...other}
     >
-      <Button onClick={openContinueModal} ref={modalButton}>
+      <Button onClick={openContinueModal} ref={modalButton} variant="primary">
         Open Modal
       </Button>
 

--- a/src/components/Popover/PopoverExample.tsx
+++ b/src/components/Popover/PopoverExample.tsx
@@ -68,7 +68,7 @@ export const PopoverExample: React.FC<Props> = ({
       }}
       {...other}
     >
-      <Button onClick={openPopover} ref={popoverButton}>
+      <Button onClick={openPopover} ref={popoverButton} variant="primary">
         Open Popover
       </Button>
 

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -14,7 +14,7 @@ const Template: Story<Props> = (args) => (
   <div style={{ margin: '10rem' }}>
     <ShowHide
       trigger={
-        <Button type="button">
+        <Button type="button" variant="primary">
           <Icon name="expand-more" purpose="decorative" />
         </Button>
       }

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -82,7 +82,7 @@ export const TableHeaderCell = ({
       scope={scope}
       {...other}
     >
-      <Button onClick={onClick} status="neutral" variant="secondary">
+      <Button onClick={onClick} status="neutral">
         {text}
         <Icon name="arrow-narrow-down" purpose="decorative" />
       </Button>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -18,7 +18,7 @@ const defaultArgs = {
     </span>
   ),
   children: (
-    <Button className={clsx(styles['trigger--spacing'])}>
+    <Button className={clsx(styles['trigger--spacing'])} variant="primary">
       Tooltip trigger
     </Button>
   ),
@@ -55,6 +55,7 @@ export const LeftPlacement: StoryObj<Args> = {
           styles['trigger--spacing-bottom'],
           styles['trigger--spacing-left-large'],
         )}
+        variant="primary"
       >
         Tooltip trigger
       </Button>
@@ -71,6 +72,7 @@ export const TopPlacement: StoryObj<Args> = {
           styles['trigger--spacing-top'],
           styles['trigger--spacing-left'],
         )}
+        variant="primary"
       >
         Tooltip trigger
       </Button>
@@ -87,6 +89,7 @@ export const BottomPlacement: StoryObj<Args> = {
           styles['trigger--spacing-bottom'],
           styles['trigger--spacing-left'],
         )}
+        variant="primary"
       >
         Tooltip trigger
       </Button>
@@ -113,7 +116,10 @@ export const LongText: StoryObj<Args> = {
 export const LongButtonText: StoryObj<Args> = {
   args: {
     children: (
-      <Button className={clsx(styles['trigger--spacing-top'])}>
+      <Button
+        className={clsx(styles['trigger--spacing-top'])}
+        variant="primary"
+      >
         Tooltip trigger with longer text to test placement
       </Button>
     ),
@@ -128,7 +134,7 @@ export const Interactive: StoryObj<Args> = {
   args: {
     visible: undefined,
     children: (
-      <Button className={clsx(styles['trigger--spacing'])}>
+      <Button className={clsx(styles['trigger--spacing'])} variant="primary">
         Hover here to see tooltip after clicking somewhere outside.
       </Button>
     ),


### PR DESCRIPTION
### Summary:
@ifrost1 suggested we make the default variant "secondary" for `Button` etc. The reasoning here is that, ideally, there should really only be one primary button (the Most Important Action based on what the user is doing), which means we should be using more secondary buttons than primary, so making that the default prop value should reduce the number of times devs need to specify the variant and also possibly nudge them to use that variant.

### Test Plan:
No big chromatic changes (aside from some story name updates and some story buttons that I want to use the default variant regardless of what that is, like full width and loading button stories)