### PR TITLE
fix: numberAriaLabel conditional project card

### DIFF
--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -95,7 +95,7 @@ export const ProjectCard = ({
       {...other}
     >
       <CardHeader className={styles['project-card__header']}>
-        {number && (
+        {number && numberAriaLabel && (
           <NumberIcon
             aria-label={numberAriaLabel}
             className={styles['project-card__number']}


### PR DESCRIPTION
### Summary:
- Added conditional to include `numberAriaLabel` around the `NumberIcon` within project card. Emma was getting warnings implementing since that prop is required in `NumberIcon` but the number isn't always in the card. This should fix that.

### Test Plan:
- `yarn test` runs
- `yarn types` runs
- `yarn lint` runs
- `yarn start` runs