### PR TITLE
feat(dropdown-button): rename children prop to text

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -390,9 +390,8 @@ const DropdownTrigger = function (
       ) : (
         <DropdownButton
           className={clsx(className, compact && styles.compactDropdownButton)}
-        >
-          {children}
-        </DropdownButton>
+          text={children}
+        />
       )}
     </Listbox.Button>
   );

--- a/src/components/DropdownButton/DropdownButton.stories.tsx
+++ b/src/components/DropdownButton/DropdownButton.stories.tsx
@@ -11,6 +11,6 @@ type Args = React.ComponentProps<typeof DropdownButton>;
 
 export const Default: StoryObj<Args> = {
   args: {
-    children: "Dropdown button",
+    text: "Dropdown button",
   },
 };

--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -5,7 +5,7 @@ import styles from "./DropdownButton.module.css";
 
 type Props = {
   className?: string;
-  children?: ReactNode;
+  text?: ReactNode;
 };
 
 /**
@@ -16,16 +16,16 @@ type Props = {
  * A styled button with an expand icon to be used in triggering Popovers, Dropdowns, etc.
  */
 const DropdownButton = forwardRef<HTMLButtonElement, Props>(
-  ({ children, className, ...rest }, ref) => {
+  ({ text, className, ...rest }, ref) => {
     return (
       <button
         className={clsx(styles.dropdownButton, className)}
         ref={ref}
         {...rest}
       >
-        {/* Wrapping span ensures that `children` and icon will be correctly pushed to
-            either side of the button even if `children` contains more than one element. */}
-        <span>{children}</span>
+        {/* Wrapping span ensures that `text` and icon will be correctly pushed to
+            either side of the button even if `text` contains more than one element. */}
+        <span>{text}</span>
         <Icon name="expand-more" purpose="decorative" size="1.25rem" />
       </button>
     );


### PR DESCRIPTION
### Summary:
#### High level summary
NOTE: We're planning to merge these API update PRs in a sequence. The sequence will go:
- for each PR, merge in the EDS API update PR
- publish a new package version
- update the package in traject in a PR that has already been reviewed and is waiting to update the component API based on the EDS PR and merge that in
- move on to the next component

To prepare for migrating the `main` branch to use the v1 component versions on `next`, I'm updating the `DropdownButton` component to match the one on `next`. To keep things simple, I only updated the API as necessary and left the internal logic as much as possible. The rest of the component will be updated later.

After landing this, I'll publish a new npm package version, update the EDS package in `traject` and update the component usage to match these changes. That way when we merge the full `next` branch in and deploy, we won't have to update the tags in `traject` and all the other components at the same time. (This component may be published with one or more other components since it's not used as much).

#### API changes for this component:
- `children` => `text`

NOTE: I did not make any changes to the `Dropdown` API itself because the `Dropdown.Button` can actually take a function instead of text. I'm also wondering if we want this API change at all since `Button` uses `children`. It feels a little out-of-sync 🤔 

For an example of a `Dropdown` using a function for children of the `Dropdown.Button`, take a look at the `InteractiveExampleUsingFunctionChildren` story: https://github.com/chanzuckerberg/edu-design-system/blob/d8e6f690611a8b8bdccdaa5b8fe7bcbc7cee4ed6/src/components/Dropdown/Dropdown.stories.tsx#L109

### Test Plan:
- no type errors
- no chromatic changes
- `Dropdown` component stories work as expected