### PR TITLE
docs: update import examples in component docstrings

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -99,7 +99,7 @@ const variantToIconAssetsMap: {
 
 /**
  * ```ts
- * import {Banner} from "@chanzuckerberg/eds-components";
+ * import {Banner} from "@chanzuckerberg/eds";
  * ```
  *
  * A banner used to provide and highlight information to a user or ask for a decision or action.

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -24,6 +24,10 @@ export type Props = ClickableStyleProps<React.ElementType> & {
 };
 
 /**
+ * ```ts
+ * import {Button} from "@chanzuckerberg/eds";
+ * ```
+ *
  * Component for making buttons that do not navigate the user to another page.
  *
  * This component is called `Button` because it should be used to make `<button>` elements;

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 /**
  * ```ts
- * import {ButtonGroup} from "@chanzuckerberg/eds-components";
+ * import {ButtonGroup} from "@chanzuckerberg/eds";
  * ```
  *
  * A container for buttons grouped together horizontally or vertically.

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -25,7 +25,7 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
 
 /**
  * ```ts
- * import {Checkbox} from "@chanzuckerberg/eds-components";
+ * import {Checkbox} from "@chanzuckerberg/eds";
  * ```
  * ```ts
  * import {CheckboxInput, CheckboxLabel} from '@chanzuckerberg/eds-components';

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -39,6 +39,10 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
 } & React.ComponentProps<IComponent>;
 
 /**
+ * ```ts
+ * import {ClickableStyle} from "@chanzuckerberg/eds";
+ * ```
+ *
  * A helper component that contains all the styling for buttons and links.
  *
  * If you're styling a `<button>` or `<a>` element, you can use the `Button`

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -4,7 +4,7 @@ import styles from './Fieldset.module.css';
 
 type FieldsetProps = {
   /**
-   * The contents of the fieldset. We suggest a Fieldset.Title followed by
+   * The contents of the fieldset. We suggest a FieldsetLegend followed by
    * interactive elements.
    *
    * Should be wrapped in a fragment to allow our styling to control the spacing
@@ -19,10 +19,10 @@ type FieldsetProps = {
 
 /**
  * ```ts
- * import {Fieldset} from "@chanzuckerberg/eds-components";
+ * import {Fieldset} from "@chanzuckerberg/eds";
  * ```
  *
- * A container for a fieldset including a legend and one or more form inputs.
+ * A container for a fieldset that includes a legend and one or more form inputs.
  */
 export function Fieldset({ children, className }: FieldsetProps) {
   const componentClassName = clsx(className, styles['fieldset']);

--- a/src/components/FieldsetItems/FieldsetItems.tsx
+++ b/src/components/FieldsetItems/FieldsetItems.tsx
@@ -19,6 +19,10 @@ export type FieldsetItemsProps = {
 };
 
 /**
+ * ```ts
+ * import {FieldsetItems} from "@chanzuckerberg/eds";
+ * ```
+ *
  * Helper sub-component for styling the control elements in the component.
  */
 export const FieldsetItems = ({

--- a/src/components/FieldsetLegend/FieldsetLegend.tsx
+++ b/src/components/FieldsetLegend/FieldsetLegend.tsx
@@ -18,7 +18,11 @@ export interface FieldsetLegendProps {
 }
 
 /**
- * Primary UI component for user interaction
+ * ```ts
+ * import {FieldsetLegend} from "@chanzuckerberg/eds";
+ * ```
+ *
+ * Helper sub-component for styling the legend in a fieldset.
  */
 export const FieldsetLegend = ({
   className,

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -36,7 +36,7 @@ type Props = {
 
 /**
  * ```ts
- * import {Heading} from "@chanzuckerberg/eds-components";
+ * import {Heading} from "@chanzuckerberg/eds";
  * ```
  */
 

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -85,9 +85,19 @@ interface SvgStyle extends CSSProperties {
 }
 
 /**
+ * ```ts
+ * import {Icon} from "@chanzuckerberg/eds";
+ * ```
+ *
  * Render arbitrary SVG path data while enforcing good accessibility practices.
  *
  * If you're looking for specific icon files, look in the `src/icons` directory.
+ *
+ * Example usage:
+ *
+ * ```
+ * <Icon name="arrow-foward" purpose="informative" title="go forward" />
+ * ```
  */
 export const Icon = (props: IconProps) => {
   const {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -10,6 +10,10 @@ export type Props = ClickableStyleProps<React.ElementType> & {
 };
 
 /**
+ * ```ts
+ * import {Link} from "@chanzuckerberg/eds";
+ * ```
+ *
  * Component for making styled anchor tags.
  *
  * This component is called Link because it should be used to make `<a>` elements;

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -41,7 +41,7 @@ type Props = {
 
 /**
  * ```ts
- * import {Tag} from "@chanzuckerberg/eds-components";
+ * import {Tag} from "@chanzuckerberg/eds";
  * ```
  *
  * This component provides a tag (pill shaped badge) wrapper.

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -28,7 +28,7 @@ export type Props = {
 
 /**
  * ```ts
- * import {Toast} from "@chanzuckerberg/eds-components";
+ * import {Toast} from "@chanzuckerberg/eds";
  * ```
  *
  * A toast used to provide information on the state of the page, usually in response to a

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -71,7 +71,7 @@ type Plugin = Plugins[number];
 
 /**
  * ```ts
- * import {Tooltip} from "@chanzuckerberg/eds-components";
+ * import {Tooltip} from "@chanzuckerberg/eds";
  * ```
  *
  * A styled tooltip built on Tippy.js.


### PR DESCRIPTION
### Summary:
This PR:
- adds import examples to component docstrings that don't have one
- updates existing import examples to use the updated package name (`@chanzuckerberg/eds` instead of `@chanzuckerberg/eds-components`)
- touches up a couple of component docstrings that I found a little hard to parse or still used the original super vague component docstring ("Primary UI component for user interaction")

I only touched the components we've already published because I'm focusing more on the upcoming merge of `next` into `main`, but I would like to update the other components and the plop file at some point. https://app.shortcut.com/czi-edu/story/194027/add-import-example-to-component-docstrings-and-better-starter-docstring-in-plopfile

### Test Plan:
Check out the components in storybook and verify their documentation has been updated.