### PR TITLE
feat(banner): remove internal dismiss logic

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -41,6 +41,10 @@ const getDescription = (status?: Variant) => (
   </>
 );
 
+const dismissMethod = () => {
+  console.log('dismissing~');
+};
+
 export const Brand: StoryObj<Args> = {
   render: ({ variant, ...other }) => {
     return (
@@ -137,7 +141,7 @@ export const ErrorWithAction: StoryObj<Args> = {
 export const BrandDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -145,7 +149,7 @@ export const NeutralDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     variant: 'neutral',
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -153,7 +157,7 @@ export const SuccessDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     variant: 'success',
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -161,7 +165,7 @@ export const WarningDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     variant: 'warning',
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -169,7 +173,7 @@ export const ErrorDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     variant: 'error',
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -177,7 +181,7 @@ export const DismissableWithAction: StoryObj<Args> = {
   ...Brand,
   args: {
     action: getAction(),
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -185,7 +189,11 @@ export const DismissableBelowContent: StoryObj<Args> = {
   render: (args) => (
     <>
       <Heading size="h1">Page Title</Heading>
-      <Banner description={getDescription()} dismissable={true} {...args} />
+      <Banner
+        description={getDescription()}
+        onDismiss={dismissMethod}
+        {...args}
+      />
     </>
   ),
 };
@@ -201,7 +209,7 @@ export const VerticalDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     orientation: 'vertical',
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 
@@ -218,7 +226,7 @@ export const VerticalDismissableWithAction: StoryObj<Args> = {
   args: {
     orientation: 'vertical',
     action: getAction(),
-    dismissable: true,
+    onDismiss: dismissMethod,
   },
 };
 

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -1,9 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import React from 'react';
-import { Banner } from './Banner';
 import * as BannerStoryFile from './Banner.stories';
 import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
@@ -12,20 +10,6 @@ describe('<Banner />', () => {
 
   generateSnapshots(BannerStoryFile);
 
-  it('dismisses when dismissed if dismissable', () => {
-    render(
-      <Banner
-        data-testid="banner-test"
-        description="suuuuup"
-        dismissable={true}
-        title="Helloooooo"
-      />,
-    );
-
-    expect(screen.getByTestId('banner-test')).toBeInTheDocument();
-    userEvent.click(screen.getByRole('button'));
-    expect(screen.queryByTestId('banner-test')).not.toBeInTheDocument();
-  });
   it('should display warning message when attempting to use isFlat', () => {
     const { Flat } = composeStories(BannerStoryFile);
     render(<Flat />);

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode } from 'react';
 import styles from './Banner.module.css';
 import Button from '../Button';
 import Heading, { HeadingElement } from '../Heading';
@@ -26,11 +26,7 @@ export interface Props {
    */
   descriptionAs?: 'p' | 'span';
   /**
-   * Toggles the ability to dismiss the banner via an close button in the top right of the banner
-   */
-  dismissable?: boolean;
-  /**
-   * Optional callback to be triggered when the banner is dismissed
+   * Callback when banner is dismissed. When passed in, renders banner with a close icon in the top right.
    */
   onDismiss?: () => void;
   /**
@@ -109,9 +105,9 @@ const variantToIconAssetsMap: {
  * ```tsx
  * <Banner
  *   onDismiss={handleDismiss}
- *   title="Some title"
- *   description="Some description"
- *   action={<Button>Some action</Button>}
+ *   title="Some Title"
+ *   description={<>Some description, possibly with a <Link href="www.some-other-resource.com">link to some other resource</Link>.</>}
+ *   action={<Button onClick={handleAction}>Action</Button>}
  * />
  * ```
  */
@@ -120,7 +116,6 @@ export const Banner = ({
   className,
   description,
   descriptionAs = 'p',
-  dismissable,
   isFlat,
   onDismiss,
   orientation,
@@ -129,23 +124,11 @@ export const Banner = ({
   titleAs = 'h3',
   ...other
 }: Props) => {
-  const [dismissed, setDismissed] = useState(false);
-
   if (isFlat && process.env.NODE_ENV !== 'production') {
     console.warn(
       'The isFlat style is deprecated and will be removed in an upcoming release.\n',
       'Please remove this prop to use the default elevated style (with a border and drop shadow) instead.',
     );
-  }
-
-  function handleDismiss(e: any) {
-    e.preventDefault();
-    onDismiss && onDismiss();
-    setDismissed(true);
-  }
-
-  if (dismissed) {
-    return null;
   }
 
   const isHorizontal = !orientation;
@@ -162,16 +145,16 @@ export const Banner = ({
     variant === 'success' && styles['banner--success'],
     // Other options
     isHorizontal && styles['banner--horizontal'],
-    dismissable && styles['banner--dismissable'],
+    onDismiss && styles['banner--dismissable'],
     isFlat && styles['banner--flat'],
   );
 
   return (
     <article className={componentClassName} {...other}>
-      {dismissable && (
+      {onDismiss && (
         <Button
           className={styles['banner__close-btn']}
-          onClick={handleDismiss}
+          onClick={onDismiss}
           status={variant}
           variant="icon"
         >


### PR DESCRIPTION
### Summary:
There's one thing about our `Banner` in the `next` branch that's very different than the one on `main` and that's the dismiss logic/API.

In the `main` `Banner`, you pass in an `onDismiss` prop to give the `Banner` a close button in the top right. You handle the dismiss logic yourself.

In the `next` `Banner`, the component has some internal dismiss logic that it tracks with component state. To make the `Banner` dismissable, you pass in `dismissable={true}`. The `onDismiss` prop is only needed if there's some logic you need to run at the time that the `Banner` is dismissed.

Now that I'm updating the API in `traject`, I'm wondering if we want to keep that logic or not. 

### Test Plan:
