### PR TITLE
Ifrost/204796 append classnames drag drop container

### DIFF
--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -306,6 +306,7 @@ export const DragDrop = ({
 
                     return (
                       <DragDropContainer
+                        columnClassName={container.columnClassName}
                         container={container}
                         emptyContent={container.emptyContent}
                         items={items}

--- a/src/components/DragDrop/DragDropTypes.ts
+++ b/src/components/DragDrop/DragDropTypes.ts
@@ -21,4 +21,5 @@ export interface ContainerType {
   itemIds: string[];
   header?: React.ReactNode;
   emptyContent?: React.ReactNode;
+  columnClassName?: string;
 }

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<DragDrop /> Default story renders snapshot 1`] = `
           </div>
         </header>
         <ol
-          class="drag-drop__container-inner"
+          class="drag-drop__container-inner undefined"
           data-rbd-droppable-context-id="0"
           data-rbd-droppable-id="container-1"
         >
@@ -252,7 +252,7 @@ exports[`<DragDrop /> Default story renders snapshot 1`] = `
           </div>
         </header>
         <div
-          class="drag-drop__container-inner"
+          class="drag-drop__container-inner undefined"
           data-rbd-droppable-context-id="0"
           data-rbd-droppable-id="container-2"
         >
@@ -427,7 +427,7 @@ exports[`<DragDrop /> HoveredHandle story renders snapshot 1`] = `
           </div>
         </header>
         <ol
-          class="drag-drop__container-inner"
+          class="drag-drop__container-inner undefined"
           data-rbd-droppable-context-id="1"
           data-rbd-droppable-id="container-1"
         >
@@ -650,7 +650,7 @@ exports[`<DragDrop /> HoveredHandle story renders snapshot 1`] = `
           </div>
         </header>
         <div
-          class="drag-drop__container-inner"
+          class="drag-drop__container-inner undefined"
           data-rbd-droppable-context-id="1"
           data-rbd-droppable-id="container-2"
         >

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -13,6 +13,11 @@ export interface Props {
    */
   className?: string;
   /**
+   * Column class names that can be appended to the component.
+   * 1) Used to add additional styles to the column
+   */
+  columnClassName?: string;
+  /**
    * Prop that will contain an id for each container and an array of itemIds that will be used on initial render
    */
   container: ContainerType;
@@ -34,6 +39,7 @@ export const DragDropContainer = ({
   container,
   items,
   emptyContent,
+  columnClassName,
 }: Props) => {
   const componentClassName = clsx(
     styles['drag-drop__container'],
@@ -56,7 +62,9 @@ export const DragDropContainer = ({
         {(provided: DroppableProvided) =>
           items.length > 0 ? (
             <ol
-              className={styles['drag-drop__container-inner']}
+              className={`${styles['drag-drop__container-inner']} ${
+                container.columnClassName && container.columnClassName
+              }`}
               ref={provided.innerRef}
               {...provided.droppableProps}
             >
@@ -67,7 +75,9 @@ export const DragDropContainer = ({
             </ol>
           ) : (
             <div
-              className={styles['drag-drop__container-inner']}
+              className={`${styles['drag-drop__container-inner']} ${
+                container.columnClassName && container.columnClassName
+              }`}
               ref={provided.innerRef}
               {...provided.droppableProps}
             >


### PR DESCRIPTION
### Summary:
- Adds `columnClassName` prop to the drag drop column to give teams flexibility around adding additional styles like large padding bottom on the column to accommodate bottom aligned dropdowns since the overflow is set to auto for scroll on small screens.
- Request from CAD team

### Test Plan:
- `yarn types` runs
- `yarn test` runs
- `yarn lint` runs without errors
- `yarn start` runs