### PR TITLE
test: make stylelint run on .storybook files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "generate-icon-types": "node ./scripts/generateIconTypes.js",
     "lint": "yarn run lint:styles && yarn run lint:scripts",
     "lint:fix": "yarn run lint:styles:fix && yarn run lint:scripts:fix",
-    "lint:styles": "stylelint --ignore-path .gitignore src/**/*.css",
+    "lint:styles": "stylelint --ignore-path .gitignore src/**/*.css .storybook/**/*.css",
     "lint:styles:fix": "yarn run lint:styles --fix",
     "lint:scripts": "eslint --quiet --ignore-path .gitignore --ext=js,jsx,ts,tsx .",
     "lint:scripts:fix": "yarn run lint:scripts --fix",


### PR DESCRIPTION
### Summary:
`stylelint` is currently only running on files in the `src` directory, which means it's not running on recipes and pages in the `.storybook` directory. This PR just adds `.storybook` to the list of places to lint.

### Test Plan:
Add an empty css class in the css modules file for a recipe and a page,
run `yarn lint`,
and verify those errors are reported.