### PR TITLE
chore(numbericon): remove aria labelledby prop for aria label req

### DIFF
--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -56,11 +56,6 @@ export const DifferentNumbers: StoryObj<Args> = {
         disable: true,
       },
     },
-    'aria-labelledby': {
-      table: {
-        disable: true,
-      },
-    },
   },
   render: (args) => (
     <div>

--- a/src/components/NumberIcon/NumberIcon.test.tsx
+++ b/src/components/NumberIcon/NumberIcon.test.tsx
@@ -1,18 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
-import { render } from '@testing-library/react';
-import React from 'react';
-import { NumberIcon } from './NumberIcon';
 import * as stories from './NumberIcon.stories';
-import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<NumberIcon />', () => {
-  const consoleWarnMock = consoleWarnMockHelper();
   generateSnapshots(stories);
-  it('should warn if no valid label', () => {
-    render(<NumberIcon number={1} />);
-    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
-    expect(consoleWarnMock).toHaveBeenCalledWith(
-      'No accessible name for the number icon.',
-    );
-  });
 });

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -7,11 +7,7 @@ export interface Props {
   /**
    * Screen-reader text for the number icon.
    */
-  'aria-label'?: string;
-  /**
-   * Id that links a label text for the number icon.
-   */
-  'aria-labelledby'?: string;
+  'aria-label': string;
   /**
    * CSS class names that can be appended to the component.
    */
@@ -52,13 +48,6 @@ export const NumberIcon = ({
   variant = 'base',
   ...other
 }: Props) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    !other['aria-label'] &&
-    !other['aria-labelledby']
-  ) {
-    console.warn('No accessible name for the number icon.');
-  }
   const componentClassName = clsx(
     styles['number-icon'],
     styles[`number-icon--${variant}`],


### PR DESCRIPTION
### Summary:
- removes `aria-labelledby` prop
- requires `aria-label` prop
- type checking makes previous console warns redundant hence removing
### Test Plan:
- unit tests pass
- no visual regressions