### PR TITLE
chore(text): re-add spacing prop

### DIFF
--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -77,3 +77,18 @@
   /* TODO: replace with tier 2 token */
   font-weight: var(--eds-font-weight-bold);
 }
+
+/**
+ * Spacing
+ */
+.text--half-spacing {
+  margin-bottom: var(--eds-size-half);
+}
+
+.text--1x-spacing {
+  margin-bottom: var(--eds-size-1);
+}
+
+.text--2x-spacing {
+  margin-bottom: var(--eds-size-2);
+}

--- a/src/components/Text/Text.stories.module.css
+++ b/src/components/Text/Text.stories.module.css
@@ -21,6 +21,11 @@
   align-items: center;
 }
 
+.spacing {
+  border: var(--eds-theme-border-width) solid
+    var(--eds-theme-color-border-neutral-default);
+}
+
 /**
  * 1) Variants are segmented into left, middle, and right columns.
  * 2) Background variants were chosen to represent typical body backgrounds.

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -78,6 +78,25 @@ export const Overline: StoryObj<Args> = {
   },
 };
 
+export const Spacing: StoryObj<Args> = {
+  render: () => (
+    <div>
+      <Text className={styles['spacing']} spacing="half">
+        Spacing Half
+      </Text>
+      <Text className={styles['spacing']} spacing="1x">
+        Spacing 1x
+      </Text>
+      <Text className={styles['spacing']} spacing="2x">
+        Spacing 2x
+      </Text>
+      <Text className={styles['spacing']}>
+        Bottom text to show spacing for spacing 2x
+      </Text>
+    </div>
+  ),
+};
+
 /**
  * 1) Used mainly for visual regression testing and to show the different color options available.
  * 2) Has problems with snapshots since it has too many components and other stories generate enough confidence for our needs.

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -27,6 +27,7 @@ export type Props = {
   className?: string;
   variant?: Variant;
   size?: Size;
+  spacing?: 'half' | '1x' | '2x';
   tabIndex?: number;
   weight?: 'bold' | 'normal' | null;
 } & React.HTMLAttributes<HTMLElement>;
@@ -44,6 +45,7 @@ export const Text = forwardRef(
       className,
       variant,
       size = 'body',
+      spacing,
       weight,
       /**
        * Components that wrap typography sometimes requires props such as event handlers
@@ -66,6 +68,7 @@ export const Text = forwardRef(
       styles[`text--${size}`],
       variant && styles[`text--${variant}`],
       weight && styles[`text--${weight}-weight`],
+      spacing && styles[`text--${spacing}-spacing`],
     );
     return (
       <TagName className={componentClassName} ref={ref} {...other}>

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -64,6 +64,31 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
 </p>
 `;
 
+exports[`<Text /> Spacing story renders snapshot 1`] = `
+<div>
+  <p
+    class="spacing text text--body text--half-spacing"
+  >
+    Spacing Half
+  </p>
+  <p
+    class="spacing text text--body text--1x-spacing"
+  >
+    Spacing 1x
+  </p>
+  <p
+    class="spacing text text--body text--2x-spacing"
+  >
+    Spacing 2x
+  </p>
+  <p
+    class="spacing text text--body"
+  >
+    Bottom text to show spacing for spacing 2x
+  </p>
+</div>
+`;
+
 exports[`<Text /> TextVariantInherit story renders snapshot 1`] = `
 <p
   class="text text--body text--error"


### PR DESCRIPTION
### Summary:
When migrating the `Text` component in `traject`, it became obvious that removing the `spacing` prop was going to be too much of a hassle. As such, it was re-added on `main`. This PR makes the same change on `next` to keep them in sync.

### Screenshots
#### Text storybook on main
<img width="997" alt="text spacing story on main branch" src="https://user-images.githubusercontent.com/7761701/166846098-c8a6066c-0611-4bf9-b0de-e0e58408fd74.png">

#### Text storybook on next
<img width="997" alt="text spacing story on next branch" src="https://user-images.githubusercontent.com/7761701/166846110-30eba246-df48-4e66-aab5-bdc7d189fb64.png">

### Test Plan:
Verify there is now a `Spacing` story and the levels look the same as the one on `main`.