### PR TITLE
docs(banner): update component comment to use updated API

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -109,12 +109,9 @@ const variantToIconAssetsMap: {
  * ```tsx
  * <Banner
  *   onDismiss={handleDismiss}
- *   text={
- *     <>
- *       <BannerTitle>Some title</Banner.Title>
- *       <BannerDescription>Some description</Banner.Description>
- *     </>
- *   }
+ *   title="Some title"
+ *   description="Some description"
+ *   action={<Button>Some action</Button>}
  * />
  * ```
  */


### PR DESCRIPTION
### Summary:
The `Banner` component comment has an API example that's stale. The example is representative of the first version of the API I used on `next`. The API was changed during the PR process, but I forgot to update the example.

### Test Plan:
Verify the updated example appears in storybook.