### PR TITLE
chore(token-specimen): suppress content editable warning

### DIFF
--- a/.storybook/components/TokenSpecimen/TokenSpecimen.js
+++ b/.storybook/components/TokenSpecimen/TokenSpecimen.js
@@ -21,6 +21,7 @@ export class TokenSpecimen extends Component {
           }
           contentEditable
           style={this.props.inlineStyles}
+          suppressContentEditableWarning={true}
         >
           AaBbCcDdEeFfGg
         </div>
@@ -34,6 +35,7 @@ export class TokenSpecimen extends Component {
           }
           contentEditable
           style={this.props.inlineStyles}
+          suppressContentEditableWarning={true}
         >
           Almost before we knew it, we had left the ground.
         </div>

--- a/.storybook/components/TokenSpecimen/TokenSpecimen.js
+++ b/.storybook/components/TokenSpecimen/TokenSpecimen.js
@@ -21,7 +21,7 @@ export class TokenSpecimen extends Component {
           }
           contentEditable
           style={this.props.inlineStyles}
-          suppressContentEditableWarning={true}
+          suppressContentEditableWarning
         >
           AaBbCcDdEeFfGg
         </div>
@@ -35,7 +35,7 @@ export class TokenSpecimen extends Component {
           }
           contentEditable
           style={this.props.inlineStyles}
-          suppressContentEditableWarning={true}
+          suppressContentEditableWarning
         >
           Almost before we knew it, we had left the ground.
         </div>


### PR DESCRIPTION
### Summary:
I noticed a console error in storybook about:
>Warning: A component is `contentEditable` and contains `children` managed by React.

I think what it's concerned about is that a user can click into the typography token sample text, edit the text, and then something could cause react to rerender the component, which would wipe away the user's changes. This editing capability is just so people can see what different strings will look like with these presets, so I think it's fine to just suppress the warning, which I'm doing in this PR. (I don't expect people to actually use this, especially since there's nothing in the UI to communicate that it's even possible, so I would also be fine with just removing the content editable feature.)

<img width="1615" alt="colors tier 1 definitions story in storybook with the relevant error highlighted in the browser dev tools" src="https://user-images.githubusercontent.com/7761701/173156673-7a15a000-f173-40ae-8188-7cf69da43541.png">

### Test Plan:
Navigate to any of the token stories in storybook and verify this error is now gone.