### PR TITLE
feat(page-level-banner): add component

### DIFF
--- a/src/components/PageLevelBanner/PageLeveBanner.module.css
+++ b/src/components/PageLevelBanner/PageLeveBanner.module.css
@@ -6,19 +6,17 @@
 
 /**
  * 1) Message of information, success, caution, or warning to the user
- * 2) Default styles are for mobile view; desktop view is further down
+ * 2) Position is relative to allow for absolute-positioned close button
+ * 3) Grid is used to separate the icon from the text with correct spacing
  */
 .banner {
-  display: grid;
-  gap: var(--eds-size-2);
-  position: relative;
+  position: relative; /* 2 */
+  display: grid; /* 3 */
+  gap: var(--eds-size-2); /* 3 */
+  grid-template-columns: min-content 1fr; /* 3 */
+  padding: var(--eds-size-2) var(--eds-size-4);
   background-color: var(--eds-theme-color-neutral-subtle-background);
   border-bottom: var(--eds-border-width-md) solid var(--messaging-border-color);
-
-  /* 2 */
-  padding: var(--eds-size-4);
-  text-align: center;
-  justify-items: center;
 }
 
 /**
@@ -27,7 +25,7 @@
  */
 .banner__icon {
   color: var(--messaging-icon-color); /* 1 */
-  --icon-size-default: var(--eds-size-5);
+  --icon-size-default: var(--eds-size-3);
 }
 
 .banner__textContent {
@@ -46,35 +44,12 @@
   right: var(--eds-size-half);
 }
 
-/*------------------------------------*\
-    # DESKTOP VIEW
-\*------------------------------------*/
-
-@media screen and (min-width: $eds-bp-md) {
-  /**
-   * PageLeveBanner desktop view
-   * 1) Everything is left-aligned
-   * 2) Padding is reduced
-   * 3) Icon is smaller to match the heading line height
-   */
-  .banner {
-    grid-template-columns: min-content 1fr;
-    text-align: left; /* 1 */
-    justify-items: flex-start; /* 1 */
-    padding: var(--eds-size-2) var(--eds-size-4); /* 2 */
-
-    .banner__icon {
-      --icon-size-default: var(--eds-size-3); /* 3 */
-    }
-  }
-
-  /**
-   * Dismissable banner desktop view
-   * 1) Add extra right padding to account for close button
-   */
-  .banner--dismissable {
-    padding-right: var(--eds-size-9); /* 1 */
-  }
+/**
+ * Dismissable banner
+ * 1) Add extra right padding to account for close button
+ */
+.banner--dismissable {
+  padding-right: var(--eds-size-9); /* 1 */
 }
 
 /*------------------------------------*\

--- a/src/components/PageLevelBanner/PageLeveBanner.module.css
+++ b/src/components/PageLevelBanner/PageLeveBanner.module.css
@@ -1,0 +1,114 @@
+@import '../../design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # PAGE LEVEL BANNER
+\*------------------------------------*/
+
+/**
+ * 1) Message of information, success, caution, or warning to the user
+ * 2) Default styles are for mobile view; desktop view is further down
+ */
+.banner {
+  display: grid;
+  gap: var(--eds-size-2);
+  position: relative;
+  background-color: var(--eds-theme-color-neutral-subtle-background);
+  border-bottom: var(--eds-border-width-md) solid var(--messaging-border-color);
+
+  /* 2 */
+  padding: var(--eds-size-4);
+  text-align: center;
+  justify-items: center;
+}
+
+/**
+ * PageLeveBanner informational icon
+ * 1) Icon color matches the thick bottom border
+ */
+.banner__icon {
+  color: var(--messaging-icon-color); /* 1 */
+  --icon-size-default: var(--eds-size-5);
+}
+
+.banner__textContent {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+/**
+ * PageLeveBanner close button
+ * 1) Button used to dismiss dismissable banners
+ */
+.banner__close-btn.banner__close-btn {
+  position: absolute;
+  top: var(--eds-size-half);
+  right: var(--eds-size-half);
+}
+
+/*------------------------------------*\
+    # DESKTOP VIEW
+\*------------------------------------*/
+
+@media screen and (min-width: $eds-bp-md) {
+  /**
+   * PageLeveBanner desktop view
+   * 1) Everything is left-aligned
+   * 2) Padding is reduced
+   * 3) Icon is smaller to match the heading line height
+   */
+  .banner {
+    grid-template-columns: min-content 1fr;
+    text-align: left; /* 1 */
+    justify-items: flex-start; /* 1 */
+    padding: var(--eds-size-2) var(--eds-size-4); /* 2 */
+
+    .banner__icon {
+      --icon-size-default: var(--eds-size-3); /* 3 */
+    }
+  }
+
+  /**
+   * Dismissable banner desktop view
+   * 1) Add extra right padding to account for close button
+   */
+  .banner--dismissable {
+    padding-right: var(--eds-size-9); /* 1 */
+  }
+}
+
+/*------------------------------------*\
+    # VARIANTS
+\*------------------------------------*/
+
+/**
+ * PageLeveBanner success
+ */
+.banner--success {
+  @mixin messagingSuccess;
+  border-color: var(--eds-theme-color-border-utility-success-strong);
+}
+
+/**
+ * PageLeveBanner warning
+ */
+.banner--warning {
+  @mixin messagingWarning;
+  border-color: var(--eds-theme-color-border-utility-warning-strong);
+}
+
+/**
+ * PageLeveBanner error
+ */
+.banner--error {
+  @mixin messagingError;
+  border-color: var(--eds-theme-color-border-utility-error-strong);
+}
+
+/**
+ * PageLeveBanner brand
+ */
+.banner--brand {
+  @mixin messagingBrand;
+  border-color: var(--eds-theme-color-border-brand-primary-strong);
+}

--- a/src/components/PageLevelBanner/PageLeveBanner.stories.tsx
+++ b/src/components/PageLevelBanner/PageLeveBanner.stories.tsx
@@ -1,0 +1,119 @@
+import type { StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { PageLeveBanner, Variant } from './PageLeveBanner';
+import Button from '../Button';
+
+export default {
+  title: 'Molecules/Messaging/PageLeveBanner',
+  component: PageLeveBanner,
+  args: {
+    title:
+      'New curriculum updates are available for one or more of your courses.',
+  },
+};
+
+type Args = React.ComponentProps<typeof PageLeveBanner>;
+
+const getDescription = (status?: Variant) => (
+  <>
+    Summit Learning has a full-time team dedicated to constantly improving our
+    curriculum. To see the updates,{' '}
+    <Button
+      onClick={(event: any) => event.preventDefault()}
+      status={status}
+      variant="link"
+    >
+      click into the course
+    </Button>
+    .
+  </>
+);
+
+const dismissMethod = () => {
+  console.log('dismissing~');
+};
+
+export const Brand: StoryObj<Args> = {
+  render: ({ variant, ...other }) => {
+    return (
+      <PageLeveBanner
+        description={getDescription(variant)}
+        variant={variant}
+        {...other}
+      />
+    );
+  },
+};
+
+export const Success: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'success',
+  },
+  parameters: {
+    chromatic: { viewports: [560, 960, 1200] },
+  },
+};
+
+export const Warning: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'warning',
+  },
+};
+
+export const Error: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'error',
+  },
+};
+
+export const NoDescription: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    description: undefined,
+  },
+};
+
+export const NoTitle: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    title: undefined,
+  },
+};
+
+export const BrandDismissable: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    onDismiss: dismissMethod,
+  },
+  parameters: {
+    chromatic: { viewports: [560, 960, 1200] },
+  },
+};
+
+export const SuccessDismissable: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'success',
+    onDismiss: dismissMethod,
+  },
+};
+
+export const WarningDismissable: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'warning',
+    onDismiss: dismissMethod,
+  },
+};
+
+export const ErrorDismissable: StoryObj<Args> = {
+  ...Brand,
+  args: {
+    variant: 'error',
+    onDismiss: dismissMethod,
+  },
+};

--- a/src/components/PageLevelBanner/PageLeveBanner.stories.tsx
+++ b/src/components/PageLevelBanner/PageLeveBanner.stories.tsx
@@ -51,9 +51,6 @@ export const Success: StoryObj<Args> = {
   args: {
     variant: 'success',
   },
-  parameters: {
-    chromatic: { viewports: [560, 960, 1200] },
-  },
 };
 
 export const Warning: StoryObj<Args> = {
@@ -88,9 +85,6 @@ export const BrandDismissable: StoryObj<Args> = {
   ...Brand,
   args: {
     onDismiss: dismissMethod,
-  },
-  parameters: {
-    chromatic: { viewports: [560, 960, 1200] },
   },
 };
 

--- a/src/components/PageLevelBanner/PageLeveBanner.test.tsx
+++ b/src/components/PageLevelBanner/PageLeveBanner.test.tsx
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as PageLeveBannerStoryFile from './PageLeveBanner.stories';
+
+describe('<PageLeveBanner />', () => {
+  generateSnapshots(PageLeveBannerStoryFile);
+});

--- a/src/components/PageLevelBanner/PageLeveBanner.tsx
+++ b/src/components/PageLevelBanner/PageLeveBanner.tsx
@@ -1,0 +1,143 @@
+import clsx from 'clsx';
+import React, { ReactNode } from 'react';
+import styles from './PageLeveBanner.module.css';
+import Button from '../Button';
+import Heading, { HeadingElement } from '../Heading';
+import Icon from '../Icon';
+import Text from '../Text';
+
+export type Variant = 'brand' | 'success' | 'warning' | 'error';
+
+export type PageLeveBannerProps = {
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
+   * The description/body text of the banner
+   */
+  description?: ReactNode;
+  /**
+   * The element the description renders as
+   */
+  descriptionAs?: 'p' | 'span';
+  /**
+   * Callback when banner is dismissed. When passed in, renders banner with a close icon in the top right.
+   */
+  onDismiss?: () => void;
+  /**
+   * The title/heading of the banner
+   */
+  title?: ReactNode;
+  /**
+   * The element the title renders as
+   */
+  titleAs?: HeadingElement;
+  /**
+   * Stylistic variations for the banner type.
+   * - **brand** - results in a purple banner
+   * - **success** - results in a green banner
+   * - **warning** - results in a yellow banner
+   * - **error** - results in a red banner
+   */
+  variant?: Variant;
+};
+
+const variantToIconAssetsMap: {
+  [key: string]: {
+    name: 'notifications' | 'forum' | 'check-circle' | 'warning' | 'dangerous';
+    title: string;
+  };
+} = {
+  brand: {
+    name: 'notifications',
+    title: 'attention',
+  },
+  success: {
+    name: 'check-circle',
+    title: 'success',
+  },
+  warning: {
+    name: 'warning',
+    title: 'warning',
+  },
+  error: {
+    name: 'dangerous',
+    title: 'error',
+  },
+};
+
+/**
+ * ```ts
+ * import {PageLeveBanner} from "@chanzuckerberg/eds";
+ * ```
+ *
+ * A banner placed at the top of the page with important information.
+ *
+ * Example usage:
+ *
+ * ```tsx
+ * <PageLeveBanner
+ *   onDismiss={handleDismiss}
+ *   title="Some Title"
+ *   description={<>Some description, possibly with a <Link href="https://go.czi.team/eds">link to some other resource</Link>.</>}
+ * />
+ * ```
+ */
+export const PageLeveBanner = ({
+  className,
+  description,
+  descriptionAs = 'p',
+  onDismiss,
+  variant = 'brand',
+  title,
+  titleAs = 'h3',
+}: PageLeveBannerProps) => {
+  const componentClassName = clsx(
+    // Base styles
+    styles['banner'],
+    className,
+    // Variants
+    variant === 'brand' && styles['banner--brand'],
+    variant === 'error' && styles['banner--error'],
+    variant === 'warning' && styles['banner--warning'],
+    variant === 'success' && styles['banner--success'],
+    // Other options
+    onDismiss && styles['banner--dismissable'],
+  );
+
+  return (
+    <article className={componentClassName}>
+      {onDismiss && (
+        <Button
+          className={styles['banner__close-btn']}
+          onClick={onDismiss}
+          status="neutral"
+          variant="icon"
+        >
+          <Icon name={'close'} purpose="informative" title={'dismiss module'} />
+        </Button>
+      )}
+
+      <Icon
+        className={styles['banner__icon']}
+        name={variantToIconAssetsMap[variant].name}
+        purpose="informative"
+        title={variantToIconAssetsMap[variant].title}
+      />
+      <div>
+        {title && (
+          <Heading as={titleAs} size="title-md" variant={variant}>
+            {title}
+          </Heading>
+        )}
+        {description && (
+          <Text as={descriptionAs} size="sm" variant="neutral">
+            {description}
+          </Text>
+        )}
+      </div>
+    </article>
+  );
+};
+PageLeveBanner.displayName = 'PageLeveBanner';

--- a/src/components/PageLevelBanner/__snapshots__/PageLeveBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLeveBanner.test.tsx.snap
@@ -1,0 +1,483 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PageLeveBanner /> Brand story renders snapshot 1`] = `
+<article
+  class="banner banner--brand"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="1"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--brand"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--brand"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> BrandDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--brand banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="7"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="8"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--brand"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--brand"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> Error story renders snapshot 1`] = `
+<article
+  class="banner banner--error"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="4"
+    >
+      error
+    </title>
+    <use
+      xlink:href="test-file-stub#dangerous"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--error"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--error"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> ErrorDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--error banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="13"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="14"
+    >
+      error
+    </title>
+    <use
+      xlink:href="test-file-stub#dangerous"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--error"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--error"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> NoDescription story renders snapshot 1`] = `
+<article
+  class="banner banner--brand"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="5"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--brand"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> NoTitle story renders snapshot 1`] = `
+<article
+  class="banner banner--brand"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="6"
+    >
+      attention
+    </title>
+    <use
+      xlink:href="test-file-stub#notifications"
+    />
+  </svg>
+  <div>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--brand"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> Success story renders snapshot 1`] = `
+<article
+  class="banner banner--success"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="2"
+    >
+      success
+    </title>
+    <use
+      xlink:href="test-file-stub#check-circle"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--success"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--success"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> SuccessDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--success banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="9"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="10"
+    >
+      success
+    </title>
+    <use
+      xlink:href="test-file-stub#check-circle"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--success"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--success"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> Warning story renders snapshot 1`] = `
+<article
+  class="banner banner--warning"
+>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="3"
+    >
+      warning
+    </title>
+    <use
+      xlink:href="test-file-stub#warning"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--warning"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--warning"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;
+
+exports[`<PageLeveBanner /> WarningDismissable story renders snapshot 1`] = `
+<article
+  class="banner banner--warning banner--dismissable"
+>
+  <button
+    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="11"
+      >
+        dismiss module
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
+  <svg
+    class="icon banner__icon"
+    fill="currentColor"
+    role="img"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <title
+      id="12"
+    >
+      warning
+    </title>
+    <use
+      xlink:href="test-file-stub#warning"
+    />
+  </svg>
+  <div>
+    <h3
+      class="heading heading--size-title-md heading--warning"
+    >
+      New curriculum updates are available for one or more of your courses.
+    </h3>
+    <p
+      class="text text--sm text--neutral"
+    >
+      Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
+       
+      <button
+        class="clickable-style button button--link clickable-style--link clickable-style--warning"
+        type="button"
+      >
+        click into the course
+      </button>
+      .
+    </p>
+  </div>
+</article>
+`;

--- a/src/components/PageLevelBanner/index.ts
+++ b/src/components/PageLevelBanner/index.ts
@@ -1,0 +1,2 @@
+export { PageLeveBanner as default } from './PageLeveBanner';
+export type { Variant, PageLeveBannerProps } from './PageLeveBanner';

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { default as NumberIcon } from './components/NumberIcon';
 export { default as OverflowList } from './components/OverflowList';
 export { default as OverflowListItem } from './components/OverflowListItem';
 export { default as PageHeader } from './components/PageHeader';
+export { default as PageLevelBanner } from './components/PageLevelBanner';
 export { default as Panel } from './components/Panel';
 export { default as ProjectCard } from './components/ProjectCard';
 export { default as Section } from './components/Section';


### PR DESCRIPTION
### Summary:
Shortcut: https://app.shortcut.com/czi-edu/story/199935/banner-align-with-eds-in-figma
Figma: https://www.figma.com/file/Ff7hJoSvXX9hkAmIklnsT2/EDS---UI-Components-(Main)?node-id=2974%3A17980

Follow-up to https://github.com/chanzuckerberg/edu-design-system/pull/1114 In that PR, I'm updating the `Banner` styles to match the new designs a little more. As I explained there, I'm going to leave the `Banner` component to support existing usage (section banner inside the page) and make a new `PageLevelBanner` component for the new usage (top level banner only used at the top of the page). This PR adds that component.

This component is mostly copy/pasted from `Banner` with a few important changes:
- no `action` prop (this component does not support buttons, just links in the text)
- this banner has a border on the bottom but nothing on the other sides and no drop shadow (also has no bottom margin since there's no drop shadow to account for)
- no "neutral" variant
- no `orientation` prop (but I did keep the mobile design)
- no `isFlat` variant
- there's a little more horizontal padding
- there is no custom mobile view; I asked design if they wanted to keep the banner mobile view and they specifically said they want it to look like the desktop view

I chose to copy/paste the code instead of trying to find a way to share it between the 2 components because:
1) I think it would be annoyingly complicated
2) we're hoping to deprecate and remove the `Banner` entirely, and it would be nice to not have to detangle it from another component when that happens

### Screenshots
#### Storybook
<img width="1156" alt="all the page level banner stories" src="https://user-images.githubusercontent.com/7761701/172722997-0351410b-e3cc-4cba-80e7-92db78df1331.png">

#### Figma
<img width="547" alt="the page level banner designs in figma" src="https://user-images.githubusercontent.com/7761701/172723010-c97ebb22-b241-4639-a0ca-1cf416f9c62b.png">

### Test Plan:
Storybook + chromatic.