### PR TITLE
chore: override transition for prefers reduced motion everywhere

### DIFF
--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -19,6 +19,10 @@
     margin-bottom: 0;
     padding-left: var(--eds-size-2-and-half);
     transition: width var(--eds-anim-move-quick) var(--eds-anim-ease);
+
+    @media screen and (prefers-reduced-motion) {
+      transition: none;
+    }
   }
 }
 

--- a/.storybook/recipes/PageShell/PageShell.module.css
+++ b/.storybook/recipes/PageShell/PageShell.module.css
@@ -26,4 +26,8 @@
   &:focus {
     transform: translateY(0%);
   }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -156,6 +156,30 @@ Use the following conventions:
 }
 ```
 
+### Disable animations for prefers reduced motion setting
+
+There are some disabilities (ex: vestibular disorders) that cause users to become nauseous when they see a lot of movement happening on screen. Luckily, there is an operating system accessibility setting called "prefers reduced motion" that we can detect with CSS using a media query. Just to be safe, we disable all animations for users who have this setting turned on.
+
+Examples:
+
+```scss
+.dropdown-button__icon {
+  transition: transform var(--eds-anim-move-medium) var(--eds-anim-ease);
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+.loading-indicator__icon {
+  animation: rotateIcon 2s linear infinite;
+
+  @media screen and (prefers-reduced-motion) {
+    animation: none;
+  }
+}
+```
+
 ### CSS Comments
 
 EDS uses the following commenting conventions, which take much inspiration from [these commenting guidelines](https://cssguidelin.es/#commenting).

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -33,6 +33,10 @@ a.card {
   &:hover {
     box-shadow: var(--eds-box-shadow-md);
   }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 /**

--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -142,6 +142,10 @@
     border-color: var(--eds-theme-color-border-neutral-subtle);
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
   * 1) The unstyled variant removes all styling from items.
   */
@@ -182,6 +186,10 @@
   border-radius: var(--eds-border-radius-lg);
   background: var(--eds-theme-color-background-neutral-default);
   transition: opacity var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 
   .drag-drop__item--hover & {
     opacity: 0;

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -80,6 +80,10 @@
     @mixin focus;
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
   * Dropdown menu link within a lined dropdown menu item
   * 1) Add bottom border to the item

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -45,6 +45,10 @@
     position: static;
     margin-bottom: var(--eds-size-4);
   }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 /**

--- a/src/components/LinkList/LinkList.module.css
+++ b/src/components/LinkList/LinkList.module.css
@@ -85,6 +85,10 @@
   position: relative;
   top: 5px;
   transition: fill var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 .link-list__text + .link-list__icon {

--- a/src/components/NavContainer/NavContainer.module.css
+++ b/src/components/NavContainer/NavContainer.module.css
@@ -21,6 +21,10 @@
   z-index: var(--eds-z-index-bottom); /* 2 */
   transition: all var(--eds-anim-move-quick) var(--eds-anim-ease);
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
    * Large screen styles
    * 1) Un-hide navcontainer to display nav by default on larger screens

--- a/src/components/Popover/Popover.module.css
+++ b/src/components/Popover/Popover.module.css
@@ -32,6 +32,10 @@
     @mixin focus;
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /** Psuedo-element ::after
   * 1) Adds a cosmetic triangle to the bottom edge of the popover, pointing toward the button that opened the popover
   */
@@ -56,6 +60,10 @@
     transform: translateY(0);
     transition: opacity var(--eds-anim-fade-quick) var(--eds-anim-ease);
     z-index: var(--eds-z-index-top);
+
+    @media screen and (prefers-reduced-motion) {
+      transition: none;
+    }
   }
 }
 

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -29,6 +29,10 @@
   &:focus-visible {
     @mixin focusInverted;
   }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 /**

--- a/src/components/ProjectCard/ProjectCard.module.css
+++ b/src/components/ProjectCard/ProjectCard.module.css
@@ -10,6 +10,10 @@
 .project-card {
   position: relative;
   transition: all var(--eds-anim-fade-quick) var(--eds-anim-fade-quick);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 .project-card__header.project-card__header {

--- a/src/components/ShowHide/ShowHide.module.css
+++ b/src/components/ShowHide/ShowHide.module.css
@@ -12,8 +12,8 @@
   display: none;
 
   /**
-     * 1) Button that toggles open and closes a panel
-     */
+   * 1) Button that toggles open and closes a panel
+   */
   .show-hide.eds-is-active & {
     margin-top: var(--eds-size-1);
     display: block;
@@ -21,34 +21,21 @@
 }
 
 /**
-   * Button icon within show hide component
-   * 1) Add transition for icon flip when activated
-   */
-.show-hide__btn .button__icon {
-  position: relative;
-  top: 4px;
-  height: var(--eds-size-1);
-  width: var(--eds-size-1);
-  transition: transform var(--eds-anim-fade-quick) var(--eds-anim-ease); /* 1 */
+ * Button icon within show hide component
+ * 1) Add transition for icon flip when activated
+ */
+.show-hide svg {
+  transition: transform var(--eds-anim-fade-long) var(--eds-anim-ease); /* 1 */
 
   @media screen and (prefers-reduced-motion) {
     transition: none;
   }
+}
 
-  /**
-   * Button icon within small show hide component
-   */
-  .show-hide--sm & {
-    top: 2px;
-    height: var(--eds-size-1);
-    width: var(--eds-size-1);
-  }
-
-  /**
-   * Button icon within active show hide component
-   * 1) Rotate icon 180 deg when show hide component is open
-   */
-  .show-hide.eds-is-active & {
-    transform: rotate(90deg); /* 1 */
-  }
+/**
+ * Button icon within active show hide component
+ * 1) Rotate icon 180 deg when show hide component is open
+ */
+.show-hide.eds-is-active svg {
+  transform: rotate(90deg); /* 1 */
 }

--- a/src/components/ShowHide/ShowHide.module.css
+++ b/src/components/ShowHide/ShowHide.module.css
@@ -31,6 +31,10 @@
   width: var(--eds-size-1);
   transition: transform var(--eds-anim-fade-quick) var(--eds-anim-ease); /* 1 */
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
    * Button icon within small show hide component
    */

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -67,6 +67,10 @@
     @mixin focus;
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   .tabs--inverted & {
     color: var(--eds-theme-color-text-neutral-default-inverse);
   }

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -137,6 +137,10 @@
     @mixin focus;
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
    * Timeline nav link within active timeline-nav item
    */

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -84,6 +84,10 @@
     border-color: var(--eds-theme-color-border-brand-primary-strong);
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
    * Input error state
    */

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
@@ -86,6 +86,10 @@
     visibility var(--eds-anim-move-quick) var(--eds-anim-ease),
     overflow var(--eds-anim-move-quick) steps(1, end),
     opacity var(--eds-anim-move-quick) var(--eds-anim-ease);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 /**
@@ -127,6 +131,10 @@
 .accordion__panel-icon.accordion__panel-icon {
   margin-left: auto;
   transition: transform var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }
 
 /**

--- a/src/upcoming-components/Drawer/Drawer.module.css
+++ b/src/upcoming-components/Drawer/Drawer.module.css
@@ -66,6 +66,10 @@
     @mixin focus;
   }
 
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
   /**
   * Modal window inside active modal
   * 1) Transform added for animation

--- a/src/upcoming-components/LoadingIndicator/LoadingIndicator.module.css
+++ b/src/upcoming-components/LoadingIndicator/LoadingIndicator.module.css
@@ -13,6 +13,10 @@
 
 .loading-indicator__icon {
   animation: rotateIcon 2s linear infinite;
+
+  @media screen and (prefers-reduced-motion) {
+    animation: none;
+  }
 }
 
 /* The animation code */

--- a/src/upcoming-components/SkeletonBar/SkeletonBar.module.css
+++ b/src/upcoming-components/SkeletonBar/SkeletonBar.module.css
@@ -21,6 +21,10 @@
   );
   background-size: 400% 100%;
   animation: pulse 5s linear infinite;
+
+  @media screen and (prefers-reduced-motion) {
+    animation: none;
+  }
 }
 
 .skeleton-bar--sm {

--- a/src/upcoming-components/Tags/Tags.module.css
+++ b/src/upcoming-components/Tags/Tags.module.css
@@ -53,4 +53,8 @@
   margin-left: var(--eds-size-1);
   pointer-events: none;
   transition: var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
 }


### PR DESCRIPTION
### Summary:
Most of the animations in the repo right now don't have an override for animations when the user has the OS accessibility feature "prefers reduced motion" turned on, so I went ahead and added those overrides. I also added a section about this to the documentation.

<img width="673" alt="preview of section being added to documentation" src="https://user-images.githubusercontent.com/7761701/175556198-6ab06308-6d50-41a2-9f40-94494a92bb98.png">

### Test Plan:
I spot-checked a couple of the components to verify that the animation runs when the setting is turned off and does not run when the setting is turned on.