### PR TITLE
build: remove descending-specificty rule and allow nesting depth of 2

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,19 +1,15 @@
 {
-  "extends": [
-    "stylelint-config-recommended"
-  ],
+  "extends": ["stylelint-config-recommended"],
   "rules": {
     "at-rule-no-unknown": [
       true,
       {
-        "ignoreAtRules": [
-          "define-mixin",
-          "mixin"
-        ]
+        "ignoreAtRules": ["define-mixin", "mixin"]
       }
     ],
     "custom-property-empty-line-before": "never",
-    "max-nesting-depth": 1,
+    "max-nesting-depth": 2,
+    "no-descending-specificity": null,
     "selector-class-pattern": null,
     "selector-pseudo-class-no-unknown": [
       true,

--- a/src/components/FileUploadField/FileUploadField.module.css
+++ b/src/components/FileUploadField/FileUploadField.module.css
@@ -62,7 +62,6 @@
     color: var(--eds-theme-color-text-disabled);
     cursor: not-allowed;
 
-    /* stylelint-disable-next-line max-nesting-depth */
     &.file-upload-field__hit-area--drag-over {
       border-color: var(--eds-theme-color-disabled-border);
     }

--- a/src/components/Grid/Grid.module.css
+++ b/src/components/Grid/Grid.module.css
@@ -1,5 +1,3 @@
-/* stylelint-disable max-nesting-depth */
-
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\

--- a/src/components/GridItem/GridItem.module.css
+++ b/src/components/GridItem/GridItem.module.css
@@ -1,5 +1,3 @@
-/* stylelint-disable max-nesting-depth */
-
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\

--- a/src/components/LinkList/LinkList.module.css
+++ b/src/components/LinkList/LinkList.module.css
@@ -71,7 +71,6 @@
     color: var(--eds-theme-color-text-neutral-default-inverse);
     text-decoration: none;
 
-    /* stylelint-disable-next-line max-nesting-depth */
     &:focus-visible {
       @mixin focusInverted;
     }

--- a/src/components/ListDetail/ListDetail.module.css
+++ b/src/components/ListDetail/ListDetail.module.css
@@ -105,7 +105,6 @@
       * List list detail item after
       * 1) Don't add a line after the last list item
       */
-    /* stylelint-disable-next-line max-nesting-depth */
     &:after {
       content: none;
     }
@@ -160,7 +159,6 @@
     background: var(--eds-theme-color-border-neutral-subtle); /* 2 */
     border-radius: 50%; /* 3 */
 
-    /* stylelint-disable-next-line max-nesting-depth */
     .list-detail__item.eds-is-active & {
       background: var(--eds-theme-color-text-neutral-default); /* 4 */
     }

--- a/src/components/Radio/Radio.module.css
+++ b/src/components/Radio/Radio.module.css
@@ -74,7 +74,6 @@
     border-radius: 50%;
     background: transparent;
 
-    /* stylelint-disable-next-line max-nesting-depth */
     &:hover {
       border-color: var(--eds-theme-color-form-input-border-hover);
     }
@@ -82,7 +81,6 @@
     /**
      *  Custom radio background inside of focused control 
      */
-    /* stylelint-disable-next-line max-nesting-depth */
     .radio__input:focus-visible + & {
       @mixin focus;
     }
@@ -90,7 +88,6 @@
     /**
      *  Custom radio background inside of disabled control 
      */
-    /* stylelint-disable-next-line max-nesting-depth */
     .radio__input:disabled + & {
       border-color: var(--eds-theme-color-disabled-border);
       background-color: var(--eds-theme-color-background-disabled);
@@ -117,12 +114,10 @@
     background: var(--eds-theme-color-background-brand-primary-strong);
     opacity: 0; /* 2 */
 
-    /* stylelint-disable-next-line max-nesting-depth */
     .radio--inverted & {
       border-color: var(--eds-theme-color-border-brand-primary-subtle);
     }
 
-    /* stylelint-disable-next-line max-nesting-depth */
     .radio__input:checked + & {
       opacity: 1; /* 2 */
     }

--- a/src/components/RadioField/RadioField.module.css
+++ b/src/components/RadioField/RadioField.module.css
@@ -74,7 +74,6 @@
     margin-bottom: 0;
     margin-right: var(--eds-size-2); /* 2 */
 
-    /* stylelint-disable-next-line max-nesting-depth */
     &:last-of-type {
       margin-right: 0;
     }

--- a/src/components/StackedBlock/StackedBlock.module.css
+++ b/src/components/StackedBlock/StackedBlock.module.css
@@ -25,7 +25,6 @@
   margin-bottom: 0;
 
   .stacked-block--break & {
-    /* stylelint-disable-next-line max-nesting-depth */
     @media all and (min-width: $eds-bp-md) {
       margin-right: var(--eds-size-4);
     }

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -1,6 +1,3 @@
-/* stylelint-disable no-descending-specificity */
-/* stylelint-disable max-nesting-depth */
-
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\
@@ -172,6 +169,7 @@
      */
   .table--stacked .table__header & {
     @media all and (max-width: $eds-bp-md) {
+      /* stylelint-disable-next-line max-nesting-depth */
       &:after {
         content: none;
       }
@@ -196,6 +194,7 @@
       display: block;
       @mixin eds-theme-typography-body-text-md;
 
+      /* stylelint-disable-next-line max-nesting-depth */
       @media all and (min-width: $eds-bp-md) {
         content: none; /* 2 */
       }
@@ -261,6 +260,7 @@
     > .table__row
     > & {
     &:first-child {
+      /* stylelint-disable-next-line max-nesting-depth */
       @media all and (max-width: $eds-bp-md) {
         @mixin eds-theme-typography-heading-3;
       }

--- a/src/components/TableObject/TableObject.module.css
+++ b/src/components/TableObject/TableObject.module.css
@@ -28,7 +28,6 @@
     /**
      * Right overflow gradient for the overflow list
      */
-    /* stylelint-disable-next-line max-nesting-depth */
     &:before {
       content: '';
       display: block;
@@ -53,7 +52,6 @@
     /**
      * Right overflow gradient for the overflow list
      */
-    /* stylelint-disable-next-line max-nesting-depth */
     &:after {
       content: '';
       display: block;

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -79,7 +79,6 @@
     box-shadow: inset 0 calc(var(--eds-border-width-lg) * -1) 0 0
       var(--eds-theme-color-border-brand-primary-strong);
 
-    /* stylelint-disable-next-line max-nesting-depth */
     .tabs--inverted & {
       color: var(--eds-theme-color-text-neutral-default-inverse);
       box-shadow: inset 0 calc(var(--eds-border-width-lg) * -1) 0 0

--- a/src/components/TextList/TextList.module.css
+++ b/src/components/TextList/TextList.module.css
@@ -1,5 +1,3 @@
-/* stylelint-disable no-descending-specificity */
-
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\
@@ -43,7 +41,6 @@
   }
 
   .text-list--tiny.text-list--inline & {
-    /* stylelint-disable-next-line max-nesting-depth */
     &:before {
       top: var(--eds-size-1);
       height: var(--eds-size-half);


### PR DESCRIPTION
### Summary:

- remove [no-descending-specificity](https://stylelint.io/user-guide/rules/list/no-descending-specificity/) rule, as it's been more confusing than valuable
- increase `max-nesting-depth` allowed to 2 -- [we agreed awhile ago](https://czi-edu.slack.com/archives/C0310HJ9WEN/p1648490911423979?thread_ts=1648488617.379909&cid=C0310HJ9WEN) that this was fine given other code guidelines, but never got around to it

### Test Plan:
build passes