### PR TITLE
chore(plop): add spaces in css file headline

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "size-limit": "^4.12.0",
+    "snake-case": "^3.0.4",
     "standard-version": "^9.3.2",
     "storybook-css-modules-preset": "^1.1.1",
     "style-dictionary": "^3.7.0",

--- a/plop-templates/Component/Component.module.css.hbs
+++ b/plop-templates/Component/Component.module.css.hbs
@@ -1,7 +1,7 @@
 @import '../../design-tokens/mixins.css';
 
 /*------------------------------------*\
-    # {{upperCase name}}
+    # {{spacedUpperCase name}}
 \*------------------------------------*/
 
 /**

--- a/plop-templates/Recipe/Recipe.module.css.hbs
+++ b/plop-templates/Recipe/Recipe.module.css.hbs
@@ -1,7 +1,7 @@
 @import '../../../src/design-tokens/mixins.css';
 
 /*------------------------------------*\
-    # {{upperCase name}}
+    # {{spacedUpperCase name}}
 \*------------------------------------*/
 
 /**

--- a/plopfile.js
+++ b/plopfile.js
@@ -1,7 +1,10 @@
 const pascalCase = require('pascal-case');
+const { snakeCase } = require('snake-case');
 
 module.exports = (plop) => {
-  plop.setHelper('upperCase', (txt) => txt.toUpperCase());
+  plop.setHelper('spacedUpperCase', (txt) =>
+    snakeCase(txt).split('_').join(' ').toUpperCase(),
+  );
 
   // This helper allows us to place a variable inside curly braces without spaces
   // between the text and the braces.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1734,6 +1734,7 @@ __metadata:
     react-portal: ^4.2.1
     react-uid: ^2.3.1
     size-limit: ^4.12.0
+    snake-case: ^3.0.4
     standard-version: ^9.3.2
     storybook-css-modules-preset: ^1.1.1
     style-dictionary: ^3.7.0


### PR DESCRIPTION
### Summary:
In the css modules files for components and recipes, we have a headline text that looks like `# A COMPONENT NAME`. Right now, the plop generator doesn't add spaces between the words (so it would come out like `# ACOMPONENTNAME`, which is really hard to read). In this PR, I updated the helper that formats that text to place spaces between the words.

### Test Plan:
Test out plop for both components and recipes using both a spaced component name (ex: "a component name") and pascal cased component name (ex: "AComponentName"), and verify that all of these cases produce an uppercase text headline in the css file with spaces between the words, as expected.