### PR TITLE
fix(modal): render tooltips on top of modal

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -26,7 +26,8 @@
 
 /**
  * The modal container which positions the modal in the center of the screen.
- * 1) Ensures modal is above other components.
+ * 1) Ensures modal is above other components. This is not a design token for now since we need to align on 
+ *    z-indeces across the app and in the platform. https://app.shortcut.com/czi-edu/story/203871
  */
 .modal {
   display: flex;

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -34,7 +34,7 @@
   justify-content: center;
   padding: var(--eds-size-2);
 
-  z-index: var(--eds-z-index-top); /* 1 */
+  z-index: 1050; /* 1 */
 }
 
 /**

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 import { useState } from 'react';
 import Modal, { ModalContent } from './Modal';
 import styles from './Modal.stories.module.css';
-import { Button, ButtonGroup, Heading, Text } from '../../';
+import { Button, ButtonGroup, Heading, Text, Tooltip } from '../../';
 import { VARIANTS } from '../Heading/Heading';
 
 export default {
@@ -46,14 +46,17 @@ const getChildren = (
     >
       {showStepper && <Modal.Stepper activeStep={2} totalSteps={5} />}
       <ButtonGroup className={styles['footer__button-group']}>
-        <Button
-          onClick={
-            () => {} /* eslint-disable-line @typescript-eslint/no-empty-function */
-          }
-          status="neutral"
-        >
-          Button 1
-        </Button>
+        {/* This has to be manually tested since Tooltip tests are flaky in Chromatic */}
+        <Tooltip text="Tooltip should spawn on top of modal">
+          <Button
+            onClick={
+              () => {} /* eslint-disable-line @typescript-eslint/no-empty-function */
+            }
+            status="neutral"
+          >
+            Button 1
+          </Button>
+        </Tooltip>
         <Button
           onClick={
             () => {} /* eslint-disable-line @typescript-eslint/no-empty-function */

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -1090,6 +1090,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
         class="footer__button-group button-group button-group--spacing-1x"
       >
         <button
+          aria-describedby="tippy-11"
           class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
           tabindex="0"
           type="button"

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,4 @@
-import Tippy from '@tippyjs/react';
+import Tippy, { TippyProps } from '@tippyjs/react';
 import clsx from 'clsx';
 import * as React from 'react';
 import styles from './Tooltip.module.css';
@@ -67,7 +67,7 @@ type TooltipProps = {
    * controls if/when the bubble appears (on hover, click, focus, etc).
    */
   visible?: boolean;
-};
+} & TippyProps;
 
 // @tippyjs/react does not expose tippy.js types, have to extract via props and grab element type from array type
 type Plugins = NonNullable<React.ComponentProps<typeof Tippy>['plugins']>;
@@ -79,6 +79,7 @@ type Plugin = Plugins[number];
  * ```
  *
  * A styled tooltip built on Tippy.js.
+ * If used within the EDS Modal component, pass zIndex greater than 99999.
  *
  * https://atomiks.github.io/tippyjs/
  * https://github.com/atomiks/tippyjs-react
@@ -122,9 +123,9 @@ export const Tooltip = ({
       {...rest}
       className={clsx(
         styles['tooltip'],
-        className,
         variant === 'light' && styles['tooltip--light'],
         variant === 'dark' && styles['tooltip--dark'],
+        className,
       )}
       content={text}
       duration={duration}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -79,7 +79,6 @@ type Plugin = Plugins[number];
  * ```
  *
  * A styled tooltip built on Tippy.js.
- * If used within the EDS Modal component, pass zIndex greater than 99999.
  *
  * https://atomiks.github.io/tippyjs/
  * https://github.com/atomiks/tippyjs-react


### PR DESCRIPTION
### Summary:
- Tooltips have a default z-index of 9999
- Tooltips need to render on top of modal
- Modal z-index shrank to 1050 to match [bootstrap modal z-index](https://github.com/FB-PLP/traject/blob/fe07779f6bca7920df27be8750dabf7517b34a74/app/assets/stylesheets/v2/_overrides/_bootswatch_variables.scss#L263-L276)
- Tooltips props extended with Tippy props (the base component) to allow custom z-index if 9999 is too high
- Created story to align more z-indexes https://app.shortcut.com/czi-edu/story/203871

### Test Plan:
- Unit tests pass
- No visual regression
- Manual test tooltip spawning above modal:
  - In Modal stories, hover over button 1