### PR TITLE
chore(text): reintroduce spacing variant in Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.12.1-alpha.0](https://github.com/chanzuckerberg/edu-design-system/compare/v0.12.0...v0.12.1-alpha.0) (2022-04-27)
+
+* chore(text): reintroduce spacing variant for text
+
 ## [0.12.0](https://github.com/chanzuckerberg/edu-design-system/compare/v0.10.0...v0.12.0) (2022-04-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-## [0.12.1-alpha.0](https://github.com/chanzuckerberg/edu-design-system/compare/v0.12.0...v0.12.1-alpha.0) (2022-04-27)
-
-* chore(text): reintroduce spacing variant for text
 
 ## [0.12.0](https://github.com/chanzuckerberg/edu-design-system/compare/v0.10.0...v0.12.0) (2022-04-27)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "0.12.1-alpha.0",
+  "version": "0.12.0",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "0.12.0",
+  "version": "0.12.1-alpha.0",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -6,7 +6,7 @@
  * 1) Needs `:where` pseudoclass to reduce specificity so Tailwind and other class overrides 
  *    for margin can happen where used.
  */
-:where(.text) { /* 1 */
+.text { /* 1 */
   @apply mb-0;
 }
 
@@ -83,4 +83,19 @@
 
 .text--bold-weight {
   @apply font-bold;
+}
+
+/**
+ * Spacing
+ */
+.text--half-spacing {
+  @apply mb-1;
+}
+
+.text--1x-spacing {
+  @apply mb-2;
+}
+
+.text--2x-spacing {
+  @apply mb-4;
 }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -3,8 +3,7 @@
 \*------------------------------------ */
 
 /**
- * 1) Needs `:where` pseudoclass to reduce specificity so Tailwind and other class overrides 
- *    for margin can happen where used.
+ * 1) Removes default browser spacing.
  */
 .text { /* 1 */
   @apply mb-0;

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -81,7 +81,7 @@ export const Overline: StoryObj<Args> = {
 
 export const Spacing: StoryObj<Args> = {
   render: () => (
-    <>
+    <div>
       <Text className="border" spacing="half">
         Spacing Half
       </Text>
@@ -92,7 +92,7 @@ export const Spacing: StoryObj<Args> = {
         Spacing 2x
       </Text>
       <Text className="border">Bottom text to show spacing for spacing 2x</Text>
-    </>
+    </div>
   ),
 };
 

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -79,6 +79,23 @@ export const Overline: StoryObj<Args> = {
   },
 };
 
+export const Spacing: StoryObj<Args> = {
+  render: () => (
+    <>
+      <Text className="border" spacing="half">
+        Spacing Half
+      </Text>
+      <Text className="border" spacing="1x">
+        Spacing 1x
+      </Text>
+      <Text className="border" spacing="2x">
+        Spacing 2x
+      </Text>
+      <Text className="border">Bottom text to show spacing for spacing 2x</Text>
+    </>
+  ),
+};
+
 /**
  * 1) Used mainly for visual regression testing and to show the different color options available.
  * 2) Has problems with snapshots since it has too many components and other stories generate enough confidence for our needs.

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -27,6 +27,7 @@ export type Props = {
   className?: string;
   variant?: Variant;
   size?: Size;
+  spacing?: "half" | "1x" | "2x";
   tabIndex?: number;
   weight?: "bold" | "normal" | null;
 } & React.HTMLAttributes<HTMLElement>;
@@ -44,6 +45,7 @@ export const Text = forwardRef(
       className,
       variant,
       size = "body",
+      spacing,
       weight,
       /**
        * Components that wrap typography sometimes requires props such as event handlers
@@ -66,6 +68,7 @@ export const Text = forwardRef(
       styles[`text--${size}`],
       variant && styles[`text--${variant}`],
       weight && styles[`text--${weight}-weight`],
+      spacing && styles[`text--${spacing}-spacing`],
     );
     return (
       <TagName className={componentClassName} ref={ref} {...other}>

--- a/src/components/Text/__snapshots__/Text.spec.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.spec.tsx.snap
@@ -64,6 +64,14 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
 </p>
 `;
 
+exports[`<Text /> Spacing story renders snapshot 1`] = `
+<p
+  class="border text text--body text--half-spacing"
+>
+  Spacing Half
+</p>
+`;
+
 exports[`<Text /> TextVariantInherit story renders snapshot 1`] = `
 <p
   class="text text--body text--error"

--- a/src/components/Text/__snapshots__/Text.spec.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.spec.tsx.snap
@@ -65,11 +65,28 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
 `;
 
 exports[`<Text /> Spacing story renders snapshot 1`] = `
-<p
-  class="border text text--body text--half-spacing"
->
-  Spacing Half
-</p>
+<div>
+  <p
+    class="border text text--body text--half-spacing"
+  >
+    Spacing Half
+  </p>
+  <p
+    class="border text text--body text--1x-spacing"
+  >
+    Spacing 1x
+  </p>
+  <p
+    class="border text text--body text--2x-spacing"
+  >
+    Spacing 2x
+  </p>
+  <p
+    class="border text text--body"
+  >
+    Bottom text to show spacing for spacing 2x
+  </p>
+</div>
 `;
 
 exports[`<Text /> TextVariantInherit story renders snapshot 1`] = `


### PR DESCRIPTION
### Summary:
- global styles in LP set margin bottom for `p` overriding the `:where(.text)` margin reset
- published alpha, tests passing in text/heading use with alpha in https://github.com/FB-PLP/traject/pull/10779
- once merged, will be publishing patch build `0.12.1` off `jlee/v0.12.1` and updating aforementioned pr to it 

### Test Plan:
- ci tests pass

### Next steps:
- merge v0.12.1 into v0.13.0 and release v0.13.1