### PR TITLE
chore(token-presets): add key to map

### DIFF
--- a/.storybook/components/DesignTokens/Tier1/TypographyPresets.js
+++ b/.storybook/components/DesignTokens/Tier1/TypographyPresets.js
@@ -58,6 +58,7 @@ export class Tier1TypographyPresets extends Component {
   render() {
     const renderTypeToken = (
       preset,
+      index,
       { boldVariant = true, lightVariant = false } = {},
     ) => {
       const { fontSize, lineHeight } = PRESET_SIZE_MAP[preset];
@@ -68,7 +69,7 @@ export class Tier1TypographyPresets extends Component {
       };
 
       return (
-        <>
+        <Grid key={`tier-1-typography-preset-${index}`}>
           <TokenSpecimen
             name={`eds-typography-preset-${preset}`}
             specimenClassName={`u-typography-preset-${preset}`}
@@ -88,17 +89,17 @@ export class Tier1TypographyPresets extends Component {
               {...commonProps}
             />
           )}
-        </>
+        </Grid>
       );
     };
 
     return (
       <Grid>
-        {Object.keys(PRESET_SIZE_MAP).map((preset) => {
+        {Object.keys(PRESET_SIZE_MAP).map((preset, index) => {
           if (preset === '005') {
-            return renderTypeToken(preset, { lightVariant: true });
+            return renderTypeToken(preset, index, { lightVariant: true });
           }
-          return renderTypeToken(preset);
+          return renderTypeToken(preset, index);
         })}
       </Grid>
     );


### PR DESCRIPTION
### Summary:
I noticed a console warning in storybook about:
>Warning: Each child in a list should have a unique "key" prop.
>
>Check the render method of `Tier1TypographyPresets`.

In this PR, I'm adding a key to quell react's concerns.

<img width="1615" alt="colors tier 1 definitions story in storybook with the relevant error highlighted in the browser dev tools" src="https://user-images.githubusercontent.com/7761701/173156658-ef8d91ae-f047-47b8-a107-5b4f19c9204e.png">

### Test Plan:
Navigate to any of the token stories in storybook and verify this error is now gone.

