### PR TITLE
chore(messaging): darken icons and dark borders in mixins

### DIFF
--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -24,14 +24,14 @@
   border-style: solid;
   border-radius: var(--eds-theme-border-radius);
   border-width: var(--eds-theme-border-width);
-  border-color: var(--border-light-color);
+  border-color: var(--messaging-border-color);
 
   /* Vertical-specific styles */
   padding: var(--eds-size-4);
   text-align: center;
   justify-items: center;
   border-top-width: var(--eds-border-width-lg);
-  border-top-color: var(--border-dark-color); /* 3 */
+  border-top-color: var(--messaging-icon-color); /* 3 */
 }
 
 /**
@@ -40,7 +40,7 @@
  *    vertical orientation)
  */
 .banner__icon {
-  color: var(--border-dark-color); /* 1 */
+  color: var(--messaging-icon-color); /* 1 */
   --icon-size-default: var(--eds-size-5);
 }
 
@@ -97,8 +97,8 @@
 
     border-top-width: var(--eds-theme-border-width); /* 3 */
     border-left-width: var(--eds-border-width-lg); /* 3 */
-    border-top-color: var(--border-light-color); /* 3 */
-    border-left-color: var(--border-dark-color); /* 3 */
+    border-top-color: var(--messaging-border-color); /* 3 */
+    border-left-color: var(--messaging-icon-color); /* 3 */
 
     .banner__icon {
       --icon-size-default: var(--eds-size-3); /* 4 */
@@ -175,6 +175,6 @@
  */
 .banner--flat {
   box-shadow: none; /* 1 */
-  --border-light-color: transparent; /* 2 */
+  --messaging-border-color: transparent; /* 2 */
   margin-bottom: 0; /* 3 */
 }

--- a/src/components/InlineNotification/InlineNotification.module.css
+++ b/src/components/InlineNotification/InlineNotification.module.css
@@ -10,7 +10,6 @@
 .inline-notification {
   display: inline-flex;
   padding: var(--eds-size-quarter) var(--eds-size-half);
-  border: var(--eds-theme-border-width) solid var(--border-dark-color);
   border-radius: var(--eds-theme-border-radius);
 }
 
@@ -20,6 +19,7 @@
  */
 .inline-notification__icon {
   flex-shrink: 0; /* 1 */
+  color: var(--messaging-icon-color);
 }
 
 /**
@@ -35,34 +35,30 @@
  */
 .inline-notification--brand {
   @mixin messagingBrand;
+
+  border: var(--eds-theme-border-width) solid
+    var(--eds-theme-color-border-brand-primary-strong);
 }
 .inline-notification--success {
   @mixin messagingSuccess;
+
+  border: var(--eds-theme-border-width) solid
+    var(--eds-theme-color-border-utility-success-default);
 }
 .inline-notification--warning {
   @mixin messagingWarning;
+
+  border: var(--eds-theme-border-width) solid
+    var(--eds-theme-color-border-utility-warning-strong);
 }
 .inline-notification--yield {
   @mixin messagingYield;
+
+  border: var(--eds-theme-border-width) solid
+    var(--eds-theme-color-border-grade-revise-strong);
 }
 .inline-notification--subtle {
   background-color: var(--eds-theme-color-background-neutral-default);
-}
-
-/**
- * Icon color variants.
- */
-.inline-notification__icon--brand {
-  fill: var(--eds-theme-color-icon-brand-primary);
-}
-.inline-notification__icon--success {
-  fill: var(--eds-theme-color-icon-utility-success);
-}
-.inline-notification__icon--warning {
-  fill: var(--eds-theme-color-icon-utility-warning);
-}
-.inline-notification__icon--yield {
-  fill: var(--eds-theme-color-background-grade-revise-default);
 }
 
 /**

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -28,7 +28,7 @@
   border-left-width: var(--eds-border-width-lg); /* 3 */
   border-radius: var(--eds-size-half);
 
-  border-color: var(--border-light-color); /* 4 */
+  border-color: var(--messaging-border-color); /* 4 */
   border-left-color: var(--border-dark-color); /* 4 */
 
   box-shadow: var(--eds-box-shadow-sm);

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -144,48 +144,52 @@
 }
 
 @define-mixin messagingBrand {
-  --border-light-color: var(--eds-theme-color-border-brand-primary-subtle);
-  --border-dark-color: var(--eds-theme-color-border-brand-primary-strong);
+  --messaging-border-color: var(--eds-theme-color-border-brand-primary-subtle);
+  --messaging-icon-color: var(--eds-theme-color-icon-brand-primary);
 
   background: var(--eds-theme-color-background-brand-primary-default);
   color: var(--eds-theme-color-text-brand-primary);
 }
 
 @define-mixin messagingNeutral {
-  --border-light-color: var(--eds-theme-color-border-neutral-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-neutral-subtle);
+  --messaging-border-color: var(--eds-theme-color-border-neutral-subtle);
+  --messaging-icon-color: var(--eds-theme-color-icon-neutral-subtle);
 
   background: var(--eds-theme-color-background-neutral-subtle);
   color: var(--eds-theme-color-text-neutral-default);
 }
 
 @define-mixin messagingSuccess {
-  --border-light-color: var(--eds-theme-color-border-utility-success-subtle);
-  --border-dark-color: var(--eds-theme-color-border-utility-success-default);
+  --messaging-border-color: var(
+    --eds-theme-color-border-utility-success-subtle
+  );
+  --messaging-icon-color: var(--eds-theme-color-icon-utility-success);
 
   background: var(--eds-theme-color-background-utility-success);
   color: var(--eds-theme-color-text-utility-success);
 }
 
 @define-mixin messagingWarning {
-  --border-light-color: var(--eds-theme-color-border-utility-warning-subtle);
-  --border-dark-color: var(--eds-theme-color-border-utility-warning-strong);
+  --messaging-border-color: var(
+    --eds-theme-color-border-utility-warning-subtle
+  );
+  --messaging-icon-color: var(--eds-theme-color-icon-utility-warning);
 
   background: var(--eds-theme-color-background-utility-warning);
   color: var(--eds-theme-color-text-utility-warning);
 }
 
 @define-mixin messagingError {
-  --border-light-color: var(--eds-theme-color-border-utility-error-subtle);
-  --border-dark-color: var(--eds-theme-color-icon-utility-error);
+  --messaging-border-color: var(--eds-theme-color-border-utility-error-subtle);
+  --messaging-icon-color: var(--eds-theme-color-icon-utility-error);
 
   background: var(--eds-theme-color-background-utility-error);
   color: var(--eds-theme-color-text-utility-error);
 }
 
 @define-mixin messagingYield {
-  --border-light-color: var(--eds-theme-color-border-grade-revise-subtle);
-  --border-dark-color: var(--eds-theme-color-border-grade-revise-strong);
+  --messaging-border-color: var(--eds-theme-color-border-grade-revise-strong);
+  --messaging-icon-color: var(--eds-theme-color-border-grade-revise-strong);
 
   background: var(--eds-theme-color-background-grade-revise-subtle);
   color: var(--eds-theme-color-text-neutral-default);


### PR DESCRIPTION
### Summary:
The icons and darker borders in the "warning", "success", and "brand" variants of the messaging components (`Banner`, `Toast`, InlineNotification`) are a little too light. This PR darkens them to be consistent with the mocks.

The messaging components are in a slightly awkward place right now because the border around the `InlineNotification` is darker than the border around the `Banner` and `Toast` but lighter than the dark border on the side of `Banner` and `Toast`. So we have 3 border colors (2 of which are being used in `Banner` and `Toast` and 1 that's being used in `InlineNotification`). From the mocks, it looks like the `InlineNotification` border will be used in the `Banner`, but when used in combination with the drop shadow that's on the `Banner` and `Toast`, that border looks really dark.

So as much as I wanted to keep these components in sync, I'm just going to accept that the `InlineNotification` is going to have its own border color that's separate from `Toast` and `Banner`.  We can rejigger this when the `Banner` and `Toast` are updated (or when the `Banner` is updated because I think `Toast` might be staying the same? in which case that will be the odd one out).

I'm also renaming the messaging mixin css variables to be a little more specific:
- `--dark-border-color` is now `--messaging-icon-color` because it's being used for the icon in all of the components (and the `Banner` and `Toast` just happen to also use it as the dark border color)
- `--light-border-color` is now `--messaging-border-color` since the other border color was renamed to `icon`

### Screenshots
#### Brand
##### Before
![Screen Shot 2022-05-27 at 9 41 06 AM](https://user-images.githubusercontent.com/7761701/170742780-341b761c-3ece-44c1-991a-11c908c4283d.png)

##### After
![Screen Shot 2022-05-27 at 9 40 42 AM](https://user-images.githubusercontent.com/7761701/170742796-4e08fbdf-2b03-4849-9d57-ff41de7380c3.png)

#### Success
##### Before
![Screen Shot 2022-05-27 at 9 41 12 AM](https://user-images.githubusercontent.com/7761701/170742835-9d083935-cdaf-4bd2-ace7-16bfe5ff6627.png)

##### After
![Screen Shot 2022-05-27 at 9 40 49 AM](https://user-images.githubusercontent.com/7761701/170742868-fbfdc2b0-3ae0-42f8-b3c3-dbe9b430ccbf.png)

#### Warning
##### Before
![Screen Shot 2022-05-27 at 9 41 14 AM](https://user-images.githubusercontent.com/7761701/170742974-6fa64d7d-b074-4eb9-b5e2-21ad461539a4.png)

##### After
![Screen Shot 2022-05-27 at 9 40 53 AM](https://user-images.githubusercontent.com/7761701/170742985-a1774f09-f981-44f2-9f4a-9fa2fab068df.png)

### Test Plan:
- brand, warning, and success Banner and Toast icons are darker and match the mocks
- the light borders on the `Banner` and `Toast`s are unchanged
- `InlineNotification` is unchanged