### PR TITLE
chore(timeline-nav): remove console log from testing

### DIFF
--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -329,7 +329,6 @@ export const TimelineNav = ({
         >
           {/* TODO: improve `any` type */}
           {timelineNavItems().map((tab: TimelineNavItem, i: number) => {
-            console.log(tab);
             const isActive = activeIndexState === i;
             const itemVariant = variant && tab.props.variant;
             return (


### PR DESCRIPTION
### Summary:
While running tests, I noticed there's a `console.log` in `TimelineNav` that I'm guessing was for testing. This PR removes that logging.
<img width="449" alt="code terminal with a bunch of really long text being logged by the TimelineNav component" src="https://user-images.githubusercontent.com/7761701/174191819-f7f6cd42-9731-4212-b15e-6246f09a10ed.png">

### Test Plan:
Run `yarn test` and verify you don't see any logging.