### PR TITLE
fix(cardwithnotification): re-export subcomponents directly

### DIFF
--- a/.storybook/recipes/CardWithNotification/CardWithNotification.tsx
+++ b/.storybook/recipes/CardWithNotification/CardWithNotification.tsx
@@ -2,7 +2,13 @@ import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 import styles from './CardWithNotification.module.css';
 
-import { Card, InlineNotification } from '../../../src';
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  InlineNotification,
+} from '../../../src';
 import { VARIANTS } from '../../../src/components/InlineNotification/InlineNotification';
 
 export interface Props {
@@ -58,6 +64,6 @@ export const CardWithNotification = ({
 /**
  * Re-exports subcomponents so consuming apps don't have to import the Card component or the individual subcomponents.
  */
-CardWithNotification.Body = Card.Body;
-CardWithNotification.Footer = Card.Footer;
-CardWithNotification.Header = Card.Header;
+CardWithNotification.Body = CardBody;
+CardWithNotification.Footer = CardFooter;
+CardWithNotification.Header = CardHeader;


### PR DESCRIPTION
### Summary:
- CardWithNotification indirect export causes component naming issues:
![image](https://user-images.githubusercontent.com/86632227/174151333-1dfe9851-d9df-409e-876f-707e182b15ce.png)

- Direct importing and re-exporting fixes component naming issues:
![image](https://user-images.githubusercontent.com/86632227/174151355-4e269534-f210-4d7d-8613-131b2f7b473d.png)


### Test Plan:
- names correctly represented when built
- unit tests pass
- no visual regressions