### PR TITLE
feat(banner, toast): use status prop with close and action buttons

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -19,20 +19,20 @@ type Args = React.ComponentProps<typeof Banner> & {
   action: ReactNode;
 };
 
-const getAction = (variant?: Variant) => (
-  <Button status={variant} variant="secondary">
+const getAction = (status?: Variant) => (
+  <Button status={status} variant="secondary">
     See updates
   </Button>
 );
 
-const getDescription = (variant?: Variant) => (
+const getDescription = (status?: Variant) => (
   <>
     Summit Learning has a full-time team dedicated to constantly improving our
     curriculum. To see the updates,{' '}
     <Button
       href="/"
       onClick={(event) => event.preventDefault()}
-      status={variant}
+      status={status}
       variant="link"
     >
       click into the course

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj } from '@storybook/react';
-import React from 'react';
-import { Banner } from './Banner';
+import React, { ReactNode } from 'react';
+import { Banner, Variant } from './Banner';
 import Button from '../Button';
 import Heading from '../Heading';
 
@@ -8,20 +8,6 @@ export default {
   title: 'Molecules/Messaging/Banner',
   component: Banner,
   args: {
-    description: (
-      <>
-        Summit Learning has a full-time team dedicated to constantly improving
-        our curriculum. To see the updates,{' '}
-        <Button
-          href="/"
-          onClick={(event) => event.preventDefault()}
-          variant="link"
-        >
-          click into the course
-        </Button>
-        .
-      </>
-    ),
     title:
       'New curriculum updates are available for one or more of your courses.',
   },
@@ -30,14 +16,40 @@ export default {
 type Args = React.ComponentProps<typeof Banner> & {
   title: string;
   description: string;
-  action: any;
+  action: ReactNode;
 };
 
-const action = <Button variant="secondary">See updates</Button>;
+const getAction = (variant?: Variant) => (
+  <Button status={variant} variant="secondary">
+    See updates
+  </Button>
+);
+
+const getDescription = (variant?: Variant) => (
+  <>
+    Summit Learning has a full-time team dedicated to constantly improving our
+    curriculum. To see the updates,{' '}
+    <Button
+      href="/"
+      onClick={(event) => event.preventDefault()}
+      status={variant}
+      variant="link"
+    >
+      click into the course
+    </Button>
+    .
+  </>
+);
 
 export const Brand: StoryObj<Args> = {
-  render: (args) => {
-    return <Banner {...args} />;
+  render: ({ variant, ...other }) => {
+    return (
+      <Banner
+        description={getDescription(variant)}
+        variant={variant}
+        {...other}
+      />
+    );
   },
 };
 
@@ -86,14 +98,14 @@ export const NoTitle: StoryObj<Args> = {
 export const BrandWithAction: StoryObj<Args> = {
   ...Brand,
   args: {
-    action: action,
+    action: getAction(),
   },
 };
 
 export const NeutralWithAction: StoryObj<Args> = {
   ...Neutral,
   args: {
-    action: action,
+    action: getAction('neutral'),
     variant: 'neutral',
   },
 };
@@ -101,7 +113,7 @@ export const NeutralWithAction: StoryObj<Args> = {
 export const SuccessWithAction: StoryObj<Args> = {
   ...Success,
   args: {
-    action: action,
+    action: getAction('success'),
     variant: 'success',
   },
 };
@@ -109,7 +121,7 @@ export const SuccessWithAction: StoryObj<Args> = {
 export const WarningWithAction: StoryObj<Args> = {
   ...Warning,
   args: {
-    action: action,
+    action: getAction('warning'),
     variant: 'warning',
   },
 };
@@ -117,7 +129,7 @@ export const WarningWithAction: StoryObj<Args> = {
 export const ErrorWithAction: StoryObj<Args> = {
   ...Error,
   args: {
-    action: action,
+    action: getAction('error'),
     variant: 'error',
   },
 };
@@ -164,7 +176,7 @@ export const ErrorDismissable: StoryObj<Args> = {
 export const DismissableWithAction: StoryObj<Args> = {
   ...Brand,
   args: {
-    action: action,
+    action: getAction(),
     dismissable: true,
   },
 };
@@ -173,7 +185,7 @@ export const DismissableBelowContent: StoryObj<Args> = {
   render: (args) => (
     <>
       <Heading size="h1">Page Title</Heading>
-      <Banner dismissable={true} {...args} />
+      <Banner description={getDescription()} dismissable={true} {...args} />
     </>
   ),
 };
@@ -197,7 +209,7 @@ export const VerticalWithAction: StoryObj<Args> = {
   ...Brand,
   args: {
     orientation: 'vertical',
-    action: action,
+    action: getAction(),
   },
 };
 
@@ -205,7 +217,7 @@ export const VerticalDismissableWithAction: StoryObj<Args> = {
   ...Brand,
   args: {
     orientation: 'vertical',
-    action: action,
+    action: getAction(),
     dismissable: true,
   },
 };

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -6,6 +6,8 @@ import Heading, { HeadingElement } from '../Heading';
 import Icon from '../Icon';
 import Text from '../Text';
 
+export type Variant = 'brand' | 'neutral' | 'success' | 'warning' | 'error';
+
 export interface Props {
   /**
    * A button or link that's placed in the banner separately from the main content.
@@ -64,7 +66,7 @@ export interface Props {
    * - **warning** - results in a yellow banner
    * - **error** - results in a red banner
    */
-  variant?: 'brand' | 'neutral' | 'success' | 'warning' | 'error';
+  variant?: Variant;
 }
 
 const variantToIconAssetsMap: {
@@ -173,6 +175,7 @@ export const Banner = ({
         <Button
           className={styles['banner__close-btn']}
           onClick={handleDismiss}
+          status={variant}
           variant="icon"
         >
           <Icon name={'close'} purpose="informative" title={'dismiss module'} />

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -300,7 +300,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--error"
           href="/"
           type="button"
         >
@@ -318,7 +318,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
   class="banner banner--error banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--error"
     type="button"
   >
     <svg
@@ -369,7 +369,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--error"
           href="/"
           type="button"
         >
@@ -418,7 +418,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--error"
           href="/"
           type="button"
         >
@@ -431,7 +431,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--error"
         type="button"
       >
         See updates
@@ -526,7 +526,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
           href="/"
           type="button"
         >
@@ -544,7 +544,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   class="banner banner--neutral banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -595,7 +595,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
           href="/"
           type="button"
         >
@@ -644,7 +644,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
           href="/"
           type="button"
         >
@@ -657,7 +657,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
         type="button"
       >
         See updates
@@ -782,7 +782,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--success"
           href="/"
           type="button"
         >
@@ -800,7 +800,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   class="banner banner--success banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--success"
     type="button"
   >
     <svg
@@ -851,7 +851,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--success"
           href="/"
           type="button"
         >
@@ -900,7 +900,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--success"
           href="/"
           type="button"
         >
@@ -913,7 +913,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--success"
         type="button"
       >
         See updates
@@ -1215,7 +1215,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--warning"
           href="/"
           type="button"
         >
@@ -1233,7 +1233,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   class="banner banner--warning banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--warning"
     type="button"
   >
     <svg
@@ -1284,7 +1284,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--warning"
           href="/"
           type="button"
         >
@@ -1333,7 +1333,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          class="clickable-style button button--link clickable-style--link clickable-style--warning"
           href="/"
           type="button"
         >
@@ -1346,7 +1346,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--warning"
         type="button"
       >
         See updates

--- a/src/components/Banner/index.ts
+++ b/src/components/Banner/index.ts
@@ -1,1 +1,2 @@
 export { Banner as default } from './Banner';
+export type { Variant } from './Banner';

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -61,7 +61,7 @@ export const Toast = ({
         <p className={styles['toast__text']}>{children}</p>
       </div>
       {onDismiss && (
-        <Button onClick={onDismiss} variant="icon">
+        <Button onClick={onDismiss} status={variant} variant="icon">
           <Icon
             name="close"
             purpose="informative"


### PR DESCRIPTION
### Summary:
Now that the `Button` component can produce all 5 colors for `secondary`, `icon`, and `link` variants, we can use those in the `Banner` and `Toast` components. The only one used inside the components is the icon button in the close button; the others are just in the `Banner` stories file to give a more accurate demonstration what the `Banner` usage should look like.

### Test Plan:
Verify in storybook and chromatic that the `Banner` stories are unchanged except now they have close buttons, links, and action buttons that match the rest of the color of the banner.