### PR TITLE
feat(text, heading): allow all 3 neutral text colors via variant prop

### DIFF
--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -340,7 +340,7 @@ export const CoursePlannerEdit = () => {
         <DragDropContainerHeader>
           <Toolbar className="u-margin-bottom-md" variant="bare">
             <ToolbarItem>
-              <Heading as="h2" size="title-sm" variant="base">
+              <Heading as="h2" size="title-sm" variant="neutralStrong">
                 Available projects
               </Heading>
             </ToolbarItem>
@@ -361,7 +361,7 @@ export const CoursePlannerEdit = () => {
         <DragDropContainerHeader>
           <Toolbar className="u-margin-bottom-md" variant="bare">
             <ToolbarItem>
-              <Heading as="h2" size="title-sm" variant="base">
+              <Heading as="h2" size="title-sm" variant="neutralStrong">
                 Planned projects
               </Heading>
             </ToolbarItem>
@@ -508,7 +508,7 @@ export const CoursePlannerEdit = () => {
                 as="h2"
                 className="u-margin-bottom-md"
                 size="headline-sm"
-                variant="base"
+                variant="neutralStrong"
               >
                 Select projects for your History 6 plan
               </Heading>

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -340,7 +340,7 @@ export const CoursePlannerEdit = () => {
         <DragDropContainerHeader>
           <Toolbar className="u-margin-bottom-md" variant="bare">
             <ToolbarItem>
-              <Heading as="h2" size="title-sm" variant="neutralStrong">
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
                 Available projects
               </Heading>
             </ToolbarItem>
@@ -361,7 +361,7 @@ export const CoursePlannerEdit = () => {
         <DragDropContainerHeader>
           <Toolbar className="u-margin-bottom-md" variant="bare">
             <ToolbarItem>
-              <Heading as="h2" size="title-sm" variant="neutralStrong">
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
                 Planned projects
               </Heading>
             </ToolbarItem>
@@ -508,7 +508,7 @@ export const CoursePlannerEdit = () => {
                 as="h2"
                 className="u-margin-bottom-md"
                 size="headline-sm"
-                variant="neutralStrong"
+                variant="neutral-strong"
               >
                 Select projects for your History 6 plan
               </Heading>

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -56,7 +56,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h2"
             className="u-margin-bottom-xl"
             size="headline-md"
-            variant="base"
+            variant="neutralStrong"
           >
             What is this Project About?
           </Heading>
@@ -71,7 +71,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h3"
             className="u-margin-bottom-sm"
             size="title-md"
-            variant="base"
+            variant="neutralStrong"
           >
             Essential Questions
           </Heading>
@@ -90,7 +90,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h3"
             className="u-margin-bottom-sm"
             size="title-md"
-            variant="base"
+            variant="neutralStrong"
           >
             Key Take Aways
           </Heading>
@@ -130,7 +130,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="base"
+                  variant="neutralStrong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -146,7 +146,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="base"
+                  variant="neutralStrong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -162,7 +162,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="base"
+                  variant="neutralStrong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -180,7 +180,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="base"
+                  variant="neutralStrong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -196,7 +196,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="base"
+                  variant="neutralStrong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -227,7 +227,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="base"
+              variant="neutralStrong"
             >
               What to Focus on this Checkpoint
             </Heading>
@@ -279,7 +279,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="base"
+              variant="neutralStrong"
             >
               Resources for You
             </Heading>
@@ -311,7 +311,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="base"
+              variant="neutralStrong"
             >
               Resources for You
             </Heading>

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -56,7 +56,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h2"
             className="u-margin-bottom-xl"
             size="headline-md"
-            variant="neutralStrong"
+            variant="neutral-strong"
           >
             What is this Project About?
           </Heading>
@@ -71,7 +71,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h3"
             className="u-margin-bottom-sm"
             size="title-md"
-            variant="neutralStrong"
+            variant="neutral-strong"
           >
             Essential Questions
           </Heading>
@@ -90,7 +90,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
             as="h3"
             className="u-margin-bottom-sm"
             size="title-md"
-            variant="neutralStrong"
+            variant="neutral-strong"
           >
             Key Take Aways
           </Heading>
@@ -130,7 +130,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="neutralStrong"
+                  variant="neutral-strong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -146,7 +146,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="neutralStrong"
+                  variant="neutral-strong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -162,7 +162,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="neutralStrong"
+                  variant="neutral-strong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -180,7 +180,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="neutralStrong"
+                  variant="neutral-strong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -196,7 +196,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
                   as="h3"
                   className="u-margin-bottom-sm"
                   size="title-xs"
-                  variant="neutralStrong"
+                  variant="neutral-strong"
                 >
                   What Was Medieval Japan Like?
                 </Heading>
@@ -227,7 +227,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="neutralStrong"
+              variant="neutral-strong"
             >
               What to Focus on this Checkpoint
             </Heading>
@@ -279,7 +279,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="neutralStrong"
+              variant="neutral-strong"
             >
               Resources for You
             </Heading>
@@ -311,7 +311,7 @@ export const ProjectOverview = ({ activeIndex = 0 }: Props) => {
               as="h3"
               className="u-margin-bottom-lg"
               size="headline-sm"
-              variant="neutralStrong"
+              variant="neutral-strong"
             >
               Resources for You
             </Heading>

--- a/.storybook/recipes/TableCard/TableCard.tsx
+++ b/.storybook/recipes/TableCard/TableCard.tsx
@@ -70,7 +70,7 @@ export const TableCard = ({
           as="h2"
           className="u-margin-bottom-md"
           size="title-sm"
-          variant="neutralStrong"
+          variant="neutral-strong"
         >
           {title}
         </Heading>

--- a/.storybook/recipes/TableCard/TableCard.tsx
+++ b/.storybook/recipes/TableCard/TableCard.tsx
@@ -70,7 +70,7 @@ export const TableCard = ({
           as="h2"
           className="u-margin-bottom-md"
           size="title-sm"
-          variant="base"
+          variant="neutralStrong"
         >
           {title}
         </Heading>

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ import { Heading } from '@chanzuckerberg/eds';
 and then use them in your React components
 
 ```jsx
-<Heading variant="neutral" size="h2">
+<Heading variant="neutralStrong" size="h2">
   Coffee!
 </Heading>
 ```

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -139,6 +139,8 @@ export const Banner = ({
     isFlat && styles['banner--flat'],
   );
 
+  const variantComputed = variant === 'neutral' ? 'neutralStrong' : variant;
+
   return (
     <article className={componentClassName}>
       <Icon
@@ -151,12 +153,12 @@ export const Banner = ({
       <div className={clsx(styles['banner__text-and-action'])}>
         <div>
           {title && (
-            <Heading as={titleAs} size="title-md" variant={variant}>
+            <Heading as={titleAs} size="title-md" variant={variantComputed}>
               {title}
             </Heading>
           )}
           {description && (
-            <Text as={descriptionAs} size="sm" variant="base">
+            <Text as={descriptionAs} size="sm" variant="neutralMedium">
               {description}
             </Text>
           )}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -139,7 +139,7 @@ export const Banner = ({
     isFlat && styles['banner--flat'],
   );
 
-  const variantComputed = variant === 'neutral' ? 'neutralStrong' : variant;
+  const variantComputed = variant === 'neutral' ? 'neutral-strong' : variant;
 
   return (
     <article className={componentClassName}>
@@ -158,7 +158,7 @@ export const Banner = ({
             </Heading>
           )}
           {description && (
-            <Text as={descriptionAs} size="sm" variant="neutralMedium">
+            <Text as={descriptionAs} size="sm" variant="neutral-medium">
               {description}
             </Text>
           )}

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -75,7 +75,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -142,7 +142,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -207,7 +207,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -285,7 +285,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -331,7 +331,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -398,7 +398,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -455,7 +455,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -496,12 +496,12 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
   >
     <div>
       <h3
-        class="heading heading--size-title-md heading--neutral"
+        class="heading heading--size-title-md heading--neutral-strong"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -542,12 +542,12 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
   >
     <div>
       <h3
-        class="heading heading--size-title-md heading--neutral"
+        class="heading heading--size-title-md heading--neutral-strong"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -609,12 +609,12 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
   >
     <div>
       <h3
-        class="heading heading--size-title-md heading--neutral"
+        class="heading heading--size-title-md heading--neutral-strong"
       >
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -699,7 +699,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
   >
     <div>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -745,7 +745,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -791,7 +791,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -858,7 +858,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -915,7 +915,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -961,7 +961,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1028,7 +1028,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1106,7 +1106,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1163,7 +1163,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1209,7 +1209,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          
@@ -1276,7 +1276,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
         New curriculum updates are available for one or more of your courses.
       </h3>
       <p
-        class="text text--sm text--base"
+        class="text text--sm text--neutral-medium"
       >
         Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
          

--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -89,9 +89,6 @@
 .heading--error {
   color: var(--eds-theme-color-text-utility-error);
 }
-.heading--base {
-  color: var(--eds-theme-color-text-neutral-strong);
-}
 .heading--brand {
   color: var(--eds-theme-color-text-brand-primary);
 }
@@ -101,7 +98,13 @@
 .heading--inherit {
   color: inherit;
 }
-.heading--neutral {
+.heading--neutral-subtle {
+  color: var(--eds-theme-color-text-neutral-subtle);
+}
+.heading--neutral-medium {
+  color: var(--eds-theme-color-text-neutral-default);
+}
+.heading--neutral-strong {
   color: var(--eds-theme-color-text-neutral-strong);
 }
 .heading--success {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -3,9 +3,9 @@ import React, { forwardRef } from 'react';
 import styles from './Heading.module.css';
 
 export const VARIANTS = [
-  'neutralSubtle',
-  'neutralMedium',
-  'neutralStrong',
+  'neutral-subtle',
+  'neutral-medium',
+  'neutral-strong',
   'brand',
   'success',
   'warning',
@@ -94,11 +94,11 @@ export const Heading = forwardRef(
     }
 
     let variantComputed: string | undefined = variant;
-    if (variant === 'neutralSubtle') {
+    if (variant === 'neutral-subtle') {
       variantComputed = 'neutral-subtle';
-    } else if (variant === 'neutralMedium') {
+    } else if (variant === 'neutral-medium') {
       variantComputed = 'neutral-medium';
-    } else if (variant === 'neutralStrong') {
+    } else if (variant === 'neutral-strong') {
       variantComputed = 'neutral-strong';
     }
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -93,21 +93,12 @@ export const Heading = forwardRef(
       }
     }
 
-    let variantComputed: string | undefined = variant;
-    if (variant === 'neutral-subtle') {
-      variantComputed = 'neutral-subtle';
-    } else if (variant === 'neutral-medium') {
-      variantComputed = 'neutral-medium';
-    } else if (variant === 'neutral-strong') {
-      variantComputed = 'neutral-strong';
-    }
-
     const TagName = as || getComputedAs(size);
     const componentClassName = clsx(
       className,
       styles['heading'],
       styles[`heading--size-${size}`],
-      variant && styles[`heading--${variantComputed}`],
+      variant && styles[`heading--${variant}`],
     );
     return (
       <TagName className={componentClassName} ref={ref} {...other}>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -3,14 +3,15 @@ import React, { forwardRef } from 'react';
 import styles from './Heading.module.css';
 
 export const VARIANTS = [
-  'error',
-  'base',
+  'neutralSubtle',
+  'neutralMedium',
+  'neutralStrong',
   'brand',
-  'inherit',
-  'neutral',
   'success',
   'warning',
+  'error',
   'white',
+  'inherit',
   /**
    * @deprecated Info variant is deprecated.
    */ 'info',
@@ -92,12 +93,21 @@ export const Heading = forwardRef(
       }
     }
 
+    let variantComputed: string | undefined = variant;
+    if (variant === 'neutralSubtle') {
+      variantComputed = 'neutral-subtle';
+    } else if (variant === 'neutralMedium') {
+      variantComputed = 'neutral-medium';
+    } else if (variant === 'neutralStrong') {
+      variantComputed = 'neutral-strong';
+    }
+
     const TagName = as || getComputedAs(size);
     const componentClassName = clsx(
       className,
       styles['heading'],
       styles[`heading--size-${size}`],
-      variant && styles[`heading--${variant}`],
+      variant && styles[`heading--${variantComputed}`],
     );
     return (
       <TagName className={componentClassName} ref={ref} {...other}>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef } from 'react';
 import styles from './Heading.module.css';
 
 export const VARIANTS = [
+  'inherit',
   'neutral-subtle',
   'neutral-medium',
   'neutral-strong',
@@ -11,7 +12,6 @@ export const VARIANTS = [
   'warning',
   'error',
   'white',
-  'inherit',
   /**
    * @deprecated Info variant is deprecated.
    */ 'info',

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Step 1"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         1
@@ -32,7 +32,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 2 Step 2"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -69,7 +69,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -106,7 +106,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -143,7 +143,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -349,7 +349,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -382,7 +382,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         1
@@ -436,7 +436,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 1 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         1
@@ -452,7 +452,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 2 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         2
@@ -468,7 +468,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 3 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         3
@@ -484,7 +484,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 4 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         4
@@ -500,7 +500,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 5 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         5
@@ -516,7 +516,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 6 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         6
@@ -532,7 +532,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 7 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         7
@@ -548,7 +548,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 8 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         8
@@ -564,7 +564,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 9 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         9
@@ -580,7 +580,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 10 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         10
@@ -596,7 +596,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 21 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         21
@@ -612,7 +612,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 32 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         32
@@ -628,7 +628,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 43 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         43
@@ -644,7 +644,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 54 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         54
@@ -660,7 +660,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
     >
       <span
         aria-label="current step 65 Horizontal step"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         65
@@ -687,7 +687,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 1 Step 1"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         1
@@ -707,7 +707,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 2 Step 2"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -744,7 +744,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -781,7 +781,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -818,7 +818,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -986,7 +986,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         5
@@ -1075,7 +1075,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 3 Step 3"
-        class="text text--sm text--base number-icon number-icon--base horizontal-step__number-icon"
+        class="text text--sm text--neutral-medium number-icon number-icon--base horizontal-step__number-icon"
         role="img"
       >
         3
@@ -1095,7 +1095,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 4 Step 4"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg
@@ -1132,7 +1132,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
     >
       <span
         aria-label="current step 5 Step 5"
-        class="text text--sm text--base number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
+        class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete horizontal-step__number-icon horizontal-step__number-icon--incomplete"
         role="img"
       >
         <svg

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -119,7 +119,7 @@ export const InlineNotification = ({
       <Text
         as="span"
         className={textClassName}
-        variant={variant === 'yield' ? 'base' : variant}
+        variant={variant === 'yield' ? 'neutralMedium' : variant}
       >
         {text}
       </Text>

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -119,7 +119,7 @@ export const InlineNotification = ({
       <Text
         as="span"
         className={textClassName}
-        variant={variant === 'yield' ? 'neutralMedium' : variant}
+        variant={variant === 'yield' ? 'neutral-medium' : variant}
       >
         {text}
       </Text>

--- a/src/components/InlineNotification/__snapshots__/InlineNotification.test.tsx.snap
+++ b/src/components/InlineNotification/__snapshots__/InlineNotification.test.tsx.snap
@@ -137,7 +137,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       />
     </svg>
     <span
-      class="text text--body text--base inline-notification__text"
+      class="text text--body text--neutral-medium inline-notification__text"
     >
       yield inline notification lorem ipsum
     </span>
@@ -309,7 +309,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       />
     </svg>
     <span
-      class="text text--body text--base inline-notification__text"
+      class="text text--body text--neutral-medium inline-notification__text"
     >
       yield inline notification lorem ipsum
     </span>
@@ -481,7 +481,7 @@ exports[`<InlineNotification /> StrongVariants story renders snapshot 1`] = `
       />
     </svg>
     <span
-      class="text text--body text--base inline-notification__text"
+      class="text text--body text--neutral-medium inline-notification__text"
     >
       yield inline notification lorem ipsum
     </span>
@@ -596,7 +596,7 @@ exports[`<InlineNotification /> SubtleVariants story renders snapshot 1`] = `
       />
     </svg>
     <span
-      class="text text--body text--base inline-notification__text"
+      class="text text--body text--neutral-medium inline-notification__text"
     >
       yield inline notification lorem ipsum
     </span>

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -79,7 +79,7 @@ export const NumberIcon = ({
       className={componentClassName}
       role="img"
       size="sm"
-      variant={variant === 'base' ? 'base' : 'white'}
+      variant={variant === 'base' ? 'neutralMedium' : 'white'}
       {...other}
     >
       {incomplete && numberIconTitle ? (

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -79,7 +79,7 @@ export const NumberIcon = ({
       className={componentClassName}
       role="img"
       size="sm"
-      variant={variant === 'base' ? 'neutralMedium' : 'white'}
+      variant={variant === 'base' ? 'neutral-medium' : 'white'}
       {...other}
     >
       {incomplete && numberIconTitle ? (

--- a/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
+++ b/src/components/NumberIcon/__snapshots__/NumberIcon.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<NumberIcon /> Default story renders snapshot 1`] = `
 <span
   aria-label="Step 1"
-  class="text text--sm text--base number-icon number-icon--base"
+  class="text text--sm text--neutral-medium number-icon number-icon--base"
   role="img"
 >
   1
@@ -14,133 +14,133 @@ exports[`<NumberIcon /> DifferentNumbers story renders snapshot 1`] = `
 <div>
   <span
     aria-label="Step 0"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     0
   </span>
   <span
     aria-label="Step 1"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     1
   </span>
   <span
     aria-label="Step 2"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     2
   </span>
   <span
     aria-label="Step 3"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     3
   </span>
   <span
     aria-label="Step 4"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     4
   </span>
   <span
     aria-label="Step 5"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     5
   </span>
   <span
     aria-label="Step 6"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     6
   </span>
   <span
     aria-label="Step 7"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     7
   </span>
   <span
     aria-label="Step 8"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     8
   </span>
   <span
     aria-label="Step 9"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     9
   </span>
   <span
     aria-label="Step 10"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     10
   </span>
   <span
     aria-label="Step 21"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     21
   </span>
   <span
     aria-label="Step 32"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     32
   </span>
   <span
     aria-label="Step 43"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     43
   </span>
   <span
     aria-label="Step 54"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     54
   </span>
   <span
     aria-label="Step 65"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     65
   </span>
   <span
     aria-label="Step 76"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     76
   </span>
   <span
     aria-label="Step 87"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     87
   </span>
   <span
     aria-label="Step 98"
-    class="text text--sm text--base number-icon number-icon--base"
+    class="text text--sm text--neutral-medium number-icon number-icon--base"
     role="img"
   >
     98
@@ -151,7 +151,7 @@ exports[`<NumberIcon /> DifferentNumbers story renders snapshot 1`] = `
 exports[`<NumberIcon /> Small story renders snapshot 1`] = `
 <span
   aria-label="Step 1"
-  class="text text--sm text--base number-icon number-icon--base number-icon--sm"
+  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm"
   role="img"
 >
   1

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -42,10 +42,11 @@ export interface Props {
    */
   headingVariant?:
     | 'error'
-    | 'base'
     | 'brand'
     | 'inherit'
-    | 'neutral'
+    | 'neutralSubtle'
+    | 'neutralMedium'
+    | 'neutralStrong'
     | 'success'
     | 'warning'
     | 'white';
@@ -78,7 +79,7 @@ export const PageHeader = ({
   className,
   description,
   headingSize = 'headline-lg',
-  headingVariant = 'base',
+  headingVariant = 'neutralStrong',
   overline,
   orientation,
   right,

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -44,9 +44,9 @@ export interface Props {
     | 'error'
     | 'brand'
     | 'inherit'
-    | 'neutralSubtle'
-    | 'neutralMedium'
-    | 'neutralStrong'
+    | 'neutral-subtle'
+    | 'neutral-medium'
+    | 'neutral-strong'
     | 'success'
     | 'warning'
     | 'white';
@@ -79,7 +79,7 @@ export const PageHeader = ({
   className,
   description,
   headingSize = 'headline-lg',
-  headingVariant = 'neutralStrong',
+  headingVariant = 'neutral-strong',
   overline,
   orientation,
   right,

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -41,14 +41,14 @@ export interface Props {
    * Size property
    */
   headingVariant?:
-    | 'error'
-    | 'brand'
     | 'inherit'
     | 'neutral-subtle'
     | 'neutral-medium'
     | 'neutral-strong'
+    | 'brand'
     | 'success'
     | 'warning'
+    | 'error'
     | 'white';
   /**
    * Controls the layout of the PageHeader, specifically the placement of the left and right slots.

--- a/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<PageHeader /> Centered story renders snapshot 1`] = `
     class="page-header__left"
   >
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
     </h1>
@@ -29,7 +29,7 @@ exports[`<PageHeader /> Default story renders snapshot 1`] = `
     class="page-header__left"
   >
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
     </h1>
@@ -45,7 +45,7 @@ exports[`<PageHeader /> TitleAfter story renders snapshot 1`] = `
     class="page-header__left"
   >
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
       <div
@@ -79,7 +79,7 @@ exports[`<PageHeader /> TwoUp story renders snapshot 1`] = `
     class="page-header__left"
   >
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
     </h1>
@@ -105,7 +105,7 @@ exports[`<PageHeader /> WithDescription story renders snapshot 1`] = `
     class="page-header__left"
   >
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
     </h1>
@@ -135,7 +135,7 @@ exports[`<PageHeader /> WithOverline story renders snapshot 1`] = `
       </div>
     </div>
     <h1
-      class="page-header__title heading heading--size-headline-lg heading--base"
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
     >
       Page header title
     </h1>

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -122,7 +122,7 @@ export const PageLevelBanner = ({
           </Heading>
         )}
         {description && (
-          <Text as={descriptionAs} size="sm" variant="neutralMedium">
+          <Text as={descriptionAs} size="sm" variant="neutral-medium">
             {description}
           </Text>
         )}

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -122,7 +122,7 @@ export const PageLevelBanner = ({
           </Heading>
         )}
         {description && (
-          <Text as={descriptionAs} size="sm" variant="base">
+          <Text as={descriptionAs} size="sm" variant="neutralMedium">
             {description}
           </Text>
         )}

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -68,7 +68,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -131,7 +131,7 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -173,7 +173,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -260,7 +260,7 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
   </svg>
   <div>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -302,7 +302,7 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -344,7 +344,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -407,7 +407,7 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        
@@ -449,7 +449,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
       New curriculum updates are available for one or more of your courses.
     </h3>
     <p
-      class="text text--sm text--base"
+      class="text text--sm text--neutral-medium"
     >
       Summit Learning has a full-time team dedicated to constantly improving our curriculum. To see the updates,
        

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -109,7 +109,7 @@ export const ProjectCard = ({
           as={headingAs}
           className={styles['project-card__title']}
           size="body-sm"
-          variant="neutralStrong"
+          variant="neutral-strong"
         >
           {title}
         </Heading>

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -109,7 +109,7 @@ export const ProjectCard = ({
           as={headingAs}
           className={styles['project-card__title']}
           size="body-sm"
-          variant="base"
+          variant="neutralStrong"
         >
           {title}
         </Heading>

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
   >
     <span
       aria-label="Project 1"
-      class="text text--sm text--base number-icon number-icon--base number-icon--sm project-card__number"
+      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
       role="img"
     >
       1
@@ -19,7 +19,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
     class="card__body project-card__body"
   >
     <h3
-      class="project-card__title heading heading--size-body-sm heading--base"
+      class="project-card__title heading heading--size-body-sm heading--neutral-strong"
     >
       Project card title
     </h3>
@@ -183,7 +183,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
     class="card__body project-card__body"
   >
     <h3
-      class="project-card__title heading heading--size-body-sm heading--base"
+      class="project-card__title heading heading--size-body-sm heading--neutral-strong"
     >
       DragDropItem provides handle to the left
     </h3>
@@ -345,7 +345,7 @@ exports[`<ProjectCard /> WithoutDropdown story renders snapshot 1`] = `
   >
     <span
       aria-label="Project 1"
-      class="text text--sm text--base number-icon number-icon--base number-icon--sm project-card__number"
+      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
       role="img"
     >
       1
@@ -355,7 +355,7 @@ exports[`<ProjectCard /> WithoutDropdown story renders snapshot 1`] = `
     class="card__body project-card__body"
   >
     <h3
-      class="project-card__title heading heading--size-body-sm heading--base"
+      class="project-card__title heading heading--size-body-sm heading--neutral-strong"
     >
       DragDropItem provides handle to the left
     </h3>
@@ -390,7 +390,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
   >
     <span
       aria-label="Project 1"
-      class="text text--sm text--base number-icon number-icon--base number-icon--sm project-card__number"
+      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
       role="img"
     >
       1
@@ -400,7 +400,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
     class="card__body project-card__body"
   >
     <h3
-      class="project-card__title heading heading--size-body-sm heading--base"
+      class="project-card__title heading heading--size-body-sm heading--neutral-strong"
     >
       Project card title
     </h3>

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -44,8 +44,14 @@
 .text--error {
   color: var(--eds-theme-color-text-utility-error);
 }
-.text--base {
+.text--neutral-subtle {
+  color: var(--eds-theme-color-text-neutral-subtle);
+}
+.text--neutral-medium {
   color: var(--eds-theme-color-text-neutral-default);
+}
+.text--neutral-strong {
+  color: var(--eds-theme-color-text-neutral-strong);
 }
 .text--brand {
   color: var(--eds-theme-color-text-brand-primary);
@@ -55,9 +61,6 @@
 }
 .text--inherit {
   color: inherit;
-}
-.text--neutral {
-  color: var(--eds-theme-color-text-neutral-subtle);
 }
 .text--success {
   color: var(--eds-theme-color-text-utility-success);

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -31,14 +31,15 @@ export default {
 } as Meta<Args>;
 
 const variants = [
-  'error',
-  'base',
+  'neutralSubtle',
+  'neutralMedium',
+  'neutralStrong',
   'brand',
-  'inherit',
-  'neutral',
   'success',
   'warning',
+  'error',
   'white',
+  'inherit',
 ];
 
 type Args = React.ComponentProps<typeof Text>;

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -31,6 +31,7 @@ export default {
 } as Meta<Args>;
 
 const variants = [
+  'inherit',
   'neutral-subtle',
   'neutral-medium',
   'neutral-strong',
@@ -39,7 +40,6 @@ const variants = [
   'warning',
   'error',
   'white',
-  'inherit',
 ];
 
 type Args = React.ComponentProps<typeof Text>;

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -31,9 +31,9 @@ export default {
 } as Meta<Args>;
 
 const variants = [
-  'neutralSubtle',
-  'neutralMedium',
-  'neutralStrong',
+  'neutral-subtle',
+  'neutral-medium',
+  'neutral-strong',
   'brand',
   'success',
   'warning',

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -14,9 +14,9 @@ export type Size =
   | 'callout';
 
 export type Variant =
-  | 'neutralSubtle'
-  | 'neutralMedium'
-  | 'neutralStrong'
+  | 'neutral-subtle'
+  | 'neutral-medium'
+  | 'neutral-strong'
   | 'brand'
   | 'success'
   | 'warning'
@@ -92,11 +92,11 @@ export const Text = forwardRef(
     ref: ForwardedRef<HTMLParagraphElement>, // Setting as HTMLParagraphElement to satisfy TS, but unit test covers both span and p cases for sanity
   ) => {
     let variantComputed: string | undefined = variant;
-    if (variant === 'neutralSubtle') {
+    if (variant === 'neutral-subtle') {
       variantComputed = 'neutral-subtle';
-    } else if (variant === 'neutralMedium') {
+    } else if (variant === 'neutral-medium') {
       variantComputed = 'neutral-medium';
-    } else if (variant === 'neutralStrong') {
+    } else if (variant === 'neutral-strong') {
       variantComputed = 'neutral-strong';
     }
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -14,14 +14,15 @@ export type Size =
   | 'callout';
 
 export type Variant =
-  | 'error'
-  | 'base'
+  | 'neutralSubtle'
+  | 'neutralMedium'
+  | 'neutralStrong'
   | 'brand'
-  | 'inherit'
-  | 'neutral'
   | 'success'
   | 'warning'
+  | 'error'
   | 'white'
+  | 'inherit'
   /**
    * @deprecated Info variant is deprecated.
    */
@@ -90,6 +91,15 @@ export const Text = forwardRef(
     }: Props,
     ref: ForwardedRef<HTMLParagraphElement>, // Setting as HTMLParagraphElement to satisfy TS, but unit test covers both span and p cases for sanity
   ) => {
+    let variantComputed: string | undefined = variant;
+    if (variant === 'neutralSubtle') {
+      variantComputed = 'neutral-subtle';
+    } else if (variant === 'neutralMedium') {
+      variantComputed = 'neutral-medium';
+    } else if (variant === 'neutralStrong') {
+      variantComputed = 'neutral-strong';
+    }
+
     if (variant === 'info' && process.env.NODE_ENV !== 'production') {
       console.warn(
         'Info variant is deprecated, please consider another variant.',
@@ -100,7 +110,7 @@ export const Text = forwardRef(
     const componentClassName = clsx(
       styles['text'],
       styles[`text--${size}`],
-      variant && styles[`text--${variant}`],
+      variant && styles[`text--${variantComputed}`],
       weight && styles[`text--${weight}-weight`],
       spacing && styles[`text--${spacing}-spacing`],
       as === 'div' && styles['text-passage'],

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -91,15 +91,6 @@ export const Text = forwardRef(
     }: Props,
     ref: ForwardedRef<HTMLParagraphElement>, // Setting as HTMLParagraphElement to satisfy TS, but unit test covers both span and p cases for sanity
   ) => {
-    let variantComputed: string | undefined = variant;
-    if (variant === 'neutral-subtle') {
-      variantComputed = 'neutral-subtle';
-    } else if (variant === 'neutral-medium') {
-      variantComputed = 'neutral-medium';
-    } else if (variant === 'neutral-strong') {
-      variantComputed = 'neutral-strong';
-    }
-
     if (variant === 'info' && process.env.NODE_ENV !== 'production') {
       console.warn(
         'Info variant is deprecated, please consider another variant.',
@@ -110,7 +101,7 @@ export const Text = forwardRef(
     const componentClassName = clsx(
       styles['text'],
       styles[`text--${size}`],
-      variant && styles[`text--${variantComputed}`],
+      variant && styles[`text--${variant}`],
       weight && styles[`text--${weight}-weight`],
       spacing && styles[`text--${spacing}-spacing`],
       as === 'div' && styles['text-passage'],

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -14,6 +14,7 @@ export type Size =
   | 'callout';
 
 export type Variant =
+  | 'inherit'
   | 'neutral-subtle'
   | 'neutral-medium'
   | 'neutral-strong'
@@ -22,7 +23,6 @@ export type Variant =
   | 'warning'
   | 'error'
   | 'white'
-  | 'inherit'
   /**
    * @deprecated Info variant is deprecated.
    */

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -29,7 +29,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <span
               aria-label="incomplete step"
-              class="text text--sm text--base number-icon number-icon--base number-icon--incomplete timeline-nav__icon"
+              class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete timeline-nav__icon"
               role="img"
             >
               <svg
@@ -95,7 +95,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <span
               aria-label="step 1"
-              class="text text--sm text--base number-icon number-icon--base timeline-nav__icon"
+              class="text text--sm text--neutral-medium number-icon number-icon--base timeline-nav__icon"
               role="img"
             >
               1
@@ -346,7 +346,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <span
               aria-label="incomplete step"
-              class="text text--sm text--base number-icon number-icon--base number-icon--incomplete timeline-nav__icon"
+              class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--incomplete timeline-nav__icon"
               role="img"
             >
               <svg
@@ -412,7 +412,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <span
               aria-label="step 6"
-              class="text text--sm text--base number-icon number-icon--base timeline-nav__icon"
+              class="text text--sm text--neutral-medium number-icon number-icon--base timeline-nav__icon"
               role="img"
             >
               6


### PR DESCRIPTION
### Summary:
We have 3 different neutral color tokens for text:
- `neutral-subtle`
- `neutral-default`
- `neutral-strong`

Currently the `Text` component only supports `neutral-default` via the "base" variant and `neutral-subtle` via the "neutral" variant. The `Heading` component only supports `neutral-strong` via both the "base" and "neutral" variants.

I talked to design and they said all 3 tokens should be available to both components. I suggested that we replace the "base" and "neutral" variant options with 3 different options representing the 3 neutral tokens:
- "neutral-subtle"
- "neutral-medium"
- "neutral-strong"

I suggested using "medium" instead of "default" because the `neutral-strong` token is typically used for the `Heading` component, so it feels confusing to me to use "default" when "strong" is really the default.

#### Heading variants, before and after in storybook
Before version is on the left, after is on the right.
<img width="1490" alt="heading variants change in chromatic" src="https://user-images.githubusercontent.com/7761701/180579976-5bf96618-dd86-4fa5-a0b4-afc896f26f5b.png">

#### Text variants, before and after in storybook
Before version is on the left, after is on the right.
<img width="1496" alt="text variants change in chromatic" src="https://user-images.githubusercontent.com/7761701/180579984-f492a68e-9106-460a-8db6-912ef5a06be7.png">

### Test Plan:
Verify there are no chromatic changes outside of the `Text` and `Heading` components,
and verify the new `Text` and `Heading` variants appear as expected.