### PR TITLE
chore: move options out of control in story argTypes

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -19,20 +19,20 @@ export default {
     variant: {
       control: {
         type: 'select',
-        options: ['primary', 'secondary', 'icon', 'link'],
       },
+      options: ['primary', 'secondary', 'icon', 'link'],
     },
     status: {
       control: {
         type: 'select',
-        options: ['brand', 'neutral', 'success', 'warning', 'error'],
       },
+      options: ['brand', 'neutral', 'success', 'warning', 'error'],
     },
     size: {
       control: {
         type: 'select',
-        options: ['sm', 'md', 'lg'],
       },
+      options: ['sm', 'md', 'lg'],
     },
     fullWidth: {
       control: 'boolean',

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -12,14 +12,14 @@ export default {
     name: {
       control: {
         type: 'select',
-        options: ALL_ICONS,
       },
+      options: ALL_ICONS,
     },
     color: {
       control: {
         type: 'select',
-        options: ['currentColor', ...Object.keys(ColorTokens)],
       },
+      options: ['currentColor', ...Object.keys(ColorTokens)],
     },
   },
 };

--- a/src/components/InlineNotification/InlineNotification.stories.tsx
+++ b/src/components/InlineNotification/InlineNotification.stories.tsx
@@ -14,8 +14,8 @@ export default {
     variant: {
       control: {
         type: 'select',
-        options: VARIANTS,
       },
+      options: VARIANTS,
     },
   },
   parameters: {

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -18,20 +18,20 @@ export default {
     variant: {
       control: {
         type: 'select',
-        options: ['primary', 'secondary', 'icon', 'link'],
       },
+      options: ['primary', 'secondary', 'icon', 'link'],
     },
     status: {
       control: {
         type: 'select',
-        options: ['brand', 'neutral', 'success', 'warning', 'error'],
       },
+      options: ['brand', 'neutral', 'success', 'warning', 'error'],
     },
     size: {
       control: {
         type: 'select',
-        options: ['sm', 'md', 'lg'],
       },
+      options: ['sm', 'md', 'lg'],
     },
     fullWidth: {
       control: 'boolean',

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -7,16 +7,14 @@ import Icon from '../Icon';
 export default {
   title: 'Molecules/Messaging/Tag',
   component: Tag,
-
   argTypes: {
     variant: {
       control: {
         type: 'select',
-        options: VARIANTS,
       },
+      options: VARIANTS,
     },
   },
-
   args: {
     text: 'Tag text',
     variant: 'neutral' as const,


### PR DESCRIPTION
### Summary:
I noticed a console warning about how we're using `options` in `argTypes` in our stories. It looks like we just need to move that property outside of the `control` object so they're siblings. This PR goes through and makes that change for all the relevant components.

<img width="1615" alt="the relevant console warning in the browser dev tools on the button story page" src="https://user-images.githubusercontent.com/7761701/173153635-0cd19a13-a975-4f82-911e-f3b3c25aec8a.png">

### Test Plan:
Navigate to all the changes components (and `Checkbox` because that also uses `options` but didn't have this issue) and verify none of the components have this warning in the console now.