### PR TITLE
chore: add beta information to component docstrings

### DIFF
--- a/plop-templates/Component/Component.tsx.hbs
+++ b/plop-templates/Component/Component.tsx.hbs
@@ -10,7 +10,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const {{pascalCase name}} = ({
 	className,

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -11,7 +11,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Component that presents the user's avatar image with additional styling passed in.
  */
 export const Avatar = ({ className, ...other }: Props) => {
   const componentClassName = clsx('avatar', className, {});

--- a/src/components/AvatarImage/AvatarImage.tsx
+++ b/src/components/AvatarImage/AvatarImage.tsx
@@ -10,7 +10,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Component that presents the user's avatar SVG.
  */
 export const AvatarImage = ({ className, ...other }: Props) => {
   const componentClassName = clsx(styles['avatar-image'], className, {});

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -25,7 +25,10 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * List of Breadcrumb components showing the user where they are in the system and allow them
+ * to navigate to parent pages.
  */
 export const Breadcrumbs = ({
   className,

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -20,7 +20,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * A single breadcrumb, to be used in the Breadcrumbs component.
  */
 export const BreadcrumbsItem = ({ className, text, href, ...other }: Props) => {
   const componentClassName = clsx(styles['breadcrumbs__item'], className, {});

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -21,7 +21,10 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Card component used to visually group information. Yypically contains a title, image,
+ * text, and/or calls to action.
  */
 export const Card = ({ className, children, inverted, ...other }: Props) => {
   const componentClassName = clsx(

--- a/src/components/CardBody/CardBody.tsx
+++ b/src/components/CardBody/CardBody.tsx
@@ -13,7 +13,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Body of the Card component.
  */
 export const CardBody = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx('card__body', className, {});

--- a/src/components/CardFooter/CardFooter.tsx
+++ b/src/components/CardFooter/CardFooter.tsx
@@ -13,7 +13,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Footer of the Card component.
  */
 export const CardFooter = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx('card__footer', className, {});

--- a/src/components/CardHeader/CardHeader.tsx
+++ b/src/components/CardHeader/CardHeader.tsx
@@ -13,7 +13,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Header of the Card component.
  */
 export const CardHeader = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx('card__header', className, {});

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -43,6 +43,8 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {DataBar} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DataBarSegment/DataBarSegment.tsx
+++ b/src/components/DataBarSegment/DataBarSegment.tsx
@@ -30,6 +30,8 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {DataBarSegment} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -31,7 +31,10 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Grid component used to layout GridItem components into a grid pattern. This is flexible component
+ * allowing for a variety of responsive layout components.
  */
 export const Grid = ({
   className,

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Single grid item to be used in the Grid component.
  */
 export const GridItem = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx(styles['grid__item'], className, {});

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -32,6 +32,11 @@ export interface Props {
   children?: ReactNode;
 }
 
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Global container for the header component. This helps set the stage for header recipes across applications.
+ */
 export const Header = ({
   behavior,
   className,

--- a/src/components/HorizontalStep/HorizontalStep.tsx
+++ b/src/components/HorizontalStep/HorizontalStep.tsx
@@ -25,6 +25,8 @@ export type Props = {
 };
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {HorizontalStep} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -20,6 +20,8 @@ export type Props = {
 };
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {HorizontalStepper} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -8,7 +8,6 @@ export interface Props {
    * - **brand** yields a branded horizontal rule
    */
   variant?: 'brand';
-
   /**
    * Size variations:
    * - **lg** yields a thicker horizontal rule
@@ -21,7 +20,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Horizontal rule component to present a horizontal line separating content.
  */
 export const Hr = ({ className, size, variant, ...other }: Props) => {
   const componentClassName = clsx(

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -39,7 +39,10 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Component that controls an overarching page layout. By default, the layout renders
+ * a fixed-position left sidebar on larger screens.
  */
 export const Layout = ({
   behavior,

--- a/src/components/LayoutContainer/LayoutContainer.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.tsx
@@ -23,7 +23,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Layout container. Caps the width of the content to the maximum width and centers the container.
  */
 export const LayoutContainer = ({
   className,

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Component that caps the length of an excerpt of text to be easily readable.
  */
 export const LayoutLinelengthContainer = ({
   className,

--- a/src/components/LayoutSection/LayoutSection.tsx
+++ b/src/components/LayoutSection/LayoutSection.tsx
@@ -22,7 +22,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Layout section.
  */
 export const LayoutSection = ({
   children,

--- a/src/components/LinkList/LinkList.tsx
+++ b/src/components/LinkList/LinkList.tsx
@@ -34,7 +34,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * List of links.
  */
 export const LinkList = ({
   behavior,

--- a/src/components/LinkListItem/LinkListItem.tsx
+++ b/src/components/LinkListItem/LinkListItem.tsx
@@ -47,7 +47,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Link list item to be used inside the LinkList component.
  */
 export const LinkListItem = ({
   className,

--- a/src/components/ListDetail/ListDetail.tsx
+++ b/src/components/ListDetail/ListDetail.tsx
@@ -79,6 +79,8 @@ export interface Props {
 }
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * List Detail Component
  * 1) Provides a list-view pane for item labels/titles, and a details pane for each item's content. When an item in the list is selected, the details pane is updated.
  */

--- a/src/components/ListDetailPanel/ListDetailPanel.tsx
+++ b/src/components/ListDetailPanel/ListDetailPanel.tsx
@@ -42,7 +42,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Panel to be used inside of the ListDetail component.
  */
 export const ListDetailPanel = ({
   ariaLabelledBy,

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -27,7 +27,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Branding image or text of the site.
  */
 export const Logo = ({ alt, className, href, src, title, ...other }: Props) => {
   const componentClassName = clsx(styles['logo'], className, {});

--- a/src/components/LogoImage/LogoImage.tsx
+++ b/src/components/LogoImage/LogoImage.tsx
@@ -17,7 +17,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Logo image svg to be used inside the Logo component.
  */
 export const LogoImage = ({
   className,

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const Main = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx(styles['main'], className, {});

--- a/src/components/NavContainer/NavContainer.tsx
+++ b/src/components/NavContainer/NavContainer.tsx
@@ -19,7 +19,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Container that houses navigation to be toggled on and off on small screens.
  */
 export const NavContainer = ({
   children,

--- a/src/components/NotificationList/NotificationList.tsx
+++ b/src/components/NotificationList/NotificationList.tsx
@@ -14,6 +14,11 @@ export interface Props {
   children?: ReactNode;
 }
 
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * List of NotificationListItem components.
+ */
 export const NotificationList = ({ className, children, ...other }: Props) => {
   const componentClassName = clsx(styles['notification-list'], className, {});
   return <ul className={componentClassName}>{children}</ul>;

--- a/src/components/NotificationListItem/NotificationListItem.tsx
+++ b/src/components/NotificationListItem/NotificationListItem.tsx
@@ -39,6 +39,11 @@ interface State {
   isRead: boolean | null;
 }
 
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Single notification item to be used in NotificationList.
+ */
 export const NotificationListItem = ({
   className,
   date,

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -31,6 +31,8 @@ export interface Props {
 }
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {NumberIcon} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/OverflowList/OverflowList.tsx
+++ b/src/components/OverflowList/OverflowList.tsx
@@ -22,7 +22,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const OverflowList = ({ className, children, ...other }: Props) => {
   /**

--- a/src/components/OverflowListItem/OverflowListItem.tsx
+++ b/src/components/OverflowListItem/OverflowListItem.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const OverflowListItem = ({ className, children, ...other }: Props) => {
   const componentClassName = clsx(styles['overflow-list__item'], className, {});

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -40,7 +40,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Header to be used at the top of a page.
  */
 export const PageHeader = ({
   align,

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -29,7 +29,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const Panel = ({
   className,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -52,7 +52,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Content container that pops out over other content.
  */
 export const Popover = ({
   ariaDescribedBy,

--- a/src/components/PopoverBody/PopoverBody.tsx
+++ b/src/components/PopoverBody/PopoverBody.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Body for the Popover component.
  */
 export const PopoverBody: React.FC<Props> = ({
   children,

--- a/src/components/PopoverFooter/PopoverFooter.tsx
+++ b/src/components/PopoverFooter/PopoverFooter.tsx
@@ -14,7 +14,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Footer for the Popover component.
  */
 export const PopoverFooter: React.FC<Props> = ({
   children,

--- a/src/components/PopoverHeader/PopoverHeader.tsx
+++ b/src/components/PopoverHeader/PopoverHeader.tsx
@@ -22,7 +22,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Header for the Popover component.
  */
 export const PopoverHeader: React.FC<Props> = ({
   className,

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -24,7 +24,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Primary navigation existing in the header and maybe the footer.
  */
 export const PrimaryNav = ({
   className,

--- a/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -28,7 +28,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Individual item within the PrimaryNav.
  */
 export const PrimaryNavItem = React.forwardRef<HTMLLIElement, Props>(
   function PrimaryNavItem(

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -31,7 +31,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * TODO: update this comment with a description of the component.
  */
 export const Section = ({
   className,

--- a/src/components/ShowHide/ShowHide.tsx
+++ b/src/components/ShowHide/ShowHide.tsx
@@ -44,7 +44,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Component that shows and hides child content at the press of a button.
  */
 export const ShowHide = ({
   align,

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -30,7 +30,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Individual tab within the Tabs component.
  */
 export const Tab = ({
   children,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -92,7 +92,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * List of of links where each link toggles open associated information in a tab panel.
  */
 export const Tabs = ({
   activeIndex = 0,

--- a/src/components/TextPassage/TextPassage.tsx
+++ b/src/components/TextPassage/TextPassage.tsx
@@ -33,7 +33,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * A passage of text, including various components (i.e. article, blog post).
  */
 export const TextPassage = ({
   capLinelength = true,

--- a/src/components/UtilityNav/UtilityNav.tsx
+++ b/src/components/UtilityNav/UtilityNav.tsx
@@ -28,7 +28,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Utility navigation existing in the header and maybe the footer.
  */
 export const UtilityNav = ({
   className,

--- a/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -32,7 +32,9 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * Individual item within the UtilityNav component.
  */
 export const UtilityNavItem = React.forwardRef<HTMLLIElement, Props>(
   function UtilityNavItem(


### PR DESCRIPTION
### Summary:
We've decided that we're going to all our pilot work branching directly off of `next`. That means in-progress components are going to ship with package publishes, be accessible from within `traject`, and show up in the EDS storybook. To communicate that these components are in-progress, I'm adding comments to the components to state that they're in-progress. (We used to do this with our components in EDSCandidates in `traject` as well.)

Since I'm messing with the component comments, I also added basic descriptions or todo comments, and I updated the plop template file as well.

#### In follow-up PRs, I will:
- utilize storybook badges to add a secondary method for communicating that these components are in beta
- add import examples to these component docstrings per our preferred documentation pattern
- also make these changes to components in the `upcoming-components` directory (I'm focusing on the components in `components` for right now since those are the ones that will appear in storybook)

#### What to look for when reviewing this PR:
I'm especially looking for feedback on:
- the wording of the copy about how these components are in-progress
- whether any of these components are actually mature and should not have the beta text

### Test Plan:
Verify these comments are appearing in storybook as expected.