### PR TITLE
chore(modalheader): allow class names for brand asset wrapper

### DIFF
--- a/src/components/ModalHeader/ModalHeader.tsx
+++ b/src/components/ModalHeader/ModalHeader.tsx
@@ -20,9 +20,14 @@ export type Props = {
    * Placeholder for brand asset.
    */
   brandAsset?: ReactNode;
+  /**
+   * CSS class names that can be appended to the brand asset.
+   */
+  assetClassName?: string;
 };
 
 export const ModalHeader = ({
+  assetClassName,
   brandAsset,
   children,
   className,
@@ -34,11 +39,15 @@ export const ModalHeader = ({
     variant === 'brand' && styles['modal-header--brand'],
     className,
   );
+  const brandAssetClassName = clsx(
+    styles['modal-header__brand-asset'],
+    assetClassName,
+  );
   return (
     <div className={componentClassName} {...other}>
       {children}
       {variant === 'brand' && brandAsset && (
-        <div className={styles['modal-header__brand-asset']}>{brandAsset}</div>
+        <div className={brandAssetClassName}>{brandAsset}</div>
       )}
     </div>
   );


### PR DESCRIPTION
### Summary:
- more flexibility is requested in styling the brand asset
- adds `assetClassName` prop to be appended to the brand asset wrapper
### Test Plan:
- unit tests pass
- no visual regression

![image](https://user-images.githubusercontent.com/86632227/175128511-753232f5-a629-4adf-a44f-2964832f5d87.png)
