### PR TITLE
Text size "lg" updates

### DIFF
--- a/docs/typography.stories.mdx
+++ b/docs/typography.stories.mdx
@@ -48,6 +48,12 @@ import styles from "./typography.module.css";
     </tr>
     <tr>
       <td>
+        <Text size="lg">Large text</Text>
+      </td>
+      <td>18 / 24</td>
+    </tr>
+    <tr>
+      <td>
         <Text size="body">Body text</Text>
       </td>
       <td>16 / 24</td>

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -16,7 +16,7 @@
 }
 
 .text--lg {
-  @apply text-h2 font-bold;
+  @apply text-h2 font-normal;
 }
 
 .text--sm {


### PR DESCRIPTION
### Summary:
2 small cleanups:
- Makes "lg" size font-normal for consistency with other sizes (consumers can still pass `weight="bold"` if needed)
- Adds "lg" size to type ramp

### Test Plan:
<img width="500" alt="Screen Shot 2022-05-02 at 1 24 25 PM" src="https://user-images.githubusercontent.com/15840841/166294841-02ff9d24-7217-4e4b-863d-7e69dfc22e44.png">

