### PR TITLE
chore(clickable-style): downgrade error to warning for invalid combos

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.test.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.test.tsx
@@ -1,41 +1,62 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { ClickableStyle } from './ClickableStyle';
+import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<ClickableStyle />', () => {
-  test('throws an error for primary neutral combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="neutral" variant="primary" />);
-    }).toThrow(/Invalid prop combo/);
+  const consoleWarnMock = consoleWarnMockHelper();
+
+  it('logs a warning for primary neutral combo', () => {
+    render(
+      <ClickableStyle as="button" status="neutral" variant="primary">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 
-  test('throws an error for primary success combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="success" variant="primary" />);
-    }).toThrow(/Invalid prop combo/);
+  it('logs a warning for primary success combo', () => {
+    render(
+      <ClickableStyle status="neutral" variant="primary">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 
-  test('throws an error for primary warning combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="warning" variant="primary" />);
-    }).toThrow(/Invalid prop combo/);
+  it('logs a warning for primary warning combo', () => {
+    render(
+      <ClickableStyle status="warning" variant="primary">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 
-  test('throws an error for link success combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="success" variant="link" />);
-    }).toThrow(/Invalid prop combo/);
+  it('logs a warning for link success combo', () => {
+    render(
+      <ClickableStyle status="success" variant="link">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 
-  test('throws an error for link warning combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="warning" variant="link" />);
-    }).toThrow(/Invalid prop combo/);
+  it('logs a warning for link warning combo', () => {
+    render(
+      <ClickableStyle status="warning" variant="link">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 
-  test('throws an error for link error combo', () => {
-    expect(() => {
-      render(<ClickableStyle status="error" variant="link" />);
-    }).toThrow(/Invalid prop combo/);
+  it('logs a warning for link error combo', () => {
+    render(
+      <ClickableStyle status="error" variant="link">
+        Clickable style
+      </ClickableStyle>,
+    );
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -78,7 +78,8 @@ const throwInvalidPropComboError = (variant: Variant, status: Status) => {
     return `'${validStatuses[0]}' and '${validStatuses[1]}'`;
   };
 
-  throw new Error(
+  // TODO: change to `throw new Error()` when invalid combos have been removed from downstream product
+  console.warn(
     // We have to add the strings and variables together because string interpolation doesn't work in console messages.
     "\n*** Invalid prop combo ***:\n\nThe `Button` and `Link` components do not support using the '" +
       variant +
@@ -110,7 +111,7 @@ const throwInvalidPropComboError = (variant: Variant, status: Status) => {
 export const ClickableStyle = React.forwardRef(
   <IComponent extends React.ElementType>(
     {
-      as: Component,
+      as: Component = 'button',
       className,
       fullWidth,
       size = 'lg',


### PR DESCRIPTION
### Summary:
We're now throwing an error in `Button` and `Link` components if an unsupported `status`/`variant` prop combination is being used. Unfortunately, there's an instance in `traject` that is using an invalid combination and it will take a little work to fix it. (The instance is in `Token`, which is being used in a few different places with different styling overrides, so I don't want to update it without taking the time to work out the styles and verify there are no regressions.) Ticket to fix this: https://app.shortcut.com/czi-edu/story/204850/fix-variant-in-token-in-traject

This PR downgrades the error to a console warning so we're still alerting devs that they're using the wrong combination but it doesn't break every page with a token on it.

I also added a default `as` to `ClickableStyle` because it's really annoying to debug rendering issues caused by not passing one in.

### Test Plan:
All automated tests should pass,
and the `Button` and `Link` chromatic snapshots should be unchanged.