### PR TITLE
docs(banner): add deprecated badge to flat story

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,5 +1,7 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj } from '@storybook/react';
 import React from 'react';
+
 import { Banner, Variant } from './Banner';
 import Button from '../Button';
 import Heading from '../Heading';
@@ -231,4 +233,7 @@ export const Flat: StoryObj<Args> = {
   args: {
     isFlat: true,
   },
+};
+Flat.parameters = {
+  badges: [BADGE.DEPRECATED],
 };


### PR DESCRIPTION
### Summary:
The `Dark` `Tooltip` variant already has the deprecated badge in storybook, so this PR only adds the deprecated badge to the `Flat` `Banner` variant.

![flat variant story for the banner component in storybook with a "deprecated" tag and an arrow pointing to the badge to highlight it](https://user-images.githubusercontent.com/7761701/168335128-49340b55-9886-4bb9-bfa9-f835520ea61e.png)

### Test Plan:
Very the `Flat` `Banner` variant has the "deprecated" badge (but the other variants don't).