### PR TITLE
feat(list detail): adjustments

### DIFF
--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -20,11 +20,11 @@
 }
 
 /**
- * List detail header
+ * List detail nav
  * 1) Contains the tab list
  * 2) Tab overflow behavior
  */
-.list-detail__header {
+.list-detail__nav {
   width: 100%;
   position: relative;
   padding: var(--eds-size-4) var(--eds-size-2);
@@ -89,9 +89,9 @@
     position: absolute;
     left: 0.25rem;
     top: 1.75rem; /* 2 */
-    height: 45%; /* 3 */ 
+    height: 45%; /* 3 */
     width: 0.0625rem;
-    background:  var(--eds-theme-color-border-neutral-subtle); /* 4 */
+    background: var(--eds-theme-color-border-neutral-subtle); /* 4 */
     border-radius: var(--eds-theme-border-radius);
   }
 
@@ -146,6 +146,7 @@
    * 1) Set to 9px to center the border
    * 2) This is the same color used for the vertical line when list style is "ordered"
    * 3) Using a percentage here instead of --eds-theme-border-radius because this is a cosmetic element (a cicular bullet), not a typical bordered object
+   * 4) Make the pseudoelement bullet dark when li is active
    */
   &:before {
     content: '';
@@ -158,6 +159,11 @@
     width: 9px; /* 1 */
     background: var(--eds-theme-color-border-neutral-subtle); /* 2 */
     border-radius: 50%; /* 3 */
+
+    /* stylelint-disable-next-line max-nesting-depth */
+    .list-detail__item.eds-is-active & {
+      background: var(--eds-theme-color-text-neutral-default); /* 4 */
+    }
   }
 
   /**
@@ -165,7 +171,7 @@
   * 1) Remove the bullet since the icon will take its place
   */
   li[class*='list-detail__item--'] & {
-    /* stylelint-disable-next-line max-nesting-depth */
+    /* stylelint-disable-next-line */
     &:before {
       content: none;
     }
@@ -177,7 +183,8 @@
 * 1) Used on list items using number variant; provides a cosmetic cicular border
 * 2) Using flex to keep the number centered
 * 3) Since this will display as a cirlce, keep height and width equal; should be wide enough to fit a two-digit number
-* 4) Using a percentage here instead of --eds-theme-border-radius because this is not a typical bordered object
+* 4) Using a percentage here instead of --eds-theme-border-radius because this must always render as a circle
+* 5) Make the border dark when li is active
 */
 .list-detail__number {
   position: relative;
@@ -185,14 +192,18 @@
   justify-content: center;
   align-items: center;
   left: -4px;
-  width: 1.5rem; /* 3 */ 
+  width: 1.5rem; /* 3 */
   height: 1.5rem; /* 3 */
   border-radius: 50%; /* 4 */
   border: 1px solid var(--eds-theme-color-border-neutral-subtle);
   margin-right: 9px;
   font-size: var(--eds-font-size-12);
   margin-left: -4px;
-  background: var(--eds-theme-color-background-neutral-default); 
+  background: var(--eds-theme-color-background-neutral-default);
+
+  .list-detail__item.eds-is-active & {
+    border: 1px solid var(--eds-theme-color-text-neutral-default); /* 5 */
+  }
 }
 
 /**

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 const Template: Story<Props> = (args) => (
   <ListDetail {...args}>
-    <ListDetailPanel title="Overview" variant="bullet">
+    <ListDetailPanel title="Overview">
       <TextPassage>
         <h3>Overview</h3>
         <p>

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -95,7 +95,7 @@ const Template: Story<Props> = (args) => (
       </TextPassage>
     </ListDetailPanel>
 
-    <ListDetailPanel title="ListDetailPanel 5">
+    <ListDetailPanel title="ListDetailPanel 5" variant="complete">
       <TextPassage>
         <h3>ListDetailPanel 5</h3>
         <p>

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -12,6 +12,17 @@ export default {
 
 const Template: Story<Props> = (args) => (
   <ListDetail {...args}>
+    <ListDetailPanel title="Overview" variant="bullet">
+      <TextPassage>
+        <h3>Overview</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
     <ListDetailPanel title="ListDetailPanel 1" variant="number">
       <TextPassage>
         <h3>ListDetailPanel 1</h3>
@@ -51,6 +62,30 @@ const Template: Story<Props> = (args) => (
     <ListDetailPanel title="ListDetailPanel 4" variant="success">
       <TextPassage>
         <h3>ListDetailPanel 4</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+
+    <ListDetailPanel title="ListDetailPanel 5">
+      <TextPassage>
+        <h3>ListDetailPanel 5</h3>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex{' '}
+        </p>
+      </TextPassage>
+    </ListDetailPanel>
+
+    <ListDetailPanel title="ListDetailPanel 6" variant="number">
+      <TextPassage>
+        <h3>ListDetailPanel 5</h3>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -226,7 +226,7 @@ export const ListDetail = ({
 
   return (
     <div className={componentClassName} {...other}>
-      <div className={styles['list-detail__header']}>
+      <nav className={styles['list-detail__nav']}>
         <ol
           className={clsx(styles['list-detail__list'], {
             [styles['list-detail__list--ordered']]: variant === 'ordered',
@@ -298,6 +298,20 @@ export const ListDetail = ({
                       />
                     ) : itemVariant === 'number' ? (
                       <span className={styles['list-detail__number']}>{i}</span>
+                    ) : itemVariant === 'incomplete' ? (
+                      <Icon
+                        className={styles['list-detail__icon']}
+                        color={EdsThemeColorBackgroundGradeCompleteDefault}
+                        name="star" /* TODO: need to add star-outline variant to Icon */
+                        purpose="decorative"
+                      />
+                    ) : itemVariant === 'complete' ? (
+                      <Icon
+                        className={styles['list-detail__icon']}
+                        color={EdsThemeColorBackgroundGradeCompleteDefault}
+                        name="star"
+                        purpose="decorative"
+                      />
                     ) : (
                       ''
                     )}
@@ -308,7 +322,7 @@ export const ListDetail = ({
             );
           })}
         </ol>
-      </div>
+      </nav>
       <div className={styles['list-detail__body']}>
         {childrenWithProps[activeIndexState]}
       </div>

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -222,13 +222,12 @@ export const ListDetail = ({
       return child;
     },
   );
-  const TagName = variant === 'ordered' ? 'ol' : 'ul';
   const componentClassName = clsx(styles['list-detail'], className, {});
 
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['list-detail__header']}>
-        <TagName
+        <ol
           className={clsx(styles['list-detail__list'], {
             [styles['list-detail__list--ordered']]: variant === 'ordered',
           })}
@@ -241,6 +240,7 @@ export const ListDetail = ({
               <li
                 className={clsx(
                   styles['list-detail__item'],
+
                   isActive && styles['eds-is-active'],
                 )}
                 key={'list-detail-item-' + i}
@@ -266,6 +266,8 @@ export const ListDetail = ({
                   <div
                     className={clsx(styles['list-detail__link-left'], {
                       [styles['list-detail__link-hidden']]: [
+                        'bullet',
+                        'complete',
                         'number',
                         'success',
                         'warning',
@@ -295,9 +297,7 @@ export const ListDetail = ({
                         purpose="decorative"
                       />
                     ) : itemVariant === 'number' ? (
-                      <span className={styles['list-detail__number']}>
-                        {i + 1}
-                      </span>
+                      <span className={styles['list-detail__number']}>{i}</span>
                     ) : (
                       ''
                     )}
@@ -307,7 +307,7 @@ export const ListDetail = ({
               </li>
             );
           })}
-        </TagName>
+        </ol>
       </div>
       <div className={styles['list-detail__body']}>
         {childrenWithProps[activeIndexState]}

--- a/src/components/ListDetailPanel/ListDetailPanel.tsx
+++ b/src/components/ListDetailPanel/ListDetailPanel.tsx
@@ -26,7 +26,14 @@ export interface Props {
   /**
    * The tab variant
    */
-  variant?: 'bullet' | 'complete' | 'error' | 'number' | 'success' | 'warning';
+  variant?:
+    | 'bullet'
+    | 'complete'
+    | 'error'
+    | 'incomplete'
+    | 'number'
+    | 'success'
+    | 'warning';
   /**
    * The tab title
    */
@@ -46,7 +53,6 @@ export const ListDetailPanel = ({
   title,
   ...other
 }: Props) => {
-  const [isComplete, setIsComplete] = useState(completed || false);
   const componentClassName = clsx(styles['list-detail__panel'], className, {});
   return (
     <nav

--- a/src/components/ListDetailPanel/ListDetailPanel.tsx
+++ b/src/components/ListDetailPanel/ListDetailPanel.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import styles from '../ListDetail/ListDetail.module.css';
 
 export interface Props {
@@ -16,13 +16,17 @@ export interface Props {
    */
   className?: string;
   /**
+   * Mark list as completed
+   */
+  completed?: boolean;
+  /**
    * HTML id for the component
    */
   id?: any;
   /**
    * The tab variant
    */
-  variant?: 'error' | 'number' | 'success' | 'warning';
+  variant?: 'bullet' | 'complete' | 'error' | 'number' | 'success' | 'warning';
   /**
    * The tab title
    */
@@ -36,14 +40,16 @@ export const ListDetailPanel = ({
   ariaLabelledBy,
   children,
   className,
+  completed,
   id,
   variant,
   title,
   ...other
 }: Props) => {
+  const [isComplete, setIsComplete] = useState(completed || false);
   const componentClassName = clsx(styles['list-detail__panel'], className, {});
   return (
-    <div
+    <nav
       aria-hidden={false}
       aria-labelledby={ariaLabelledBy}
       className={componentClassName}
@@ -52,6 +58,6 @@ export const ListDetailPanel = ({
       {...other}
     >
       {children}
-    </div>
+    </nav>
   );
 };


### PR DESCRIPTION
### Summary:
Shortcut: https://app.shortcut.com/czi-edu/story/190151/timeline-nav-build-responsive-behavior

This PR adds new list item variants to the list items: complete and incomplete*, plus the ability to have a bulleted and non-numbered first item in the list, with the second list item getting index of 1. Also, for list items using the "number" variant, the number and its circle border both get the neutral default text color when the list item is selected/active.

*NOTE: currently the Icon component does not have a variant for "star-outline"; this needs to be ticketed separately. 

From Figma:
Complete (green solid star icon):
<img width="391" alt="Screen Shot 2022-04-22 at 11 22 26 AM" src="https://user-images.githubusercontent.com/24812780/164756354-3380a6a4-1f4a-4136-b986-333aa06dd188.png">

Incomplete (neutral subtle star outline icon* (see note above)):
<img width="305" alt="Screen Shot 2022-04-22 at 11 16 17 AM" src="https://user-images.githubusercontent.com/24812780/164756465-ab94b5cb-ca4a-440d-9a90-62a16c5dc1ea.png">

Active numbered list item with neutral default color on number and outline:
<img width="366" alt="Screen Shot 2022-04-22 at 11 15 53 AM" src="https://user-images.githubusercontent.com/24812780/164756537-4a753501-defa-4cd8-a93a-7f800c2f75f2.png">


First item "Overview" (not numbered in the list's counter, which starts with index 1 applied to the second <li>):
<img width="321" alt="Screen Shot 2022-04-22 at 11 16 08 AM" src="https://user-images.githubusercontent.com/24812780/164755839-ed4c0f44-a417-466b-9697-65253817a313.png">





### Test Plan:
Confirm in Storybook that each of the variants described above works as described/matches the Figma prototype.