### PR TITLE
chore(release): 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,33 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [1.5.1](https://github.com/chanzuckerberg/edu-design-system/compare/v1.4.0...v1.5.1) (2022-07-13)
-
+### [1.6.0](https://github.com/chanzuckerberg/edu-design-system/compare/v1.5.1...v1.6.0) (2022-07-19)
 
 ### Features
 
-* added columnClassName drag drop styles ([63e7d8c](https://github.com/chanzuckerberg/edu-design-system/commit/63e7d8ccdd522ecfb26d76b60a78621b7b460a33))
-* optional dropdown items project card ([4fb073a](https://github.com/chanzuckerberg/edu-design-system/commit/4fb073afb677b59aa78bed0005978e4c84201d8b))
-
+- added clickable behavior to BaselineCard ([3df4ada](https://github.com/chanzuckerberg/edu-design-system/commit/3df4ada7cd8f20527ea4ffed73da04e83b708c64))
+- added TableObject, TableObjectBody, TableObjectFooter, and TableObjectHeader components ([01ad741](https://github.com/chanzuckerberg/edu-design-system/commit/01ad741279e663938c61fca766cd8dbd7eeb6147#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80))
 
 ### Bug Fixes
 
-* consistent string array type column class ([264655e](https://github.com/chanzuckerberg/edu-design-system/commit/264655eaef9ff57f70451f5ad02057080d34ff53))
-* numberAriaLabel conditional project card ([48f5e23](https://github.com/chanzuckerberg/edu-design-system/commit/48f5e237fdc8de3e8d0084c59ded44463e739a20))
-* snapshot dragdrop update ([de921bd](https://github.com/chanzuckerberg/edu-design-system/commit/de921bd639b01dfee7d46c03c9974f78b8bba197))
-* snapshot test project card ([53817b6](https://github.com/chanzuckerberg/edu-design-system/commit/53817b662ef4c26098d225b1bd26dd4481e0703e))
-* type on drag drop container column class ([17b13c4](https://github.com/chanzuckerberg/edu-design-system/commit/17b13c440c86700dc5ce274e59b36268641ad4c3))
-* use clsx for classnames column class ([534aa08](https://github.com/chanzuckerberg/edu-design-system/commit/534aa08e08ee4c3f315c13d35504f36e086a02be))
+- improved screen reader description for close button in banner components ([23284e6](https://github.com/chanzuckerberg/edu-design-system/commit/23284e6806f488df8e68c0cf85dd7ad309dcc7d3))
+- made meta prop optional in ProjectCard ([986ec95](https://github.com/chanzuckerberg/edu-design-system/commit/986ec95bab304fdbe71da165fbd784dd12c88efb))
+
+### [1.5.1](https://github.com/chanzuckerberg/edu-design-system/compare/v1.4.0...v1.5.1) (2022-07-13)
+
+### Features
+
+- added columnClassName drag drop styles ([63e7d8c](https://github.com/chanzuckerberg/edu-design-system/commit/63e7d8ccdd522ecfb26d76b60a78621b7b460a33))
+- optional dropdown items project card ([4fb073a](https://github.com/chanzuckerberg/edu-design-system/commit/4fb073afb677b59aa78bed0005978e4c84201d8b))
+
+### Bug Fixes
+
+- consistent string array type column class ([264655e](https://github.com/chanzuckerberg/edu-design-system/commit/264655eaef9ff57f70451f5ad02057080d34ff53))
+- numberAriaLabel conditional project card ([48f5e23](https://github.com/chanzuckerberg/edu-design-system/commit/48f5e237fdc8de3e8d0084c59ded44463e739a20))
+- snapshot dragdrop update ([de921bd](https://github.com/chanzuckerberg/edu-design-system/commit/de921bd639b01dfee7d46c03c9974f78b8bba197))
+- snapshot test project card ([53817b6](https://github.com/chanzuckerberg/edu-design-system/commit/53817b662ef4c26098d225b1bd26dd4481e0703e))
+- type on drag drop container column class ([17b13c4](https://github.com/chanzuckerberg/edu-design-system/commit/17b13c440c86700dc5ce274e59b36268641ad4c3))
+- use clsx for classnames column class ([534aa08](https://github.com/chanzuckerberg/edu-design-system/commit/534aa08e08ee4c3f315c13d35504f36e086a02be))
 
 ## [1.5.0](https://github.com/chanzuckerberg/edu-design-system/compare/v1.4.0...v1.5.0) (2022-07-07)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",


### PR DESCRIPTION
### Summary:
Just to keep `next` up-to-date with `main`.