### PR TITLE
docs: add guidelines for component comment

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -192,9 +192,9 @@ For example:
 \*------------------------------------*/
 
 /**
- * Button
+ * ButtonGroup
  */
-.button {
+.button-group {
 }
 
 /**
@@ -360,6 +360,38 @@ export interface Props {
 ```
 
 All component props must be defined with appropriate [TypeScript type](https://www.typescriptlang.org/docs/handbook/basic-types.html) applied. Each prop must contain a comment above the prop declaration to document the prop's function. These comments and prop declarations are automatically converted into prop documentation in Storybook. As a general guideline, try to organize component prop definitions alphabetically.
+
+### Component comments
+
+All components should be documented with a comment directly before the component declaration. (It's important that there are no spaces between the comment and the component so that the comment will appear in storybook.)
+
+The comment should begin with an import example, include a general description of the component, possibly note behavior that may not be obvious to developers (so they don't have to dig through the code to understand what it does), and end with example usage.
+
+Example:
+
+````
+/**
+ * ```ts
+ * import {ButtonGroup} from "@chanzuckerberg/eds";
+ * ```
+ *
+ * A container for buttons grouped together horizontally or vertically.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * <ButtonGroup
+ *   className={componentClassName}
+ *   spacing='1x'
+ *   orientation='vertical'
+ * >
+ *   <Button>Left button</Button>
+ *   <Button>Right button</Button>
+ * </ButtonGroup>
+ * ```
+ */
+ export const ButtonGroup = ({
+````
 
 ### Export module
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -15,10 +15,12 @@ type Props = {
   className?: string;
   /**
    * How much space there should be between the buttons.
+   * 'max' does not work with 'vertical' orientation.
    */
   spacing?: 'none' | '1x' | 'max';
   /**
    * Whether the buttons should be laid out horizontally or stacked vertically.
+   * 'vertical' does not work with 'max' spacing.
    */
   orientation?: 'horizontal' | 'vertical';
 };
@@ -29,6 +31,19 @@ type Props = {
  * ```
  *
  * A container for buttons grouped together horizontally or vertically.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * <ButtonGroup
+ *   className={componentClassName}
+ *   spacing='1x'
+ *   orientation='vertical'
+ * >
+ *   <Button>Left button</Button>
+ *   <Button>Right button</Button>
+ * </ButtonGroup>
+ * ```
  */
 export function ButtonGroup({
   children,


### PR DESCRIPTION
### Summary:
A while back I updated the component comments to match our preferred pattern, but I didn't update the docs to explain this. This PR updates the documentation and also updates the component I referenced. I added that component comments should include example usage, which we've sometimes been doing but not always, so I'm wondering how people feel about adding that to the guidelines. I think it's useful and I find that sort of thing really helpful when reading documentation for other systems, but I also understand if people feel like it's overkill for simple components.

<img width="1073" alt="ButtonGroup in storybook in the docs tab with the component comment displayed" src="https://user-images.githubusercontent.com/7761701/174192778-62ecc110-f3aa-4601-879a-8b6f725ac263.png">
<img width="615" alt="the documentation with the new section visible" src="https://user-images.githubusercontent.com/7761701/174192780-518a5ff3-7637-4006-b15a-cbb38b07dfaf.png">

### Test Plan:
Verify the `ButtonGroup` comment is showing properly in storybook and that the new documentation section appears as expected.