### PR TITLE
chore(timeline nav): fix styling issues

### DIFF
--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="20"
+      id="19"
     >
       Active Step 1
     </title>
@@ -545,7 +545,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="21"
+      id="20"
     >
       Step 2
     </title>
@@ -563,7 +563,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="22"
+      id="21"
     >
       Step 3
     </title>

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -527,7 +527,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="19"
+      id="20"
     >
       Active Step 1
     </title>
@@ -545,7 +545,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="20"
+      id="21"
     >
       Step 2
     </title>
@@ -563,7 +563,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="21"
+      id="22"
     >
       Step 3
     </title>

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -18,10 +18,7 @@
     background: var(--eds-theme-color-background-neutral-default);
     border-bottom-left-radius: var(--eds-border-radius-xl);
     border-top-left-radius: var(--eds-border-radius-xl);
-    border-width: var(--eds-theme-border-width);
-    border-color: var(--eds-theme-color-border-neutral-subtle);
-    border-style: none;
-    transition: unset;
+    transition: none;
     overflow: visible;
   }
 

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -14,13 +14,15 @@
   overflow: hidden;
   transition: transform var(--eds-anim-fade-long) var(--eds-anim-ease);
   background: var(--eds-theme-color-background-neutral-default);
+  border-width: var(--eds-theme-border-width);
+  border-style: solid;
+  border-color: var(--eds-theme-color-border-neutral-subtle);
+  border-bottom-left-radius: var(--eds-border-radius-xl);
+  border-top-left-radius: var(--eds-border-radius-xl);
 
   @media all and (min-width: $eds-bp-lg) {
+    border-style: none;
     transition: unset;
-    border-width: var(--eds-theme-border-width);
-    border-style: solid;
-    border-color: var(--eds-theme-color-border-neutral-subtle);
-    border-radius: var(--eds-border-radius-md);
     overflow: visible;
   }
 
@@ -88,7 +90,7 @@
     visibility: visible;
     transform: translateX(0);
     padding: var(--eds-size-5) var(--eds-size-8);
-    box-shadow: -6px 0px 10px -2px var(--eds-theme-color-border-neutral-subtle); /* 1 */
+    box-shadow: 0px 2px 8px var(--eds-theme-color-border-neutral-subtle); /* 1 */ 
   }
 }
 

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -13,14 +13,13 @@
   width: 100%;
   overflow: hidden;
   transition: transform var(--eds-anim-fade-long) var(--eds-anim-ease);
-  background: var(--eds-theme-color-background-neutral-default);
-  border-width: var(--eds-theme-border-width);
-  border-style: solid;
-  border-color: var(--eds-theme-color-border-neutral-subtle);
-  border-bottom-left-radius: var(--eds-border-radius-xl);
-  border-top-left-radius: var(--eds-border-radius-xl);
-
+  
   @media all and (min-width: $eds-bp-lg) {
+    background: var(--eds-theme-color-background-neutral-default);
+    border-bottom-left-radius: var(--eds-border-radius-xl);
+    border-top-left-radius: var(--eds-border-radius-xl);
+    border-width: var(--eds-theme-border-width);
+    border-color: var(--eds-theme-color-border-neutral-subtle);
     border-style: none;
     transition: unset;
     overflow: visible;
@@ -144,7 +143,11 @@
 .timeline-nav__item {
   position: relative;
   flex-shrink: 0; /* 1 */
-  padding-bottom: var(--eds-size-4);
+  padding-bottom: var(--eds-size-5);
+
+  @media all and (min-width: $eds-bp-lg) {
+    padding-bottom: var(--eds-size-10);
+  }
 }
 
 /**
@@ -252,7 +255,6 @@
   position: relative;
   height: fit-content;
   padding: var(--eds-size-half) 0;
-  background: var(--eds-theme-color-background-neutral-default); /* 1*/
   z-index: var(--eds-z-index-100);
 }
 
@@ -293,6 +295,12 @@
   border-color: var(--eds-theme-color-border-neutral-default);
   position: relative;
   margin-right: var(--eds-size-half);
+  background: var(--eds-color-neutral-100);
+  border-radius: 100%;
+  
+  @media all and (min-width: $eds-bp-lg) {
+    background: var(--eds-theme-color-background-neutral-default);
+  }
 
   .timeline-nav__item.eds-is-active & {
     color: 1px solid var(--eds-theme-color-text-neutral-default);

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -7,7 +7,7 @@
 /**
  * 1) List of of links where each link toggles open associated information
  */
-.timeline-nav {
+ .timeline-nav {
   display: flex;
   gap: var(--eds-size-2);
   width: 100%;
@@ -247,11 +247,15 @@
     border: 1px solid var(--eds-theme-color-text-neutral-default); /* 5 */
   }
 }
-
+/**
+* Timeline nav link-left 
+* 1) Provides white background to fake a visual gap in the vertical line between nav items
+*/
 .timeline-nav__link-left {
   position: relative;
   height: fit-content;
   padding: var(--eds-size-half) 0;
+  background: var(--eds-theme-color-background-neutral-default); /* 1*/
   z-index: var(--eds-z-index-100);
 }
 


### PR DESCRIPTION
### Summary:
https://app.shortcut.com/czi-edu/story/204977/timeline-nav-styles


### Test Plan:

- Spacing between items: < lg breakpoints: space between each nav item should be --eds-size-5 (40px); lg and > breakpoints: space between each nav item should be --eds-size-10 (80px)
- Border and box shadow: < lg breakpoints: no background color, no box shadow; lg and > breakpoints: background is neutral default, top-left and bottom-left border radii are border-radius-xl, box shadow (on timeline-nav__body) is 0px 2px 8px var(--eds-theme-color-border-neutral-subtle)
- Fixed issue with background color behind .timeline-nav__link-left