### PR TITLE
chore(banner): stop passing down extra props to underlying element

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -123,7 +123,6 @@ export const Banner = ({
   variant = "brand",
   title,
   titleAs = "h3",
-  ...other
 }: BannerProps) => {
   if (isFlat && process.env.NODE_ENV !== "production") {
     console.warn(
@@ -151,7 +150,7 @@ export const Banner = ({
   );
 
   return (
-    <article className={componentClassName} {...other}>
+    <article className={componentClassName}>
       {onDismiss && (
         <Button
           className={styles["banner__close-btn"]}


### PR DESCRIPTION
### Summary:
In updating the `Banner` usage in `traject`, I ran into an annoying issue with the `NuxMegaphone`, which is wrapping the `Banner`. It uses a nux data store, which injects some props into the component behind our backs. When we updated the `Banner` API recently, we started passing any additional props that were passed in down to the underlying `article` element. One of the props being injected, `reloadRoute`, is not a valid HTML attribute, so the tests are throwing an error. I was able to update get the tests to run in order to update the snapshots by making this change directly in the node module locally, but those test will presumably fail for the next dev trying to update those snapshots.

tl;dr I'm removing the `other` props being passed down to the `article` because the `NuxMegaphone` is weird

You can see the test failures here: https://app.circleci.com/pipelines/github/FB-PLP/traject/69835/workflows/3cdbb626-32d7-47bd-be66-0ffbfcbe423d/jobs/1175423

### Test Plan:
I made the change in the node modules locally in `traject` and verified the tests ran normally.