### PR TITLE
chore(banner): update text styles to match figma

### DIFF
--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -55,10 +55,6 @@
   gap: var(--eds-size-2);
 }
 
-.banner__textContent {
-  gap: var(--eds-size-1);
-}
-
 .banner__action {
   justify-self: center;
   align-self: center;
@@ -67,13 +63,11 @@
 /**
  * Banner close button
  * 1) Button used to dismiss dismissable banners
- * 2) Match close button icon color to the banner text color
  */
 .banner__close-btn.banner__close-btn {
   position: absolute;
   top: var(--eds-size-half);
   right: var(--eds-size-half);
-  color: inherit; /* 2 */
 }
 
 /*------------------------------------*\

--- a/src/components/Banner/Banner.stories.module.css
+++ b/src/components/Banner/Banner.stories.module.css
@@ -1,3 +1,3 @@
-.headingBottomSpacing {
+.heading {
   margin-bottom: 1rem;
 }

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -3,6 +3,7 @@ import type { StoryObj } from '@storybook/react';
 import React from 'react';
 
 import { Banner, Variant } from './Banner';
+import styles from './Banner.stories.module.css';
 import Button from '../Button';
 import Heading from '../Heading';
 
@@ -188,7 +189,9 @@ export const DismissableWithAction: StoryObj<Args> = {
 export const DismissableBelowContent: StoryObj<Args> = {
   render: (args) => (
     <>
-      <Heading size="h1">Page Title</Heading>
+      <Heading className={styles.headingBottomSpacing} size="h1">
+        Page Title
+      </Heading>
       <Banner
         {...args}
         description={getDescription()}

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -189,7 +189,7 @@ export const DismissableWithAction: StoryObj<Args> = {
 export const DismissableBelowContent: StoryObj<Args> = {
   render: (args) => (
     <>
-      <Heading className={styles.headingBottomSpacing} size="h1">
+      <Heading className={styles['heading']} size="h1">
         Page Title
       </Heading>
       <Banner

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -13,6 +13,9 @@ export default {
     title:
       'New curriculum updates are available for one or more of your courses.',
   },
+  parameters: {
+    badges: [BADGE.DEPRECATED],
+  },
 };
 
 type Args = React.ComponentProps<typeof Banner>;
@@ -233,7 +236,4 @@ export const Flat: StoryObj<Args> = {
   args: {
     isFlat: true,
   },
-};
-Flat.parameters = {
-  badges: [BADGE.DEPRECATED],
 };

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -1,23 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
-import { composeStories } from '@storybook/testing-react';
-import { render } from '@testing-library/react';
-import React from 'react';
 import * as BannerStoryFile from './Banner.stories';
-import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<Banner />', () => {
-  const consoleWarnMock = consoleWarnMockHelper();
-
   generateSnapshots(BannerStoryFile);
-
-  it('should display warning message when attempting to use isFlat', () => {
-    const { Flat } = composeStories(BannerStoryFile);
-    render(<Flat />);
-    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
-    expect(consoleWarnMock).toBeCalledWith(
-      'The isFlat style is deprecated and will be removed in an upcoming release.\n',
-      'Please remove this prop to use the default elevated style (with a border and drop shadow) instead.',
-    );
-    consoleWarnMock.mockRestore();
-  });
 });

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -90,8 +90,7 @@ const variantToIconAssetsMap: {
 
 /**
  * @deprecated The Banner component is deprecated and will be removed in an upcoming release.
- * If your banner appears at the top of the page, please use the PageLevelBanner instead.
- * If the banner appears lower in the page, please use the InlineNoticication component.
+ * Please visit Zeroheight to find the right notification component for your needs: https://eds.czi.design/
  *
  * ```ts
  * import {Banner} from "@chanzuckerberg/eds";

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -30,12 +30,8 @@ export type BannerProps = {
    */
   onDismiss?: () => void;
   /**
-   * This prop is deprecated and will be removed in an upcoming release. Please use the default false value for isFlat.
-   *
    * The perceived elevation of the banner. A banner with isFlat appears flat against the surface while
    * a banner with isFlat as false has a border and drop shadow.
-   *
-   * @deprecated
    */
   isFlat?: boolean;
   /**
@@ -93,6 +89,10 @@ const variantToIconAssetsMap: {
 };
 
 /**
+ * @deprecated The Banner component is deprecated and will be removed in an upcoming release.
+ * If your banner appears at the top of the page, please use the PageLevelBanner instead.
+ * If the banner appears lower in the page, please use the InlineNoticication component.
+ *
  * ```ts
  * import {Banner} from "@chanzuckerberg/eds";
  * ```
@@ -153,7 +153,7 @@ export const Banner = ({
         <Button
           className={styles['banner__close-btn']}
           onClick={onDismiss}
-          status={variant}
+          status="neutral"
           variant="icon"
         >
           <Icon name={'close'} purpose="informative" title={'dismiss module'} />
@@ -168,14 +168,14 @@ export const Banner = ({
       />
 
       <div className={clsx(styles['banner__textAndAction'])}>
-        <div className={clsx(styles['banner__textContent'])}>
+        <div>
           {title && (
-            <Heading as={titleAs} size="title-sm" variant="inherit">
+            <Heading as={titleAs} size="title-md" variant={variant}>
               {title}
             </Heading>
           )}
           {description && (
-            <Text as={descriptionAs} variant="inherit">
+            <Text as={descriptionAs} size="sm" variant="neutral">
               {description}
             </Text>
           )}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -121,13 +121,6 @@ export const Banner = ({
   title,
   titleAs = 'h3',
 }: BannerProps) => {
-  if (isFlat && process.env.NODE_ENV !== 'production') {
-    console.warn(
-      'The isFlat style is deprecated and will be removed in an upcoming release.\n',
-      'Please remove this prop to use the default elevated style (with a border and drop shadow) instead.',
-    );
-  }
-
   const isHorizontal = !orientation;
 
   const componentClassName = clsx(

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
 
 exports[`<Banner /> DismissableBelowContent story renders snapshot 1`] = `
 <h1
-  class="heading heading--size-h1"
+  class="headingBottomSpacing heading heading--size-h1"
 >
   Page Title
 </h1>

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
 
 exports[`<Banner /> DismissableBelowContent story renders snapshot 1`] = `
 <h1
-  class="headingBottomSpacing heading heading--size-h1"
+  class="heading heading heading--size-h1"
 >
   Page Title
 </h1>

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -22,16 +22,14 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -53,7 +51,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -90,16 +88,14 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -138,16 +134,14 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -187,7 +181,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -224,16 +218,14 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -282,16 +274,14 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--error"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -313,7 +303,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
   class="banner banner--error banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--error"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -350,16 +340,14 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--error"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -398,16 +386,14 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--error"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -456,16 +442,14 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -504,16 +488,14 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--neutral"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -572,16 +554,14 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--neutral"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -620,16 +600,14 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--neutral"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -678,11 +656,9 @@ exports[`<Banner /> NoDescription story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
@@ -713,11 +689,9 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -756,16 +730,14 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--success"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -787,7 +759,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   class="banner banner--success banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--success"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -824,16 +796,14 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--success"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -872,16 +842,14 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--success"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -930,16 +898,14 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -961,7 +927,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
   class="banner banner--brand banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -998,16 +964,14 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1029,7 +993,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
   class="banner banner--brand banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -1066,16 +1030,14 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1124,16 +1086,14 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--brand"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1182,16 +1142,14 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--warning"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1213,7 +1171,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   class="banner banner--warning banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--warning"
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
     type="button"
   >
     <svg
@@ -1250,16 +1208,14 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--warning"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1298,16 +1254,14 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
   <div
     class="banner__textAndAction"
   >
-    <div
-      class="banner__textContent"
-    >
+    <div>
       <h3
-        class="heading heading--size-title-sm heading--inherit"
+        class="heading heading--size-title-md heading--warning"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--body text--inherit"
+        class="text text--sm text--neutral"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          


### PR DESCRIPTION
### Summary:
We have brand new shiny `Banner` component styles, which are similar to the old banner but there are important changes. The component in those designs is intended to be used as a top level page banner whereas the existing `Banner` is used in the page, sometimes even in sidebars.

As such, I'm going to make a new component, called `PageLevelBanner` to serve that need. For the existing `Banner`, I'm going to make a couple of style changes so it matches the new `PageLevelBanner` a little bit, but I'm not going to change too much. I mostly just want to update the text to be gray because the links will now be gray, but I'm also updating the spacing a little bit as well. In the future, we actually want people to use the `InlineNotification` for these in-page banners (also known as "section banners"), so this component will be deprecated and slowly phased out.

Changes made in this PR:
- `description` text is now gray (the `title` is still variant-colored)
- close button icon is now gray
- remove gap between `title` and `description`
- `title` text is a little bigger
- `description` text is a little smaller
- add deprecation badge to the whole component, not just the `isFlat` style

Changes in the new design I'm *not* making in this component:
- more horizontal padding
  - since the `Banner` component is sometimes used in sidebars, I don't want to add more horizontal padding that might make existing instances more squished
- light border and box shadow removed; dark border moved to the bottom
  - these new borders make sense on the `PageLevelBanner` because it's at the top of the page and only needs the bottom border to separate it from the content below. since the `Banner` is used inside the page, it needs separated on all 4 sides

### Screenshots
#### Before
<img width="1506" alt="error with action and brand dismissable banner stories in storybook, before this change" src="https://user-images.githubusercontent.com/7761701/172673001-c1dbedc8-eacb-4538-bb18-43334ee0e37a.png">

#### After
<img width="1506" alt="error with action and brand dismissable banner stories in storybook, after this change" src="https://user-images.githubusercontent.com/7761701/172673012-7a573f21-c171-476f-a97c-40e574296378.png">

#### PageLevelBanner in figma
<img width="547" alt="page level banner designs in figma" src="https://user-images.githubusercontent.com/7761701/172673144-8dedc06f-7598-44ea-a5a6-5a7b0f19a4c3.png">

### Test Plan:
Storybook + chromatic