### PR TITLE
fix(banner): move close button to end of content

### DIFF
--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -36,9 +36,8 @@ const getDescription = (status?: Variant) => (
       status="neutral"
       variant="link"
     >
-      click into the course
+      click into the course.
     </Button>
-    .
   </>
 );
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -141,21 +141,6 @@ export const Banner = ({
 
   return (
     <article className={componentClassName}>
-      {onDismiss && (
-        <Button
-          className={styles['banner__close-btn']}
-          onClick={onDismiss}
-          status="neutral"
-          variant="icon"
-        >
-          <Icon
-            name="close"
-            purpose="informative"
-            title="dismiss notification"
-          />
-        </Button>
-      )}
-
       <Icon
         className={styles['banner__icon']}
         name={variantToIconAssetsMap[variant].name}
@@ -181,6 +166,21 @@ export const Banner = ({
           <div className={clsx(styles['banner__action'])}>{action}</div>
         )}
       </div>
+
+      {onDismiss && (
+        <Button
+          className={styles['banner__close-btn']}
+          onClick={onDismiss}
+          status="neutral"
+          variant="icon"
+        >
+          <Icon
+            name="close"
+            purpose="informative"
+            title="dismiss notification"
+          />
+        </Button>
+      )}
     </article>
   );
 };

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -38,9 +38,8 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -51,27 +50,6 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="13"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -79,7 +57,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="14"
+      id="13"
     >
       attention
     </title>
@@ -106,12 +84,32 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="14"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -153,9 +151,8 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -185,27 +182,6 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
 <article
   class="banner banner--brand banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="23"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -213,7 +189,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="24"
+      id="23"
     >
       attention
     </title>
@@ -240,9 +216,8 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -257,6 +232,27 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       </button>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="24"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -298,9 +294,8 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -311,27 +306,6 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--error banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="21"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -339,7 +313,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="22"
+      id="21"
     >
       error
     </title>
@@ -366,12 +340,32 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="22"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -413,9 +407,8 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -471,9 +464,8 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -518,9 +510,8 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -531,27 +522,6 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--neutral banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="15"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -559,7 +529,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="16"
+      id="15"
     >
       notice
     </title>
@@ -586,12 +556,32 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="16"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -633,9 +623,8 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -719,9 +708,8 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -766,9 +754,8 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -779,27 +766,6 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--success banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="17"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -807,7 +773,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="18"
+      id="17"
     >
       success
     </title>
@@ -834,12 +800,32 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="18"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -881,9 +867,8 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -939,9 +924,8 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -952,27 +936,6 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--brand banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="28"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -980,7 +943,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="29"
+      id="28"
     >
       attention
     </title>
@@ -1007,12 +970,32 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="29"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -1020,27 +1003,6 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
 <article
   class="banner banner--brand banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="31"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -1048,7 +1010,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="32"
+      id="31"
     >
       attention
     </title>
@@ -1075,9 +1037,8 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -1092,6 +1053,27 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       </button>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="32"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -1133,9 +1115,8 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div
@@ -1191,9 +1172,8 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
@@ -1204,27 +1184,6 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--warning banner--horizontal banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="19"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -1232,7 +1191,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="20"
+      id="19"
     >
       warning
     </title>
@@ -1259,12 +1218,32 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="20"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -1306,9 +1285,8 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
           data-bootstrap-override="clickable-style-link"
           type="button"
         >
-          click into the course
+          click into the course.
         </button>
-        .
       </p>
     </div>
     <div

--- a/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
@@ -19,9 +19,8 @@ export default {
           status="neutral"
           variant="link"
         >
-          click into the course
+          click into the course.
         </Button>
-        .
       </>
     ),
   },

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -108,6 +108,26 @@ export const PageLevelBanner = ({
 
   return (
     <article className={componentClassName}>
+      <Icon
+        className={styles['banner__icon']}
+        name={variantToIconAssetsMap[variant].name}
+        purpose="informative"
+        title={variantToIconAssetsMap[variant].title}
+      />
+
+      <div>
+        {title && (
+          <Heading as={titleAs} size="title-md" variant={variant}>
+            {title}
+          </Heading>
+        )}
+        {description && (
+          <Text as={descriptionAs} size="sm" variant="neutral">
+            {description}
+          </Text>
+        )}
+      </div>
+
       {onDismiss && (
         <Button
           className={styles['banner__close-btn']}
@@ -122,25 +142,6 @@ export const PageLevelBanner = ({
           />
         </Button>
       )}
-
-      <Icon
-        className={styles['banner__icon']}
-        name={variantToIconAssetsMap[variant].name}
-        purpose="informative"
-        title={variantToIconAssetsMap[variant].title}
-      />
-      <div>
-        {title && (
-          <Heading as={titleAs} size="title-md" variant={variant}>
-            {title}
-          </Heading>
-        )}
-        {description && (
-          <Text as={descriptionAs} size="sm" variant="neutral">
-            {description}
-          </Text>
-        )}
-      </div>
     </article>
   );
 };

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.tsx.snap
@@ -35,9 +35,8 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
 </article>
@@ -47,27 +46,6 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--brand banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="7"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -75,7 +53,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="8"
+      id="7"
     >
       attention
     </title>
@@ -99,11 +77,31 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="8"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -142,9 +140,8 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
 </article>
@@ -154,27 +151,6 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--error banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="13"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -182,7 +158,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="14"
+      id="13"
     >
       error
     </title>
@@ -206,11 +182,31 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="14"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -273,9 +269,8 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
 </article>
@@ -316,9 +311,8 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
 </article>
@@ -328,27 +322,6 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--success banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="9"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -356,7 +329,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="10"
+      id="9"
     >
       success
     </title>
@@ -380,11 +353,31 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="10"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;
 
@@ -423,9 +416,8 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
 </article>
@@ -435,27 +427,6 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
 <article
   class="banner banner--warning banner--dismissable"
 >
-  <button
-    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
-    data-bootstrap-override="clickable-style-icon"
-    type="button"
-  >
-    <svg
-      class="icon"
-      fill="currentColor"
-      role="img"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <title
-        id="11"
-      >
-        dismiss notification
-      </title>
-      <use
-        xlink:href="test-file-stub#close"
-      />
-    </svg>
-  </button>
   <svg
     class="icon banner__icon"
     fill="currentColor"
@@ -463,7 +434,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="12"
+      id="11"
     >
       warning
     </title>
@@ -487,10 +458,30 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-link"
         type="button"
       >
-        click into the course
+        click into the course.
       </button>
-      .
     </p>
   </div>
+  <button
+    class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button banner__close-btn button--icon"
+    data-bootstrap-override="clickable-style-icon"
+    type="button"
+  >
+    <svg
+      class="icon"
+      fill="currentColor"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title
+        id="12"
+      >
+        dismiss notification
+      </title>
+      <use
+        xlink:href="test-file-stub#close"
+      />
+    </svg>
+  </button>
 </article>
 `;


### PR DESCRIPTION
### Summary:
The close button in our `Banner` and `PageLevelBanner` components comes before the content of the banners for screen reader users. That could be confusing because they don't know what the close button would actually be closing. The close button and content are contained in an `article` element, so they're semantically grouped, but screen reader users shouldn't have to read the content and then go *back* to the close button to remove the component. This PR moves the button to the end of the component, after the content. The appearance of the banner is unchanged.

### Videos
#### Before
https://user-images.githubusercontent.com/7761701/180834055-f8a5b8fe-5942-4033-8aca-dd80aeb7eda5.mp4

#### After
https://user-images.githubusercontent.com/7761701/180834088-677469e6-a63e-4805-8156-f3f71ca01a8d.mp4

### Test Plan:
Verify there are no visual changes (except I moved the period in the banner content to be part of the link), and screen readers now hit the close button last, just before the end of the article.