### PR TITLE
chore(link): translateY 101% so the focus bg is fully off-screen

### DIFF
--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -72,7 +72,8 @@
    * Pseudo element with background color for focus state
    * 1) Uses an absolutely-positioned pseudo element with a background color to animate it up and down
    * 2) The pseudo element has a negative z-index to position it behind the text
-   * 3) The element is pushed down out of sight to hide it
+   * 3) The element is pushed down out of sight to hide it. Needs to be 101%, not 100%, to or the very top
+   *    will be visible
    * 4) We set transform-origin: to bottom so it animates up from the bottom, not out from the middle
    * 5) And we pull it back up on focus so it's visible
    */
@@ -87,7 +88,7 @@
     z-index: var(--eds-z-index-bottom); /* 2 */
     background-color: var(--eds-theme-color-background-brand-primary-strong);
 
-    transform: translateY(100%); /* 3 */
+    transform: translateY(101%); /* 3 */
     transform-origin: bottom; /* 4 */
     transition: transform var(--eds-anim-move-medium) var(--eds-anim-ease);
 


### PR DESCRIPTION
### Summary:
This is super tedious but on the link styles, the focus background is moved down 100% except on focus, and there is the tiniest sliver visible. This PR changes it to 101% to push it just a little bit further down so it's fully off-screen.

### Screenshots
#### Before
<img width="1812" alt="link in storybook with a little tiny annoying line visible under the link text" src="https://user-images.githubusercontent.com/7761701/177609114-dba19a6f-0eb5-4005-beaf-927ecda5875f.png">

#### After
<img width="1812" alt="link in storybook with no annoying lines visible under the link text" src="https://user-images.githubusercontent.com/7761701/177609128-0d07cfa5-8888-43c5-8252-4e64816f4a88.png">

### Test Plan:
Verified on the `Link` component default story (be advised that, for whatever reason, this only appears when the element underneath is also a link). This change isn't being picked up by chromatic, presumably because the line is too small?