### PR TITLE
chore(docs): add beta badge to components that haven't been officially released

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { Avatar, Props } from './Avatar';
 export default {
   title: 'Example/Avatar',
   component: Avatar,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Avatar {...args} />;

--- a/src/components/AvatarImage/AvatarImage.stories.tsx
+++ b/src/components/AvatarImage/AvatarImage.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { AvatarImage, Props } from './AvatarImage';
 export default {
   title: 'Example/AvatarImage',
   component: AvatarImage,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <AvatarImage {...args} />;

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,6 +9,9 @@ export default {
   title: 'Molecules/Navigation/Breadcrumbs',
   component: Breadcrumbs,
   subcomponents: { BreadcrumbsItem },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,5 +1,7 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Meta } from '@storybook/react';
 import React from 'react';
+
 import { Card } from './Card';
 import CardBody from '../CardBody';
 import CardFooter from '../CardFooter';
@@ -14,6 +16,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/DataBar/DataBar.stories.tsx
+++ b/src/components/DataBar/DataBar.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -28,6 +29,9 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof DataBar>;

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -1,5 +1,7 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, StoryObj, Meta } from '@storybook/react';
 import React, { ComponentProps } from 'react';
+
 import { DragDrop, Props } from './DragDrop';
 import Card from '../Card';
 
@@ -17,6 +19,9 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta<Args>;
 
 type Args = ComponentProps<typeof DragDrop>;

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -13,6 +14,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -12,6 +13,9 @@ import UtilityNavItem from '../UtilityNavItem';
 export default {
   title: 'Organisms/Global/Header',
   component: Header,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -25,6 +26,9 @@ export default {
       </div>
     ),
   ],
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof HorizontalStepper>;

--- a/src/components/Hr/Hr.stories.tsx
+++ b/src/components/Hr/Hr.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { Hr, Props } from './Hr';
 export default {
   title: 'Atoms/Text/Hr',
   component: Hr,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Hr {...args} />;

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -12,6 +13,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -11,6 +12,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { LayoutLinelengthContainer, Props } from './LayoutLinelengthContainer';
 export default {
   title: 'Molecules/Layout and Containers/Linelength Container',
   component: LayoutLinelengthContainer,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/LinkList/LinkList.stories.tsx
+++ b/src/components/LinkList/LinkList.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,6 +8,9 @@ import LinkListItem from '../LinkListItem';
 export default {
   title: 'Molecules/Navigation/LinkList',
   component: LinkList,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/ListDetail/ListDetail.stories.tsx
+++ b/src/components/ListDetail/ListDetail.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -9,6 +10,9 @@ export default {
   title: 'Example/ListDetail',
   component: ListDetail,
   subcomponents: { ListDetailPanel },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { Logo, Props } from './Logo';
 export default {
   title: 'Molecules/Global/Logo',
   component: Logo,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <Logo {...args} />;

--- a/src/components/LogoImage/LogoImage.stories.tsx
+++ b/src/components/LogoImage/LogoImage.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { LogoImage, Props } from './LogoImage';
 export default {
   title: 'Molecules/Global/LogoImage',
   component: LogoImage,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <LogoImage {...args} />;

--- a/src/components/Main/Main.stories.tsx
+++ b/src/components/Main/Main.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -11,6 +12,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/NavContainer/NavContainer.stories.tsx
+++ b/src/components/NavContainer/NavContainer.stories.tsx
@@ -1,5 +1,7 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Meta } from '@storybook/react';
 import React from 'react';
+
 import { NavContainer } from './NavContainer';
 import PrimaryNav from '../PrimaryNav';
 import PrimaryNavItem from '../PrimaryNavItem';
@@ -9,6 +11,9 @@ import UtilityNavItem from '../UtilityNavItem';
 export default {
   title: 'Molecules/Global/NavContainer',
   component: NavContainer,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 export const Default = () => (

--- a/src/components/NotificationList/NotificationList.stories.tsx
+++ b/src/components/NotificationList/NotificationList.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -10,6 +11,9 @@ export default {
   title: 'Molecules/Lists/NotificationList',
   component: NotificationList,
   subcomponents: { NotificationListItem },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 export const Default: StoryObj<Props & NotificationListItemProps> = {

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj } from '@storybook/react';
 import React from 'react';
 
@@ -9,6 +10,9 @@ export default {
   args: {
     'aria-label': 'Step 1',
     number: '1',
+  },
+  parameters: {
+    badges: [BADGE.BETA],
   },
 };
 

--- a/src/components/OverflowList/OverflowList.stories.tsx
+++ b/src/components/OverflowList/OverflowList.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,6 +8,9 @@ import { OverflowListItem } from '../OverflowListItem/OverflowListItem';
 export default {
   title: 'Molecules/Lists/OverflowList',
   component: OverflowList,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,6 +8,9 @@ import Tag from '../Tag';
 export default {
   title: 'Molecules/Text/PageHeader',
   component: PageHeader,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => <PageHeader {...args} />;

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { Panel, Props } from './Panel';
 export default {
   title: 'Molecules/Layout and Containers/Panel',
   component: Panel,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,6 +9,7 @@ export default {
   component: PopoverExample,
   parameters: {
     layout: 'centered',
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/PrimaryNav/PrimaryNav.stories.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,6 +9,9 @@ export default {
   title: 'Molecules/Navigation/PrimaryNav',
   component: PrimaryNav,
   subcomponents: { PrimaryNavItem },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/Section/Section.stories.tsx
+++ b/src/components/Section/Section.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { Section, Props } from './Section';
 export default {
   title: 'Organisms/Sections/Section',
   component: Section,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -13,6 +14,7 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
+    badges: [BADGE.BETA],
   },
 } as Meta;
 

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,6 +9,9 @@ import TextPassage from '../TextPassage';
 export default {
   title: 'Organisms/Interactive/Tabs',
   component: Tabs,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/TextPassage/TextPassage.stories.tsx
+++ b/src/components/TextPassage/TextPassage.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -6,6 +7,9 @@ import { TextPassage, Props } from './TextPassage';
 export default {
   title: 'Organisms/Text/TextPassage',
   component: TextPassage,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/UtilityNav/UtilityNav.stories.tsx
+++ b/src/components/UtilityNav/UtilityNav.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,6 +9,9 @@ export default {
   title: 'Molecules/Navigation/UtilityNav',
   component: UtilityNav,
   subcomponents: { UtilityNavItem },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (


### PR DESCRIPTION
### Summary:
I already added a "BETA" comment to all components that haven't been officially released yet; in this follow-up, I'm also adding a beta badge to the stories for those components.

![avatar component in storybook which a little purple beta badge and an arrow drawn on the screenshot pointing to the badge to highlight that change](https://user-images.githubusercontent.com/7761701/168333468-ba0c100e-4e6c-43f1-a213-939cfcbe1242.png)

### Test Plan:
I went through the components in storybook and verified all the ones that weren't in the repo before the BM project have a beta tag.