### PR TITLE
chore: don't import from @storybook/addon-docs/blocks

### DIFF
--- a/.storybook/components/DesignTokens/Legacy/LegacyTypography.stories.mdx
+++ b/.storybook/components/DesignTokens/Legacy/LegacyTypography.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs';
 
 import { Heading, Text } from '../../../../src';
 import styles from './TypographyTable.module.css';


### PR DESCRIPTION
### Summary:
I noticed a console warning in storybook about 
>browser.js:39 Importing from '@storybook/addon-docs/blocks' is deprecated, import directly from '@storybook/addon-docs' instead:
>
>https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-scoped-blocks-imports

<img width="1743" alt="storybook with the warning in question circled in the browser dev tools" src="https://user-images.githubusercontent.com/7761701/173148130-2f80b912-1464-4f1b-aeb7-a9d2ee2346cb.png">

This PR follows the warning's advice and updates the one place where we were importing from "@storybook/addon-docs/blocks" to instead import from "@storybook/addon-docs".

### Test Plan:
Load up storybook and verify that warning is gone.