### PR TITLE
Csnizik/190341 clickable card recipe

### DIFF
--- a/.storybook/recipes/BaselineCard/BaselineCard.module.css
+++ b/.storybook/recipes/BaselineCard/BaselineCard.module.css
@@ -13,6 +13,15 @@
 }
 
 /**
+* Baseline card container
+* 1) Used to pass the cardRef object to Card component
+*/
+.baseline-card__container {
+  @mixin reset;
+  display: block;
+}
+
+/**
  * Baseline card label.
  */
 .baseline-card__label {
@@ -22,12 +31,77 @@
 }
 
 /**
+* Baseline card clickable 
+* 1) When an href prop is passed in, the card gets a :hover style to indicate
+* that it is clickable.
+*/
+.baseline-card--clickable {
+  transition: box-shadow var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+  &:hover {
+    cursor: pointer;
+    box-shadow: var(--eds-box-shadow-xl);
+  }
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+/**
  * Baseline card body for more content.
  */
 .baseline-card__body {
   @mixin eds-theme-typography-body-text-sm;
 
   color: var(--eds-theme-color-text-neutral-subtle);
+}
+
+/**
+* Baseline card link (based on WordPress' .screen-reader-text class)
+* 1) On a clickable card, the link should be visually hidden but still
+* accessible to screen readers. It should also become visible when it 
+* receives keyboard focus, i.e. using the Tab key
+* 2) Set width and height to 1px; some screen readers don't announce 
+* an element with a size of 0 px
+* 3) Hide the link
+* 4) Prevent screen readers reading the text letter for letter, as the
+* text is placed in a 1 pixel wide space. Many screen reader and browser
+* combinations announce broken words as they would appear visually.
+* 5) Clip is deprecated, but is added to support older browsers that don't support clip-path yet.
+* 
+* See https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
+*/
+
+.baseline-card__link {
+  border: 0;
+  clip: rect(1px, 1px, 1px, 1px);
+  clip-path: inset(50%);
+  width: 1px; /* 2 */
+  height: 1px;
+  margin: -1px; /* 3 */
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+  word-wrap: normal !important; /* 4 */
+}
+
+.baseline-card__link:focus {
+  @mixin eds-theme-typography-body-text-sm;
+  background-color: var(--eds-theme-color-background-neutral-default);
+  clip: auto !important; /* 5 */
+  clip-path: none;
+  color: var(--eds-theme-color-text-neutral-default);
+  display: block;
+  font-size: 1em;
+  height: auto;
+  left: var(--eds-size-half);
+  line-height: normal;
+  padding: var(--eds-size-half) var(--eds-size-1);
+  text-decoration: none;
+  top: var(--eds-size-half);
+  width: auto;
+  z-index: var(--eds-z-index-top); /* 1 */
 }
 
 /**

--- a/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: BaselineCard,
   args: {
     label: 'Selection of Evidence',
-    body: "In this Focus Area, you explore the main question: How does the structures of organisms enable life's functions?",
+    body: `In this Focus Area, you explore the main question: How does the structures of organisms enable life's functions?`,
   },
 } as Meta<Args>;
 
@@ -17,15 +17,13 @@ type Args = React.ComponentProps<typeof BaselineCard>;
 export const Default: StoryObj<Args> = {};
 
 export const Clickable: StoryObj<Args> = {
-  args: {},
-  decorators: [
-    (Story) => (
-      // eslint-disable-next-line jsx-a11y/anchor-is-valid
-      <a href="#">
-        <Story />
-      </a>
-    ),
-  ],
+  args: {
+    label: 'Clickable card',
+    body: 'This card is linked and clickable. Clicking anywhere on the card will open a link in a new tab. Its link is visually hidden but is still focusable when tabbing. Text within the card can still be selected. Right-clicking within the card works.',
+    linkHref:
+      'https://css-tricks.com/block-links-the-search-for-a-perfect-solution/',
+    linkText: 'Block links article',
+  },
 };
 
 export const WithMetadata: StoryObj<Args> = {

--- a/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: BaselineCard,
   args: {
     label: 'Selection of Evidence',
-    body: `In this Focus Area, you explore the main question: How does the structures of organisms enable life's functions?`,
+    body: "In this Focus Area, you explore the main question: How does the structures of organisms enable life's functions?",
   },
 } as Meta<Args>;
 
@@ -20,9 +20,10 @@ export const Clickable: StoryObj<Args> = {
   args: {
     label: 'Clickable card',
     body: 'This card is linked and clickable. Clicking anywhere on the card will open a link in a new tab. Its link is visually hidden but is still focusable when tabbing. Text within the card can still be selected. Right-clicking within the card works.',
-    linkHref:
-      'https://css-tricks.com/block-links-the-search-for-a-perfect-solution/',
-    linkText: 'Block links article',
+    linkProps: {
+      href: 'https://css-tricks.com/block-links-the-search-for-a-perfect-solution/',
+      text: 'Block links article',
+    },
   },
 };
 

--- a/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.stories.tsx
@@ -16,6 +16,18 @@ type Args = React.ComponentProps<typeof BaselineCard>;
 
 export const Default: StoryObj<Args> = {};
 
+export const Clickable: StoryObj<Args> = {
+  args: {},
+  decorators: [
+    (Story) => (
+      // eslint-disable-next-line jsx-a11y/anchor-is-valid
+      <a href="#">
+        <Story />
+      </a>
+    ),
+  ],
+};
+
 export const WithMetadata: StoryObj<Args> = {
   args: {
     metadata: {

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import clsx from 'clsx';
 import React, { MutableRefObject, useEffect, useRef } from 'react';
 import styles from './BaselineCard.module.css';
@@ -31,14 +30,10 @@ export interface Props {
    * CSS class names that can be appended to the component.
    */
   className?: string;
-  /**
-   * Clickable card: link URL
+  /*
+   * Clickable card: link properties
    */
-  linkHref?: string;
-  /**
-   * Clickable card: link text
-   */
-  linkText?: string;
+  linkProps?: LinkType;
   /**
    * Label for the baseline card, placed in the card header.
    */
@@ -53,13 +48,25 @@ export interface Props {
   metadata?: Metadata;
 }
 
+/*
+ * Clickable card: link properties
+ * 1) Href and text are required attributes
+ * 2) Text will be used by screen readers; it will only be visible when the
+ * link is focused by a keyboard
+ * 3) Target attribute is optional
+ */
+export type LinkType = {
+  href: string /* 1 */;
+  text: string /* 2 */;
+  target?: '_blank' | '_parent' | '_self' | '_top' /* 3 */;
+};
+
 /**
  * Recipe for a Card component that displays a common card use case.
  */
 export const BaselineCard = ({
   className,
-  linkHref,
-  linkText,
+  linkProps,
   label,
   body,
   metadata,
@@ -109,7 +116,7 @@ export const BaselineCard = ({
 
   const componentClassName = clsx(
     styles['baseline-card'],
-    linkHref && styles['baseline-card--clickable'],
+    linkProps && styles['baseline-card--clickable'],
     className,
   );
   return (
@@ -125,16 +132,14 @@ export const BaselineCard = ({
         </CardHeader>
         <CardBody className={styles['baseline-card__body']}>
           {body}
-          {` `}
-          {linkHref && (
+          {linkProps && (
             <a
               className={styles['baseline-card__link']}
-              href={linkHref}
+              href={linkProps.href}
               ref={linkRef}
-              rel="noreferrer"
-              target="_blank"
+              target={linkProps.target ? linkProps.target : '_self'}
             >
-              {linkText}
+              {linkProps.text}
             </a>
           )}
         </CardBody>

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -63,6 +63,9 @@ export type LinkType = {
 
 /**
  * Recipe for a Card component that displays a common card use case.
+ * A link may be added to the card to create a clickable card.
+ * NOTE: when card is clickable, it does not support links or buttons
+ * in the contents of the card.
  */
 export const BaselineCard = ({
   className,

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -1,5 +1,6 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import clsx from 'clsx';
-import React from 'react';
+import React, { MutableRefObject, useEffect, useRef } from 'react';
 import styles from './BaselineCard.module.css';
 
 import { Card, CardBody, CardFooter, CardHeader, Tag } from '../../../src';
@@ -31,6 +32,14 @@ export interface Props {
    */
   className?: string;
   /**
+   * Clickable card: link URL
+   */
+  linkHref?: string;
+  /**
+   * Clickable card: link text
+   */
+  linkText?: string;
+  /**
    * Label for the baseline card, placed in the card header.
    */
   label: string;
@@ -49,64 +58,133 @@ export interface Props {
  */
 export const BaselineCard = ({
   className,
+  linkHref,
+  linkText,
   label,
   body,
   metadata,
   ...other
 }: Props) => {
-  const componentClassName = clsx(styles['baseline-card'], className, {});
+  /**
+   * Initialize refs to use on the card container and the link
+   *  (for clickable card)
+   */
+  const cardRef = useRef() as MutableRefObject<HTMLDivElement>;
+  const linkRef = useRef() as MutableRefObject<HTMLAnchorElement>;
+
+  /**
+   * useEffect hook
+   * 1) On component load or update, check for both a cardRef and a linkRef.
+   * The presence of both means this card has a clickable link.
+   * 2) Attach click handler to the card.
+   * 3) Check to see if text is selected; if so, do not call .click() on the
+   * linkRef
+   * 4) Pass the click to the linkRef.
+   * 5) Cleanup.
+   *
+   * TODO: If the visible text of the card also contains links, these will
+   * need to have an event listener added to them to stop propagation of the
+   * click event; otherwise, users will not be able to click on these inner
+   * links.
+   */
+  useEffect(() => {
+    if (!cardRef.current || !linkRef.current) {
+      /* 1 */
+      return;
+    }
+    const curr = cardRef.current;
+    curr.addEventListener('click', handleClick); /* 2 */
+
+    function handleClick() {
+      const isTextSelected = window.getSelection()?.toString(); /* 3 */
+      if (!isTextSelected) {
+        linkRef.current.click(); /* 4 */
+      }
+    }
+    /* 5 */
+    return () => {
+      curr.removeEventListener('click', handleClick, false);
+    };
+  }, []);
+
+  const componentClassName = clsx(
+    styles['baseline-card'],
+    linkHref && styles['baseline-card--clickable'],
+    className,
+  );
   return (
-    <Card className={componentClassName} {...other}>
-      <CardHeader className={styles['baseline-card__label']}>
-        {label}
-      </CardHeader>
-      <CardBody className={styles['baseline-card__body']}>{body}</CardBody>
-      {metadata && (
-        <CardFooter className={styles['baseline-card__footer']}>
-          <table className={styles['baseline-card__table']}>
-            <tbody className={styles['baseline-card__table-body']}>
-              <tr className={styles['baseline-card__table-row']}>
-                <th
-                  className={styles['baseline-card__table-label']}
-                  scope="row"
-                >
-                  Score
-                </th>
-                <td>
-                  <Tag
-                    className={styles['baseline-card__score']}
-                    hasOutline
-                    text={metadata.score}
-                    variant={metadata.variant}
-                  />
-                </td>
-              </tr>
-              <tr className={styles['baseline-card__table-row']}>
-                <th
-                  className={styles['baseline-card__table-label']}
-                  scope="row"
-                >
-                  Attempts
-                </th>
-                <td className={styles['baseline-card__table-data']}>
-                  {metadata.attempts}
-                </td>
-              </tr>
-              <tr className={styles['baseline-card__table-row']}>
-                <th
-                  className={styles['baseline-card__table-label']}
-                  scope="row"
-                >
-                  Line Passes On
-                </th>
-                <td className={styles['baseline-card__table-data']}>
-                  {metadata.deadline}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </CardFooter>
-      )}
-    </Card>
+    /**
+     * 1) Wrapping the Card component in a container for attaching cardRef
+     * to the card without adding a ref prop to <Card />
+     */
+
+    <div className={styles['baseline-card__container']} ref={cardRef}>
+      <Card className={componentClassName} {...other}>
+        <CardHeader className={styles['baseline-card__label']}>
+          {label}
+        </CardHeader>
+        <CardBody className={styles['baseline-card__body']}>
+          {body}
+          {` `}
+          {linkHref && (
+            <a
+              className={styles['baseline-card__link']}
+              href={linkHref}
+              ref={linkRef}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {linkText}
+            </a>
+          )}
+        </CardBody>
+        {metadata && (
+          <CardFooter className={styles['baseline-card__footer']}>
+            <table className={styles['baseline-card__table']}>
+              <tbody className={styles['baseline-card__table-body']}>
+                <tr className={styles['baseline-card__table-row']}>
+                  <th
+                    className={styles['baseline-card__table-label']}
+                    scope="row"
+                  >
+                    Score
+                  </th>
+                  <td>
+                    <Tag
+                      className={styles['baseline-card__score']}
+                      hasOutline
+                      text={metadata.score}
+                      variant={metadata.variant}
+                    />
+                  </td>
+                </tr>
+                <tr className={styles['baseline-card__table-row']}>
+                  <th
+                    className={styles['baseline-card__table-label']}
+                    scope="row"
+                  >
+                    Attempts
+                  </th>
+                  <td className={styles['baseline-card__table-data']}>
+                    {metadata.attempts}
+                  </td>
+                </tr>
+                <tr className={styles['baseline-card__table-row']}>
+                  <th
+                    className={styles['baseline-card__table-label']}
+                    scope="row"
+                  >
+                    Line Passes On
+                  </th>
+                  <td className={styles['baseline-card__table-data']}>
+                    {metadata.deadline}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </CardFooter>
+        )}
+      </Card>
+    </div>
   );
 };

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -20,24 +20,6 @@
   background-color: var(--eds-theme-color-background-neutral-default);
 }
 
-/**
- * Linked card
- * 1) Card that is wrapped in an a tag
- */
-a.card {
-  appearance: none;
-  text-decoration: none;
-  color: var(--eds-theme-color-text-neutral-default);
-  transition: box-shadow var(--eds-anim-fade-quick) var(--eds-anim-ease);
-
-  &:hover {
-    box-shadow: var(--eds-box-shadow-md);
-  }
-
-  @media screen and (prefers-reduced-motion) {
-    transition: none;
-  }
-}
 
 /**
  * Raised card


### PR DESCRIPTION
### Summary:
https://app.shortcut.com/czi-edu/story/190341/base-card-recipe

Allows link text and link url to be passed to a card; the link text/url are visually hidden but still accessible to screen readers and via keyboard navigation. The entire card becomes clickable to follow the link, but users can still click on the card to select text or access shortcuts via right-clicking. 

### Test Plan:

- yarn lint passes
- yarn test passes
- yarn types passes
- yarn start works