### PR TITLE
chore(clickable-style): add data-bootstrap-override attributes

### DIFF
--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -52,6 +53,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -101,6 +103,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -147,6 +150,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -159,6 +163,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -182,6 +187,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -231,6 +237,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -243,6 +250,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -287,6 +295,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -304,6 +313,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -353,6 +363,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -399,6 +410,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -411,6 +423,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--error"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -455,6 +468,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -501,6 +515,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -518,6 +533,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -567,6 +583,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -613,6 +630,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -625,6 +643,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -697,6 +716,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -743,6 +763,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -760,6 +781,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -809,6 +831,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -855,6 +878,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -867,6 +891,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--success"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -911,6 +936,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -928,6 +954,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -977,6 +1004,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -994,6 +1022,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -1043,6 +1072,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -1055,6 +1085,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -1099,6 +1130,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -1111,6 +1143,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates
@@ -1155,6 +1188,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -1172,6 +1206,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -1221,6 +1256,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -1267,6 +1303,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
          
         <button
           class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          data-bootstrap-override="clickable-style-link"
           type="button"
         >
           click into the course
@@ -1279,6 +1316,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--warning"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         See updates

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Button /> Default story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -12,6 +13,7 @@ exports[`<Button /> Default story renders snapshot 1`] = `
 exports[`<Button /> Destructive story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   Button
@@ -21,6 +23,7 @@ exports[`<Button /> Destructive story renders snapshot 1`] = `
 exports[`<Button /> DestructiveLeftIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   <svg
@@ -40,6 +43,7 @@ exports[`<Button /> DestructiveLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> FullWidth story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -49,6 +53,7 @@ exports[`<Button /> FullWidth story renders snapshot 1`] = `
 exports[`<Button /> IconButtonDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon button--disabled clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   disabled=""
   tabindex="-1"
   type="button"
@@ -70,6 +75,7 @@ exports[`<Button /> IconButtonDisabled story renders snapshot 1`] = `
 exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   <svg
@@ -93,6 +99,7 @@ exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
 exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   <svg
@@ -116,6 +123,7 @@ exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
 exports[`<Button /> IconButtonLeftIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   <svg
@@ -135,6 +143,7 @@ exports[`<Button /> IconButtonLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> IconButtonLeftIconSmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   <svg
@@ -154,6 +163,7 @@ exports[`<Button /> IconButtonLeftIconSmall story renders snapshot 1`] = `
 exports[`<Button /> IconButtonRightIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -173,6 +183,7 @@ exports[`<Button /> IconButtonRightIcon story renders snapshot 1`] = `
 exports[`<Button /> IconButtonRightIconSmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -192,6 +203,7 @@ exports[`<Button /> IconButtonRightIconSmall story renders snapshot 1`] = `
 exports[`<Button /> IconError story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--error"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -211,6 +223,7 @@ exports[`<Button /> IconError story renders snapshot 1`] = `
 exports[`<Button /> IconNeutral story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -230,6 +243,7 @@ exports[`<Button /> IconNeutral story renders snapshot 1`] = `
 exports[`<Button /> IconSuccess story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--success"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -249,6 +263,7 @@ exports[`<Button /> IconSuccess story renders snapshot 1`] = `
 exports[`<Button /> IconWarning story renders snapshot 1`] = `
 <button
   class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--warning"
+  data-bootstrap-override="clickable-style-icon"
   type="button"
 >
   Button
@@ -268,6 +283,7 @@ exports[`<Button /> IconWarning story renders snapshot 1`] = `
 exports[`<Button /> Link story renders snapshot 1`] = `
 <button
   class="clickable-style button button--link clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   type="button"
 >
   Button
@@ -277,6 +293,7 @@ exports[`<Button /> Link story renders snapshot 1`] = `
 exports[`<Button /> LinkDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--link button--disabled clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   disabled=""
   tabindex="-1"
   type="button"
@@ -288,6 +305,7 @@ exports[`<Button /> LinkDisabled story renders snapshot 1`] = `
 exports[`<Button /> LinkNeutral story renders snapshot 1`] = `
 <button
   class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+  data-bootstrap-override="clickable-style-link"
   type="button"
 >
   Button
@@ -297,6 +315,7 @@ exports[`<Button /> LinkNeutral story renders snapshot 1`] = `
 exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--link clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   type="button"
 >
   Button
@@ -321,6 +340,7 @@ exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
 exports[`<Button /> Loading story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary button--disabled eds-is-loading clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
   type="button"
@@ -350,6 +370,7 @@ exports[`<Button /> Loading story renders snapshot 1`] = `
 exports[`<Button /> Primary story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   Button
@@ -359,6 +380,7 @@ exports[`<Button /> Primary story renders snapshot 1`] = `
 exports[`<Button /> PrimaryDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary button--disabled clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   disabled=""
   tabindex="-1"
   type="button"
@@ -370,6 +392,7 @@ exports[`<Button /> PrimaryDisabled story renders snapshot 1`] = `
 exports[`<Button /> PrimaryLeftIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   <svg
@@ -389,6 +412,7 @@ exports[`<Button /> PrimaryLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> PrimaryMedium story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--md clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   Button
@@ -398,6 +422,7 @@ exports[`<Button /> PrimaryMedium story renders snapshot 1`] = `
 exports[`<Button /> PrimaryRightIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   Button
@@ -417,6 +442,7 @@ exports[`<Button /> PrimaryRightIcon story renders snapshot 1`] = `
 exports[`<Button /> PrimarySmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--primary clickable-style--sm clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   type="button"
 >
   Button
@@ -426,6 +452,7 @@ exports[`<Button /> PrimarySmall story renders snapshot 1`] = `
 exports[`<Button /> SecondaryDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
   type="button"
@@ -437,6 +464,7 @@ exports[`<Button /> SecondaryDisabled story renders snapshot 1`] = `
 exports[`<Button /> SecondaryError story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--error"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -446,6 +474,7 @@ exports[`<Button /> SecondaryError story renders snapshot 1`] = `
 exports[`<Button /> SecondaryLeftIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   <svg
@@ -465,6 +494,7 @@ exports[`<Button /> SecondaryLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> SecondaryMedium story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -474,6 +504,7 @@ exports[`<Button /> SecondaryMedium story renders snapshot 1`] = `
 exports[`<Button /> SecondaryRightIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -493,6 +524,7 @@ exports[`<Button /> SecondaryRightIcon story renders snapshot 1`] = `
 exports[`<Button /> SecondarySmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -502,6 +534,7 @@ exports[`<Button /> SecondarySmall story renders snapshot 1`] = `
 exports[`<Button /> SecondarySuccess story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--success"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -511,6 +544,7 @@ exports[`<Button /> SecondarySuccess story renders snapshot 1`] = `
 exports[`<Button /> SecondaryWarning story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--warning"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -520,6 +554,7 @@ exports[`<Button /> SecondaryWarning story renders snapshot 1`] = `
 exports[`<Button /> Tertiary story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -529,6 +564,7 @@ exports[`<Button /> Tertiary story renders snapshot 1`] = `
 exports[`<Button /> TertiaryDisabled story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
   type="button"
@@ -540,6 +576,7 @@ exports[`<Button /> TertiaryDisabled story renders snapshot 1`] = `
 exports[`<Button /> TertiaryLeftIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   <svg
@@ -559,6 +596,7 @@ exports[`<Button /> TertiaryLeftIcon story renders snapshot 1`] = `
 exports[`<Button /> TertiaryMedium story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -568,6 +606,7 @@ exports[`<Button /> TertiaryMedium story renders snapshot 1`] = `
 exports[`<Button /> TertiaryRightIcon story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -587,6 +626,7 @@ exports[`<Button /> TertiaryRightIcon story renders snapshot 1`] = `
 exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
   Button
@@ -596,6 +636,7 @@ exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
 exports[`<Button /> passes class names down properly 1`] = `
 <button
   class="clickable-style button exampleClassName button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   data-testid="example-class-name"
   type="button"
 >
@@ -606,6 +647,7 @@ exports[`<Button /> passes class names down properly 1`] = `
 exports[`<Button /> passes test ids down properly 1`] = `
 <button
   class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   data-testid="example-test-id"
   type="button"
 >

--- a/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
+++ b/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
   <button
     aria-expanded="false"
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Open Dropdown
@@ -122,6 +123,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
   <button
     aria-expanded="false"
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Open Dropdown
@@ -237,6 +239,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
   <button
     aria-expanded="false"
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Open Dropdown
@@ -352,6 +355,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
   <button
     aria-expanded="false"
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Open Dropdown

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
@@ -6,12 +6,14 @@ exports[`<ButtonGroup /> Default story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Button 2
@@ -25,12 +27,14 @@ exports[`<ButtonGroup /> SpacingMax story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Button 2
@@ -44,12 +48,14 @@ exports[`<ButtonGroup /> SpacingNone story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Button 2
@@ -63,12 +69,14 @@ exports[`<ButtonGroup /> Vertical story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Button 2
@@ -82,30 +90,35 @@ exports[`<ButtonGroup /> WithFiveButtons story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 2
   </button>
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 3
   </button>
   <button
     class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 4
   </button>
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Button 5

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -152,7 +152,16 @@ export const ClickableStyle = React.forwardRef(
       fullWidth && styles['clickable-style--full-width'],
     );
 
-    return <Component className={componentClassName} ref={ref} {...other} />;
+    const dataAttribute = `clickable-style-${variant}`;
+
+    return (
+      <Component
+        className={componentClassName}
+        data-bootstrap-override={dataAttribute}
+        ref={ref}
+        {...other}
+      />
+    );
   },
 );
 ClickableStyle.displayName = 'ClickableStyle';

--- a/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
+++ b/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
@@ -33,6 +33,7 @@ exports[`<FieldNote /> WithText story renders snapshot 1`] = `
         Even 
         <a
           class="clickable-style clickable-style--link clickable-style--brand"
+          data-bootstrap-override="clickable-style-link"
           href="#"
         >
           text links

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`<Link /> Default story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   href="/"
 >
   Link
@@ -12,6 +13,7 @@ exports[`<Link /> Default story renders snapshot 1`] = `
 exports[`<Link /> Destructive story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   Link
@@ -21,6 +23,7 @@ exports[`<Link /> Destructive story renders snapshot 1`] = `
 exports[`<Link /> DestructiveLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   <svg
@@ -40,6 +43,7 @@ exports[`<Link /> DestructiveLeftIcon story renders snapshot 1`] = `
 exports[`<Link /> FullWidth story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -49,6 +53,7 @@ exports[`<Link /> FullWidth story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleIconOnly story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   <svg
@@ -72,6 +77,7 @@ exports[`<Link /> IconClickableStyleIconOnly story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleIconOnlySmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   <svg
@@ -95,6 +101,7 @@ exports[`<Link /> IconClickableStyleIconOnlySmall story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   <svg
@@ -114,6 +121,7 @@ exports[`<Link /> IconClickableStyleLeftIcon story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleLeftIconSmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   <svg
@@ -133,6 +141,7 @@ exports[`<Link /> IconClickableStyleLeftIconSmall story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -152,6 +161,7 @@ exports[`<Link /> IconClickableStyleRightIcon story renders snapshot 1`] = `
 exports[`<Link /> IconClickableStyleRightIconSmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -171,6 +181,7 @@ exports[`<Link /> IconClickableStyleRightIconSmall story renders snapshot 1`] = 
 exports[`<Link /> IconError story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--error"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -190,6 +201,7 @@ exports[`<Link /> IconError story renders snapshot 1`] = `
 exports[`<Link /> IconNeutral story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -209,6 +221,7 @@ exports[`<Link /> IconNeutral story renders snapshot 1`] = `
 exports[`<Link /> IconSuccess story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--success"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -228,6 +241,7 @@ exports[`<Link /> IconSuccess story renders snapshot 1`] = `
 exports[`<Link /> IconWarning story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--icon clickable-style--warning"
+  data-bootstrap-override="clickable-style-icon"
   href="/"
 >
   Link
@@ -247,6 +261,7 @@ exports[`<Link /> IconWarning story renders snapshot 1`] = `
 exports[`<Link /> LinkNeutral story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--link clickable-style--neutral"
+  data-bootstrap-override="clickable-style-link"
   href="/"
 >
   Link
@@ -256,6 +271,7 @@ exports[`<Link /> LinkNeutral story renders snapshot 1`] = `
 exports[`<Link /> LinkRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   href="/"
 >
   Link
@@ -280,6 +296,7 @@ exports[`<Link /> LinkRightIcon story renders snapshot 1`] = `
 exports[`<Link /> Primary story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   Link
@@ -289,6 +306,7 @@ exports[`<Link /> Primary story renders snapshot 1`] = `
 exports[`<Link /> PrimaryLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   <svg
@@ -308,6 +326,7 @@ exports[`<Link /> PrimaryLeftIcon story renders snapshot 1`] = `
 exports[`<Link /> PrimaryMedium story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--md clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   Link
@@ -317,6 +336,7 @@ exports[`<Link /> PrimaryMedium story renders snapshot 1`] = `
 exports[`<Link /> PrimaryRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   Link
@@ -336,6 +356,7 @@ exports[`<Link /> PrimaryRightIcon story renders snapshot 1`] = `
 exports[`<Link /> PrimarySmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--primary clickable-style--brand"
+  data-bootstrap-override="clickable-style-primary"
   href="/"
 >
   Link
@@ -345,6 +366,7 @@ exports[`<Link /> PrimarySmall story renders snapshot 1`] = `
 exports[`<Link /> Secondary story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -354,6 +376,7 @@ exports[`<Link /> Secondary story renders snapshot 1`] = `
 exports[`<Link /> SecondaryError story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--error"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -363,6 +386,7 @@ exports[`<Link /> SecondaryError story renders snapshot 1`] = `
 exports[`<Link /> SecondaryLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   <svg
@@ -382,6 +406,7 @@ exports[`<Link /> SecondaryLeftIcon story renders snapshot 1`] = `
 exports[`<Link /> SecondaryMedium story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--md clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -391,6 +416,7 @@ exports[`<Link /> SecondaryMedium story renders snapshot 1`] = `
 exports[`<Link /> SecondaryRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -410,6 +436,7 @@ exports[`<Link /> SecondaryRightIcon story renders snapshot 1`] = `
 exports[`<Link /> SecondarySmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--brand"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -419,6 +446,7 @@ exports[`<Link /> SecondarySmall story renders snapshot 1`] = `
 exports[`<Link /> SecondarySuccess story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--success"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -428,6 +456,7 @@ exports[`<Link /> SecondarySuccess story renders snapshot 1`] = `
 exports[`<Link /> SecondaryWarning story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--warning"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -437,6 +466,7 @@ exports[`<Link /> SecondaryWarning story renders snapshot 1`] = `
 exports[`<Link /> Tertiary story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -446,6 +476,7 @@ exports[`<Link /> Tertiary story renders snapshot 1`] = `
 exports[`<Link /> TertiaryLeftIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   <svg
@@ -465,6 +496,7 @@ exports[`<Link /> TertiaryLeftIcon story renders snapshot 1`] = `
 exports[`<Link /> TertiaryMedium story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--md clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -474,6 +506,7 @@ exports[`<Link /> TertiaryMedium story renders snapshot 1`] = `
 exports[`<Link /> TertiaryRightIcon story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -493,6 +526,7 @@ exports[`<Link /> TertiaryRightIcon story renders snapshot 1`] = `
 exports[`<Link /> TertiarySmall story renders snapshot 1`] = `
 <a
   class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--neutral"
+  data-bootstrap-override="clickable-style-secondary"
   href="/"
 >
   Link
@@ -502,6 +536,7 @@ exports[`<Link /> TertiarySmall story renders snapshot 1`] = `
 exports[`<Link /> passes class names down properly 1`] = `
 <a
   class="clickable-style exampleClassName clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   data-testid="example-class-name"
   href="/"
 >
@@ -512,6 +547,7 @@ exports[`<Link /> passes class names down properly 1`] = `
 exports[`<Link /> passes test ids down properly 1`] = `
 <a
   class="clickable-style clickable-style--link clickable-style--brand"
+  data-bootstrap-override="clickable-style-link"
   data-testid="example-test-id"
   href="/"
 >

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -60,12 +60,14 @@ exports[`Modal Brand story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -125,12 +127,14 @@ exports[`Modal Default story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -202,12 +206,14 @@ exports[`Modal DefaultInteractive story renders snapshot 1`] = `
       >
         <button
           class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
           class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          data-bootstrap-override="clickable-style-primary"
           type="button"
         >
           Button 2
@@ -268,12 +274,14 @@ exports[`Modal Mobile story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -343,12 +351,14 @@ exports[`Modal MobileBrand story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -408,12 +418,14 @@ exports[`Modal MobileLandscape story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -483,12 +495,14 @@ exports[`Modal MobileLandscapeBrand story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -610,12 +624,14 @@ exports[`Modal Tablet story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -685,12 +701,14 @@ exports[`Modal TabletBrand story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -780,12 +798,14 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
       >
         <button
           class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
           class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          data-bootstrap-override="clickable-style-primary"
           type="button"
         >
           Button 2
@@ -877,12 +897,14 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
       >
         <button
           class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
           class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          data-bootstrap-override="clickable-style-primary"
           type="button"
         >
           Button 2
@@ -1037,12 +1059,14 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
     >
       <button
         class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
         class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Button 2
@@ -1092,6 +1116,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
         <button
           aria-describedby="tippy-11"
           class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          data-bootstrap-override="clickable-style-secondary"
           tabindex="0"
           type="button"
         >
@@ -1099,6 +1124,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
         </button>
         <button
           class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          data-bootstrap-override="clickable-style-primary"
           type="button"
         >
           Button 2

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -32,6 +32,7 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -48,6 +49,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -94,6 +96,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -136,6 +139,7 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -152,6 +156,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -198,6 +203,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -264,6 +270,7 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -306,6 +313,7 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -322,6 +330,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -368,6 +377,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -410,6 +420,7 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course
@@ -426,6 +437,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    data-bootstrap-override="clickable-style-icon"
     type="button"
   >
     <svg
@@ -472,6 +484,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
        
       <button
         class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        data-bootstrap-override="clickable-style-link"
         type="button"
       >
         click into the course

--- a/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`<Popover /> BottomLeft story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Open Popover
@@ -48,6 +49,7 @@ exports[`<Popover /> BottomLeft story renders snapshot 1`] = `
             >
               <button
                 class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
                 Mark All Seen
@@ -276,6 +278,7 @@ exports[`<Popover /> BottomRight story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Open Popover
@@ -317,6 +320,7 @@ exports[`<Popover /> BottomRight story renders snapshot 1`] = `
             >
               <button
                 class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
                 Mark All Seen
@@ -545,6 +549,7 @@ exports[`<Popover /> Default story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Open Popover
@@ -586,6 +591,7 @@ exports[`<Popover /> Default story renders snapshot 1`] = `
             >
               <button
                 class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
                 Mark All Seen
@@ -814,6 +820,7 @@ exports[`<Popover /> TopLeft story renders snapshot 1`] = `
 >
   <button
     class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    data-bootstrap-override="clickable-style-primary"
     type="button"
   >
     Open Popover
@@ -855,6 +862,7 @@ exports[`<Popover /> TopLeft story renders snapshot 1`] = `
             >
               <button
                 class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
                 Mark All Seen

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -52,6 +52,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
         aria-expanded="false"
         aria-label="Open project dropdown"
         class="clickable-style button project-card__menu-button button--icon clickable-style--sm clickable-style--icon clickable-style--neutral"
+        data-bootstrap-override="clickable-style-icon"
         type="button"
       >
         <svg
@@ -215,6 +216,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
         aria-expanded="false"
         aria-label="Open project dropdown"
         class="clickable-style button project-card__menu-button button--icon clickable-style--sm clickable-style--icon clickable-style--neutral"
+        data-bootstrap-override="clickable-style-icon"
         type="button"
       >
         <svg

--- a/src/components/ShowHide/__snapshots__/ShowHide.test.tsx.snap
+++ b/src/components/ShowHide/__snapshots__/ShowHide.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`<ShowHide /> Default story renders snapshot 1`] = `
     <button
       aria-expanded="false"
       class="clickable-style button show-hide__trigger button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       text="Actions"
       type="button"
     >

--- a/src/components/TextField/__snapshots__/TextField.test.ts.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.ts.snap
@@ -164,6 +164,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
       >
         <button
           class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+          data-bootstrap-override="clickable-style-icon"
           type="button"
         >
           Button

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -458,6 +458,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
   >
     <button
       class="clickable-style button timeline-nav__back button--link clickable-style--link clickable-style--neutral"
+      data-bootstrap-override="clickable-style-link"
       type="button"
     >
       <svg

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-5"
       class="clickable-style button trigger--spacing-bottom trigger--spacing-left button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger
@@ -60,6 +61,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-2"
       class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger
@@ -118,6 +120,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
       <button
         aria-describedby="tippy-8"
         class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        data-bootstrap-override="clickable-style-primary"
         type="button"
       >
         Hover here to see tooltip after clicking somewhere outside.
@@ -173,6 +176,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-3"
       class="clickable-style button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger
@@ -227,6 +231,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-1"
       class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger
@@ -281,6 +286,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-7"
       class="clickable-style button trigger--spacing-top button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger with longer text to test placement
@@ -335,6 +341,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-6"
       class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger
@@ -387,6 +394,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
     <button
       aria-describedby="tippy-4"
       class="clickable-style button trigger--spacing-top trigger--spacing-left button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      data-bootstrap-override="clickable-style-primary"
       type="button"
     >
       Tooltip trigger


### PR DESCRIPTION
### Summary:
I tested the new link styles in `traject` using an alpha build, and I noticed that bootstrap styles are adding an underline for `a` tags on hover and focus for "primary" and "secondary" variants, and that's also reducing the text-decoration thickness for "link" variants on hover and focus.

This PR adds data-bootstrap-override attributes for the different `ClickableStyle` variants so I can override these styles in `traject`.

### Test Plan:
There should be no visible changes in chromatic or storybook.