### PR TITLE
build: re-enable axe-storybook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,9 +65,8 @@ jobs:
             --exit-zero-on-changes \
             --exit-once-uploaded \
             --skip 'dependabot/**'
-      # TODO: re-enable once components are more ready
-      # - name: Run Accessibility Tests 💛
-      #   run: yarn run storybook:axeOnly
+      - name: Run Accessibility Tests 💛
+        run: yarn run storybook:axeOnly
 
   lint:
     runs-on: ubuntu-latest

--- a/.storybook/components/DesignTokens/Tier1/Tier1Tokens.stories.js
+++ b/.storybook/components/DesignTokens/Tier1/Tier1Tokens.stories.js
@@ -17,6 +17,10 @@ export default {
         story: 'Individual story description, may contain `markdown` markup',
       },
     },
+    axe: {
+      // For documentation purposes only
+      skip: true,
+    },
   },
 };
 

--- a/.storybook/components/DesignTokens/Tier2/Tier2Tokens.stories.js
+++ b/.storybook/components/DesignTokens/Tier2/Tier2Tokens.stories.js
@@ -8,6 +8,12 @@ import { Tier2TypographyUsage } from './TypographyUsage';
 export default {
   title: 'Design Tokens/Tier 2: Usage',
   component: Tier2Colors,
+  parameters: {
+    axe: {
+      // For documentation purposes only
+      skip: true,
+    },
+  },
 };
 
 export const Borders = () => <Tier2Borders />;

--- a/.storybook/components/Docs/Documents.stories.tsx
+++ b/.storybook/components/Docs/Documents.stories.tsx
@@ -12,6 +12,9 @@ export default {
   component: Documentation,
   parameters: {
     chromatic: { disableSnapshot: true },
+    axe: {
+      skip: true,
+    },
   },
 };
 

--- a/.storybook/components/IconGrid/IconGrid.stories.js
+++ b/.storybook/components/IconGrid/IconGrid.stories.js
@@ -4,6 +4,12 @@ import IconGrid from './IconGrid';
 export default {
   title: 'Atoms/Icons/IconGrid',
   component: IconGrid,
+  parameters: {
+    axe: {
+      // for documentation purposes only
+      skip: true,
+    },
+  },
 };
 
 export const Default = () => <IconGrid />;

--- a/.storybook/components/Utilities/Utilities.stories.js
+++ b/.storybook/components/Utilities/Utilities.stories.js
@@ -9,6 +9,12 @@ import { WidthUtilities } from './WidthUtilities';
 export default {
   component: ColorUtilities,
   title: 'Atoms/Utilities',
+  parameters: {
+    axe: {
+      // For documentation purposes only
+      skip: true,
+    },
+  },
 };
 
 export const Color = () => <ColorUtilities />;

--- a/.storybook/pages/Announcements/Announcements.stories.tsx
+++ b/.storybook/pages/Announcements/Announcements.stories.tsx
@@ -6,6 +6,12 @@ import { Announcements } from './Announcements';
 export default {
   title: 'Pages/Announcements',
   component: Announcements,
+  parameters: {
+    axe: {
+      // TODO: remove when "fpo" content is fully stubbed out
+      disabledRules: ['color-contrast'],
+    },
+  },
 } as Meta;
 
 const Template = (args) => <Announcements {...args} />;

--- a/.storybook/pages/CoursesYear/CoursesYear.stories.tsx
+++ b/.storybook/pages/CoursesYear/CoursesYear.stories.tsx
@@ -6,6 +6,12 @@ import { CoursesYear } from './CoursesYear';
 export default {
   title: 'Pages/Courses/Year',
   component: CoursesYear,
+  parameters: {
+    axe: {
+      // TODO: remove when "fpo" content is fully stubbed out
+      disabledRules: ['color-contrast'],
+    },
+  },
 } as Meta;
 
 const Template: Story = (args) => <CoursesYear {...args} />;

--- a/.storybook/pages/CurriculumCourses/CurriculumCourses.stories.tsx
+++ b/.storybook/pages/CurriculumCourses/CurriculumCourses.stories.tsx
@@ -6,6 +6,12 @@ import { CurriculumCourses } from './CurriculumCourses';
 export default {
   title: 'Pages/Curriculum/Courses/Overview',
   component: CurriculumCourses,
+  parameters: {
+    axe: {
+      // TODO: remove when "fpo" content is fully stubbed out
+      disabledRules: ['color-contrast'],
+    },
+  },
 } as Meta;
 
 const Template: Story = (args) => <CurriculumCourses {...args} />;

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.stories.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.stories.tsx
@@ -6,6 +6,12 @@ import { FeedbackOverview } from './FeedbackOverview';
 export default {
   title: 'Pages/Feedback/Overview',
   component: FeedbackOverview,
+  parameters: {
+    axe: {
+      // TODO: remove when "fpo" content is fully stubbed out
+      disabledRules: ['color-contrast'],
+    },
+  },
 } as Meta;
 
 const Template: Story = (args) => <FeedbackOverview {...args} />;

--- a/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.stories.tsx
@@ -6,6 +6,12 @@ import { ProjectOverview } from './ProjectOverview';
 export default {
   title: 'Pages/Projects/Overview',
   component: ProjectOverview,
+  parameters: {
+    axe: {
+      // TODO: ListDetail default text is too light
+      disabledRules: ['color-contrast'],
+    },
+  },
 } as Meta;
 
 const Template: Story = (args) => <ProjectOverview {...args} />;

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -192,6 +192,7 @@ export const DismissableBelowContent: StoryObj<Args> = {
       <Banner
         description={getDescription()}
         onDismiss={dismissMethod}
+        titleAs="h2"
         {...args}
       />
     </>

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -9,6 +9,12 @@ export default {
   title: 'Molecules/Blocks/Card',
   component: Card,
   subcomponents: { CardHeader, CardBody, CardFooter },
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 export const Default = () => (

--- a/src/components/CheckboxField/CheckboxField.stories.tsx
+++ b/src/components/CheckboxField/CheckboxField.stories.tsx
@@ -109,9 +109,16 @@ Error.args = {
   isError: true,
   fieldNote: 'This is a field with an error',
 };
+
 export const Inverted = InvertedTemplate.bind({});
 Inverted.args = {
   label: 'Checkbox field',
   inverted: true,
   fieldNote: 'This is an inverted field',
+};
+Inverted.parameters = {
+  axe: {
+    // TODO: re-enable when component is worked on
+    disabledRules: ['color-contrast'],
+  },
 };

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -8,6 +8,12 @@ export default {
   title: 'Molecules/Layout and Containers/Grid',
   component: Grid,
   subcomponents: { GridItem },
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -7,6 +7,12 @@ import LayoutSection from '../LayoutSection';
 export default {
   title: 'Molecules/Layout and Containers/Layout',
   component: Layout,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.stories.tsx
@@ -6,6 +6,12 @@ import { LayoutContainer, Props } from './LayoutContainer';
 export default {
   title: 'Molecules/Layout and Containers/Layout Container',
   component: LayoutContainer,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -112,3 +112,9 @@ const Template: Story<Props> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {};
+Default.parameters = {
+  axe: {
+    // TODO: default text is too light
+    disabledRules: ['color-contrast'],
+  },
+};

--- a/src/components/ListDetailPanel/ListDetailPanel.tsx
+++ b/src/components/ListDetailPanel/ListDetailPanel.tsx
@@ -55,7 +55,7 @@ export const ListDetailPanel = ({
 }: Props) => {
   const componentClassName = clsx(styles['list-detail__panel'], className, {});
   return (
-    <nav
+    <div
       aria-hidden={false}
       aria-labelledby={ariaLabelledBy}
       className={componentClassName}
@@ -64,6 +64,6 @@ export const ListDetailPanel = ({
       {...other}
     >
       {children}
-    </nav>
+    </div>
   );
 };

--- a/src/components/Main/Main.stories.tsx
+++ b/src/components/Main/Main.stories.tsx
@@ -6,6 +6,12 @@ import { Main, Props } from './Main';
 export default {
   title: 'Molecules/Layout and Containers/Main',
   component: Main,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -6,6 +6,12 @@ import { Radio, Props } from './Radio';
 export default {
   title: 'Atoms/Forms/Radio',
   component: Radio,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Radio {...args} />;

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -8,6 +8,12 @@ import Icon from '../Icon';
 export default {
   title: 'Molecules/Interactive/ShowHide',
   component: ShowHide,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/TableObject/TableObject.stories.tsx
+++ b/src/components/TableObject/TableObject.stories.tsx
@@ -16,6 +16,12 @@ export default {
   title: 'Organisms/Tables/Table Object',
   component: TableObject,
   subcomponents: { TableObjectBody, TableObjectHeader },
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -6,6 +6,12 @@ import { TextInput, Props } from './TextInput';
 export default {
   title: 'Atoms/Forms/TextInput',
   component: TextInput,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <TextInput {...args} />;

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -6,6 +6,12 @@ import { Textarea, Props } from './Textarea';
 export default {
   title: 'Atoms/Forms/Textarea',
   component: Textarea,
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Textarea {...args} />;

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -8,6 +8,12 @@ export default {
   title: 'Organisms/Toolbars/Toolbar',
   component: Toolbar,
   subcomponents: { ToolbarItem },
+  parameters: {
+    axe: {
+      // TODO: re-enable when component is worked on
+      skip: true,
+    },
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (


### PR DESCRIPTION
### Summary:
[ch187481]

Turn axe-storybook back on! most existing errors are from "fpo" blocks, the one exception is `ListDetail` text color 😬  which we've already flagged to design

### Test Plan:
build passes