### PR TITLE
fix(banner, page-level-banner): darken content text to base

### DIFF
--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -171,7 +171,7 @@ export const Banner = ({
             </Heading>
           )}
           {description && (
-            <Text as={descriptionAs} size="sm" variant="neutral">
+            <Text as={descriptionAs} size="sm" variant="base">
               {description}
             </Text>
           )}

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -97,7 +97,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -144,7 +144,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -231,7 +231,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -289,7 +289,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -357,7 +357,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -404,7 +404,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -462,7 +462,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -509,7 +509,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -577,7 +577,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -624,7 +624,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -710,7 +710,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
   >
     <div>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -757,7 +757,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -825,7 +825,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -872,7 +872,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -930,7 +930,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -998,7 +998,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1066,7 +1066,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1124,7 +1124,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1182,7 +1182,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1250,7 +1250,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1297,7 +1297,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--neutral"
+        class="text text--sm text--base"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -136,7 +136,7 @@ export const PageLevelBanner = ({
           </Heading>
         )}
         {description && (
-          <Text as={descriptionAs} size="sm" variant="neutral">
+          <Text as={descriptionAs} size="sm" variant="base">
             {description}
           </Text>
         )}

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -90,7 +90,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -133,7 +133,7 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -197,7 +197,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -264,7 +264,7 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
   </svg>
   <div>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -307,7 +307,7 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -371,7 +371,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -414,7 +414,7 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -478,7 +478,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--neutral"
+      class="text text--sm text--base"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        


### PR DESCRIPTION
### Summary:
In https://github.com/chanzuckerberg/edu-design-system/pull/1162 I made the "neutral" variant of the `Text` component lighter. The `Banner` and. `PageLevelBanner` are using that variant, but the figma designs show them having darker text, like before that change. This change makes them dark again by adding `variant="base"` to their `Text` usage.

<img width="1541" alt="banner change in chromatic" src="https://user-images.githubusercontent.com/7761701/180574996-1ed416dd-9664-4a3a-8c7b-8e7785e9210a.png">

### Test Plan:
Verify that banner text content is darker again.