### PR TITLE
feat(tag): rename yellow variant to yield

### DIFF
--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -8,7 +8,7 @@ export type Color =
   | "error"
   | "success"
   | "warning"
-  | "yellow"
+  | "yield"
   | "brand";
 
 export const stylesByColor = {
@@ -16,7 +16,7 @@ export const stylesByColor = {
   warning: styles.colorWarning,
   brand: styles.colorBrand,
   error: styles.colorError,
-  yellow: styles.colorYellow,
+  yield: styles.colorYellow,
   success: styles.colorSuccess,
 };
 


### PR DESCRIPTION
### Summary:
I missed this change when updating `Tag`: the "yellow" `variant` is now called "yield". (This variant isn't used in `traject` yet.)

### Test Plan:
Verify the variants in storybook now list "yield" as an option instead of "yellow".