### PR TITLE
chore(ci): build storybook separately from chromatic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,14 +52,12 @@ jobs:
         run: yarn install --immutable
       - name: Build design tokens
         run: yarn build:tokens
-      - name: Build Storybook
+      - name: Build Storybook 📚
         run: yarn build:storybook
-      # We are relying on Chromatic to build the Storybook due to incompatibility between
-      # `--storybook-build-dir` which prevents Chromatic's Storybook build and uses a pre-built Storybook
-      # and `--only-changed` which enables Chromatic TurboSnap
-      # https://github.com/chromaui/chromatic-cli/issues/403
-      # Once fixed, Storybook build can be its own step for modularity
-      - name: Build Storybook and Publish to Chromatic
+      # TODO: Since the storybook builds to root now, no longer need to fiddle with "--storybook-base-dir", "--webpack-stats-json",
+      # and other related storybook/chromatic flags, explore turning TurboSnap back on with "--only-changed".
+      # https://app.shortcut.com/czi-edu/story/203071
+      - name: Publish to Chromatic 🦄
         run: |
           yarn run chromatic \
             --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,8 @@ jobs:
         run: yarn install --immutable
       - name: Build design tokens
         run: yarn build:tokens
+      - name: Build Storybook
+        run: yarn build:storybook
       # We are relying on Chromatic to build the Storybook due to incompatibility between
       # `--storybook-build-dir` which prevents Chromatic's Storybook build and uses a pre-built Storybook
       # and `--only-changed` which enables Chromatic TurboSnap
@@ -61,7 +63,7 @@ jobs:
         run: |
           yarn run chromatic \
             --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} \
-            --output-dir storybook-static \
+            --storybook-build-dir storybook-static \
             --exit-zero-on-changes \
             --exit-once-uploaded \
             --skip 'dependabot/**'


### PR DESCRIPTION
### Summary:
- build storybook in a step separate from chromatic
- should fix [ci errors](https://github.com/chanzuckerberg/edu-design-system/runs/6941477884?check_suite_focus=true) when chromatic thinks there are no differences in code and hence never builds storybook for axe testing
### Test Plan:
https://github.com/chanzuckerberg/edu-design-system/runs/7047367707?check_suite_focus=true
- check that storybook is built in separate step
- check that chromatic does not build storybook
- check that axe tests work