### PR TITLE
chore(modal): allow passing of modalContainerClassName to target modal container

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -26,7 +26,7 @@
 
 /**
  * The modal container which positions the modal in the center of the screen.
- * 1) Set a default z-index on the modal container. This is our smallest z-index token.
+ * 1) Ensures modal is above other components.
  */
 .modal {
   display: flex;
@@ -34,7 +34,7 @@
   justify-content: center;
   padding: var(--eds-size-2);
 
-  z-index: var(--eds-z-index-100); /* 1 */
+  z-index: var(--eds-z-index-top); /* 1 */
 }
 
 /**

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -77,6 +77,10 @@ type ModalProps = ModalContentProps & {
    * Whether or not the modal is visible.
    */
   open: boolean;
+  /**
+   * Additional classnames passed in for the modal container.
+   */
+  modalContainerClassName?: string;
 };
 
 type Context = {
@@ -176,7 +180,14 @@ export const ModalContent = (props: ModalContentProps) => {
  * </Modal>
  */
 export const Modal = (props: ModalProps) => {
-  const { ariaLabel, initialFocus, onClose, open, ...rest } = props;
+  const {
+    ariaLabel,
+    initialFocus,
+    modalContainerClassName,
+    onClose,
+    open,
+    ...rest
+  } = props;
   const { children } = rest;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -187,6 +198,8 @@ export const Modal = (props: ModalProps) => {
       );
     }
   }
+
+  const componentClassName = clsx(styles['modal'], modalContainerClassName);
 
   return (
     <Transition
@@ -201,7 +214,7 @@ export const Modal = (props: ModalProps) => {
     >
       <Dialog
         aria-label={ariaLabel}
-        className={styles['modal']}
+        className={componentClassName}
         initialFocus={initialFocus}
         // Passing onClose to the Dialog allows it to close the modal when the ESC key is triggered.
         onClose={onClose}


### PR DESCRIPTION
### Summary:
- increases modal z-index
- allows passing of `modalContainerClassName` to style the container
[sc-203638]
### Test Plan:
- styling allowed via classname: 
![Screen Shot 2022-06-28 at 3 43 18 PM](https://user-images.githubusercontent.com/86632227/176317124-509b51db-52c0-4c44-8cfd-b526b482b1b1.png)
- no jest failures
- no visual regression

