### PR TITLE
chore(feedback overview): card display for tables on < md breakpoints

### DIFF
--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -92,7 +92,6 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                 </TableObject.Header>
                 <TableObject.Body>
                   <Table
-                    behavior="stacked"
                     caption="Feedback overview"
                     hideCaption={true}
                     highlightFirstCell={true}

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -92,6 +92,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                 </TableObject.Header>
                 <TableObject.Body>
                   <Table
+                    behavior="stacked"
                     caption="Feedback overview"
                     hideCaption={true}
                     highlightFirstCell={true}

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -208,8 +208,11 @@
  * Table Cell
  */
 .table__cell {
-  padding: var(--eds-size-2) var(--eds-size-1);
   @mixin eds-theme-typography-body-text-sm;
+
+  @media all and (min-width: $eds-bp-md) {
+    padding: var(--eds-size-2) var(--eds-size-1);
+  }
 
   /**
      * Condensed table
@@ -291,7 +294,22 @@
     }
   }
 
+  /**
+  * 1) When using the stacked and highlight-first-cell variants, the 
+  * first cell in each row gets padding-bottom added on smaller breakpoints.
+  * 2) The first cell's column title is not displayed, allowing the first cell's
+  * value to appear as the card's "title".
+  **/
   .table--stacked.table--highlight-first-cell & {
+    &:first-child {
+      padding-bottom: var(--eds-size-1) /* 1 */;
+
+      /* stylelint-disable-next-line max-nesting-depth */
+      @media all and (min-width: $eds-bp-md) {
+        padding-bottom: unset;
+      }
+    }
+
     &:first-child:before {
       content: none;
     }


### PR DESCRIPTION
### Summary:
https://app.shortcut.com/czi-edu/story/207521/table-card-mobile-treatment-for-feedback-overview
Adds extra padding beneath first cell when the Highlight First Cell and Stacked variants are used.

<img width="685" alt="Screen Shot 2022-07-25 at 2 08 25 PM" src="https://user-images.githubusercontent.com/24812780/180856553-d8daefee-20b3-4117-a920-08a4724c122c.png">


### Test Plan:
For breakpoints > md: table in Feedback Overview should remain unchanged
For smaller breakpoints: each row should appear as a card that closely matches the formatting in Figma (see screenshot or link above)
