### PR TITLE
chore(tooltip): delay chromatic snapshots to see if it helps with flakiness

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -31,6 +31,11 @@ export default {
   title: 'Molecules/Messaging/Tooltip',
   component: Tooltip,
   args: defaultArgs,
+  parameters: {
+    chromatic: {
+      delay: 900,
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Tooltip>;

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -33,6 +33,8 @@ export default {
   args: defaultArgs,
   parameters: {
     chromatic: {
+      // These stories are very flaky, though we're not sure why.
+      // We delay the snapshot just in case there's a timing issue at play here.
       delay: 900,
     },
   },


### PR DESCRIPTION
### Summary:
Just what it says. @anniehu4 already turned off the animation for the tooltip stories, but these still keep coming up in chromatic. The chromatic snapshots show the tooltip as having moved ever to slightly, maybe 1 or 2 pixels, left or right. The only thing I know to try is delaying the snapshot in case there's some weirdness around the tooltip is still rendering when the snapshot is being taken. The button triggering the tooltip is not appearing changed; only the tooltip itself.

### Test Plan:
Wait and see if chromatic continues to flag changes in these stories on other PRs after this PR has merged.