### PR TITLE
chore(plop): fix sorting logic

### DIFF
--- a/plopfile.js
+++ b/plopfile.js
@@ -54,12 +54,23 @@ module.exports = (plop) => {
         if (fs.existsSync(indexFile)) {
           // Split the index file into lines.
           const lines = fs.readFileSync(indexFile, 'utf8').split('\n');
+          // Only sort lines that begin with "export {" in order to ignore
+          // comments and exported types.
+          const sortableLines = lines.filter((line) =>
+            /^export {.*/g.test(line),
+          );
+          // Ignore all other lines and turn them back into a string.
+          const ignoreLines = lines
+            .filter((line) => !/^export {.*/g.test(line))
+            .join('\n');
 
-          // Sort the lines.
-          const sorted = lines.sort((a, b) => a.localeCompare(b)).join('\n');
+          // Sort the sortable lines.
+          const sortedLines = sortableLines
+            .sort((a, b) => a.localeCompare(b))
+            .join('\n');
 
-          // Write the sorted lines back to the file.
-          fs.writeFileSync(indexFile, sorted + '\n');
+          // Write all of the lines back to the file.
+          fs.writeFileSync(indexFile, `${sortedLines}\n${ignoreLines}\n`);
 
           return `index.ts lines sorted`;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,9 +31,9 @@ export { default as LayoutLinelengthContainer } from './components/LayoutLinelen
 export { default as LayoutSection } from './components/LayoutSection';
 export { default as Link } from './components/Link';
 export { default as LinkList } from './components/LinkList';
+export { default as NumberIcon } from './components/NumberIcon';
 export { default as OverflowList } from './components/OverflowList';
 export { default as OverflowListItem } from './components/OverflowListItem';
-export { default as NumberIcon } from './components/NumberIcon';
 export { default as PageHeader } from './components/PageHeader';
 export { default as Panel } from './components/Panel';
 export { default as Section } from './components/Section';


### PR DESCRIPTION
### Summary:
The plop generator creates files for a new component, and it also adds the new component to the `index.src` file and sorts the file so the new export is placed correctly in the file. Recently some components were commented out in the `index.src` file, which has thrown off the sorting logic – it wants to sort the commented-out components with the rest of them, which breaks the comment blocks and generally messes up the file. You can see the output of the `plop` logic in this PR: https://github.com/chanzuckerberg/edu-design-system/pull/1063

This PR updates the sort logic to use @csnizik 's code change suggestion, which only sorts the lines that start with "export". The code suggestion is posted in this comment: https://github.com/chanzuckerberg/edu-design-system/pull/1063#issuecomment-1126290554

### Test Plan:
Run `npx plop` and verify the `index/src` file is still intact (it just moves one component, `NumberIcon`, to the right place in the list).