### PR TITLE
chore(toast): update toast to use incoming next api

### DIFF
--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -24,12 +24,14 @@
   border-radius: 0.25rem;
   border-color: var(--border-light-color); /* 4 */
   border-left-color: var(--border-dark-color); /* 4 */
-  box-shadow: 0 1px 2px 1px rgb(0 0 0 / 20%);
+
+  @apply shadow-1;
 }
 
 .toast--success {
   --border-light-color: var(--eds-color-success-200);
   --border-dark-color: var(--eds-color-success-500);
+  --icon-color: var(--eds-color-success-500);
 
   background: var(--eds-color-success-100);
   color: var(--eds-color-success-700);
@@ -38,6 +40,7 @@
 .toast--error {
   --border-light-color: var(--eds-color-alert-200);
   --border-dark-color: var(--eds-color-alert-500);
+  --icon-color: var(--eds-color-alert-500);
 
   background: var(--eds-color-alert-100);
   color: var(--eds-color-alert-700);

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -1,15 +1,69 @@
-.toastDialog {
-  @apply w-full max-w-100 pl-4 pr-2 grid gap-2 items-center;
-  @apply border border-l-4 rounded shadow-1;
+/* ------------------------------------*\
+    # TOAST
+\*------------------------------------ */
 
-  border-color: var(--border-light-color);
-  border-left-color: var(--border-dark-color);
+/**
+ * 1) Message of information, success, caution, or warning to the user
+ * 2) Container for the toast content, to provide background styling
+ * 3) The thick left border operates as a foreground band of color, 
+ *    so foreground rather than border is used
+ * 4) The border CSS variables are defined in the messaging mixins
+ */
+.toast {
+  width: 100%;
+  max-width: 25rem;
+  padding-left: 1rem;
+  padding-right: 0.5rem;
+  display: grid;
+  gap: 0.5rem;
   grid-template-columns: 1fr min-content;
-  --icon-size-default: 1.25rem;
+  align-items: center;
+  border-style: solid;
+  border-width: 1px;
+  border-left-width: 4px; /* 3 */
+  border-radius: 0.25rem;
+  border-color: var(--border-light-color); /* 4 */
+  border-left-color: var(--border-dark-color); /* 4 */
+  box-shadow: 0 0 0 1px var(--eds-color-neutral-200), 0 2px 3px rgb(0 0 0 / 2%), 0 4px 8px rgb(0 0 0 / 8%);
 }
 
-.content {
-  @apply py-4 grid gap-4 items-center;
+.toast--success {
+  --border-light-color: var(--eds-color-success-200);
+  --border-dark-color: var(--eds-color-success-500);
 
+  background: var(--eds-color-success-100);
+  color: var(--eds-color-success-700);
+}
+
+.toast--error {
+  --border-light-color: var(--eds-color-alert-200);
+  --border-dark-color: var(--eds-color-alert-500);
+
+  background: var(--eds-color-alert-100);
+  color: var(--eds-color-alert-700);
+}
+
+/**
+ * 1) The toast content, usually an icon and text message. Does not include the optional close button
+ * 2) Grid places the icon on the left and message on the right, with both vertically aligned to the center.
+ */
+.toast__content {
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  display: grid; /* 2 */
+  gap: 1rem;
   grid-template-columns: min-content 1fr;
+  align-items: center;
+}
+
+/**
+ * The text in the toast. Styled via mixins over using Text component.
+ */
+.toast__text {
+  margin: 0;
+  padding: 0;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.25rem;
+  color: inherit;
 }

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -24,7 +24,7 @@
   border-radius: 0.25rem;
   border-color: var(--border-light-color); /* 4 */
   border-left-color: var(--border-dark-color); /* 4 */
-  box-shadow: 0 0 0 1px var(--eds-color-neutral-200), 0 2px 3px rgb(0 0 0 / 2%), 0 4px 8px rgb(0 0 0 / 8%);
+  box-shadow: 0 1px 2px 1px rgb(0 0 0 / 20%);
 }
 
 .toast--success {

--- a/src/components/Toast/Toast.stories.tsx
+++ b/src/components/Toast/Toast.stories.tsx
@@ -15,19 +15,19 @@ type Args = React.ComponentProps<typeof Toast>;
 
 export const Success: StoryObj<Args> = {
   args: {
-    color: "success",
+    variant: "success",
   },
 };
 
-export const Alert: StoryObj<Args> = {
+export const Error: StoryObj<Args> = {
   args: {
-    color: "alert",
+    variant: "error",
   },
 };
 
 export const NotDismissable: StoryObj<Args> = {
   args: {
-    color: "success",
+    variant: "success",
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore onDismiss is not nullable, but this is needed to remove the arg from
     // storybook's actions addon

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -2,27 +2,24 @@ import clsx from "clsx";
 import React from "react";
 import Button from "../Button";
 import Icon from "../Icon";
-import Text from "../Text";
-import colorStyles from "../common/Notifications/Notification.module.css";
-import NotificationIcon from "../common/Notifications/NotificationIcon";
 import styles from "./Toast.module.css";
 
-export type Color = "success" | "alert";
+export type Variant = "success" | "error";
 
-type Props = {
+export type Props = {
   /**
-   * Additional class names passed in for styling.
+   * Additional class names that can be appended to the component, passed in for styling.
    */
   className?: string;
   /**
-   * The contents of the toast.
+   * The child node(s) contains the toast message. Note: the toast message is displayed inside a TextPassage, so children can contain raw HTML
    */
   children: React.ReactNode;
   /**
    * The color of the Toast, based on EDS defined colors. Also determines the icon used.
    * Note that the Icon mapping matches the style of Banners.
    */
-  color: Color;
+  variant: Variant;
   /**
    * Callback when Toast is dismissed.
    */
@@ -38,44 +35,43 @@ type Props = {
  * user action. Ex: The user updates their profile, and a toast pop-up informs them that the
  * data was successfully saved.
  */
-export default function Toast({
+export const Toast = ({
   children,
   className,
-  color,
+  variant,
   onDismiss,
   // Allow for additional attributes such as aria roles
-  ...rest
-}: Props) {
-  // While the v0 to v1 migration is happening, the Button and Toast will briefly
-  // be out of sync regarding the name of the red component style.
-  const buttonStatus = color === "alert" ? "error" : color;
-
+  ...other
+}: Props) => {
+  const componentClassName = clsx(
+    className,
+    styles["toast"],
+    variant === "success" && styles["toast--success"],
+    variant === "error" && styles["toast--error"],
+  );
   return (
-    <div
-      className={clsx(
-        className,
-        styles.toastDialog,
-        color === "success" && colorStyles.colorSuccess,
-        color === "alert" && colorStyles.colorAlert,
-      )}
-      {...rest}
-    >
-      <div className={styles.content}>
-        <NotificationIcon variant={color} />
-        <Text size="sm" variant="inherit">
-          {children}
-        </Text>
+    <div className={componentClassName} {...other}>
+      <div className={styles["toast__content"]}>
+        <Icon
+          name={variant === "success" ? "check-circle" : "warning"}
+          purpose="informative"
+          size="1.5rem"
+          title={variant}
+        />
+        <p className={styles["toast__text"]}>{children}</p>
       </div>
       {onDismiss && (
-        <Button onClick={onDismiss} status={buttonStatus} variant="icon">
+        <Button onClick={onDismiss} status={variant} variant="icon">
           <Icon
             name="close"
             purpose="informative"
-            size={"2rem"}
-            title={"dismiss message"}
+            size="2rem"
+            title="dismiss message"
           />
         </Button>
       )}
     </div>
   );
-}
+};
+
+export default Toast;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -53,9 +53,10 @@ export const Toast = ({
     <div className={componentClassName} {...other}>
       <div className={styles["toast__content"]}>
         <Icon
-          name={variant === "success" ? "check-circle" : "warning"}
+          color="var(--icon-color)"
+          name={variant === "success" ? "check-circle" : "cancel"}
           purpose="informative"
-          size="1.5rem"
+          size="1.25rem"
           title={variant}
         />
         <p className={styles["toast__text"]}>{children}</p>

--- a/src/components/Toast/__snapshots__/Toast.spec.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.spec.tsx.snap
@@ -9,11 +9,11 @@ exports[`<Toast /> Error story renders snapshot 1`] = `
   >
     <svg
       class="icon"
-      fill="currentColor"
-      height="1.5rem"
+      fill="var(--icon-color)"
+      height="1.25rem"
       role="img"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
@@ -22,7 +22,7 @@ exports[`<Toast /> Error story renders snapshot 1`] = `
         error
       </title>
       <use
-        xlink:href="test-file-stub#warning"
+        xlink:href="test-file-stub#cancel"
       />
     </svg>
     <p
@@ -43,11 +43,11 @@ exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
   >
     <svg
       class="icon"
-      fill="currentColor"
-      height="1.5rem"
+      fill="var(--icon-color)"
+      height="1.25rem"
       role="img"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title
@@ -77,11 +77,11 @@ exports[`<Toast /> Success story renders snapshot 1`] = `
   >
     <svg
       class="icon"
-      fill="currentColor"
-      height="1.5rem"
+      fill="var(--icon-color)"
+      height="1.25rem"
       role="img"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title

--- a/src/components/Toast/__snapshots__/Toast.spec.tsx.snap
+++ b/src/components/Toast/__snapshots__/Toast.spec.tsx.snap
@@ -1,33 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Toast /> Alert story renders snapshot 1`] = `
+exports[`<Toast /> Error story renders snapshot 1`] = `
 <div
-  class="toastDialog colorAlert"
+  class="toast toast--error"
 >
   <div
-    class="content"
+    class="toast__content"
   >
-    <div
-      class="iconContainer iconAlert"
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="icon"
-        fill="currentColor"
-        role="img"
-        xmlns="http://www.w3.org/2000/svg"
+      <title
+        id="2"
       >
-        <title
-          id="2"
-        >
-          alert
-        </title>
-        <use
-          xlink:href="test-file-stub#dangerous"
-        />
-      </svg>
-    </div>
+        error
+      </title>
+      <use
+        xlink:href="test-file-stub#warning"
+      />
+    </svg>
     <p
-      class="text text--sm text--inherit"
+      class="toast__text"
     >
       You've got toast!
     </p>
@@ -37,32 +36,31 @@ exports[`<Toast /> Alert story renders snapshot 1`] = `
 
 exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
 <div
-  class="toastDialog colorSuccess"
+  class="toast toast--success"
 >
   <div
-    class="content"
+    class="toast__content"
   >
-    <div
-      class="iconContainer iconSuccess"
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="icon"
-        fill="currentColor"
-        role="img"
-        xmlns="http://www.w3.org/2000/svg"
+      <title
+        id="3"
       >
-        <title
-          id="3"
-        >
-          success
-        </title>
-        <use
-          xlink:href="test-file-stub#check-circle"
-        />
-      </svg>
-    </div>
+        success
+      </title>
+      <use
+        xlink:href="test-file-stub#check-circle"
+      />
+    </svg>
     <p
-      class="text text--sm text--inherit"
+      class="toast__text"
     >
       You've got toast!
     </p>
@@ -72,32 +70,31 @@ exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
 
 exports[`<Toast /> Success story renders snapshot 1`] = `
 <div
-  class="toastDialog colorSuccess"
+  class="toast toast--success"
 >
   <div
-    class="content"
+    class="toast__content"
   >
-    <div
-      class="iconContainer iconSuccess"
+    <svg
+      class="icon"
+      fill="currentColor"
+      height="1.5rem"
+      role="img"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <svg
-        class="icon"
-        fill="currentColor"
-        role="img"
-        xmlns="http://www.w3.org/2000/svg"
+      <title
+        id="1"
       >
-        <title
-          id="1"
-        >
-          success
-        </title>
-        <use
-          xlink:href="test-file-stub#check-circle"
-        />
-      </svg>
-    </div>
+        success
+      </title>
+      <use
+        xlink:href="test-file-stub#check-circle"
+      />
+    </svg>
     <p
-      class="text text--sm text--inherit"
+      class="toast__text"
     >
       You've got toast!
     </p>

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Toast";
+export { Toast as default } from "./Toast";


### PR DESCRIPTION
### Summary:
[sc-193788]
- updates toast to match incoming `next` api
  - `color` prop renamed to `variant`
  - `alert` color/variant renamed to `error`
- Icon may be slightly different due to spritemap icon architecture
  - pending #1012 
### Test Plan:
- chromatic: little visual differences
  - icon changes
  - story naming change (error/alert)
