### PR TITLE
chore(modaltitle): allow heading props for modal title

### DIFF
--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -16,7 +16,7 @@ export const VARIANTS = [
    */ 'info',
 ] as const;
 export type Variant = typeof VARIANTS[number];
-export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'h7';
+export type HeadingElement = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 // For now, "h1"-"h6" sizes point to the old type ramp, while
 // "headline-*" and "title-*" sizes point to the new type ramp.
 // These will be brought in sync with the next major release.
@@ -30,7 +30,7 @@ const TOKEN_TO_SIZE = {
   'body-xs': 'h7',
   'title-xs': 'h5',
 };
-export type HeadingSize = HeadingElement | keyof typeof TOKEN_TO_SIZE;
+export type HeadingSize = HeadingElement | 'h7' | keyof typeof TOKEN_TO_SIZE;
 
 type Props = {
   /**

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -257,6 +257,14 @@ export const ControlHeadingInteractive: StoryObj<HeadingArgs> = {
       <Modal.Body>Modal Content</Modal.Body>
     </InteractiveExample>
   ),
+  /**
+   * Purpose of this story is to have different controls for the Modal.Title but defaults to what all the other stories are.
+   * Hence will snap similarly to the other stories has no value in snapping both unit and Chromatic.
+   */
+  parameters: {
+    snapshot: { skip: true },
+    chromatic: { disableSnapshot: false },
+  },
 };
 
 export const WithoutCloseButton: StoryObj<InteractiveArgs> = {

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -263,7 +263,6 @@ export const ControlHeadingInteractive: StoryObj<HeadingArgs> = {
    */
   parameters: {
     snapshot: { skip: true },
-    chromatic: { disableSnapshot: false },
   },
 };
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import Modal, { ModalContent } from './Modal';
 import styles from './Modal.stories.module.css';
 import { Button, ButtonGroup, Heading, Text } from '../../';
+import { VARIANTS } from '../Heading/Heading';
 
 export default {
   title: 'Organisms/Interactive/Modal',
@@ -209,6 +210,52 @@ function InteractiveExample(args: InteractiveArgs) {
 export const DefaultInteractive: StoryObj<InteractiveArgs> = {
   render: (args) => (
     <InteractiveExample {...args}>{getChildren()}</InteractiveExample>
+  ),
+};
+
+type HeadingArgs = React.ComponentProps<typeof Heading>;
+export const ControlHeadingInteractive: StoryObj<HeadingArgs> = {
+  argTypes: {
+    as: {
+      control: 'select',
+      name: 'title "as" prop',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+    },
+    size: {
+      control: 'select',
+      name: 'title "size" prop',
+      options: [
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'headline-lg',
+        'headline-md',
+        'headline-sm',
+        'title-md',
+        'title-sm',
+        'body-sm',
+        'body-xs',
+        'title-xs',
+      ],
+    },
+    variant: {
+      control: 'select',
+      name: 'title "variant" prop',
+      options: VARIANTS,
+    },
+  },
+  render: ({ as, size, variant, ...args }) => (
+    <InteractiveExample {...args}>
+      <Modal.Header>
+        <Modal.Title as={as} size={size} variant={variant}>
+          Modal Title
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>Modal Content</Modal.Body>
+    </InteractiveExample>
   ),
 };
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -231,6 +231,7 @@ export const ControlHeadingInteractive: StoryObj<HeadingArgs> = {
         'h4',
         'h5',
         'h6',
+        'h7',
         'headline-lg',
         'headline-md',
         'headline-sm',

--- a/src/components/ModalTitle/ModalTitle.tsx
+++ b/src/components/ModalTitle/ModalTitle.tsx
@@ -1,8 +1,10 @@
 import { Dialog } from '@headlessui/react';
 import React, { ReactNode } from 'react';
-import Heading from '../Heading';
+import Heading, { HeadingSize } from '../Heading';
 
-type Props = {
+type HeadingProps = React.ComponentProps<typeof Heading>;
+
+type Props = Omit<HeadingProps, 'size'> & {
   /**
    * Text for the modal title.
    */
@@ -11,15 +13,21 @@ type Props = {
    * CSS class names that can be appended to the component.
    */
   className?: string;
+  /**
+   * Modal Title Heading size. Defaults to 'headline-md'
+   */
+  size?: HeadingSize;
 };
 
-export const ModalTitle = ({ children, className, ...other }: Props) => (
-  <Dialog.Title
-    as={Heading}
-    className={className}
-    size="headline-md"
-    {...other}
-  >
-    {children}
+export const ModalTitle = ({
+  children,
+  className,
+  size = 'headline-md',
+  ...other
+}: Props) => (
+  <Dialog.Title as={React.Fragment}>
+    <Heading className={className} size={size} {...other}>
+      {children}
+    </Heading>
   </Dialog.Title>
 );


### PR DESCRIPTION
### Summary:
- allows the heading props for the modal title
  - this allows more flexibility and control over the modal title
### Test Plan:
- unit tests
- no visual regression

[sc-202061]