### PR TITLE
chore(banner): clarify close button label

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -148,7 +148,11 @@ export const Banner = ({
           status="neutral"
           variant="icon"
         >
-          <Icon name={'close'} purpose="informative" title={'dismiss module'} />
+          <Icon
+            name="close"
+            purpose="informative"
+            title="dismiss notification"
+          />
         </Button>
       )}
 

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
       <title
         id="13"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -199,7 +199,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       <title
         id="23"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -325,7 +325,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
       <title
         id="21"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -545,7 +545,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
       <title
         id="15"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -793,7 +793,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
       <title
         id="17"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -966,7 +966,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
       <title
         id="28"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -1034,7 +1034,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       <title
         id="31"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -1218,7 +1218,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
       <title
         id="19"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -115,7 +115,11 @@ export const PageLevelBanner = ({
           status="neutral"
           variant="icon"
         >
-          <Icon name={'close'} purpose="informative" title={'dismiss module'} />
+          <Icon
+            name="close"
+            purpose="informative"
+            title="dismiss notification"
+          />
         </Button>
       )}
 

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
       <title
         id="7"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -168,7 +168,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
       <title
         id="13"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -342,7 +342,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
       <title
         id="9"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"
@@ -449,7 +449,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
       <title
         id="11"
       >
-        dismiss module
+        dismiss notification
       </title>
       <use
         xlink:href="test-file-stub#close"


### PR DESCRIPTION
### Summary:
- updates close button labels of banners to be clearer
### Test Plan:
- only banner snaps affected for aria label
- no visual regressions