### PR TITLE
feat: replace nanoid with react-uid

### DIFF
--- a/jest/jest.setup.ts
+++ b/jest/jest.setup.ts
@@ -5,12 +5,6 @@ import { format } from 'util';
 // and throws errors when used in tests.
 jest.mock('svg4everybody');
 
-// nanoid generates unique string IDs; we mock out that randomness to ensure
-// consistent snapshots in tests.
-jest.mock('nanoid', () => {
-  return { nanoid: () => 'mock-id' };
-});
-
 /**
  * Ensure `console.error` calls throw an error in tests
  */

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@tippyjs/react": "4.2.5",
     "clsx": "^1.1.1",
     "downshift": "^6.1.7",
-    "nanoid": "^3.3.1",
     "react-children-by-type": "^1.1.0",
     "react-focus-lock": "^2.8.1",
     "react-portal": "^4.2.1",

--- a/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
 import React, {
   useCallback,
   useEffect,
@@ -8,6 +7,7 @@ import React, {
   MutableRefObject,
   ReactNode,
 } from 'react';
+import { useUID } from 'react-uid';
 import styles from './AccordionPanel.module.css';
 import { EdsThemeColorIconNeutralStrong } from '../../tokens-dist/ts/colors';
 import Icon from '../Icon';
@@ -62,8 +62,12 @@ export const AccordionPanel = ({
   const panelRef = useRef() as MutableRefObject<HTMLDivElement>;
   const [heightVar, setHeight] = useState('0');
   const [isActiveVar, setIsActive] = useState(isActive ? true : false);
-  const [ariaControlsVar, setAriaControls] = useState();
-  const [ariaLabelledByVar, setAriaLabelledBy] = useState();
+
+  const generatedAriaControlsId = useUID();
+  const ariaControlsVar = ariaControls || generatedAriaControlsId;
+
+  const generatedAriaLabelledById = useUID();
+  const ariaLabelledByVar = ariaLabelledBy || generatedAriaLabelledById;
 
   /**
    * Set panel height
@@ -82,14 +86,12 @@ export const AccordionPanel = ({
   }, [isActiveVar]);
 
   useEffect(() => {
-    setAriaControls(ariaControls || nanoid());
-    setAriaLabelledBy(ariaLabelledBy || nanoid());
     setPanelHeight();
     window.addEventListener('resize', setPanelHeight); /* 2 */
     return () => {
       window.removeEventListener('resize', setPanelHeight); /* 3 */
     };
-  }, [isActiveVar, ariaLabelledBy, ariaControls, setPanelHeight]);
+  }, [setPanelHeight]);
 
   /**
    * Toggle accordion panel

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="1"
     >
       attention
     </title>
@@ -64,7 +64,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="13"
       >
         dismiss module
       </title>
@@ -80,7 +80,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="14"
     >
       attention
     </title>
@@ -129,7 +129,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="8"
     >
       attention
     </title>
@@ -200,7 +200,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="23"
       >
         dismiss module
       </title>
@@ -216,7 +216,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="24"
     >
       attention
     </title>
@@ -275,7 +275,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="5"
     >
       error
     </title>
@@ -328,7 +328,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="21"
       >
         dismiss module
       </title>
@@ -344,7 +344,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="22"
     >
       error
     </title>
@@ -393,7 +393,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="12"
     >
       error
     </title>
@@ -452,7 +452,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="33"
     >
       attention
     </title>
@@ -501,7 +501,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="2"
     >
       notice
     </title>
@@ -554,7 +554,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="15"
       >
         dismiss module
       </title>
@@ -570,7 +570,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="16"
     >
       notice
     </title>
@@ -619,7 +619,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="9"
     >
       notice
     </title>
@@ -678,7 +678,7 @@ exports[`<Banner /> NoDescription story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="6"
     >
       attention
     </title>
@@ -713,7 +713,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="7"
     >
       attention
     </title>
@@ -757,7 +757,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="3"
     >
       success
     </title>
@@ -810,7 +810,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="17"
       >
         dismiss module
       </title>
@@ -826,7 +826,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="18"
     >
       success
     </title>
@@ -875,7 +875,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="10"
     >
       success
     </title>
@@ -934,7 +934,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="27"
     >
       attention
     </title>
@@ -987,7 +987,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="28"
       >
         dismiss module
       </title>
@@ -1003,7 +1003,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="29"
     >
       attention
     </title>
@@ -1056,7 +1056,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="31"
       >
         dismiss module
       </title>
@@ -1072,7 +1072,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="32"
     >
       attention
     </title>
@@ -1131,7 +1131,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="30"
     >
       attention
     </title>
@@ -1190,7 +1190,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="4"
     >
       warning
     </title>
@@ -1243,7 +1243,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="19"
       >
         dismiss module
       </title>
@@ -1259,7 +1259,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="20"
     >
       warning
     </title>
@@ -1308,7 +1308,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="11"
     >
       warning
     </title>

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './Breadcrumbs.module.css';
 
 export interface Props {
@@ -33,11 +33,8 @@ export const Breadcrumbs = ({
   ariaLabel = 'breadcrumbs links',
   ...other
 }: Props) => {
-  const [breadcrumbsId, setBreadcrumbsId] = useState();
-
-  useEffect(() => {
-    setBreadcrumbsId(id || nanoid());
-  }, [id]);
+  const generatedId = useUID();
+  const breadcrumbsId = id || generatedId;
 
   const componentClassName = clsx(styles['breadcrumbs'], className, {});
 

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -79,7 +79,7 @@ exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="10"
     >
       go back
     </title>
@@ -102,7 +102,7 @@ exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="13"
     >
       go back
     </title>
@@ -316,7 +316,7 @@ exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="14"
     >
       opens in a new tab
     </title>
@@ -362,7 +362,7 @@ exports[`<Button /> Loading story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="16"
     >
       loading
     </title>

--- a/src/components/CheckboxField/CheckboxField.tsx
+++ b/src/components/CheckboxField/CheckboxField.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './CheckboxField.module.css';
 import FieldNote from '../FieldNote';
 import Fieldset from '../Fieldset';
@@ -79,13 +79,10 @@ export const CheckboxField = ({
   inverted,
   ...other
 }: Props) => {
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
-
-  useEffect(() => {
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, fieldNote]);
+  const generatedId = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedId
+    : undefined;
 
   const componentClassName = clsx(
     styles['checkbox-field'],

--- a/src/components/CheckboxFieldItem/CheckboxFieldItem.tsx
+++ b/src/components/CheckboxFieldItem/CheckboxFieldItem.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
 import React, { ChangeEventHandler, useEffect, useRef, useState } from 'react';
+import { useUID } from 'react-uid';
 import Checkbox from '../Checkbox';
 import styles from '../CheckboxField/CheckboxField.module.css';
 
@@ -73,7 +73,8 @@ export const CheckboxFieldItem = ({
   const [checkboxChecked, setCheckedState] = useState(
     checked ? checked : false,
   );
-  const [idVar, setId] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
   /**
    * Check for previous props/states
@@ -96,8 +97,7 @@ export const CheckboxFieldItem = ({
       /* 1 */
       setCheckedState(checkboxChecked);
     }
-    setId(id || nanoid());
-  }, [prevChecked, checkboxChecked, id]);
+  }, [prevChecked, checkboxChecked]);
 
   /**
    * On change handler

--- a/src/components/Counter/Counter.tsx
+++ b/src/components/Counter/Counter.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useState } from 'react';
+import { useUID } from 'react-uid';
 import styles from './Counter.module.css';
 import Button from '../Button';
 import FieldNote from '../FieldNote';
@@ -120,17 +120,16 @@ export const Counter = ({
   const [count, setCountState] = useState(
     value !== undefined ? parseInt(value) : 1,
   );
-  const [idVar, setId] = useState();
-  const [ariaLabelledByVar, setAriaLabelledBy] = useState();
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
-  useEffect(() => {
-    setId(id || nanoid());
-    setAriaLabelledBy(ariaLabelledBy || nanoid());
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, ariaLabelledBy, fieldNote, id]);
+  const generatedAriaLabelledById = useUID();
+  const ariaLabelledByVar = ariaLabelledBy || generatedAriaLabelledById;
+
+  const generatedAriaDescribedById = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedAriaDescribedById
+    : undefined;
 
   function onIncrease(e) {
     e.preventDefault();

--- a/src/components/Fieldset/__snapshots__/Fieldset.test.ts.snap
+++ b/src/components/Fieldset/__snapshots__/Fieldset.test.ts.snap
@@ -5,7 +5,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
   class="checkbox-field fieldset"
 >
   <legend
-    aria-describedby="mock-id"
+    aria-describedby="6"
     class="fieldset-legend checkbox-field__label"
   >
     Checkbox field
@@ -29,7 +29,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
             <input
               class="checkbox__input"
               data-bootstrap-override="checkbox"
-              id="mock-id"
+              id="7"
               name="checkbox-example"
               style="--checkbox-svg-size: 1.25rem;"
               type="checkbox"
@@ -62,7 +62,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
           <label
             class="label label--md"
             data-bootstrap-override="label"
-            for="mock-id"
+            for="7"
             style="--checkbox-svg-size: 1.25rem;"
           >
             Checkbox 1
@@ -81,7 +81,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
             <input
               class="checkbox__input"
               data-bootstrap-override="checkbox"
-              id="mock-id"
+              id="9"
               name="checkbox-example"
               style="--checkbox-svg-size: 1.25rem;"
               type="checkbox"
@@ -114,7 +114,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
           <label
             class="label label--md"
             data-bootstrap-override="label"
-            for="mock-id"
+            for="9"
             style="--checkbox-svg-size: 1.25rem;"
           >
             Checkbox 2
@@ -133,7 +133,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
             <input
               class="checkbox__input"
               data-bootstrap-override="checkbox"
-              id="mock-id"
+              id="11"
               name="checkbox-example"
               style="--checkbox-svg-size: 1.25rem;"
               type="checkbox"
@@ -166,7 +166,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
           <label
             class="label label--md"
             data-bootstrap-override="label"
-            for="mock-id"
+            for="11"
             style="--checkbox-svg-size: 1.25rem;"
           >
             Checkbox 3
@@ -178,7 +178,7 @@ exports[`<Fieldset /> CheckboxField story renders snapshot 1`] = `
   <div
     aria-live="assertive"
     class="field-note checkbox-field__note"
-    id="mock-id"
+    id="6"
   >
     Checkbox fieldset usage. See CheckboxField Stories for more examples.
   </div>
@@ -446,7 +446,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
   class="radio-field fieldset"
 >
   <legend
-    aria-describedby="mock-id"
+    aria-describedby="13"
     class="fieldset-legend radio-field__label"
   >
     Radio field
@@ -466,7 +466,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         >
           <input
             class="radio__input"
-            id="mock-id"
+            id="14"
             name="radio-example"
             type="radio"
             value="radio1"
@@ -477,7 +477,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         </div>
         <label
           class="radio-field__item-label"
-          for="mock-id"
+          for="14"
         >
           Radio 1
         </label>
@@ -490,7 +490,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         >
           <input
             class="radio__input"
-            id="mock-id"
+            id="15"
             name="radio-example"
             type="radio"
             value="radio2"
@@ -501,7 +501,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         </div>
         <label
           class="radio-field__item-label"
-          for="mock-id"
+          for="15"
         >
           Radio 2
         </label>
@@ -514,7 +514,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         >
           <input
             class="radio__input"
-            id="mock-id"
+            id="16"
             name="radio-example"
             type="radio"
             value="radio3"
@@ -525,7 +525,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
         </div>
         <label
           class="radio-field__item-label"
-          for="mock-id"
+          for="16"
         >
           Radio 3
         </label>
@@ -535,7 +535,7 @@ exports[`<Fieldset /> RadioField story renders snapshot 1`] = `
   <div
     aria-live="assertive"
     class="field-note radio-field__note"
-    id="mock-id"
+    id="13"
   >
     RadioField fieldset usage. See RadioField Stories for more examples.
   </div>

--- a/src/components/FileUploadField/FileUploadField.tsx
+++ b/src/components/FileUploadField/FileUploadField.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useState, useEffect } from 'react';
+import React, { ReactNode, useState } from 'react';
+import { useUID, useUIDSeed } from 'react-uid';
 import styles from './FileUploadField.module.css';
 import Button from '../Button/';
 import FieldNote from '../FieldNote';
@@ -175,15 +175,13 @@ export const FileUploadField = ({
   const [isDragging, setIsDragging] = useState(false);
   const [fieldNoteState, setFieldNoteState] = useState(fieldNote);
 
-  const [idVar, setId] = useState();
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
-  useEffect(() => {
-    setId(id || nanoid());
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, fieldNote, id]);
+  const generatedAriaDescribedById = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedAriaDescribedById
+    : undefined;
 
   function formatBytes(bytes, decimals) {
     if (bytes === 0) return '0 Bytes';
@@ -219,7 +217,7 @@ export const FileUploadField = ({
     }
   }
 
-  function onFileInputChange(e) {
+  function onFileInputChange(e, uidSeed) {
     const fileObjects = e.target.files;
     if (!fileObjects) return;
 
@@ -243,7 +241,7 @@ export const FileUploadField = ({
       } else {
         files.push({
           fileObject: file,
-          id: nanoid(),
+          id: uidSeed(file),
         });
         setIsErrorState(isError);
       }
@@ -293,6 +291,8 @@ export const FileUploadField = ({
   }
 
   const isDisabled = disabled || (filesState && filesState >= maxFiles);
+  // useUIDSeed() generates a stable seed generator for use in iterators.
+  const uidSeed = useUIDSeed();
 
   const componentClassName = clsx(
     styles['file-upload-field'],
@@ -337,7 +337,7 @@ export const FileUploadField = ({
             isError={isError}
             multiple={multiple}
             name={name}
-            onChange={(e) => onFileInputChange(e)}
+            onChange={(e) => onFileInputChange(e, uidSeed)}
             placeholder={placeholder}
             readOnly={readOnly}
             required={required}

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { useEffect, useState, ReactNode, CSSProperties } from 'react';
+import React, { useEffect, ReactNode, CSSProperties } from 'react';
+import { useUID } from 'react-uid';
 import svg4everybody from 'svg4everybody';
 import styles from './Icon.module.css';
 import icons from '../../icons/spritemap/spritemap.svg';
@@ -110,12 +110,12 @@ export const Icon = (props: IconProps) => {
     purpose,
     size,
   } = props;
-  const [idVar, setId] = useState('');
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
   useEffect(() => {
-    setId(id || nanoid());
     svg4everybody(); // Required to get IE to render icon sprites
-  }, [id]);
+  }, []);
 
   const componentClassName = clsx(
     styles['icon'],

--- a/src/components/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.tsx.snap
@@ -57,7 +57,7 @@ exports[`<Icon /> InText story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="6"
     >
       icon with 1em line height
     </title>
@@ -76,7 +76,7 @@ exports[`<Icon /> InText story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="7"
     >
       icon with 2em line height
     </title>

--- a/src/components/InlineForm/InlineForm.tsx
+++ b/src/components/InlineForm/InlineForm.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { useEffect, useState, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './InlineForm.module.css';
 import Button from '../Button';
 import Label from '../Label';
@@ -55,11 +55,8 @@ export const InlineForm = ({
   placeholder,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
-
-  useEffect(() => {
-    setId(id || nanoid());
-  }, [id]);
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
   const componentClassName = clsx(styles['inline-form'], className, {});
   return (

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`<Link /> IconClickableStyleIconOnly story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="10"
     >
       go back
     </title>
@@ -81,7 +81,7 @@ exports[`<Link /> IconClickableStyleIconOnlySmall story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="13"
     >
       go back
     </title>
@@ -275,7 +275,7 @@ exports[`<Link /> LinkRightIcon story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="mock-id"
+      id="1"
     >
       opens in a new tab
     </title>

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
 import React, {
   ReactNode,
   useRef,
@@ -8,6 +7,7 @@ import React, {
   useCallback,
 } from 'react';
 import { allByType } from 'react-children-by-type';
+import { useUIDSeed } from 'react-uid';
 import styles from './ListDetail.module.css';
 import {
   EdsThemeColorBackgroundGradeCompleteDefault,
@@ -113,6 +113,8 @@ export const ListDetail = ({
   // we can't use the hook in an iterator like this, so generate the base and increment if needed
   const [idVar, setId] = useState([]);
   const [ariaLabelledByVar, setAriaLabelledBy] = useState([]);
+  // useUIDSeed() generates a stable seed generator for use in iterators.
+  const uidSeed = useUIDSeed();
 
   /**
    * Get previous prop
@@ -143,22 +145,22 @@ export const ListDetail = ({
   }, [prevActiveIndex, activeIndex, listDetailItemRefs]);
 
   /**
-   * Autogenerate ids on tabs if not defined
+   * Autogenerate ids on tabs if not defined.
    */
   useEffect(() => {
     setId(
-      listDetailItems().map((listDetailItem) =>
-        listDetailItem.props.id ? listDetailItem.props.id : nanoid(),
+      listDetailItems().map((item) =>
+        item.props.id ? item.props.id : uidSeed(`${item}-id`),
       ),
     );
     setAriaLabelledBy(
-      listDetailItems().map((listDetailItem) =>
-        listDetailItem.props.ariaLabelledBy
-          ? listDetailItem.props.ariaLabelledBy
-          : nanoid(),
+      listDetailItems().map((item) =>
+        item.props.ariaLabelledBy
+          ? item.props.ariaLabelledBy
+          : uidSeed(`${item}-aria-labelledby`),
       ),
     );
-  }, [listDetailItems]);
+  }, [listDetailItems, uidSeed]);
 
   /**
    * On open

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './PrimaryNav.module.css';
 
 export interface Props {
@@ -32,11 +32,8 @@ export const PrimaryNav = ({
   ariaLabel,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
-
-  useEffect(() => {
-    setId(id || nanoid());
-  }, [id]);
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
   const componentClassName = clsx(styles['primary-nav'], className);
 

--- a/src/components/RadioField/RadioField.tsx
+++ b/src/components/RadioField/RadioField.tsx
@@ -1,12 +1,7 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, {
-  ChangeEventHandler,
-  ReactNode,
-  useState,
-  useEffect,
-} from 'react';
+import React, { ChangeEventHandler, ReactNode, useState } from 'react';
 import { allByType } from 'react-children-by-type';
+import { useUID } from 'react-uid';
 import styles from './RadioField.module.css';
 import FieldNote from '../FieldNote';
 import Fieldset from '../Fieldset';
@@ -115,7 +110,10 @@ export const RadioField = ({
   /**
    * If the fieldNote is defined, add aria described by for accessibility
    */
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
+  const generatedAriaDescribedById = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedAriaDescribedById
+    : undefined;
 
   /**
    * Checked function for radio field items
@@ -129,12 +127,6 @@ export const RadioField = ({
     }
     setCheckedIndex(index); /* 2 */
   }
-
-  useEffect(() => {
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, fieldNote]);
 
   /**
    * Pass in props from RadioField to each RadioFieldItem

--- a/src/components/RadioFieldItem/RadioFieldItem.tsx
+++ b/src/components/RadioFieldItem/RadioFieldItem.tsx
@@ -1,11 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, {
-  ChangeEventHandler,
-  ReactNode,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ChangeEventHandler, ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import Radio from '../Radio';
 import styles from '../RadioField/RadioField.module.css';
 
@@ -77,11 +72,9 @@ export const RadioFieldItem = ({
   inverted,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
-  useEffect(() => {
-    setId(id || nanoid());
-  }, [id]);
   const componentClassName = clsx(
     styles['radio-field__item'],
     className,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
 import React, {
   ReactNode,
   useRef,
@@ -8,6 +7,7 @@ import React, {
   useCallback,
 } from 'react';
 import { allByType } from 'react-children-by-type';
+import { useUIDSeed } from 'react-uid';
 import styles from './Tabs.module.css';
 import {
   L_ARROW_KEYCODE,
@@ -129,6 +129,8 @@ export const Tabs = ({
   // we can't use the hook in an iterator like this, so generate the base and increment if needed
   const [idVar, setId] = useState([]);
   const [ariaLabelledByVar, setAriaLabelledBy] = useState([]);
+  // useUIDSeed() generates a stable seed generator for use in iterators.
+  const uidSeed = useUIDSeed();
 
   /**
    * Get previous prop
@@ -159,16 +161,20 @@ export const Tabs = ({
   }, [prevActiveIndex, activeIndex, tabRefs]);
 
   /**
-   * Autogenerate ids on tabs if not defined
+   * Autogenerate ids on tabs if not defined.
    */
   useEffect(() => {
-    setId(tabs().map((tab) => (tab.props.id ? tab.props.id : nanoid())));
+    setId(
+      tabs().map((tab) => (tab.props.id ? tab.props.id : uidSeed(`${tab}-id`))),
+    );
     setAriaLabelledBy(
       tabs().map((tab) =>
-        tab.props.ariaLabelledBy ? tab.props.ariaLabelledBy : nanoid(),
+        tab.props.ariaLabelledBy
+          ? tab.props.ariaLabelledBy
+          : uidSeed(`${tab}-aria-labelledby`),
       ),
     );
-  }, [tabs]);
+  }, [tabs, uidSeed]);
 
   /**
    * On open

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,12 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, {
-  ChangeEventHandler,
-  MouseEventHandler,
-  ReactNode,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ChangeEventHandler, MouseEventHandler, ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './TextField.module.css';
 import FieldNote from '../FieldNote';
 import Icon, { IconName } from '../Icon';
@@ -179,15 +173,13 @@ export const TextField = ({
   title,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
-  useEffect(() => {
-    setId(id || nanoid());
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, fieldNote, id]);
+  const generatedAriaDescribedById = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedAriaDescribedById
+    : undefined;
 
   const componentClassName = clsx(
     styles['text-field'],

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,12 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, {
-  ChangeEventHandler,
-  MouseEventHandler,
-  ReactNode,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ChangeEventHandler, MouseEventHandler, ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './TextareaField.module.css';
 import Button from '../Button';
 import FieldNote from '../FieldNote';
@@ -159,15 +153,13 @@ export const TextareaField = ({
   defaultValue,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
-  const [ariaDescribedByVar, setAriaDescribedBy] = useState();
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
-  useEffect(() => {
-    setId(id || nanoid());
-    if (fieldNote) {
-      setAriaDescribedBy(ariaDescribedBy || nanoid());
-    }
-  }, [ariaDescribedBy, fieldNote, id]);
+  const generatedAriaDescribedById = useUID();
+  const ariaDescribedByVar = fieldNote
+    ? ariaDescribedBy || generatedAriaDescribedById
+    : undefined;
 
   const componentClassName = clsx(
     styles['textarea-field'],

--- a/src/components/Toast/__snapshots__/Toast.test.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`<Toast /> Error story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="2"
       >
         error
       </title>
@@ -51,7 +51,7 @@ exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="3"
       >
         success
       </title>
@@ -85,7 +85,7 @@ exports[`<Toast /> Success story renders snapshot 1`] = `
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
-        id="mock-id"
+        id="1"
       >
         success
       </title>

--- a/src/components/UtilityNav/UtilityNav.tsx
+++ b/src/components/UtilityNav/UtilityNav.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
-import { nanoid } from 'nanoid';
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode } from 'react';
+import { useUID } from 'react-uid';
 import styles from './UtilityNav.module.css';
 
 export interface Props {
@@ -36,11 +36,8 @@ export const UtilityNav = ({
   ariaLabel,
   ...other
 }: Props) => {
-  const [idVar, setId] = useState();
-
-  useEffect(() => {
-    setId(id || nanoid());
-  }, [id]);
+  const generatedId = useUID();
+  const idVar = id || generatedId;
 
   const componentClassName = clsx(styles['utility-nav'], className);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,7 +1645,6 @@ __metadata:
     jest: ^27.5.1
     lint-staged: ^10.5.4
     make-dir-cli: ^3.0.0
-    nanoid: ^3.3.1
     plop: ^3.0.5
     postcss: ^8.4.12
     postcss-cli: ^9.1.0


### PR DESCRIPTION
### Summary:
[ch192055]

Benefits of `react-uid`:
- stable ID generator (seems like nanoid is not), which allows for potential SSR in the future
- size difference is minimal (1kB gzipped vs. 500 bytes for nanoid)
- traject already uses it
- hook syntax is close to [React's native `useId` hook](https://reactjs.org/blog/2022/03/29/react-v18.html#useid) coming in React 18 (will upgrade when traject upgrades)

### Test Plan:
- sanity check that snapshot IDs still make sense