### PR TITLE
feat(tag): make variant names consistent with other components

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -46,19 +46,19 @@
 /**
  * Color variants.
  */
-.tag--default {
+.tag--neutral {
   --tag-primary-color: var(--eds-theme-color-text-neutral-default);
   --tag-secondary-color: var(--eds-theme-color-background-neutral-medium);
   --tag-outline-color: var(--eds-theme-color-border-neutral-default);
 }
 
-.tag--stop {
+.tag--error {
   --tag-primary-color: var(--eds-theme-color-text-utility-error);
   --tag-secondary-color: var(--eds-theme-color-background-utility-error);
   --tag-outline-color: var(--eds-theme-color-border-utility-error-default);
 }
 
-.tag--go {
+.tag--success {
   --tag-primary-color: var(--eds-theme-color-text-utility-success);
   --tag-secondary-color: var(--eds-theme-color-background-utility-success);
   --tag-outline-color: var(--eds-theme-color-border-utility-success-default);

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
   args: {
     text: 'Tag text',
-    variant: 'default' as const,
+    variant: 'neutral' as const,
   },
 };
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -4,10 +4,10 @@ import styles from './Tag.module.css';
 import Text from '../Text';
 
 export const VARIANTS = [
-  'default',
-  'go',
+  'neutral',
+  'success',
   'yield',
-  'stop',
+  'error',
   'warning',
   'brand',
 ] as const;
@@ -47,24 +47,21 @@ type Props = {
  * This component provides a tag (pill shaped badge) wrapper.
  */
 export const Tag = ({
-  variant = 'default',
+  variant = 'neutral',
   className,
   icon,
   text,
   hasOutline = false,
 }: Props) => {
+  const componentClassName = clsx(
+    className,
+    styles['tag'],
+    styles[`tag--${variant}`],
+    hasOutline && styles['tag--outline'],
+  );
+
   return (
-    <Text
-      as="span"
-      className={clsx(
-        className,
-        styles['tag'],
-        styles[`tag--${variant}`],
-        hasOutline && styles['tag--outline'],
-      )}
-      size="sm"
-      weight="bold"
-    >
+    <Text as="span" className={componentClassName} size="sm" weight="bold">
       {icon}
       {text && <span className={styles['tag__body']}>{text}</span>}
     </Text>

--- a/src/components/Tag/__snapshots__/Tag.test.ts.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.ts.snap
@@ -5,21 +5,21 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   class="tagList"
 >
   <span
-    class="tag tag--default text text--sm text--bold-weight"
+    class="tag tag--neutral text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      default
+      neutral
     </span>
   </span>
   <span
-    class="tag tag--go text text--sm text--bold-weight"
+    class="tag tag--success text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      go
+      success
     </span>
   </span>
   <span
@@ -32,12 +32,12 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="tag tag--stop text text--sm text--bold-weight"
+    class="tag tag--error text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      stop
+      error
     </span>
   </span>
   <span
@@ -63,7 +63,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
 
 exports[`<Tag /> Default story renders snapshot 1`] = `
 <span
-  class="tag tag--default text text--sm text--bold-weight"
+  class="tag tag--neutral text text--sm text--bold-weight"
 >
   <span
     class="tag__body"
@@ -78,21 +78,21 @@ exports[`<Tag /> OutlineVariants story renders snapshot 1`] = `
   class="tagList"
 >
   <span
-    class="tag tag--default tag--outline text text--sm text--bold-weight"
+    class="tag tag--neutral tag--outline text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      default
+      neutral
     </span>
   </span>
   <span
-    class="tag tag--go tag--outline text text--sm text--bold-weight"
+    class="tag tag--success tag--outline text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      go
+      success
     </span>
   </span>
   <span
@@ -105,12 +105,12 @@ exports[`<Tag /> OutlineVariants story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="tag tag--stop tag--outline text text--sm text--bold-weight"
+    class="tag tag--error tag--outline text text--sm text--bold-weight"
   >
     <span
       class="tag__body"
     >
-      stop
+      error
     </span>
   </span>
   <span
@@ -139,7 +139,7 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
   class="tagList"
 >
   <span
-    class="tag tag--default tag--outline text text--sm text--bold-weight"
+    class="tag tag--neutral tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"
@@ -154,11 +154,11 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     <span
       class="tag__body"
     >
-      default
+      neutral
     </span>
   </span>
   <span
-    class="tag tag--go tag--outline text text--sm text--bold-weight"
+    class="tag tag--success tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"
@@ -173,7 +173,7 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     <span
       class="tag__body"
     >
-      go
+      success
     </span>
   </span>
   <span
@@ -196,7 +196,7 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="tag tag--stop tag--outline text text--sm text--bold-weight"
+    class="tag tag--error tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"
@@ -211,7 +211,7 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     <span
       class="tag__body"
     >
-      stop
+      error
     </span>
   </span>
   <span
@@ -260,7 +260,7 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
   class="tagList"
 >
   <span
-    class="tag tag--default tag--outline text text--sm text--bold-weight"
+    class="tag tag--neutral tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"
@@ -279,7 +279,7 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="tag tag--go tag--outline text text--sm text--bold-weight"
+    class="tag tag--success tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"
@@ -317,7 +317,7 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="tag tag--stop tag--outline text text--sm text--bold-weight"
+    class="tag tag--error tag--outline text text--sm text--bold-weight"
   >
     <svg
       aria-hidden="true"


### PR DESCRIPTION
### Summary:
Story: https://app.shortcut.com/czi-edu/story/191591/make-banner-and-tag-variant-names-consistent

The `Tag` component's variant names are out of sync with the other components so it's easier to use.

### Test Plan:
No changes in chromatic or storybook except for story name changes to match the new variants.