### PR TITLE
chore(fieldset-legend, fieldset-items): export props on separate lines

### DIFF
--- a/src/components/FieldsetItems/index.ts
+++ b/src/components/FieldsetItems/index.ts
@@ -1,1 +1,2 @@
-export { FieldsetItems as default, FieldsetItemsProps } from './FieldsetItems';
+export { FieldsetItems as default } from './FieldsetItems';
+export type { FieldsetItemsProps } from './FieldsetItems';

--- a/src/components/FieldsetLegend/index.ts
+++ b/src/components/FieldsetLegend/index.ts
@@ -1,4 +1,2 @@
-export {
-  FieldsetLegend as default,
-  FieldsetLegendProps,
-} from './FieldsetLegend';
+export { FieldsetLegend as default } from './FieldsetLegend';
+export type { FieldsetLegendProps } from './FieldsetLegend';


### PR DESCRIPTION
### Summary:
I'm seeing some warnings in storybook about 
> ./src/components/FieldsetItems/index.ts 1:0-79"export 'FieldsetItemsProps' was not found in './FieldsetItems'./src/components/FieldsetLegend/index.ts 1:0-82"export 'FieldsetLegendProps' was not found in './FieldsetLegend'

I think we need to export props on a separate line that specifies the item is a `type` in order to clear these.

### Screenshots
#### Before
<img width="1561" alt="storybook browser console before this change which has the warnings described in the summary of this PR" src="https://user-images.githubusercontent.com/7761701/164274292-327497e2-f939-49f4-9f69-773d56452704.png">

#### After
<img width="1561" alt="storybook browser console after this change which does not have the warnings described in the summary of this PR" src="https://user-images.githubusercontent.com/7761701/164274375-4421a9b1-8697-46df-88ab-c1708878d140.png">

### Test Plan:
Navigate to any page in storybook and verify there are no warnings in the browser console about field set props not being found.