### PR TITLE
chore(show-hide, drawer): use e.key instead of e.code in keyboard events

### DIFF
--- a/src/components/ShowHide/ShowHide.tsx
+++ b/src/components/ShowHide/ShowHide.tsx
@@ -100,7 +100,7 @@ export const ShowHide = ({
    * 1) If escape button is struck, close the show hide contents
    */
   function handleOnKeyDown(e: KeyboardEvent<HTMLElement>) {
-    if (e.code === ESCAPE_KEYCODE) {
+    if (e.key === ESCAPE_KEYCODE) {
       setIsActive(false); /* 1 */
     }
   }

--- a/src/upcoming-components/Drawer/Drawer.tsx
+++ b/src/upcoming-components/Drawer/Drawer.tsx
@@ -183,7 +183,7 @@ export const Drawer = ({
    * 1) If escape button is struck, close the drawer
    */
   function handleOnKeyDown(e: KeyboardEvent<HTMLElement>) {
-    if (e.code === ESCAPE_KEYCODE) {
+    if (e.key === ESCAPE_KEYCODE) {
       handleOnClose(); /* 1 */
     }
   }


### PR DESCRIPTION
### Summary:
`event.code` for some reason doesn't work in our environment, but `event.key` does. There are 4 components using `e.code`:
- `TimelineNav` (being updated in https://github.com/chanzuckerberg/edu-design-system/pull/1157)
- `ShowHide` (being updated in this PR)
- `Drawer` (being updated in this PR)

### Test Plan:
Verify that the `ShowHide` component now closes when clicking the escape key while the component is open and you're focused on the trigger. (`Drawer` is not in storybook because it's in the `upcoming-components` directory, so I just tested `ShowHide` for now.)