### PR TITLE
chore(drag and drop): detached handles variant

### DIFF
--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -62,16 +62,47 @@
 }
 
 /**
-* 1) Container that holds droppable content. Adding the unstyled prop removes all styling from items.
+* 1) Container that holds droppable content. 
 * 2) DragDropItem styles are included here rather than in the /DragDropItem directory as a workaround to CSS Modules' locally scoped class names 
 * 3) For best experience, use a margin on a single side of an item to add a gap between items. Using a margin on both top and bottom, or using flex or grid gap spacing in the drag-drop-container, cause jumpy behavior.
 */
-.drag-drop:not(.drag-drop--unstyled) .drag-drop-item {
+
+.drag-drop-item {
   padding: var(--eds-size-1);
   margin-bottom: var(--eds-size-1); /* 3 */
   background-color: var(--eds-color-neutral-100);
   border-radius: var(--eds-border-radius-md);
   box-shadow: var(--eds-box-shadow-sm);
+
+  /**
+  * 1) The unstyled variant removes all styling from items.
+  */
+  .drag-drop--unstyled & {
+    @mixin reset;
+    background-color: unset;
+    border-radius: unset;
+    box-shadow: unset;
+  }
+
+  /** 
+  * 1) When the handles variant is used, all inner content will be wrapped in an inner div, and the drag handle will be in a separate div to ensure that the drag handle remains vertically centered. 
+  */
+  .drag-drop--handles & {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--eds-size-1);
+  }
+}
+
+/**
+* 1) Used with handles variant to stack title above content.
+*/
+.drag-drop-item--inner {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
 }
 
 /** 
@@ -80,4 +111,18 @@
 .drag-drop-item--title {
   @mixin eds-typography-preset-007-bold;
   margin-bottom: var(--eds-size-2);
+}
+
+/**
+* 1) Used with handles variant to wrap children.
+*/
+.drag-drop-item--content {
+  flex-grow: 1;
+}
+
+/**
+* 1) Wrapper for drag handle.
+*/
+.drag-drop-item--handle {
+  @mixin reset;
 }

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -312,5 +312,6 @@ export const DragByHandle: StoryObj<Args> = {
       },
     },
     dragByHandle: true,
+    unstyledItems: true,
   },
 };

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -1,9 +1,10 @@
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, StoryObj, Meta } from '@storybook/react';
 import React, { ComponentProps } from 'react';
-
 import { DragDrop, Props } from './DragDrop';
+import { EdsThemeColorIconNeutralSubtle } from '../../tokens-dist/ts/colors';
 import Card from '../Card';
+import Icon from '../Icon';
 
 export default {
   title: 'Organisms/Interactive/Drag and Drop',
@@ -282,22 +283,62 @@ export const DragByHandle: StoryObj<Args> = {
       'item-1': {
         title: 'Project #1',
         children: <div className="fpo">Content here</div>,
+        handle: (
+          <Icon
+            color={EdsThemeColorIconNeutralSubtle}
+            name="drag-indicator"
+            purpose="decorative"
+            size="1.25rem"
+          />
+        ),
       },
       'item-2': {
         title: 'Project #2',
         children: <div className="fpo">Content here</div>,
+        handle: (
+          <Icon
+            color={EdsThemeColorIconNeutralSubtle}
+            name="drag-indicator"
+            purpose="decorative"
+            size="1.25rem"
+          />
+        ),
       },
       'item-3': {
         title: 'Project #3',
         children: <div className="fpo">Content here</div>,
+        handle: (
+          <Icon
+            color={EdsThemeColorIconNeutralSubtle}
+            name="drag-indicator"
+            purpose="decorative"
+            size="1.25rem"
+          />
+        ),
       },
       'item-4': {
         title: 'Project #4',
         children: <div className="fpo">Content here</div>,
+        handle: (
+          <Icon
+            color={EdsThemeColorIconNeutralSubtle}
+            name="drag-indicator"
+            purpose="decorative"
+            size="1.25rem"
+          />
+        ),
       },
       'item-5': {
         title: 'Project #5',
         children: <div className="fpo">Content here</div>,
+        handle: (
+          <Icon
+            color={EdsThemeColorIconNeutralSubtle}
+            name="drag-indicator"
+            purpose="decorative"
+            size="1.25rem"
+          />
+        ),
       },
     },
     containers: {
@@ -312,6 +353,5 @@ export const DragByHandle: StoryObj<Args> = {
       },
     },
     dragByHandle: true,
-    unstyledItems: true,
   },
 };

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -275,3 +275,42 @@ export const UnstyledItems: StoryObj<Args> = {
     multipleContainers: true,
   },
 };
+
+export const DragByHandle: StoryObj<Args> = {
+  args: {
+    items: {
+      'item-1': {
+        title: 'Project #1',
+        children: <div className="fpo">Content here</div>,
+      },
+      'item-2': {
+        title: 'Project #2',
+        children: <div className="fpo">Content here</div>,
+      },
+      'item-3': {
+        title: 'Project #3',
+        children: <div className="fpo">Content here</div>,
+      },
+      'item-4': {
+        title: 'Project #4',
+        children: <div className="fpo">Content here</div>,
+      },
+      'item-5': {
+        title: 'Project #5',
+        children: <div className="fpo">Content here</div>,
+      },
+    },
+    containers: {
+      'container-1': {
+        itemIds: ['item-1', 'item-2', 'item-3'],
+      },
+      'container-2': {
+        itemIds: ['item-4'],
+      },
+      'container-3': {
+        itemIds: ['item-5'],
+      },
+    },
+    dragByHandle: true,
+  },
+};

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -281,7 +281,6 @@ export const DragByHandle: StoryObj<Args> = {
   args: {
     items: {
       'item-1': {
-        title: 'Project #1',
         children: <div className="fpo">Content here</div>,
         handle: (
           <Icon
@@ -293,7 +292,6 @@ export const DragByHandle: StoryObj<Args> = {
         ),
       },
       'item-2': {
-        title: 'Project #2',
         children: <div className="fpo">Content here</div>,
         handle: (
           <Icon
@@ -305,7 +303,6 @@ export const DragByHandle: StoryObj<Args> = {
         ),
       },
       'item-3': {
-        title: 'Project #3',
         children: <div className="fpo">Content here</div>,
         handle: (
           <Icon
@@ -317,7 +314,6 @@ export const DragByHandle: StoryObj<Args> = {
         ),
       },
       'item-4': {
-        title: 'Project #4',
         children: <div className="fpo">Content here</div>,
         handle: (
           <Icon
@@ -346,10 +342,7 @@ export const DragByHandle: StoryObj<Args> = {
         itemIds: ['item-1', 'item-2', 'item-3'],
       },
       'container-2': {
-        itemIds: ['item-4'],
-      },
-      'container-3': {
-        itemIds: ['item-5'],
+        itemIds: ['item-4', 'item-5'],
       },
     },
     dragByHandle: true,

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -31,6 +31,7 @@ export interface Props {
    * Unstyled Items variant removes all styling from content within items
    */
   unstyledItems?: boolean;
+  dragByHandle?: boolean;
 }
 
 /**
@@ -40,6 +41,7 @@ export const DragDrop = ({
   className,
   items,
   containers,
+  dragByHandle = false,
   multipleContainers = false,
   unstyledItems = false,
 }: Props) => {
@@ -49,6 +51,7 @@ export const DragDrop = ({
   const componentClassName = clsx(
     styles['drag-drop'],
     className,
+    dragByHandle && styles['drag-drop--handles'],
     multipleContainers && styles['drag-drop--multiple'],
     unstyledItems && styles['drag-drop--unstyled'],
   );

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -54,9 +54,8 @@ export const DragDrop = ({
   const componentClassName = clsx(
     styles['drag-drop'],
     className,
-    unstyledItems
-      ? styles['drag-drop--unstyled']
-      : dragByHandle && styles['drag-drop--handles'],
+    (unstyledItems || dragByHandle) && styles['drag-drop--unstyled'],
+    dragByHandle && styles['drag-drop--handles'],
     multipleContainers && styles['drag-drop--multiple'],
   );
 
@@ -190,6 +189,7 @@ export const DragDrop = ({
                 return (
                   <DragDropContainer
                     container={container}
+                    dragByHandle={dragByHandle}
                     items={items}
                     key={container.id}
                   />

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -26,12 +26,15 @@ export interface Props {
   /**
    * By default, the last container in a context gets unique styling. If more than two containers will be used, setting this prop to true will remove this unique styling and give all containers a simple border.
    */
-  multipleContainers?: boolean;
+  multipleContainers: boolean;
   /**
    * Unstyled Items variant removes all styling from content within items
    */
-  unstyledItems?: boolean;
-  dragByHandle?: boolean;
+  unstyledItems: boolean;
+  /**
+   * DragDrop items can be dragged by grabbing a handle, or dragged by grabbing anywhere on the item (default)
+   */
+  dragByHandle: boolean;
 }
 
 /**
@@ -51,9 +54,10 @@ export const DragDrop = ({
   const componentClassName = clsx(
     styles['drag-drop'],
     className,
-    dragByHandle && styles['drag-drop--handles'],
+    unstyledItems
+      ? styles['drag-drop--unstyled']
+      : dragByHandle && styles['drag-drop--handles'],
     multipleContainers && styles['drag-drop--multiple'],
-    unstyledItems && styles['drag-drop--unstyled'],
   );
 
   const containerOrder: string[] = [];

--- a/src/components/DragDrop/DragDropTypes.ts
+++ b/src/components/DragDrop/DragDropTypes.ts
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export interface Items {
   [key: string]: ItemType;
 }
@@ -6,6 +8,7 @@ export interface ItemType {
   id?: string;
   title?: string;
   children?: React.ReactNode;
+  handle?: React.ReactNode;
 }
 
 export interface Containers {

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
@@ -433,12 +433,6 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
           Content here
         </div>
       </div>
-    </div>
-    <div
-      class="drag-drop-container"
-      data-rbd-droppable-context-id="5"
-      data-rbd-droppable-id="container-3"
-    >
       <div
         class="drag-drop-item"
         data-rbd-draggable-context-id="5"

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
@@ -298,6 +298,7 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
       >
         <div
           aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          aria-label="Handle for draggable item"
           class="drag-drop-item--handle"
           data-rbd-drag-handle-context-id="5"
           data-rbd-drag-handle-draggable-id="item-1"
@@ -332,6 +333,7 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
       >
         <div
           aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          aria-label="Handle for draggable item"
           class="drag-drop-item--handle"
           data-rbd-drag-handle-context-id="5"
           data-rbd-drag-handle-draggable-id="item-2"
@@ -366,6 +368,7 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
       >
         <div
           aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          aria-label="Handle for draggable item"
           class="drag-drop-item--handle"
           data-rbd-drag-handle-context-id="5"
           data-rbd-drag-handle-draggable-id="item-3"
@@ -406,6 +409,7 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
       >
         <div
           aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          aria-label="Handle for draggable item"
           class="drag-drop-item--handle"
           data-rbd-drag-handle-context-id="5"
           data-rbd-drag-handle-draggable-id="item-4"
@@ -440,6 +444,7 @@ exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
       >
         <div
           aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          aria-label="Handle for draggable item"
           class="drag-drop-item--handle"
           data-rbd-drag-handle-context-id="5"
           data-rbd-drag-handle-draggable-id="item-5"

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
@@ -277,6 +277,207 @@ exports[`<DragDrop /> Default story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<DragDrop /> DragByHandle story renders snapshot 1`] = `
+<div
+  style="margin: 1rem;"
+>
+  <section
+    class="drag-drop drag-drop--unstyled drag-drop--handles"
+    data-rbd-droppable-context-id="5"
+    data-rbd-droppable-id="all-containers"
+  >
+    <div
+      class="drag-drop-container"
+      data-rbd-droppable-context-id="5"
+      data-rbd-droppable-id="container-1"
+    >
+      <div
+        class="drag-drop-item"
+        data-rbd-draggable-context-id="5"
+        data-rbd-draggable-id="item-1"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          class="drag-drop-item--handle"
+          data-rbd-drag-handle-context-id="5"
+          data-rbd-drag-handle-draggable-id="item-1"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="#58636F"
+            height="1.25rem"
+            style="--icon-size: 1.25rem;"
+            width="1.25rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#drag-indicator"
+            />
+          </svg>
+        </div>
+        <div
+          class="fpo"
+        >
+          Content here
+        </div>
+      </div>
+      <div
+        class="drag-drop-item"
+        data-rbd-draggable-context-id="5"
+        data-rbd-draggable-id="item-2"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          class="drag-drop-item--handle"
+          data-rbd-drag-handle-context-id="5"
+          data-rbd-drag-handle-draggable-id="item-2"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="#58636F"
+            height="1.25rem"
+            style="--icon-size: 1.25rem;"
+            width="1.25rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#drag-indicator"
+            />
+          </svg>
+        </div>
+        <div
+          class="fpo"
+        >
+          Content here
+        </div>
+      </div>
+      <div
+        class="drag-drop-item"
+        data-rbd-draggable-context-id="5"
+        data-rbd-draggable-id="item-3"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          class="drag-drop-item--handle"
+          data-rbd-drag-handle-context-id="5"
+          data-rbd-drag-handle-draggable-id="item-3"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="#58636F"
+            height="1.25rem"
+            style="--icon-size: 1.25rem;"
+            width="1.25rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#drag-indicator"
+            />
+          </svg>
+        </div>
+        <div
+          class="fpo"
+        >
+          Content here
+        </div>
+      </div>
+    </div>
+    <div
+      class="drag-drop-container"
+      data-rbd-droppable-context-id="5"
+      data-rbd-droppable-id="container-2"
+    >
+      <div
+        class="drag-drop-item"
+        data-rbd-draggable-context-id="5"
+        data-rbd-draggable-id="item-4"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          class="drag-drop-item--handle"
+          data-rbd-drag-handle-context-id="5"
+          data-rbd-drag-handle-draggable-id="item-4"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="#58636F"
+            height="1.25rem"
+            style="--icon-size: 1.25rem;"
+            width="1.25rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#drag-indicator"
+            />
+          </svg>
+        </div>
+        <div
+          class="fpo"
+        >
+          Content here
+        </div>
+      </div>
+    </div>
+    <div
+      class="drag-drop-container"
+      data-rbd-droppable-context-id="5"
+      data-rbd-droppable-id="container-3"
+    >
+      <div
+        class="drag-drop-item"
+        data-rbd-draggable-context-id="5"
+        data-rbd-draggable-id="item-5"
+      >
+        <div
+          aria-describedby="rbd-hidden-text-5-hidden-text-46"
+          class="drag-drop-item--handle"
+          data-rbd-drag-handle-context-id="5"
+          data-rbd-drag-handle-draggable-id="item-5"
+          draggable="false"
+          role="button"
+          tabindex="0"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="#58636F"
+            height="1.25rem"
+            style="--icon-size: 1.25rem;"
+            width="1.25rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#drag-indicator"
+            />
+          </svg>
+        </div>
+        <div
+          class="fpo"
+        >
+          Content here
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`<DragDrop /> MultipleContainers story renders snapshot 1`] = `
 <div
   style="margin: 1rem;"
@@ -423,7 +624,7 @@ exports[`<DragDrop /> UnstyledItems story renders snapshot 1`] = `
   style="margin: 1rem;"
 >
   <section
-    class="drag-drop drag-drop--multiple drag-drop--unstyled"
+    class="drag-drop drag-drop--unstyled drag-drop--multiple"
     data-rbd-droppable-context-id="4"
     data-rbd-droppable-id="all-containers"
   >

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -18,12 +18,21 @@ export interface Props {
    * Prop that will be an array of items
    */
   items: ItemType[];
+  /**
+   * Prop that gets passed to DragDropItem(s)
+   */
+  dragByHandle: boolean;
 }
 
 /**
  * Primary UI component for user interaction
  */
-export const DragDropContainer = ({ className, container, items }: Props) => {
+export const DragDropContainer = ({
+  className,
+  container,
+  dragByHandle,
+  items,
+}: Props) => {
   const componentClassName = clsx(styles['drag-drop-container'], className, {});
   return container.id ? (
     <Droppable droppableId={container.id} type="item">
@@ -34,7 +43,12 @@ export const DragDropContainer = ({ className, container, items }: Props) => {
           {...provided.droppableProps}
         >
           {items.map((item: ItemType, index: number) => (
-            <DragDropItem index={index} item={item} key={item.id} />
+            <DragDropItem
+              dragByHandle={dragByHandle}
+              index={index}
+              item={item}
+              key={item.id}
+            />
           ))}
           {provided.placeholder}
         </div>

--- a/src/components/DragDropItem/DragDropItem.tsx
+++ b/src/components/DragDropItem/DragDropItem.tsx
@@ -42,6 +42,7 @@ export const DragDropItem = ({
             {...provided.draggableProps}
           >
             <div
+              aria-label="Handle for draggable item"
               className={clsx(styles['drag-drop-item--handle'])}
               {...provided.dragHandleProps}
             >

--- a/src/components/DragDropItem/DragDropItem.tsx
+++ b/src/components/DragDropItem/DragDropItem.tsx
@@ -15,18 +15,41 @@ export interface Props {
   item: ItemType;
   /** Item's original indexed position */
   index: number;
+  /**
+   * DragDrop items can be dragged by grabbing a handle, or dragged by grabbing anywhere on the item (default)
+   */
+  dragByHandle: boolean;
 }
 
 /**
  * Primary UI component for user interaction
  */
-export const DragDropItem = ({ className, item, index }: Props) => {
+export const DragDropItem = ({
+  className,
+  dragByHandle,
+  item,
+  index,
+}: Props) => {
   const componentClassName = clsx(styles['drag-drop-item'], className, {});
   // `id` is injected in <DragDrop />
   return item.id ? (
     <Draggable draggableId={item.id} index={index}>
       {(provided: DraggableProvided) => {
-        return (
+        return dragByHandle ? (
+          <div
+            className={componentClassName}
+            ref={provided.innerRef}
+            {...provided.draggableProps}
+          >
+            <div
+              className={clsx(styles['drag-drop-item--handle'])}
+              {...provided.dragHandleProps}
+            >
+              {item.handle}
+            </div>
+            {item.children}
+          </div>
+        ) : (
           <div
             className={componentClassName}
             ref={provided.innerRef}


### PR DESCRIPTION
### Summary:
Adds useHandles variant to DragDrop component. When set to true, items inherit no styles. A handle must be passed in as a prop, and the item can only be grabbed by clicking on the handle. 

https://user-images.githubusercontent.com/24812780/168608744-bdb2bc4d-a1d8-47fc-9bd0-dc9bb8ce5583.mov


### Test Plan:
New panel is added to Storybook: Organisms/Interactive/Drag and Drop/Drag By Handle. All other drag/drop functionality should be the same as the "unstyled" configuration.