### PR TITLE
feat(numbericon): add number icon

### DIFF
--- a/src/components/HorizontalStep/HorizontalStep.module.css
+++ b/src/components/HorizontalStep/HorizontalStep.module.css
@@ -39,22 +39,3 @@
   margin-right: var(--eds-size-1);
   fill: var(--eds-theme-color-icon-disabled);
 }
-
-/**
-* Horizontal Step Number
-* 1) Centers the number text in the circle.
-* 2) The circle part of the icon, made with borders and equal height and width.
-*/
-.horizontal-step__number {
-  /* 1 */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  /* 2 */
-  border: var(--eds-border-width-sm) solid
-    var(--eds-theme-color-icon-neutral-default-hover);
-  border-radius: var(--eds-border-radius-round);
-  height: var(--eds-size-3);
-  width: var(--eds-size-3);
-}

--- a/src/components/HorizontalStep/HorizontalStep.tsx
+++ b/src/components/HorizontalStep/HorizontalStep.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import React from 'react';
 import styles from './HorizontalStep.module.css';
 import Icon from '../Icon';
+import NumberIcon from '../NumberIcon';
 import Text from '../Text';
 
 export type Props = {
@@ -56,16 +57,10 @@ export const HorizontalStep = ({
         title={`completed step ${stepNumber} ${text}`}
       />
     ) : variant === 'active' ? (
-      <Text
+      <NumberIcon
         aria-label={`current step ${stepNumber} ${text}`}
-        as="span"
-        className={styles['horizontal-step__number']}
-        role="img"
-        size="sm"
-        variant="inherit"
-      >
-        {stepNumber}
-      </Text>
+        number={stepNumber}
+      />
     ) : (
       <Icon
         className={styles['horizontal-step__incomplete-icon']}

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -201,7 +201,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         1
@@ -255,7 +255,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         1
@@ -271,7 +271,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 2 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         2
@@ -287,7 +287,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 3 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         3
@@ -303,7 +303,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 4 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         4
@@ -319,7 +319,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 5 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         5
@@ -335,7 +335,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 6 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         6
@@ -351,7 +351,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 7 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         7
@@ -367,7 +367,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 8 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         8
@@ -383,7 +383,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 9 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         9
@@ -399,7 +399,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 10 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         10
@@ -415,7 +415,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 21 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         21
@@ -431,7 +431,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 32 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         32
@@ -447,7 +447,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 43 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         43
@@ -463,7 +463,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 54 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         54
@@ -479,7 +479,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 65 Horizontal step"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         65
@@ -506,7 +506,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Step 1"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         1
@@ -781,7 +781,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         5
@@ -870,7 +870,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="horizontal-step__number text text--sm text--inherit"
+        class="number-icon number-icon--base number-icon--lg text text--sm text--base"
         role="img"
       >
         3

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -1,0 +1,42 @@
+/*------------------------------------*\
+    # NUMBER ICON
+\*------------------------------------*/
+
+/**
+ * 1) 
+ */
+.number-icon {
+  /* 1 */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  /* 2 */
+  border: var(--eds-border-width-sm) solid
+    var(--eds-theme-color-icon-neutral-strong);
+  border-radius: var(--eds-border-radius-round);
+}
+
+/**
+ * Size Variants
+ */
+.number-icon--sm {
+  height: var(--eds-size-2-and-half);
+  width: var(--eds-size-2-and-half);
+}
+
+.number-icon--lg {
+  height: var(--eds-size-3);
+  width: var(--eds-size-3);
+}
+
+/**
+ * Color Variants
+ */
+.number-icon--base {
+  background-color: transparent;
+}
+.number-icon--success {
+  background-color: var(--eds-theme-color-icon-utility-success);
+  border-color: var(--eds-theme-color-icon-utility-success);
+}

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -25,11 +25,13 @@
 .number-icon--sm {
   height: var(--eds-size-2-and-half); /* 1 */
   width: var(--eds-size-2-and-half);
+  min-width: var(--eds-size-2-and-half);
 }
 
 .number-icon--lg {
   height: var(--eds-size-3); /* 1 */
   width: var(--eds-size-3);
+  min-width: var(--eds-size-3);
 }
 
 /**

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -3,7 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) 
+ * Number Icon displays a number enclosed in a circle.
+* 1) Centers the number text in the circle.
+* 2) The circle part of the icon, made with borders.
  */
 .number-icon {
   /* 1 */
@@ -12,21 +14,21 @@
   align-items: center;
 
   /* 2 */
-  border: var(--eds-border-width-sm) solid
-    var(--eds-theme-color-icon-neutral-strong);
+  border: var(--eds-border-width-sm) solid;
   border-radius: var(--eds-border-radius-round);
 }
 
 /**
  * Size Variants
+ * 1) Height and width should be the same to make the icon a circle and not oblong.
  */
 .number-icon--sm {
-  height: var(--eds-size-2-and-half);
+  height: var(--eds-size-2-and-half); /* 1 */
   width: var(--eds-size-2-and-half);
 }
 
 .number-icon--lg {
-  height: var(--eds-size-3);
+  height: var(--eds-size-3); /* 1 */
   width: var(--eds-size-3);
 }
 
@@ -35,6 +37,7 @@
  */
 .number-icon--base {
   background-color: transparent;
+  border-color: var(--eds-theme-color-icon-neutral-strong);
 }
 .number-icon--success {
   background-color: var(--eds-theme-color-icon-utility-success);

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -1,0 +1,84 @@
+import { StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { NumberIcon } from './NumberIcon';
+
+export default {
+  title: 'Atoms/Icons/NumberIcon',
+  component: NumberIcon,
+  args: {
+    'aria-label': '1',
+    number: '1',
+  },
+};
+
+type Args = React.ComponentProps<typeof NumberIcon>;
+
+export const Default: StoryObj<Args> = {};
+
+export const Small: StoryObj<Args> = {
+  args: {
+    size: 'sm',
+  },
+};
+
+export const SuccessLarge: StoryObj<Args> = {
+  args: {
+    size: 'lg',
+    variant: 'success',
+  },
+};
+
+export const SuccessSmall: StoryObj<Args> = {
+  args: {
+    size: 'sm',
+    variant: 'success',
+  },
+};
+
+/**
+ * 1) Disables controls for args that have no affect on this story
+ */
+export const DifferentNumbers: StoryObj<Args> = {
+  /* 1 */
+  argTypes: {
+    number: {
+      table: {
+        disable: true,
+      },
+    },
+    'aria-label': {
+      table: {
+        disable: true,
+      },
+    },
+    'aria-labelledby': {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  render: (args) => (
+    <div>
+      <NumberIcon {...args} aria-label="0" number={0} />
+      <NumberIcon {...args} aria-label="1" number={1} />
+      <NumberIcon {...args} aria-label="2" number={2} />
+      <NumberIcon {...args} aria-label="3" number={3} />
+      <NumberIcon {...args} aria-label="4" number={4} />
+      <NumberIcon {...args} aria-label="5" number={5} />
+      <NumberIcon {...args} aria-label="6" number={6} />
+      <NumberIcon {...args} aria-label="7" number={7} />
+      <NumberIcon {...args} aria-label="8" number={8} />
+      <NumberIcon {...args} aria-label="9" number={9} />
+      <NumberIcon {...args} aria-label="10" number={10} />
+      <NumberIcon {...args} aria-label="21" number={21} />
+      <NumberIcon {...args} aria-label="32" number={32} />
+      <NumberIcon {...args} aria-label="43" number={43} />
+      <NumberIcon {...args} aria-label="54" number={54} />
+      <NumberIcon {...args} aria-label="65" number={65} />
+      <NumberIcon {...args} aria-label="76" number={76} />
+      <NumberIcon {...args} aria-label="87" number={87} />
+      <NumberIcon {...args} aria-label="98" number={98} />
+    </div>
+  ),
+};

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Atoms/Icons/NumberIcon',
   component: NumberIcon,
   args: {
-    'aria-label': '1',
+    'aria-label': 'Step 1',
     number: '1',
   },
 };
@@ -60,25 +60,25 @@ export const DifferentNumbers: StoryObj<Args> = {
   },
   render: (args) => (
     <div>
-      <NumberIcon {...args} aria-label="0" number={0} />
-      <NumberIcon {...args} aria-label="1" number={1} />
-      <NumberIcon {...args} aria-label="2" number={2} />
-      <NumberIcon {...args} aria-label="3" number={3} />
-      <NumberIcon {...args} aria-label="4" number={4} />
-      <NumberIcon {...args} aria-label="5" number={5} />
-      <NumberIcon {...args} aria-label="6" number={6} />
-      <NumberIcon {...args} aria-label="7" number={7} />
-      <NumberIcon {...args} aria-label="8" number={8} />
-      <NumberIcon {...args} aria-label="9" number={9} />
-      <NumberIcon {...args} aria-label="10" number={10} />
-      <NumberIcon {...args} aria-label="21" number={21} />
-      <NumberIcon {...args} aria-label="32" number={32} />
-      <NumberIcon {...args} aria-label="43" number={43} />
-      <NumberIcon {...args} aria-label="54" number={54} />
-      <NumberIcon {...args} aria-label="65" number={65} />
-      <NumberIcon {...args} aria-label="76" number={76} />
-      <NumberIcon {...args} aria-label="87" number={87} />
-      <NumberIcon {...args} aria-label="98" number={98} />
+      <NumberIcon {...args} aria-label="Step 0" number={0} />
+      <NumberIcon {...args} aria-label="Step 1" number={1} />
+      <NumberIcon {...args} aria-label="Step 2" number={2} />
+      <NumberIcon {...args} aria-label="Step 3" number={3} />
+      <NumberIcon {...args} aria-label="Step 4" number={4} />
+      <NumberIcon {...args} aria-label="Step 5" number={5} />
+      <NumberIcon {...args} aria-label="Step 6" number={6} />
+      <NumberIcon {...args} aria-label="Step 7" number={7} />
+      <NumberIcon {...args} aria-label="Step 8" number={8} />
+      <NumberIcon {...args} aria-label="Step 9" number={9} />
+      <NumberIcon {...args} aria-label="Step 10" number={10} />
+      <NumberIcon {...args} aria-label="Step 21" number={21} />
+      <NumberIcon {...args} aria-label="Step 32" number={32} />
+      <NumberIcon {...args} aria-label="Step 43" number={43} />
+      <NumberIcon {...args} aria-label="Step 54" number={54} />
+      <NumberIcon {...args} aria-label="Step 65" number={65} />
+      <NumberIcon {...args} aria-label="Step 76" number={76} />
+      <NumberIcon {...args} aria-label="Step 87" number={87} />
+      <NumberIcon {...args} aria-label="Step 98" number={98} />
     </div>
   ),
 };

--- a/src/components/NumberIcon/NumberIcon.test.tsx
+++ b/src/components/NumberIcon/NumberIcon.test.tsx
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as stories from './NumberIcon.stories';
+
+describe('<NumberIcon />', () => {
+  generateSnapshots(stories);
+});

--- a/src/components/NumberIcon/NumberIcon.test.tsx
+++ b/src/components/NumberIcon/NumberIcon.test.tsx
@@ -1,6 +1,18 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { NumberIcon } from './NumberIcon';
 import * as stories from './NumberIcon.stories';
+import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<NumberIcon />', () => {
+  const consoleWarnMock = consoleWarnMockHelper();
   generateSnapshots(stories);
+  it('should warn if no valid label', () => {
+    render(<NumberIcon number={1} />);
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      'No accessible name for the number icon.',
+    );
+  });
 });

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -31,7 +31,17 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * ```ts
+ * import {NumberIcon} from "@chanzuckerberg/eds";
+ * ```
+ *
+ * Encloses a number in a circle to be used as an icon.
+ *
+ * Example usage:
+ *
+ * ```tsx
+ * <NumberIcon aria-label="1" number={1} />
+ * ```
  */
 export const NumberIcon = ({
   className,
@@ -53,9 +63,13 @@ export const NumberIcon = ({
     styles[`number-icon--${size}`],
     className,
   );
+
+  /**
+   * 1) Set as 'span' since icon use is more inline than block, but no effect since display is 'flex'.
+   */
   return (
     <Text
-      as="span"
+      as="span" /* 1 */
       className={componentClassName}
       role="img"
       size="sm"

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+import React from 'react';
+import styles from './NumberIcon.module.css';
+import Text from '../Text';
+
+export interface Props {
+  /**
+   * Screen-reader text for the number icon.
+   */
+  'aria-label'?: string;
+  /**
+   * Id that links a label text for the number icon.
+   */
+  'aria-labelledby'?: string;
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
+   * Number to be shown as the icon.
+   */
+  number: number;
+  /**
+   * The size of the icon. Defaults to 'lg'.
+   */
+  size?: 'sm' | 'lg';
+  /**
+   * The color variant of the icon. Defaults to 'base'.
+   */
+  variant?: 'base' | 'success';
+}
+
+/**
+ * Primary UI component for user interaction
+ */
+export const NumberIcon = ({
+  className,
+  number,
+  size = 'lg',
+  variant = 'base',
+  ...other
+}: Props) => {
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    !other['aria-label'] &&
+    !other['aria-labelledby']
+  ) {
+    console.warn('No accessible name for the number icon.');
+  }
+  const componentClassName = clsx(
+    styles['number-icon'],
+    styles[`number-icon--${variant}`],
+    styles[`number-icon--${size}`],
+    className,
+  );
+  return (
+    <Text
+      as="span"
+      className={componentClassName}
+      role="img"
+      size="sm"
+      variant={variant === 'base' ? 'base' : 'white'}
+      {...other}
+    >
+      {number}
+    </Text>
+  );
+};

--- a/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
+++ b/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
@@ -1,0 +1,179 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<NumberIcon /> Default story renders snapshot 1`] = `
+<span
+  aria-label="1"
+  class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+  role="img"
+>
+  1
+</span>
+`;
+
+exports[`<NumberIcon /> DifferentNumbers story renders snapshot 1`] = `
+<div>
+  <span
+    aria-label="0"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    0
+  </span>
+  <span
+    aria-label="1"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    1
+  </span>
+  <span
+    aria-label="2"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    2
+  </span>
+  <span
+    aria-label="3"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    3
+  </span>
+  <span
+    aria-label="4"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    4
+  </span>
+  <span
+    aria-label="5"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    5
+  </span>
+  <span
+    aria-label="6"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    6
+  </span>
+  <span
+    aria-label="7"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    7
+  </span>
+  <span
+    aria-label="8"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    8
+  </span>
+  <span
+    aria-label="9"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    9
+  </span>
+  <span
+    aria-label="10"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    10
+  </span>
+  <span
+    aria-label="21"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    21
+  </span>
+  <span
+    aria-label="32"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    32
+  </span>
+  <span
+    aria-label="43"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    43
+  </span>
+  <span
+    aria-label="54"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    54
+  </span>
+  <span
+    aria-label="65"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    65
+  </span>
+  <span
+    aria-label="76"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    76
+  </span>
+  <span
+    aria-label="87"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    87
+  </span>
+  <span
+    aria-label="98"
+    class="number-icon number-icon--base number-icon--lg text text--sm text--base"
+    role="img"
+  >
+    98
+  </span>
+</div>
+`;
+
+exports[`<NumberIcon /> Small story renders snapshot 1`] = `
+<span
+  aria-label="1"
+  class="number-icon number-icon--base number-icon--sm text text--sm text--base"
+  role="img"
+>
+  1
+</span>
+`;
+
+exports[`<NumberIcon /> SuccessLarge story renders snapshot 1`] = `
+<span
+  aria-label="1"
+  class="number-icon number-icon--success number-icon--lg text text--sm text--white"
+  role="img"
+>
+  1
+</span>
+`;
+
+exports[`<NumberIcon /> SuccessSmall story renders snapshot 1`] = `
+<span
+  aria-label="1"
+  class="number-icon number-icon--success number-icon--sm text text--sm text--white"
+  role="img"
+>
+  1
+</span>
+`;

--- a/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
+++ b/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<NumberIcon /> Default story renders snapshot 1`] = `
 <span
-  aria-label="1"
+  aria-label="Step 1"
   class="number-icon number-icon--base number-icon--lg text text--sm text--base"
   role="img"
 >
@@ -13,133 +13,133 @@ exports[`<NumberIcon /> Default story renders snapshot 1`] = `
 exports[`<NumberIcon /> DifferentNumbers story renders snapshot 1`] = `
 <div>
   <span
-    aria-label="0"
+    aria-label="Step 0"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     0
   </span>
   <span
-    aria-label="1"
+    aria-label="Step 1"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     1
   </span>
   <span
-    aria-label="2"
+    aria-label="Step 2"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     2
   </span>
   <span
-    aria-label="3"
+    aria-label="Step 3"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     3
   </span>
   <span
-    aria-label="4"
+    aria-label="Step 4"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     4
   </span>
   <span
-    aria-label="5"
+    aria-label="Step 5"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     5
   </span>
   <span
-    aria-label="6"
+    aria-label="Step 6"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     6
   </span>
   <span
-    aria-label="7"
+    aria-label="Step 7"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     7
   </span>
   <span
-    aria-label="8"
+    aria-label="Step 8"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     8
   </span>
   <span
-    aria-label="9"
+    aria-label="Step 9"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     9
   </span>
   <span
-    aria-label="10"
+    aria-label="Step 10"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     10
   </span>
   <span
-    aria-label="21"
+    aria-label="Step 21"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     21
   </span>
   <span
-    aria-label="32"
+    aria-label="Step 32"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     32
   </span>
   <span
-    aria-label="43"
+    aria-label="Step 43"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     43
   </span>
   <span
-    aria-label="54"
+    aria-label="Step 54"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     54
   </span>
   <span
-    aria-label="65"
+    aria-label="Step 65"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     65
   </span>
   <span
-    aria-label="76"
+    aria-label="Step 76"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     76
   </span>
   <span
-    aria-label="87"
+    aria-label="Step 87"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
     87
   </span>
   <span
-    aria-label="98"
+    aria-label="Step 98"
     class="number-icon number-icon--base number-icon--lg text text--sm text--base"
     role="img"
   >
@@ -150,7 +150,7 @@ exports[`<NumberIcon /> DifferentNumbers story renders snapshot 1`] = `
 
 exports[`<NumberIcon /> Small story renders snapshot 1`] = `
 <span
-  aria-label="1"
+  aria-label="Step 1"
   class="number-icon number-icon--base number-icon--sm text text--sm text--base"
   role="img"
 >
@@ -160,7 +160,7 @@ exports[`<NumberIcon /> Small story renders snapshot 1`] = `
 
 exports[`<NumberIcon /> SuccessLarge story renders snapshot 1`] = `
 <span
-  aria-label="1"
+  aria-label="Step 1"
   class="number-icon number-icon--success number-icon--lg text text--sm text--white"
   role="img"
 >
@@ -170,7 +170,7 @@ exports[`<NumberIcon /> SuccessLarge story renders snapshot 1`] = `
 
 exports[`<NumberIcon /> SuccessSmall story renders snapshot 1`] = `
 <span
-  aria-label="1"
+  aria-label="Step 1"
   class="number-icon number-icon--success number-icon--sm text text--sm text--white"
   role="img"
 >

--- a/src/components/NumberIcon/index.ts
+++ b/src/components/NumberIcon/index.ts
@@ -1,0 +1,1 @@
+export { NumberIcon as default } from './NumberIcon';

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export { default as ModalHeader } from './components/ModalHeader';
 export { default as NavContainer } from './components/NavContainer';
 export { default as NotificationList } from './components/NotificationList';
 export { default as NotificationListItem } from './components/NotificationListItem';
+export { default as NumberIcon } from './components/NumberIcon';
 export { default as PageHeader } from './components/PageHeader';
 export { default as Panel } from './components/Panel';
 export { default as Popover } from './components/Popover';


### PR DESCRIPTION
### Summary:
- add number icon
  - text number enclosed in a circle
- size variants: default 'lg' and 'sm'
  - Louie advised no 'md' variant, should default to 'lg'
- color variants: default 'base' and 'success'
- uses `span` but set `role='img'` and requires `aria-label` or `aria-labelledby`
  - No use case where a number icon would be purely decorative?

### Test Plan:
- snap tests and unit test written
- use in HorizontalStepper creates no visual diff

base-lg:
![base-lg](https://user-images.githubusercontent.com/86632227/167049684-64740fa8-4b34-4dd1-b184-09364ccbeed2.png)
base-sm:
![base-sm](https://user-images.githubusercontent.com/86632227/167049687-185f8d25-82b8-40b3-accc-221f85f8f769.png)
success-lg:
![success-lg](https://user-images.githubusercontent.com/86632227/167049691-e00cc233-3567-4d1c-bca5-cfc84e1f6a93.png)
success-sm:
![success-sm](https://user-images.githubusercontent.com/86632227/167049692-e03b6e8b-bcac-4472-93d3-f3baf75fb18a.png)
double-digits:
![image](https://user-images.githubusercontent.com/86632227/167049737-165bdd16-8056-4ad1-b8e1-b90fcbbb654f.png)

