### PR TITLE
 feat(clickable-style, button, link): use API from next to prep for merge

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -29,11 +29,7 @@ type Args = React.ComponentProps<typeof Banner> & {
   heading: string;
 };
 
-const action = (
-  <Button style={{ whiteSpace: "nowrap" }} variant="outline">
-    See updates
-  </Button>
-);
+const action = <Button style={{ whiteSpace: "nowrap" }}>See updates</Button>;
 
 export const Brand: StoryObj<Args> = {
   render: (args) => {

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -80,6 +80,10 @@ export default function Banner({
 }: BannerProps) {
   const isHorizontal = orientation === "horizontal";
 
+  // While the v0 to v1 migration is happening, the Button and Banner will briefly
+  // be out of sync regarding the name of the red component style.
+  const buttonStatus = color === "alert" ? "error" : color;
+
   return (
     <article
       className={clsx(
@@ -99,9 +103,9 @@ export default function Banner({
       {onDismiss && (
         <Button
           className={styles.dismiss}
-          color={color}
           onClick={onDismiss}
-          variant="plain"
+          status={buttonStatus}
+          variant="icon"
         >
           <Icon
             name="close"

--- a/src/components/Button/__snapshots__/button.spec.tsx.snap
+++ b/src/components/Button/__snapshots__/button.spec.tsx.snap
@@ -548,7 +548,7 @@ exports[`<Button /> AllRecommendedVariants story renders snapshot 1`] = `
 
 exports[`<Button /> Default story renders snapshot 1`] = `
 <button
-  class="button sizeLarge variantFlat colorBrand"
+  class="button sizeLarge variantOutline colorBrand"
   type="button"
 >
   Button
@@ -1041,7 +1041,7 @@ exports[`<Button /> TertiaryRecommendedVariants story renders snapshot 1`] = `
 
 exports[`<Button /> passes class names down properly 1`] = `
 <button
-  class="exampleClassName button sizeLarge variantFlat colorBrand"
+  class="exampleClassName button sizeLarge variantOutline colorBrand"
   data-testid="example-class-name"
   type="button"
 >
@@ -1051,7 +1051,7 @@ exports[`<Button /> passes class names down properly 1`] = `
 
 exports[`<Button /> passes test ids down properly 1`] = `
 <button
-  class="button sizeLarge variantFlat colorBrand"
+  class="button sizeLarge variantOutline colorBrand"
   data-testid="example-test-id"
   type="button"
 >

--- a/src/components/Button/button.stories.tsx
+++ b/src/components/Button/button.stories.tsx
@@ -1,9 +1,9 @@
 import { StoryObj } from "@storybook/react";
 import React from "react";
 import {
-  colors,
+  statuses,
   getStandardSet,
-  getPlainRecommendedVariants,
+  geIconRecommendedVariants,
   getLinkRecommendedVariants,
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
@@ -21,10 +21,10 @@ export default {
         type: "text",
       },
     },
-    color: {
+    status: {
       control: {
         type: "radio",
-        options: colors,
+        options: statuses,
       },
     },
   },
@@ -39,19 +39,19 @@ export const Default: StoryObj<Args> = {
 };
 
 export const PrimaryRecommendedVariants = {
-  render: () => getStandardSet(Button, "Button", "flat"),
+  render: () => getStandardSet(Button, "Button", "primary"),
 };
 
 export const SecondaryRecommendedVariants = {
-  render: () => getStandardSet(Button, "Button", "outline"),
+  render: () => getStandardSet(Button, "Button", "secondary"),
 };
 
 export const TertiaryRecommendedVariants = {
-  render: () => getStandardSet(Button, "Button", "outline", "neutral"),
+  render: () => getStandardSet(Button, "Button", "secondary", "neutral"),
 };
 
 export const PlainRecommendedVariants = {
-  render: () => getPlainRecommendedVariants(Button, "Button"),
+  render: () => geIconRecommendedVariants(Button, "Button"),
 };
 
 export const LinkRecommendedVariants = {

--- a/src/components/Button/button.tsx
+++ b/src/components/Button/button.tsx
@@ -8,7 +8,7 @@ export type ButtonProps = ButtonHTMLElementProps & {
    * The button contents or label.
    */
   children: ReactNode;
-  color?: ClickableStyleProps<"button">["color"];
+  status?: ClickableStyleProps<"button">["status"];
   "data-testid"?: string;
   size?: ClickableStyleProps<"button">["size"];
   variant?: ClickableStyleProps<"button">["variant"];
@@ -34,11 +34,11 @@ export type ButtonProps = ButtonHTMLElementProps & {
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
-      variant = "flat",
-      color = "brand",
+      variant = "secondary",
+      status = "brand",
       disabled = false,
       type = "button",
-      size = "large",
+      size = "lg",
       ...rest
     },
     ref,
@@ -47,10 +47,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <ClickableStyle
         {...rest}
         as="button"
-        color={color}
         disabled={disabled}
         ref={ref}
         size={size}
+        status={status}
         type={type}
         variant={variant}
       />

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -11,10 +11,8 @@ export default {
     orientation: "horizontal" as const,
     children: (
       <>
-        <Button color="neutral" variant="outline">
-          Button 1
-        </Button>
-        <Button>Button 2</Button>
+        <Button status="neutral">Button 1</Button>
+        <Button variant="primary">Button 2</Button>
       </>
     ),
   },
@@ -46,19 +44,11 @@ export const WithFiveButtons: StoryObj<Args> = {
   args: {
     children: (
       <>
-        <Button color="neutral" variant="outline">
-          Button 1
-        </Button>
-        <Button color="neutral" variant="outline">
-          Button 2
-        </Button>
-        <Button color="neutral" variant="outline">
-          Button 3
-        </Button>
-        <Button color="neutral" variant="outline">
-          Button 4
-        </Button>
-        <Button>Button 5</Button>
+        <Button status="neutral">Button 1</Button>
+        <Button status="neutral">Button 2</Button>
+        <Button status="neutral">Button 3</Button>
+        <Button status="neutral">Button 4</Button>
+        <Button variant="primary">Button 5</Button>
       </>
     ),
   },

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -10,11 +10,11 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
   /**
    * The color of the element.
    */
-  color: "alert" | "brand" | "neutral" | "success" | "warning";
+  status: "error" | "brand" | "neutral" | "success" | "warning";
   /**
    * The size of the element.
    */
-  size: "small" | "medium" | "large";
+  size: "sm" | "md" | "lg";
   /**
    * A hidden prop for visual testing
    */
@@ -22,7 +22,7 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
   /**
    * The style of the element.
    */
-  variant: "flat" | "outline" | "link" | "plain";
+  variant: "primary" | "secondary" | "link" | "icon";
 } & React.ComponentProps<IComponent>;
 
 /**
@@ -40,7 +40,7 @@ const ClickableStyle = React.forwardRef(
     {
       as: Component,
       children,
-      color,
+      status,
       size,
       state,
       variant,
@@ -56,21 +56,21 @@ const ClickableStyle = React.forwardRef(
           styles.button,
           // Sizes
           variant !== "link" && [
-            size === "small" && styles.sizeSmall,
-            size === "medium" && styles.sizeMedium,
-            size === "large" && styles.sizeLarge,
+            size === "sm" && styles.sizeSmall,
+            size === "md" && styles.sizeMedium,
+            size === "lg" && styles.sizeLarge,
           ],
           // Variants
-          variant === "flat" && styles.variantFlat,
-          variant === "outline" && styles.variantOutline,
+          variant === "primary" && styles.variantFlat,
+          variant === "secondary" && styles.variantOutline,
           variant === "link" && styles.variantLink,
-          variant === "plain" && styles.variantPlain,
-          // Colors
-          color === "alert" && styles.colorAlert,
-          color === "brand" && styles.colorBrand,
-          color === "neutral" && styles.colorNeutral,
-          color === "success" && styles.colorSuccess,
-          color === "warning" && styles.colorWarning,
+          variant === "icon" && styles.variantPlain,
+          // Statuses
+          status === "error" && styles.colorAlert,
+          status === "brand" && styles.colorBrand,
+          status === "neutral" && styles.colorNeutral,
+          status === "success" && styles.colorSuccess,
+          status === "warning" && styles.colorWarning,
           // Interactive States (for testing)
           state === "hover" && styles.stateHover,
           state === "focus" && styles.stateFocus,

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import Heading from "../Heading";
 import Text from "../Text";
 import {
-  colors,
+  statuses,
   getStandardSet,
-  getPlainRecommendedVariants,
+  geIconRecommendedVariants,
   getLinkRecommendedVariants,
   getDestructiveRecommendedVariants,
   getAllRecommendedVariants,
@@ -23,17 +23,17 @@ export default {
         type: "text",
       },
     },
-    color: {
+    status: {
       control: {
         type: "radio",
-        options: colors,
+        options: statuses,
       },
     },
   },
   args: {
     children: "Link",
     variant: "link" as const,
-    color: "brand" as const,
+    status: "brand" as const,
     href: "https://go.czi.team/eds",
     onClick: (event: React.MouseEvent<HTMLElement>) => {
       // Allows the user to click the links for testing without being navigated away.
@@ -65,19 +65,19 @@ export const LinkInHeading: StoryObj<Args> = {
 };
 
 export const PrimaryRecommendedVariants = {
-  render: () => getStandardSet(Link, "Link", "flat"),
+  render: () => getStandardSet(Link, "Link", "primary"),
 };
 
 export const SecondaryRecommendedVariants = {
-  render: () => getStandardSet(Link, "Link", "outline"),
+  render: () => getStandardSet(Link, "Link", "secondary"),
 };
 
 export const TertiaryRecommendedVariants = {
-  render: () => getStandardSet(Link, "Link", "outline", "neutral"),
+  render: () => getStandardSet(Link, "Link", "secondary", "neutral"),
 };
 
 export const PlainRecommendedVariants = {
-  render: () => getPlainRecommendedVariants(Link, "Link"),
+  render: () => geIconRecommendedVariants(Link, "Link"),
 };
 
 export const LinkRecommendedVariants = {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -11,7 +11,7 @@ export type LinkProps = LinkHTMLElementProps & {
    * The link contents or label.
    */
   children: ReactNode;
-  color?: ClickableStyleProps<"a">["color"];
+  status?: ClickableStyleProps<"a">["status"];
   "data-testid"?: string;
   size?: ClickableStyleProps<"a">["size"];
   variant?: ClickableStyleProps<"a">["variant"];
@@ -35,14 +35,14 @@ export type LinkProps = LinkHTMLElementProps & {
  * components are exactly the same.
  */
 const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ variant = "link", color = "brand", size = "large", ...rest }, ref) => {
+  ({ variant = "link", status = "brand", size = "lg", ...rest }, ref) => {
     return (
       <ClickableStyle
         {...rest}
         as="a"
-        color={color}
         ref={ref}
         size={size}
+        status={status}
         variant={variant}
       />
     );

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -46,6 +46,10 @@ export default function Toast({
   // Allow for additional attributes such as aria roles
   ...rest
 }: Props) {
+  // While the v0 to v1 migration is happening, the Button and Toast will briefly
+  // be out of sync regarding the name of the red component style.
+  const buttonStatus = color === "alert" ? "error" : color;
+
   return (
     <div
       className={clsx(
@@ -63,7 +67,7 @@ export default function Toast({
         </Text>
       </div>
       {onDismiss && (
-        <Button color={color} onClick={onDismiss} variant="plain">
+        <Button onClick={onDismiss} status={buttonStatus} variant="icon">
           <Icon
             name="close"
             purpose="informative"

--- a/src/components/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.spec.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-5"
-      class="mb-32 ml-32 button sizeLarge variantFlat colorBrand"
+      class="mb-32 ml-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger
@@ -59,7 +59,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-2"
-      class="mx-32 my-32 button sizeLarge variantFlat colorBrand"
+      class="mx-32 my-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger
@@ -117,7 +117,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
       </p>
       <button
         aria-describedby="tippy-8"
-        class="mx-32 my-32 button sizeLarge variantFlat colorBrand"
+        class="mx-32 my-32 button sizeLarge variantOutline colorBrand"
         type="button"
       >
         Hover here to see tooltip after clicking somewhere outside.
@@ -172,7 +172,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-3"
-      class="ml-96 my-32 button sizeLarge variantFlat colorBrand"
+      class="ml-96 my-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger
@@ -226,7 +226,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-1"
-      class="mx-32 my-32 button sizeLarge variantFlat colorBrand"
+      class="mx-32 my-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger
@@ -280,7 +280,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-7"
-      class="my-20 button sizeLarge variantFlat colorBrand"
+      class="my-20 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger with longer text to test placement
@@ -334,7 +334,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-6"
-      class="mx-32 my-32 button sizeLarge variantFlat colorBrand"
+      class="mx-32 my-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger
@@ -386,7 +386,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-4"
-      class="mt-32 ml-32 button sizeLarge variantFlat colorBrand"
+      class="mt-32 ml-32 button sizeLarge variantOutline colorBrand"
       type="button"
     >
       Tooltip trigger

--- a/src/components/storyUtils/clickableStyleUtils.tsx
+++ b/src/components/storyUtils/clickableStyleUtils.tsx
@@ -12,7 +12,7 @@ export const getStandardSet = (
   Component: typeof Button | typeof Link,
   componentName: "Button" | "Link",
   variant: ClickableStyleProps<"button">["variant"],
-  color: ClickableStyleProps<"button">["color"] = "brand",
+  status: ClickableStyleProps<"button">["status"] = "brand",
 ) => (
   <ul>
     <li>
@@ -21,12 +21,12 @@ export const getStandardSet = (
       </Heading>
       <ul className="grid gap-y-4">
         <li>
-          <Component color={color} variant={variant}>
+          <Component status={status} variant={variant}>
             {componentName}
           </Component>
         </li>
         <li>
-          <Component color={color} variant={variant}>
+          <Component status={status} variant={variant}>
             <Icon
               className={styles.arrowBackIcon}
               name="arrow-back"
@@ -36,7 +36,7 @@ export const getStandardSet = (
           </Component>
         </li>
         <li className={styles.headingBottomSpacing}>
-          <Component color={color} variant={variant}>
+          <Component status={status} variant={variant}>
             {componentName}
             <Icon
               className={styles.arrowForwardIcon}
@@ -53,7 +53,7 @@ export const getStandardSet = (
         Size Medium
       </Heading>
       <div className={styles.headingBottomSpacing}>
-        <Component color={color} size="medium" variant={variant}>
+        <Component size="md" status={status} variant={variant}>
           {componentName}
         </Component>
       </div>
@@ -64,7 +64,7 @@ export const getStandardSet = (
         Size Small
       </Heading>
       <div className={styles.headingBottomSpacing}>
-        <Component color={color} size="small" variant={variant}>
+        <Component size="sm" status={status} variant={variant}>
           {componentName}
         </Component>
       </div>
@@ -72,7 +72,7 @@ export const getStandardSet = (
   </ul>
 );
 
-export const getPlainRecommendedVariants = (
+export const geIconRecommendedVariants = (
   Component: typeof Button | typeof Link,
   componentName: "Button" | "Link",
 ) => (
@@ -83,7 +83,7 @@ export const getPlainRecommendedVariants = (
       </Heading>
       <ul className="grid gap-y-4">
         <li>
-          <Component variant="plain">
+          <Component variant="icon">
             <Icon
               className={styles.arrowBackIcon}
               name="arrow-back"
@@ -93,7 +93,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component variant="plain">
+          <Component variant="icon">
             {componentName}
             <Icon
               className={styles.arrowForwardIcon}
@@ -103,7 +103,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li className={styles.headingBottomSpacing}>
-          <Component variant="plain">
+          <Component variant="icon">
             <Icon
               className="mx-[-0.4em]"
               name="arrow-forward"
@@ -121,7 +121,7 @@ export const getPlainRecommendedVariants = (
       </Heading>
       <ul className="grid gap-y-4">
         <li>
-          <Component size="medium" variant="plain">
+          <Component size="md" variant="icon">
             <Icon
               className={styles.arrowBackIcon}
               name="arrow-back"
@@ -131,7 +131,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component size="medium" variant="plain">
+          <Component size="md" variant="icon">
             {componentName}
             <Icon
               className={styles.arrowForwardIcon}
@@ -141,7 +141,7 @@ export const getPlainRecommendedVariants = (
           </Component>
         </li>
         <li>
-          <Component size="medium" variant="plain">
+          <Component size="md" variant="icon">
             <Icon
               className="mx-[-0.55em]"
               name="add"
@@ -187,12 +187,12 @@ export const getDestructiveRecommendedVariants = (
     </Heading>
     <ul className="grid gap-y-4">
       <li>
-        <Component color="alert" variant="flat">
+        <Component status="error" variant="primary">
           {componentName}
         </Component>
       </li>
       <li>
-        <Component color="alert" variant="flat">
+        <Component status="error" variant="primary">
           <Icon
             className={styles.arrowBackIcon}
             name="arrow-back"
@@ -214,28 +214,28 @@ export const getAllRecommendedVariants = (
       <Heading className={styles.headingBottomSpacing} size="h2">
         Primary
       </Heading>
-      {getStandardSet(Component, componentName, "flat")}
+      {getStandardSet(Component, componentName, "primary")}
     </li>
 
     <li>
       <Heading className={styles.headingBottomSpacing} size="h2">
         Secondary
       </Heading>
-      {getStandardSet(Component, componentName, "outline")}
+      {getStandardSet(Component, componentName, "secondary")}
     </li>
 
     <li>
       <Heading className={styles.headingBottomSpacing} size="h2">
         Tertiary
       </Heading>
-      {getStandardSet(Component, componentName, "outline", "neutral")}
+      {getStandardSet(Component, componentName, "secondary", "neutral")}
     </li>
 
     <li>
       <Heading className={styles.headingBottomSpacing} size="h2">
         Plain
       </Heading>
-      {getPlainRecommendedVariants(Component, componentName)}
+      {geIconRecommendedVariants(Component, componentName)}
     </li>
 
     <li>
@@ -254,11 +254,11 @@ export const getAllRecommendedVariants = (
   </ul>
 );
 
-const sizes = ["large", "medium", "small"] as const;
+const sizes = ["lg", "md", "sm"] as const;
 // "link" is ommitted here because it's rendered separately since it only has one size
-const variants = ["flat", "outline", "plain"] as const;
-export const colors = [
-  "alert",
+const variants = ["primary", "secondary", "icon"] as const;
+export const statuses = [
+  "error",
   "brand",
   "neutral",
   "success",
@@ -274,7 +274,7 @@ const getVariantWithStates = (
   size?: ClickableStyleProps<"button">["size"],
 ) => {
   const states = tag === "button" ? buttonStates : linkStates;
-  const icon = variant === "plain" && (
+  const icon = variant === "icon" && (
     <Icon className="ml-2" name="add" purpose="decorative" />
   );
 
@@ -291,13 +291,12 @@ const getVariantWithStates = (
               <th scope="row">
                 <Text size="body">{state}</Text>
               </th>
-              {colors.map((color) => (
-                <td className="p-2" key={color}>
+              {statuses.map((status) => (
+                <td className="p-2" key={status}>
                   {/* To pass the "state" prop (only used for demonstration in storybook),
                   we must use ClickableStyle instead of Button or Link */}
                   <ClickableStyle
                     as={tag}
-                    color={color}
                     disabled={state === "disabled"}
                     href={tag === "a" ? "https://go.czi.team/eds" : undefined}
                     onClick={(event: React.MouseEvent<HTMLElement>) => {
@@ -306,6 +305,7 @@ const getVariantWithStates = (
                     }}
                     size={size}
                     state={state}
+                    status={status}
                     variant={variant}
                   >
                     {buttonChildren}
@@ -345,7 +345,7 @@ export const getLargeVariantsWithStates = (
     <li>{getVariantWithStates(tag, "link", buttonChildren)}</li>
     {variants.map((variant) => (
       <li key={variant}>
-        {getVariantWithStates(tag, variant, buttonChildren, "large")}
+        {getVariantWithStates(tag, variant, buttonChildren, "lg")}
       </li>
     ))}
   </ul>


### PR DESCRIPTION
### Summary:
#### High level summary:
NOTE: We're planning to merge these API update PRs in a sequence. The sequence will go:
- for each PR, merge in the EDS API update PR
- publish a new package version
- update the package in traject in a PR that has already been reviewed and is waiting to update the component API based on the EDS PR and merge that in
- move on to the next component

To prepare for migrating the `main` branch to use the v1 component versions on `next`, I'm updating the `ClickableStyle`, `Button`, and `Link` APIs (but not the internal logic – that will come later). After landing this, I'll publish a new npm package version, update the EDS package in `traject` and update the component usage to match these changes. That way when we merge the full `next` branch in and deploy, we won't have to update the buttons in `traject` and all the other components at the same time. (Several other components are also being updated separately like this).

#### API changes for these components: 
- the variants have been renamed:
  - "flat" => "primary"
  - "outline" => "secondary"
  - "plain" => "icon"
  - "link" (this is the only one unchanged)
- the "secondary" variant is now the default for `Button` (previously was "flat"/"primary"; `Link`'s default variant is still "link")
- the `color` prop has been renamed to `status`
- the "alert" color/status has been renamed to "error"
- the sizes have been renamed:
  - "large" => "lg"
  - "medium" => "md"
  - "small" => "sm"

### Test Plan:
- no type errors
- no chromatic changes for actual components besides the default `Button` story now uses the "secondary" variant (stories that use a button to trigger a tooltip just to show the tooltip have changes, but that's fine)