### PR TITLE
chore(horizontalstepper): allow line class names and change dot color

### DIFF
--- a/src/components/HorizontalStep/HorizontalStep.module.css
+++ b/src/components/HorizontalStep/HorizontalStep.module.css
@@ -34,6 +34,10 @@
   color: inherit;
 }
 
+.horizontal-step__number-icon--incomplete {
+  --number-icon-incomplete-fill: var(--eds-theme-color-icon-disabled);
+}
+
 /**
  * Horizontal Step Complete
  */

--- a/src/components/HorizontalStep/HorizontalStep.tsx
+++ b/src/components/HorizontalStep/HorizontalStep.tsx
@@ -47,6 +47,11 @@ export const HorizontalStep = ({
   /**
    * Determines which icon to display.
    */
+  const numberIconClassName = clsx(
+    styles['horizontal-step__number-icon'],
+    variant === 'incomplete' &&
+      styles['horizontal-step__number-icon--incomplete'],
+  );
   const icon =
     variant === 'complete' ? (
       <Icon
@@ -59,7 +64,7 @@ export const HorizontalStep = ({
     ) : (
       <NumberIcon
         aria-label={`current step ${stepNumber} ${text}`}
-        className={styles['horizontal-step__number-icon']}
+        className={numberIconClassName}
         incomplete={variant !== 'active'}
         number={stepNumber}
         numberIconTitle={`incomplete step ${stepNumber} ${text}`}

--- a/src/components/HorizontalStepper/HorizontalStepper.module.css
+++ b/src/components/HorizontalStepper/HorizontalStepper.module.css
@@ -10,7 +10,6 @@
 .horizontal-stepper {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
 }
 

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.module.css
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.module.css
@@ -1,0 +1,6 @@
+/**
+ * Caps dividing line to 120px width.
+ */
+.capped-line {
+  max-width: 120px;
+}

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
@@ -2,6 +2,7 @@ import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { HorizontalStepper } from './HorizontalStepper';
+import styles from './HorizontalStepper.stories.module.css';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import HorizontalStep from '../HorizontalStep';
@@ -123,4 +124,10 @@ export const HorizontalStepsDifferentNumbers: StoryObj<Args> = {
       <HorizontalStep stepNumber={65} text="Horizontal step" variant="active" />
     </ol>
   ),
+};
+
+export const CappedLine: StoryObj<Args> = {
+  args: {
+    linesClassName: styles['capped-line'],
+  },
 };

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -14,6 +14,10 @@ export type Props = {
    */
   className?: string;
   /**
+   * CSS class names that can be appended to the separating horizontal lines.
+   */
+  linesClassName?: string;
+  /**
    * Ordered list of step texts.
    */
   steps: string[];
@@ -32,7 +36,12 @@ export type Props = {
  * <HorizontalStepper activeIndex={0} steps={['Step 1', 'Step 2', 'Step 3']} />
  * ```
  */
-export const HorizontalStepper = ({ activeIndex, className, steps }: Props) => {
+export const HorizontalStepper = ({
+  activeIndex,
+  className,
+  linesClassName,
+  steps,
+}: Props) => {
   /**
    * Warns dev if the activeIndex is invalid
    * 1) Negative conditional to account for 'NaN' values which pass the number type check since "typeof NaN === 'number'"
@@ -56,14 +65,19 @@ export const HorizontalStepper = ({ activeIndex, className, steps }: Props) => {
   const stepComponents: React.ReactNode[] = [];
   steps.forEach((step, index) => {
     /* 1 */
-    if (index > 0)
+    if (index > 0) {
+      const stepperLinesClassName = clsx(
+        styles['horizontal-stepper__line'],
+        linesClassName,
+      );
       stepComponents.push(
         <hr
           aria-hidden /* 2 */
-          className={styles['horizontal-stepper__line']}
+          className={stepperLinesClassName}
           key={`horizontal-stepper__line-${index}`}
         />,
       );
+    }
 
     /* 3 */
     const stepVariant =

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -1,5 +1,180 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
+<div
+  style="margin: 1rem;"
+>
+  <ol
+    class="horizontal-stepper"
+  >
+    <li
+      class="horizontal-step horizontal-step--active"
+    >
+      <span
+        aria-label="current step 1 Step 1"
+        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        role="img"
+      >
+        1
+      </span>
+      <span
+        class="text text--sm text--inherit text--bold-weight horizontal-step__text"
+      >
+        Step 1
+      </span>
+    </li>
+    <hr
+      aria-hidden="true"
+      class="horizontal-stepper__line capped-line"
+    />
+    <li
+      class="horizontal-step horizontal-step--incomplete"
+    >
+      <span
+        aria-label="current step 2 Step 2"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        role="img"
+      >
+        <svg
+          class="icon number-icon__icon"
+          fill="#C0C4C8"
+          height="0.5rem"
+          role="img"
+          style="--icon-size: 0.5rem;"
+          width="0.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title
+            id="20"
+          >
+            incomplete step 2 Step 2
+          </title>
+          <use
+            xlink:href="test-file-stub#circle"
+          />
+        </svg>
+      </span>
+      <span
+        class="text text--sm text--inherit text--bold-weight horizontal-step__text"
+      >
+        Step 2
+      </span>
+    </li>
+    <hr
+      aria-hidden="true"
+      class="horizontal-stepper__line capped-line"
+    />
+    <li
+      class="horizontal-step horizontal-step--incomplete"
+    >
+      <span
+        aria-label="current step 3 Step 3"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        role="img"
+      >
+        <svg
+          class="icon number-icon__icon"
+          fill="#C0C4C8"
+          height="0.5rem"
+          role="img"
+          style="--icon-size: 0.5rem;"
+          width="0.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title
+            id="21"
+          >
+            incomplete step 3 Step 3
+          </title>
+          <use
+            xlink:href="test-file-stub#circle"
+          />
+        </svg>
+      </span>
+      <span
+        class="text text--sm text--inherit text--bold-weight horizontal-step__text"
+      >
+        Step 3
+      </span>
+    </li>
+    <hr
+      aria-hidden="true"
+      class="horizontal-stepper__line capped-line"
+    />
+    <li
+      class="horizontal-step horizontal-step--incomplete"
+    >
+      <span
+        aria-label="current step 4 Step 4"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        role="img"
+      >
+        <svg
+          class="icon number-icon__icon"
+          fill="#C0C4C8"
+          height="0.5rem"
+          role="img"
+          style="--icon-size: 0.5rem;"
+          width="0.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title
+            id="22"
+          >
+            incomplete step 4 Step 4
+          </title>
+          <use
+            xlink:href="test-file-stub#circle"
+          />
+        </svg>
+      </span>
+      <span
+        class="text text--sm text--inherit text--bold-weight horizontal-step__text"
+      >
+        Step 4
+      </span>
+    </li>
+    <hr
+      aria-hidden="true"
+      class="horizontal-stepper__line capped-line"
+    />
+    <li
+      class="horizontal-step horizontal-step--incomplete"
+    >
+      <span
+        aria-label="current step 5 Step 5"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        role="img"
+      >
+        <svg
+          class="icon number-icon__icon"
+          fill="#C0C4C8"
+          height="0.5rem"
+          role="img"
+          style="--icon-size: 0.5rem;"
+          width="0.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title
+            id="23"
+          >
+            incomplete step 5 Step 5
+          </title>
+          <use
+            xlink:href="test-file-stub#circle"
+          />
+        </svg>
+      </span>
+      <span
+        class="text text--sm text--inherit text--bold-weight horizontal-step__text"
+      >
+        Step 5
+      </span>
+    </li>
+  </ol>
+</div>
+`;
+
 exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
 <div
   style="margin: 1rem;"
@@ -179,7 +354,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -537,7 +712,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -574,7 +749,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -611,7 +786,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -648,7 +823,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -925,7 +1100,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -962,7 +1137,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
       >
         <svg
           class="icon number-icon__icon"
-          fill="#878C90"
+          fill="#C0C4C8"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -32,12 +32,12 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 2 Step 2"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -69,12 +69,12 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -106,12 +106,12 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -143,12 +143,12 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -349,12 +349,12 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -707,12 +707,12 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 2 Step 2"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -744,12 +744,12 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -781,12 +781,12 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -818,12 +818,12 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -1095,12 +1095,12 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"
@@ -1132,12 +1132,12 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon"
+        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
           class="icon number-icon__icon"
-          fill="#C0C4C8"
+          fill="inherit"
           height="0.5rem"
           role="img"
           style="--icon-size: 0.5rem;"

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -28,6 +28,10 @@
 
 .number-icon--incomplete {
   border: none;
+  fill: var(
+    --number-icon-incomplete-fill,
+    var(--eds-theme-color-icon-neutral-subtle)
+  );
 }
 
 /**

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
 import styles from './NumberIcon.module.css';
-import { EdsThemeColorIconNeutralSubtle } from '../../tokens-dist/ts/colors';
+import { EdsThemeColorIconDisabled } from '../../tokens-dist/ts/colors';
 import Icon from '../Icon';
 import Text from '../Text';
 
@@ -86,7 +86,7 @@ export const NumberIcon = ({
       {incomplete && numberIconTitle ? (
         <Icon
           className={styles['number-icon__icon']}
-          color={EdsThemeColorIconNeutralSubtle}
+          color={EdsThemeColorIconDisabled}
           name="circle"
           purpose="informative"
           size={size === 'sm' ? '0.25rem' : '0.5rem'}

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
 import styles from './NumberIcon.module.css';
-import { EdsThemeColorIconDisabled } from '../../tokens-dist/ts/colors';
 import Icon from '../Icon';
 import Text from '../Text';
 
@@ -64,7 +63,7 @@ export const NumberIcon = ({
     styles['number-icon'],
     styles[`number-icon--${variant}`],
     size && styles[`number-icon--${size}`],
-    incomplete === true && styles['number-icon--incomplete'],
+    incomplete && styles['number-icon--incomplete'],
     className,
   );
 
@@ -86,7 +85,7 @@ export const NumberIcon = ({
       {incomplete && numberIconTitle ? (
         <Icon
           className={styles['number-icon__icon']}
-          color={EdsThemeColorIconDisabled}
+          color="inherit"
           name="circle"
           purpose="informative"
           size={size === 'sm' ? '0.25rem' : '0.5rem'}

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -34,7 +34,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             >
               <svg
                 class="icon number-icon__icon"
-                fill="#878C90"
+                fill="#C0C4C8"
                 height="0.5rem"
                 role="img"
                 style="--icon-size: 0.5rem;"
@@ -307,7 +307,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             >
               <svg
                 class="icon number-icon__icon"
-                fill="#878C90"
+                fill="#C0C4C8"
                 height="0.5rem"
                 role="img"
                 style="--icon-size: 0.5rem;"

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -34,7 +34,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             >
               <svg
                 class="icon number-icon__icon"
-                fill="#C0C4C8"
+                fill="inherit"
                 height="0.5rem"
                 role="img"
                 style="--icon-size: 0.5rem;"
@@ -307,7 +307,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             >
               <svg
                 class="icon number-icon__icon"
-                fill="#C0C4C8"
+                fill="inherit"
                 height="0.5rem"
                 role="img"
                 style="--icon-size: 0.5rem;"


### PR DESCRIPTION
### Summary:
- allows passing `linesClassName` to `<HorizontalStepper>` to custom style the dividing lines between steps
- changes incomplete dot icon to "icon-disabled" (#C0C4C8)
![image](https://user-images.githubusercontent.com/86632227/177847929-c756a25b-3efb-40e5-9b94-ce9edf919d90.png)
[sc-205022]
### Test Plan:
- incomplete dots color changes in chromatic snaps where used
- capped line horizontal story
- unit tests pass with snap updates