### PR TITLE
test(banner): add snapshot and dismiss tests

### DIFF
--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -1,0 +1,25 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Banner } from './Banner';
+import * as BannerStoryFile from './Banner.stories';
+
+describe('<Banner />', () => {
+  generateSnapshots(BannerStoryFile);
+
+  it('dismisses when dismissed if dismissable', () => {
+    render(
+      <Banner
+        data-testid="banner-test"
+        description="suuuuup"
+        dismissable={true}
+        title="Helloooooo"
+      />,
+    );
+
+    expect(screen.getByTestId('banner-test')).toBeInTheDocument();
+    userEvent.click(screen.getByRole('button'));
+    expect(screen.queryByTestId('banner-test')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -1,0 +1,1357 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Banner /> Brand story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> DismissableBelowContent story renders snapshot 1`] = `
+<h1
+  class="heading heading--size-h1"
+>
+  Page Title
+</h1>
+`;
+
+exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Error story renders snapshot 1`] = `
+<article
+  class="banner banner--error banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      error
+    </title>
+    <use
+      xlink:href="test-file-stub#dangerous"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--error banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      error
+    </title>
+    <use
+      xlink:href="test-file-stub#dangerous"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--error banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      error
+    </title>
+    <use
+      xlink:href="test-file-stub#dangerous"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Flat story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal banner--flat"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Neutral story renders snapshot 1`] = `
+<article
+  class="banner banner--neutral banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      notice
+    </title>
+    <use
+      xlink:href="test-file-stub#forum"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--neutral banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      notice
+    </title>
+    <use
+      xlink:href="test-file-stub#forum"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--neutral banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      notice
+    </title>
+    <use
+      xlink:href="test-file-stub#forum"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> NoDescription story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> NoTitle story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Success story renders snapshot 1`] = `
+<article
+  class="banner banner--success banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      success
+    </title>
+    <use
+      xlink:href="test-file-stub#check-circle"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--success banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      success
+    </title>
+    <use
+      xlink:href="test-file-stub#check-circle"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--success banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      success
+    </title>
+    <use
+      xlink:href="test-file-stub#check-circle"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Vertical story renders snapshot 1`] = `
+<article
+  class="banner banner--brand"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--brand"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> Warning story renders snapshot 1`] = `
+<article
+  class="banner banner--warning banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      warning
+    </title>
+    <use
+      xlink:href="test-file-stub#warning"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--warning banner--horizontal banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="mock-id"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      warning
+    </title>
+    <use
+      xlink:href="test-file-stub#warning"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+  </div>
+</article>
+`;
+
+exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
+<article
+  class="banner banner--warning banner--horizontal"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="mock-id"
+    >
+      warning
+    </title>
+    <use
+      xlink:href="test-file-stub#warning"
+    />
+  </svg>
+  <div
+    class="banner__textAndAction"
+  >
+    <div
+      class="banner__textContent"
+    >
+      <h3
+        class="heading heading--size-h5"
+      >
+        New curriculum updates are available for one or more of your courses.
+      </h3>
+      <p
+        class="text text--body"
+      >
+        Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+         
+        <button
+          class="clickable-style button button--link clickable-style--link clickable-style--brand"
+          href="/"
+          type="button"
+        >
+          click into the course
+        </button>
+        .
+      </p>
+    </div>
+    <div
+      class="banner__action"
+    >
+      <button
+        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        type="button"
+      >
+        See updates
+      </button>
+    </div>
+  </div>
+</article>
+`;


### PR DESCRIPTION
### Summary:
I suddenly realized the `Banner` component didn't have a test file, so this PR adds one. Side note – it may be worth it to generate test files for all the components that don't have one already, because it's really easy to forget this when you're starting from a component that already exists.

### Test Plan:
`yarn test` passes without a hitch and now there are snapshot files for the `Banner`.