### PR TITLE
Csnizik/205790 timeline right slot

### DIFF
--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -270,6 +270,13 @@
   text-overflow: ellipsis; /* 2 */
 }
 
+/**Timeline nav right
+* 1) Optional content that will be positioned to the right of title
+*/
+.timeline-nav__link-right {
+  display: inline-block;
+}
+
 /**
 * Timeline nav link arrow
 * 1) (Only used on smaller screens) - an arrow icon at the right 

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -270,10 +270,10 @@
   text-overflow: ellipsis; /* 2 */
 }
 
-/**Timeline nav right
+/**Timeline nav title after
 * 1) Optional content that will be positioned to the right of title
 */
-.timeline-nav__link-right {
+.timeline-nav__link-title-after {
   display: inline-block;
   margin-left: var(--eds-size-half);
 }

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -275,6 +275,7 @@
 */
 .timeline-nav__link-right {
   display: inline-block;
+  margin-left: var(--eds-size-half);
 }
 
 /**

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -34,7 +34,8 @@ export default {
           </Text>
         </TimelineNavPanel>
         <TimelineNavPanel
-          right={
+          title="TimelineNavPanel 1"
+          titleAfter={
             <Icon
               color={EdsThemeColorIconUtilitySuccess}
               name="circle-small"
@@ -43,7 +44,6 @@ export default {
               title="29 students have completed"
             />
           }
-          title="TimelineNavPanel 1"
           variant="number"
         >
           <Text as="div">
@@ -70,7 +70,10 @@ export default {
         </TimelineNavPanel>
 
         <TimelineNavPanel
-          right={
+          title="
+              Panel with a long name that breaks into multiple lines on smaller
+              viewports"
+          titleAfter={
             <Icon
               color={EdsThemeColorIconBrandPrimary}
               name="circle-small"
@@ -79,9 +82,6 @@ export default {
               title="2 students need feedback"
             />
           }
-          title="
-              Panel with a long name that breaks into multiple lines on smaller
-              viewports"
           variant="warning"
         >
           <Text as="div">

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { TimelineNav } from './TimelineNav';
+import Tag from '../Tag';
 import Text from '../Text';
 import TimelineNavPanel from '../TimelineNavPanel';
 
@@ -28,7 +29,11 @@ export default {
             </p>
           </Text>
         </TimelineNavPanel>
-        <TimelineNavPanel title="TimelineNavPanel 1" variant="number">
+        <TimelineNavPanel
+          right={<Tag hasOutline text="Feedback" variant="brand" />}
+          title="TimelineNavPanel 1"
+          variant="number"
+        >
           <Text as="div">
             <h3>TimelineNavPanel 1</h3>
             <p>
@@ -40,7 +45,7 @@ export default {
           </Text>
         </TimelineNavPanel>
 
-        <TimelineNavPanel title="TimelineNavPanel 2" variant="error">
+        <TimelineNavPanel title="Putting right here" variant="error">
           <Text as="div">
             <h3>TimelineNavPanel 2</h3>
             <p>
@@ -53,6 +58,7 @@ export default {
         </TimelineNavPanel>
 
         <TimelineNavPanel
+          right={<Tag hasOutline text="New" variant="brand" />}
           title="
               Panel with a long name that breaks into multiple lines on smaller
               viewports"

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -3,7 +3,11 @@ import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { TimelineNav } from './TimelineNav';
-import Tag from '../Tag';
+import {
+  EdsThemeColorIconBrandPrimary,
+  EdsThemeColorIconUtilitySuccess,
+} from '../../tokens-dist/ts/colors';
+import Icon from '../Icon';
 import Text from '../Text';
 import TimelineNavPanel from '../TimelineNavPanel';
 
@@ -30,7 +34,15 @@ export default {
           </Text>
         </TimelineNavPanel>
         <TimelineNavPanel
-          right={<Tag hasOutline text="Feedback" variant="brand" />}
+          right={
+            <Icon
+              color={EdsThemeColorIconUtilitySuccess}
+              name="circle-small"
+              purpose="informative"
+              size="1.5em"
+              title="29 students have completed"
+            />
+          }
           title="TimelineNavPanel 1"
           variant="number"
         >
@@ -58,7 +70,15 @@ export default {
         </TimelineNavPanel>
 
         <TimelineNavPanel
-          right={<Tag hasOutline text="New" variant="brand" />}
+          right={
+            <Icon
+              color={EdsThemeColorIconBrandPrimary}
+              name="circle-small"
+              purpose="informative"
+              size="1.5em"
+              title="2 students need feedback"
+            />
+          }
           title="
               Panel with a long name that breaks into multiple lines on smaller
               viewports"
@@ -130,6 +150,6 @@ export default {
   },
 } as Meta;
 
-type Args = React.ComponentProps<typeof TimelineNav>;
+type Args = React.ComponentProps<typeof TimelineNavPanel>;
 
 export const Default: StoryObj<Args> = {};

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -45,7 +45,7 @@ export default {
           </Text>
         </TimelineNavPanel>
 
-        <TimelineNavPanel title="Putting right here" variant="error">
+        <TimelineNavPanel title="TimelineNavPanel 2" variant="error">
           <Text as="div">
             <h3>TimelineNavPanel 2</h3>
             <p>

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -32,6 +32,10 @@ export interface Props {
    */
   'aria-labelledby'?: string;
   /**
+   * Passed down to initially set the activeIndex state
+   */
+  activeIndex?: number;
+  /**
    * Calls back with the active index
    */
   onChange?: (index: number) => void;
@@ -48,44 +52,40 @@ export interface Props {
    */
   id?: string;
   /**
-   * Passed down to initially set the activeIndex state
-   */
-  activeIndex?: number;
-  /**
-   * The array of items to be passed into the component. The array must take on the specified shape
-   * TODO: improve `any` type
-   */
-  items?: Array<any>;
-  /**
-   * Indicates that field is required for form to be successfully submitted
-   */
-  required?: boolean;
-  /**
-   * Function passed down from higher level component into TimelineNav
-   */
-  timelineNavOnClick?: () => void;
-  /**
    * Overflow variants
    * - **inverted** changes the overflow shadow to the inverted color
    */
   overflow?: 'inverted';
   /**
-   * Stylistic variations:
-   * - **ordered** uses a ordered list <ol> instead of the default unordered list <ul>, and allows for icons, bullets, or numbers
+   * Indicates that field is required for form to be successfully submitted
    */
-  variant?: 'ordered';
+  required?: boolean;
+  /**
+   * Right slot: content that will be positioned to the right of title
+   */
+  right?: ReactNode;
+  /**
+   * Function passed down from higher level component into TimelineNav
+   */
+  timelineNavOnClick?: () => void;
   /**
    * Timeline nav item tab name
    */
   title?: string;
+  /**
+   * Stylistic variations:
+   * - **ordered** uses a ordered list <ol> instead of the default unordered list <ul>, and allows for icons, bullets, or numbers
+   */
+  variant?: 'ordered';
 }
 
 export interface TimelineNavItem {
   props: {
     'aria-label': string;
     children: ReactNode;
-    variant?: TimelineNavPanelVariant;
+    right?: ReactNode;
     title?: string;
+    variant?: TimelineNavPanelVariant;
   };
 }
 
@@ -109,6 +109,7 @@ export const TimelineNav = ({
   overflow,
   onChange,
   required,
+  right,
   title,
   ...other
 }: Props) => {
@@ -359,6 +360,9 @@ export const TimelineNav = ({
           {timelineNavItems().map((tab: TimelineNavItem, i: number) => {
             const isActive = activeIndexState === i;
             const itemVariant = variant && tab.props.variant;
+            {
+              console.log({ tab: tab });
+            }
             return (
               <li
                 className={clsx(
@@ -396,7 +400,11 @@ export const TimelineNav = ({
                   <div className={clsx(styles['timeline-nav__link-title'])}>
                     {tab.props.title}
                   </div>
-
+                  {tab.props.right && (
+                    <div className={clsx(styles['timeline-nav__link-right'])}>
+                      {tab.props.right}
+                    </div>
+                  )}
                   <Icon
                     className={clsx(styles['timeline-nav__link-arrow'])}
                     name="arrow-forward"

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -61,10 +61,6 @@ export interface Props {
    */
   required?: boolean;
   /**
-   * Right slot: content that will be positioned to the right of title
-   */
-  right?: ReactNode;
-  /**
    * Function passed down from higher level component into TimelineNav
    */
   timelineNavOnClick?: () => void;
@@ -72,6 +68,10 @@ export interface Props {
    * Timeline nav item tab name
    */
   title?: string;
+  /**
+   * Slot for node to appear to the right of the title. Typically used to include a Badge, Button, or other component
+   */
+  titleAfter?: ReactNode;
   /**
    * Stylistic variations:
    * - **ordered** uses a ordered list <ol> instead of the default unordered list <ul>, and allows for icons, bullets, or numbers
@@ -84,8 +84,8 @@ export interface TimelineNavItem {
     'aria-label': string;
     children: ReactNode;
     completed?: boolean;
-    right?: ReactNode;
     title?: string;
+    titleAfter?: ReactNode;
     variant?: TimelineNavPanelVariant;
   };
 }
@@ -108,9 +108,9 @@ export const TimelineNav = ({
   onChange,
   overflow,
   required,
-  right,
   timelineNavOnClick,
   title,
+  titleAfter,
   variant,
   ...other
 }: Props) => {
@@ -396,9 +396,13 @@ export const TimelineNav = ({
                   </div>
                   <div className={clsx(styles['timeline-nav__link-title'])}>
                     {tab.props.title}
-                    {tab.props.right && (
-                      <div className={clsx(styles['timeline-nav__link-right'])}>
-                        {tab.props.right}
+                    {tab.props.titleAfter && (
+                      <div
+                        className={clsx(
+                          styles['timeline-nav__link-title-after'],
+                        )}
+                      >
+                        {tab.props.titleAfter}
                       </div>
                     )}
                   </div>

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -343,7 +343,6 @@ export const TimelineNav = ({
     timelineNavItemRefs[activeIndexState].current?.focus(); /* 2 */
     setIsActive(false); /* 3 */
   };
-
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['timeline-nav__nav']}>
@@ -361,9 +360,6 @@ export const TimelineNav = ({
           {timelineNavItems().map((tab: TimelineNavItem, i: number) => {
             const isActive = activeIndexState === i;
             const itemVariant = variant && tab.props.variant;
-            {
-              console.log({ tab: tab });
-            }
             return (
               <li
                 className={clsx(

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -83,6 +83,7 @@ export interface TimelineNavItem {
   props: {
     'aria-label': string;
     children: ReactNode;
+    completed?: boolean;
     right?: ReactNode;
     title?: string;
     variant?: TimelineNavPanelVariant;
@@ -104,13 +105,7 @@ export const TimelineNav = ({
   children,
   variant,
   activeIndex = 0,
-  timelineNavOnClick,
-  id,
-  overflow,
   onChange,
-  required,
-  right,
-  title,
   ...other
 }: Props) => {
   /**
@@ -399,12 +394,12 @@ export const TimelineNav = ({
                   </div>
                   <div className={clsx(styles['timeline-nav__link-title'])}>
                     {tab.props.title}
+                    {tab.props.right && (
+                      <div className={clsx(styles['timeline-nav__link-right'])}>
+                        {tab.props.right}
+                      </div>
+                    )}
                   </div>
-                  {tab.props.right && (
-                    <div className={clsx(styles['timeline-nav__link-right'])}>
-                      {tab.props.right}
-                    </div>
-                  )}
                   <Icon
                     className={clsx(styles['timeline-nav__link-arrow'])}
                     name="arrow-forward"

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -101,11 +101,17 @@ export interface TimelineNavItem {
  * 1) Provides a list-view pane for item labels/titles, and a details pane for each item's content. When an item in the list is selected, the details pane is updated.
  */
 export const TimelineNav = ({
-  className,
-  children,
-  variant,
   activeIndex = 0,
+  children,
+  className,
+  id,
   onChange,
+  overflow,
+  required,
+  right,
+  timelineNavOnClick,
+  title,
+  variant,
   ...other
 }: Props) => {
   /**

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -106,7 +106,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             TimelineNavPanel 1
             <div
-              class="timeline-nav__link-right"
+              class="timeline-nav__link-title-after"
             >
               <svg
                 class="icon"
@@ -234,7 +234,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
               Panel with a long name that breaks into multiple lines on smaller
               viewports
             <div
-              class="timeline-nav__link-right"
+              class="timeline-nav__link-title-after"
             >
               <svg
                 class="icon"

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -528,7 +528,6 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
       class="timeline-nav__panel"
       id="1uid1"
       role="tabpanel"
-      title="Overview"
     >
       <div
         class="layout-linelength-container text text--body text-passage text-passage--body"

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -106,6 +106,19 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             TimelineNavPanel 1
           </div>
+          <div
+            class="timeline-nav__link-right"
+          >
+            <span
+              class="text text--sm text--bold-weight tag tag--brand tag--outline"
+            >
+              <span
+                class="tag__body"
+              >
+                Feedback
+              </span>
+            </span>
+          </div>
           <svg
             class="icon timeline-nav__link-arrow"
             fill="currentColor"
@@ -156,7 +169,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           <div
             class="timeline-nav__link-title"
           >
-            TimelineNavPanel 2
+            Putting right here
           </div>
           <svg
             class="icon timeline-nav__link-arrow"
@@ -211,6 +224,19 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             
               Panel with a long name that breaks into multiple lines on smaller
               viewports
+          </div>
+          <div
+            class="timeline-nav__link-right"
+          >
+            <span
+              class="text text--sm text--bold-weight tag tag--brand tag--outline"
+            >
+              <span
+                class="tag__body"
+              >
+                New
+              </span>
+            </span>
           </div>
           <svg
             class="icon timeline-nav__link-arrow"

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -169,7 +169,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           <div
             class="timeline-nav__link-title"
           >
-            Putting right here
+            TimelineNavPanel 2
           </div>
           <svg
             class="icon timeline-nav__link-arrow"

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -105,19 +105,28 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             class="timeline-nav__link-title"
           >
             TimelineNavPanel 1
-          </div>
-          <div
-            class="timeline-nav__link-right"
-          >
-            <span
-              class="text text--sm text--bold-weight tag tag--brand tag--outline"
+            <div
+              class="timeline-nav__link-right"
             >
-              <span
-                class="tag__body"
+              <svg
+                class="icon"
+                fill="#00A56A"
+                height="1.5em"
+                role="img"
+                style="--icon-size: 1.5em;"
+                width="1.5em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                Feedback
-              </span>
-            </span>
+                <title
+                  id="4"
+                >
+                  29 students have completed
+                </title>
+                <use
+                  xlink:href="test-file-stub#circle-small"
+                />
+              </svg>
+            </div>
           </div>
           <svg
             class="icon timeline-nav__link-arrow"
@@ -129,7 +138,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="4"
+              id="5"
             >
               forward
             </title>
@@ -181,7 +190,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="6"
+              id="7"
             >
               forward
             </title>
@@ -224,19 +233,28 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             
               Panel with a long name that breaks into multiple lines on smaller
               viewports
-          </div>
-          <div
-            class="timeline-nav__link-right"
-          >
-            <span
-              class="text text--sm text--bold-weight tag tag--brand tag--outline"
+            <div
+              class="timeline-nav__link-right"
             >
-              <span
-                class="tag__body"
+              <svg
+                class="icon"
+                fill="#8984E8"
+                height="1.5em"
+                role="img"
+                style="--icon-size: 1.5em;"
+                width="1.5em"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                New
-              </span>
-            </span>
+                <title
+                  id="9"
+                >
+                  2 students need feedback
+                </title>
+                <use
+                  xlink:href="test-file-stub#circle-small"
+                />
+              </svg>
+            </div>
           </div>
           <svg
             class="icon timeline-nav__link-arrow"
@@ -248,7 +266,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="8"
+              id="10"
             >
               forward
             </title>
@@ -300,7 +318,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="10"
+              id="12"
             >
               forward
             </title>
@@ -341,7 +359,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <title
-                  id="11"
+                  id="13"
                 >
                   incomplete step
                 </title>
@@ -366,7 +384,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="12"
+              id="14"
             >
               forward
             </title>
@@ -415,7 +433,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="13"
+              id="15"
             >
               forward
             </title>
@@ -467,7 +485,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             xmlns="http://www.w3.org/2000/svg"
           >
             <title
-              id="15"
+              id="17"
             >
               forward
             </title>
@@ -494,7 +512,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="16"
+          id="18"
         >
           back
         </title>
@@ -510,6 +528,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
       class="timeline-nav__panel"
       id="1uid1"
       role="tabpanel"
+      title="Overview"
     >
       <div
         class="layout-linelength-container text text--body text-passage text-passage--body"

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -34,10 +34,6 @@ export interface Props {
    */
   id?: string;
   /**
-   * Right slot: content that will be positioned to the right of title
-   */
-  right?: ReactNode;
-  /**
    * The tab variant
    */
   variant?: TimelineNavPanelVariant;
@@ -45,6 +41,10 @@ export interface Props {
    * The tab title
    */
   title?: string;
+  /**
+   * Slot for node to appear to the right of the title. Typically used to include a Badge, Button, or other component
+   */
+  titleAfter?: ReactNode;
 }
 
 /**
@@ -61,8 +61,8 @@ export const TimelineNavPanel = ({
   className,
   completed,
   id,
-  right,
   title,
+  titleAfter,
   variant,
   ...other
 }: Props) => {

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -59,11 +59,7 @@ export interface Props {
 export const TimelineNavPanel = ({
   children,
   className,
-  completed,
   id,
-  right,
-  variant,
-  title,
   ...other
 }: Props) => {
   const componentClassName = clsx(styles['timeline-nav__panel'], className, {});

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -34,6 +34,10 @@ export interface Props {
    */
   id?: string;
   /**
+   * Right slot: content that will be positioned to the right of title
+   */
+  right?: ReactNode;
+  /**
    * The tab variant
    */
   variant?: TimelineNavPanelVariant;
@@ -57,6 +61,7 @@ export const TimelineNavPanel = ({
   className,
   completed,
   id,
+  right,
   variant,
   title,
   ...other

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -59,7 +59,11 @@ export interface Props {
 export const TimelineNavPanel = ({
   children,
   className,
+  completed,
   id,
+  right,
+  title,
+  variant,
   ...other
 }: Props) => {
   const componentClassName = clsx(styles['timeline-nav__panel'], className, {});


### PR DESCRIPTION
### Summary: adds a content slot to the right of the link title. 
**UPDATED** https://www.figma.com/file/hDfTdVzAAuf2DDb3hVSnFM/Notebooks%3A-Feedback-Overview?node-id=366%3A26162

Changed story to use dot icons (but any ReactNode could go there)

### Test Plan:
- yarn lint passes
- yarn test passes
- yarn types passes
- yarn start works
