### PR TITLE
chore(link): lower spacing specificity

### DIFF
--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -52,7 +52,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -102,7 +102,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -149,7 +149,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -162,7 +162,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -186,7 +186,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -236,7 +236,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -249,7 +249,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -294,7 +294,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -312,7 +312,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
   class="banner banner--error banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -362,7 +362,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -409,7 +409,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -422,7 +422,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--error"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--error button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -467,7 +467,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -514,7 +514,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -532,7 +532,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   class="banner banner--neutral banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -582,7 +582,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -629,7 +629,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -642,7 +642,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -715,7 +715,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -762,7 +762,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -780,7 +780,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
   class="banner banner--success banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -830,7 +830,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -877,7 +877,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -890,7 +890,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--success"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--success button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -935,7 +935,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -953,7 +953,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
   class="banner banner--brand banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -1003,7 +1003,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1021,7 +1021,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
   class="banner banner--brand banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -1071,7 +1071,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1084,7 +1084,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -1129,7 +1129,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1142,7 +1142,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
@@ -1187,7 +1187,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1205,7 +1205,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
   class="banner banner--warning banner--horizontal banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -1255,7 +1255,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1302,7 +1302,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
         <button
-          class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+          class="clickable-style clickable-style--link clickable-style--neutral button button--link"
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
@@ -1315,7 +1315,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
       class="banner__action"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--warning"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--warning button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Button /> Default story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -12,7 +12,7 @@ exports[`<Button /> Default story renders snapshot 1`] = `
 
 exports[`<Button /> Destructive story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -22,7 +22,7 @@ exports[`<Button /> Destructive story renders snapshot 1`] = `
 
 exports[`<Button /> DestructiveLeftIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--error"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--error button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -42,7 +42,7 @@ exports[`<Button /> DestructiveLeftIcon story renders snapshot 1`] = `
 
 exports[`<Button /> FullWidth story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand clickable-style--full-width button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -52,7 +52,7 @@ exports[`<Button /> FullWidth story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonDisabled story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon button--disabled clickable-style--lg clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon button--disabled"
   data-bootstrap-override="clickable-style-icon"
   disabled=""
   tabindex="-1"
@@ -74,7 +74,7 @@ exports[`<Button /> IconButtonDisabled story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -98,7 +98,7 @@ exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -122,7 +122,7 @@ exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonLeftIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -142,7 +142,7 @@ exports[`<Button /> IconButtonLeftIcon story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonLeftIconSmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -162,7 +162,7 @@ exports[`<Button /> IconButtonLeftIconSmall story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonRightIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -182,7 +182,7 @@ exports[`<Button /> IconButtonRightIcon story renders snapshot 1`] = `
 
 exports[`<Button /> IconButtonRightIconSmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+  class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -202,7 +202,7 @@ exports[`<Button /> IconButtonRightIconSmall story renders snapshot 1`] = `
 
 exports[`<Button /> IconError story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--error"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--error button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -222,7 +222,7 @@ exports[`<Button /> IconError story renders snapshot 1`] = `
 
 exports[`<Button /> IconNeutral story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -242,7 +242,7 @@ exports[`<Button /> IconNeutral story renders snapshot 1`] = `
 
 exports[`<Button /> IconSuccess story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--success"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--success button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -262,7 +262,7 @@ exports[`<Button /> IconSuccess story renders snapshot 1`] = `
 
 exports[`<Button /> IconWarning story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--icon clickable-style--lg clickable-style--icon clickable-style--warning"
+  class="clickable-style clickable-style--lg clickable-style--icon clickable-style--warning button button--icon"
   data-bootstrap-override="clickable-style-icon"
   type="button"
 >
@@ -282,7 +282,7 @@ exports[`<Button /> IconWarning story renders snapshot 1`] = `
 
 exports[`<Button /> Link story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--link clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand button button--link"
   data-bootstrap-override="clickable-style-link"
   type="button"
 >
@@ -292,7 +292,7 @@ exports[`<Button /> Link story renders snapshot 1`] = `
 
 exports[`<Button /> LinkDisabled story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--link button--disabled clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand button button--link button--disabled"
   data-bootstrap-override="clickable-style-link"
   disabled=""
   tabindex="-1"
@@ -304,7 +304,7 @@ exports[`<Button /> LinkDisabled story renders snapshot 1`] = `
 
 exports[`<Button /> LinkNeutral story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+  class="clickable-style clickable-style--link clickable-style--neutral button button--link"
   data-bootstrap-override="clickable-style-link"
   type="button"
 >
@@ -314,7 +314,7 @@ exports[`<Button /> LinkNeutral story renders snapshot 1`] = `
 
 exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--link clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand button button--link"
   data-bootstrap-override="clickable-style-link"
   type="button"
 >
@@ -339,7 +339,7 @@ exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
 
 exports[`<Button /> Loading story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary button--disabled eds-is-loading clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary button--disabled eds-is-loading"
   data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
@@ -369,7 +369,7 @@ exports[`<Button /> Loading story renders snapshot 1`] = `
 
 exports[`<Button /> Primary story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -379,7 +379,7 @@ exports[`<Button /> Primary story renders snapshot 1`] = `
 
 exports[`<Button /> PrimaryDisabled story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary button--disabled clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary button--disabled"
   data-bootstrap-override="clickable-style-primary"
   disabled=""
   tabindex="-1"
@@ -391,7 +391,7 @@ exports[`<Button /> PrimaryDisabled story renders snapshot 1`] = `
 
 exports[`<Button /> PrimaryLeftIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -411,7 +411,7 @@ exports[`<Button /> PrimaryLeftIcon story renders snapshot 1`] = `
 
 exports[`<Button /> PrimaryMedium story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--md clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--md clickable-style--primary clickable-style--brand button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -421,7 +421,7 @@ exports[`<Button /> PrimaryMedium story renders snapshot 1`] = `
 
 exports[`<Button /> PrimaryRightIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -441,7 +441,7 @@ exports[`<Button /> PrimaryRightIcon story renders snapshot 1`] = `
 
 exports[`<Button /> PrimarySmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--primary clickable-style--sm clickable-style--primary clickable-style--brand"
+  class="clickable-style clickable-style--sm clickable-style--primary clickable-style--brand button button--primary"
   data-bootstrap-override="clickable-style-primary"
   type="button"
 >
@@ -451,7 +451,7 @@ exports[`<Button /> PrimarySmall story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryDisabled story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary button--disabled"
   data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
@@ -463,7 +463,7 @@ exports[`<Button /> SecondaryDisabled story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryError story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--error"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--error button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -473,7 +473,7 @@ exports[`<Button /> SecondaryError story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryLeftIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -493,7 +493,7 @@ exports[`<Button /> SecondaryLeftIcon story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryMedium story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--md clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -503,7 +503,7 @@ exports[`<Button /> SecondaryMedium story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryRightIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -523,7 +523,7 @@ exports[`<Button /> SecondaryRightIcon story renders snapshot 1`] = `
 
 exports[`<Button /> SecondarySmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -533,7 +533,7 @@ exports[`<Button /> SecondarySmall story renders snapshot 1`] = `
 
 exports[`<Button /> SecondarySuccess story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--success"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--success button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -543,7 +543,7 @@ exports[`<Button /> SecondarySuccess story renders snapshot 1`] = `
 
 exports[`<Button /> SecondaryWarning story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--warning"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--warning button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -553,7 +553,7 @@ exports[`<Button /> SecondaryWarning story renders snapshot 1`] = `
 
 exports[`<Button /> Tertiary story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -563,7 +563,7 @@ exports[`<Button /> Tertiary story renders snapshot 1`] = `
 
 exports[`<Button /> TertiaryDisabled story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary button--disabled clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary button--disabled"
   data-bootstrap-override="clickable-style-secondary"
   disabled=""
   tabindex="-1"
@@ -575,7 +575,7 @@ exports[`<Button /> TertiaryDisabled story renders snapshot 1`] = `
 
 exports[`<Button /> TertiaryLeftIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -595,7 +595,7 @@ exports[`<Button /> TertiaryLeftIcon story renders snapshot 1`] = `
 
 exports[`<Button /> TertiaryMedium story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--md clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--md clickable-style--secondary clickable-style--neutral button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -605,7 +605,7 @@ exports[`<Button /> TertiaryMedium story renders snapshot 1`] = `
 
 exports[`<Button /> TertiaryRightIcon story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -625,7 +625,7 @@ exports[`<Button /> TertiaryRightIcon story renders snapshot 1`] = `
 
 exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--sm clickable-style--secondary clickable-style--neutral"
+  class="clickable-style clickable-style--sm clickable-style--secondary clickable-style--neutral button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   type="button"
 >
@@ -635,7 +635,7 @@ exports[`<Button /> TertiarySmall story renders snapshot 1`] = `
 
 exports[`<Button /> passes class names down properly 1`] = `
 <button
-  class="clickable-style button exampleClassName button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button exampleClassName button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   data-testid="example-class-name"
   type="button"
@@ -646,7 +646,7 @@ exports[`<Button /> passes class names down properly 1`] = `
 
 exports[`<Button /> passes test ids down properly 1`] = `
 <button
-  class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+  class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
   data-bootstrap-override="clickable-style-secondary"
   data-testid="example-test-id"
   type="button"

--- a/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
+++ b/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
 >
   <button
     aria-expanded="false"
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
@@ -122,7 +122,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
 >
   <button
     aria-expanded="false"
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
@@ -238,7 +238,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
 >
   <button
     aria-expanded="false"
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
@@ -354,7 +354,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
 >
   <button
     aria-expanded="false"
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.ts.snap
@@ -5,14 +5,14 @@ exports[`<ButtonGroup /> Default story renders snapshot 1`] = `
   class="button-group button-group--spacing-1x"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -26,14 +26,14 @@ exports[`<ButtonGroup /> SpacingMax story renders snapshot 1`] = `
   class="button-group button-group--spacing-max"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -47,14 +47,14 @@ exports[`<ButtonGroup /> SpacingNone story renders snapshot 1`] = `
   class="button-group"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -68,14 +68,14 @@ exports[`<ButtonGroup /> Vertical story renders snapshot 1`] = `
   class="button-group button-group--spacing-1x button-group--vertical"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -89,35 +89,35 @@ exports[`<ButtonGroup /> WithFiveButtons story renders snapshot 1`] = `
   class="button-group button-group--spacing-1x"
 >
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 1
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 2
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 3
   </button>
   <button
-    class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary"
     data-bootstrap-override="clickable-style-secondary"
     type="button"
   >
     Button 4
   </button>
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >

--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -463,6 +463,19 @@
 }
 
 /**
+ * Margin 0 added becuase Safari has margin on buttons.
+ * 1) Needs `:where` pseudoclass to reduce specificity so class overrides
+ *    for margin can happen where used.
+ * 2) 2px padding gives the text breathing room in the focus state
+ * 3) 2px margin compensates for the padding so the link doesn't have too much space between it
+ *    and surrounding text
+ */
+:where(.clickable-style--link) {
+  padding: 2px; /* 2 */
+  margin: -2px; /* 3 */
+}
+
+/**
  * Link neutral clickable style
  */
 .clickable-style--link.clickable-style--neutral {

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -131,7 +131,6 @@ export const ClickableStyle = React.forwardRef(
     const componentClassName = clsx(
       // Base styles
       styles['clickable-style'],
-      className,
       // Sizes
       variant !== 'link' && [
         size === 'sm' && styles['clickable-style--sm'],
@@ -151,6 +150,7 @@ export const ClickableStyle = React.forwardRef(
       status === 'error' && styles['clickable-style--error'],
       // Other options
       fullWidth && styles['clickable-style--full-width'],
+      className,
     );
 
     const dataAttribute = `clickable-style-${variant}`;

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -535,7 +535,7 @@ exports[`<Link /> TertiarySmall story renders snapshot 1`] = `
 
 exports[`<Link /> passes class names down properly 1`] = `
 <a
-  class="clickable-style exampleClassName clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand exampleClassName"
   data-bootstrap-override="clickable-style-link"
   data-testid="example-class-name"
   href="/"

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -59,14 +59,14 @@ exports[`Modal Brand story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -126,14 +126,14 @@ exports[`Modal Default story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -205,14 +205,14 @@ exports[`Modal DefaultInteractive story renders snapshot 1`] = `
         class="footer__button-group button-group button-group--spacing-1x"
       >
         <button
-          class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
           data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
-          class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
           data-bootstrap-override="clickable-style-primary"
           type="button"
         >
@@ -273,14 +273,14 @@ exports[`Modal Mobile story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -350,14 +350,14 @@ exports[`Modal MobileBrand story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -417,14 +417,14 @@ exports[`Modal MobileLandscape story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -494,14 +494,14 @@ exports[`Modal MobileLandscapeBrand story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -623,14 +623,14 @@ exports[`Modal Tablet story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -700,14 +700,14 @@ exports[`Modal TabletBrand story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -797,14 +797,14 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
         class="footer__button-group button-group button-group--spacing-1x"
       >
         <button
-          class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
           data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
-          class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
           data-bootstrap-override="clickable-style-primary"
           type="button"
         >
@@ -896,14 +896,14 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
         class="footer__button-group button-group button-group--spacing-1x"
       >
         <button
-          class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
           data-bootstrap-override="clickable-style-secondary"
           type="button"
         >
           Button 1
         </button>
         <button
-          class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
           data-bootstrap-override="clickable-style-primary"
           type="button"
         >
@@ -1058,14 +1058,14 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
       class="footer__button-group button-group button-group--spacing-1x"
     >
       <button
-        class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+        class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
         data-bootstrap-override="clickable-style-secondary"
         type="button"
       >
         Button 1
       </button>
       <button
-        class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -1115,7 +1115,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
       >
         <button
           aria-describedby="tippy-11"
-          class="clickable-style button button--secondary clickable-style--lg clickable-style--secondary clickable-style--neutral"
+          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral button button--secondary"
           data-bootstrap-override="clickable-style-secondary"
           tabindex="0"
           type="button"
@@ -1123,7 +1123,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
           Button 1
         </button>
         <button
-          class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
           data-bootstrap-override="clickable-style-primary"
           type="button"
         >

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -48,7 +48,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
   class="banner banner--brand banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -95,7 +95,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -138,7 +138,7 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -155,7 +155,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
   class="banner banner--error banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -202,7 +202,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -269,7 +269,7 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -312,7 +312,7 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -329,7 +329,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
   class="banner banner--success banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -376,7 +376,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -419,7 +419,7 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
@@ -436,7 +436,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
   class="banner banner--warning banner--dismissable"
 >
   <button
-    class="clickable-style button banner__close-btn button--icon clickable-style--lg clickable-style--icon clickable-style--neutral"
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
     data-bootstrap-override="clickable-style-icon"
     type="button"
   >
@@ -483,7 +483,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
       <button
-        class="clickable-style button button--link clickable-style--link clickable-style--neutral"
+        class="clickable-style clickable-style--link clickable-style--neutral button button--link"
         data-bootstrap-override="clickable-style-link"
         type="button"
       >

--- a/src/components/Popover/__snapshots__/Popover.test.tsx.snap
+++ b/src/components/Popover/__snapshots__/Popover.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`<Popover /> BottomLeft story renders snapshot 1`] = `
   style="position: relative; display: inline-block; margin-top: 12rem;"
 >
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -48,7 +48,7 @@ exports[`<Popover /> BottomLeft story renders snapshot 1`] = `
               class="popover__header-title-after"
             >
               <button
-                class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
                 data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
@@ -277,7 +277,7 @@ exports[`<Popover /> BottomRight story renders snapshot 1`] = `
   style="position: relative; display: inline-block; margin-top: 12rem;"
 >
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -319,7 +319,7 @@ exports[`<Popover /> BottomRight story renders snapshot 1`] = `
               class="popover__header-title-after"
             >
               <button
-                class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
                 data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
@@ -548,7 +548,7 @@ exports[`<Popover /> Default story renders snapshot 1`] = `
   style="position: relative; display: inline-block; margin-top: 12rem;"
 >
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -590,7 +590,7 @@ exports[`<Popover /> Default story renders snapshot 1`] = `
               class="popover__header-title-after"
             >
               <button
-                class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
                 data-bootstrap-override="clickable-style-icon"
                 type="button"
               >
@@ -819,7 +819,7 @@ exports[`<Popover /> TopLeft story renders snapshot 1`] = `
   style="position: relative; display: inline-block; margin-top: 12rem;"
 >
   <button
-    class="clickable-style button button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+    class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary"
     data-bootstrap-override="clickable-style-primary"
     type="button"
   >
@@ -861,7 +861,7 @@ exports[`<Popover /> TopLeft story renders snapshot 1`] = `
               class="popover__header-title-after"
             >
               <button
-                class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+                class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
                 data-bootstrap-override="clickable-style-icon"
                 type="button"
               >

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -51,7 +51,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
       <button
         aria-expanded="false"
         aria-label="Open project dropdown"
-        class="clickable-style button project-card__menu-button button--icon clickable-style--sm clickable-style--icon clickable-style--neutral"
+        class="clickable-style clickable-style--sm clickable-style--icon clickable-style--neutral button project-card__menu-button button--icon"
         data-bootstrap-override="clickable-style-icon"
         type="button"
       >
@@ -215,7 +215,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
       <button
         aria-expanded="false"
         aria-label="Open project dropdown"
-        class="clickable-style button project-card__menu-button button--icon clickable-style--sm clickable-style--icon clickable-style--neutral"
+        class="clickable-style clickable-style--sm clickable-style--icon clickable-style--neutral button project-card__menu-button button--icon"
         data-bootstrap-override="clickable-style-icon"
         type="button"
       >

--- a/src/components/ShowHide/__snapshots__/ShowHide.test.tsx.snap
+++ b/src/components/ShowHide/__snapshots__/ShowHide.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<ShowHide /> Default story renders snapshot 1`] = `
   >
     <button
       aria-expanded="false"
-      class="clickable-style button show-hide__trigger button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button show-hide__trigger button--primary"
       data-bootstrap-override="clickable-style-primary"
       text="Actions"
       type="button"

--- a/src/components/TextField/__snapshots__/TextField.test.ts.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.ts.snap
@@ -163,7 +163,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
         class="text-field__input-within"
       >
         <button
-          class="clickable-style button button--icon clickable-style--sm clickable-style--icon clickable-style--brand"
+          class="clickable-style clickable-style--sm clickable-style--icon clickable-style--brand button button--icon"
           data-bootstrap-override="clickable-style-icon"
           type="button"
         >

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -457,7 +457,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
     class="timeline-nav__body"
   >
     <button
-      class="clickable-style button timeline-nav__back button--link clickable-style--link clickable-style--neutral"
+      class="clickable-style clickable-style--link clickable-style--neutral button timeline-nav__back button--link"
       data-bootstrap-override="clickable-style-link"
       type="button"
     >

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-5"
-      class="clickable-style button trigger--spacing-bottom trigger--spacing-left button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing-bottom trigger--spacing-left button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -60,7 +60,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-2"
-      class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -119,7 +119,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
       </p>
       <button
         aria-describedby="tippy-8"
-        class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing button--primary"
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
@@ -175,7 +175,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-3"
-      class="clickable-style button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing-top trigger--spacing-bottom trigger--spacing-left-large button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -230,7 +230,7 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-1"
-      class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -285,7 +285,7 @@ exports[`<Tooltip /> LongButtonText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-7"
-      class="clickable-style button trigger--spacing-top button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing-top button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -340,7 +340,7 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-6"
-      class="clickable-style button trigger--spacing button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >
@@ -393,7 +393,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
   <div>
     <button
       aria-describedby="tippy-4"
-      class="clickable-style button trigger--spacing-top trigger--spacing-left button--primary clickable-style--lg clickable-style--primary clickable-style--brand"
+      class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button trigger--spacing-top trigger--spacing-left button--primary"
       data-bootstrap-override="clickable-style-primary"
       type="button"
     >

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -10,14 +10,11 @@
  * Link button styles
  * 1) display: inline-flex allows us to manage icon placement and the focus background animation
  * 2) Smaller gap between text and icon in link button style
- * 3) 2px padding gives the text breathing room in the focus state
- * 4) 2px margin compensates for the padding so the link doesn't have too much space between it
- *    and surrounding text
- * 5) Has position relative to support the background color pseudo element
- * 6) We hide overflow so the pseudo element can be pushed out of site
- * 7) z-index 0 required for the background to appear correctly on focus
- * 8) Has smaller icons than other button styles
- * 9) Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
+ * 3) Has position relative to support the background color pseudo element
+ * 4) We hide overflow so the pseudo element can be pushed out of site
+ * 5) z-index 0 required for the background to appear correctly on focus
+ * 6) Has smaller icons than other button styles
+ * 7) Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
       color, but it will also make borders 100% opacity black
  */
 @define-mixin textLink {
@@ -34,11 +31,9 @@
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 
-  padding: 2px; /* 3 */
-  margin: -2px; /* 4 */
-  position: relative; /* 5 */
-  overflow: hidden; /* 6 */
-  z-index: var(--eds-z-index-0); /* 7 */
+  position: relative; /* 3 */
+  overflow: hidden; /* 4 */
+  z-index: var(--eds-z-index-0); /* 5 */
   transition: color var(--eds-anim-move-medium) var(--eds-anim-ease),
     text-decoration-color var(--eds-anim-move-medium) var(--eds-anim-ease);
 
@@ -47,7 +42,7 @@
   }
 
   svg {
-    --icon-size-default: 1.25em; /* 8 */
+    --icon-size-default: 1.25em; /* 6 */
   }
 
   &:hover {
@@ -56,7 +51,7 @@
   }
 
   &:focus {
-    outline: 1px solid transparent; /* 9 */
+    outline: 1px solid transparent; /* 7 */
     color: var(--eds-theme-color-text-neutral-default-inverse) !important;
     text-decoration-color: var(
       --eds-theme-color-text-neutral-default-inverse


### PR DESCRIPTION
### Summary:
In testing the new link styles in LP, I noticed that the margin is for some reason not allowing local styles to override it. Here I'm adding `:where` around those specific styles, which the button margin style already has. 

### Test Plan:
No changes in `Button` and `Link` storybook.