### PR TITLE
chore(timeline nav): a11y issue  - sequential keyboard navigation

### DIFF
--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -336,11 +336,13 @@ export const TimelineNav = ({
   /**
    * onClick (used by 'Back' button on < lg viewports)
    * 1) Return focus to the button that was clicked to open the current panel; activeIndexState holds the index of the last nav item selected in the timelinNavItemRefs array
-   * 2) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
+   * 2) Because the 'Back' button's onFocus listener removes the selected nav item from the tab order, we need to manually insert it back into the tab order by setting its tabIndex back to "0"
+   * 3) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
    */
   const onClick = () => {
     timelineNavItemRefs[activeIndexState].current?.focus(); /* 1 */
-    setIsActive(false); /* 2 */
+    timelineNavItemRefs[activeIndexState].current.tabIndex = '0'; /* 2 */
+    setIsActive(false); /* 3 */
   };
 
   /**

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -344,9 +344,9 @@ export const TimelineNav = ({
   };
 
   /**
-   * onFocus (used by 'Back' button on <lg viewports)
+   * resetTabIndex (used by 'Back' button on <lg viewports)
    * 1) This fixes an issue where a keyboard user who has focus on the
-   * 'Back' button could use alt-tab to put keyboard focus back
+   * 'Back' button could use shift-tab to put keyboard focus back
    * on the menu, which is currently off-canvas. To prevent this
    * unwanted behavior, we set the currently active menu item's
    * tabIndex to "-1" so that it can't be focusable in sequential
@@ -355,7 +355,7 @@ export const TimelineNav = ({
    * via keyboard navigation.
    * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#sect1
    */
-  const onFocus = () => {
+  const resetTabIndex = () => {
     timelineNavItemRefs[activeIndexState].current.tabIndex = '-1';
   };
 
@@ -444,17 +444,12 @@ export const TimelineNav = ({
         <Button
           className={clsx(styles['timeline-nav__back'])}
           onClick={onClick}
-          onFocus={onFocus}
+          onFocus={resetTabIndex}
           ref={backRef}
           status="neutral"
           variant="link"
         >
-          <Icon
-            id="back"
-            name="arrow-back"
-            purpose="informative"
-            title="back"
-          />
+          <Icon name="arrow-back" purpose="informative" title="back" />
           Back
         </Button>
         {childrenWithProps[activeIndexState]}

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -346,8 +346,13 @@ export const TimelineNav = ({
   /**
    * onFocus (used by 'Back' button on <lg viewports)
    * 1) This fixes an issue where a keyboard user who has focus on the
-   * Back button could use alt-tab to put keyboard focus back
-   * on the menu, which is currently off-canvas.
+   * 'Back' button could use alt-tab to put keyboard focus back
+   * on the menu, which is currently off-canvas. To prevent this
+   * unwanted behavior, we set the currently active menu item's
+   * tabIndex to "-1" so that it can't be focusable in sequential
+   * keyboard navigation. The 'Back' button should be the only way
+   * users are able to return to the nav list, both visually and
+   * via keyboard navigation.
    * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#sect1
    */
   const onFocus = () => {

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -334,12 +334,12 @@ export const TimelineNav = ({
   };
 
   /**
-   * onClick (used by 'Back' button on < lg viewports)
+   * onBack (used by 'Back' button on < lg viewports)
    * 1) Return focus to the button that was clicked to open the current panel; activeIndexState holds the index of the last nav item selected in the timelinNavItemRefs array
    * 2) Because the 'Back' button's onFocus listener removes the selected nav item from the tab order, we need to manually insert it back into the tab order by setting its tabIndex back to "0"
    * 3) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
    */
-  const onClick = () => {
+  const onBack = () => {
     timelineNavItemRefs[activeIndexState].current?.focus(); /* 1 */
     timelineNavItemRefs[activeIndexState].current.tabIndex = '0'; /* 2 */
     setIsActive(false); /* 3 */
@@ -445,7 +445,7 @@ export const TimelineNav = ({
       >
         <Button
           className={clsx(styles['timeline-nav__back'])}
-          onClick={onClick}
+          onClick={onBack}
           onFocus={resetTabIndex}
           ref={backRef}
           status="neutral"

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -334,25 +334,26 @@ export const TimelineNav = ({
   };
 
   /**
-   * onClick function
-   * 1) Triggered by 'Back' button on < lg viewports
-   * 2) Return focus to the button that was clicked to open the current panel; activeIndexState holds the index of the last nav item selected in the timelinNavItemRefs array
-   * 3) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
+   * onClick (used by 'Back' button on < lg viewports)
+   * 1) Return focus to the button that was clicked to open the current panel; activeIndexState holds the index of the last nav item selected in the timelinNavItemRefs array
+   * 2) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
    */
   const onClick = () => {
-    timelineNavItemRefs[activeIndexState].current?.focus(); /* 2 */
-    setIsActive(false); /* 3 */
+    timelineNavItemRefs[activeIndexState].current?.focus(); /* 1 */
+    setIsActive(false); /* 2 */
   };
 
+  /**
+   * onFocus (used by 'Back' button on <lg viewports)
+   * 1) This fixes an issue where a keyboard user who has focus on the
+   * Back button could use alt-tab to put keyboard focus back
+   * on the menu, which is currently off-canvas.
+   * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#sect1
+   */
   const onFocus = () => {
-    // document.activeElement.parentNode.hidden = true;
-    // console.log(document.activeElement.parentNode)
-    // timelineNavItemRefs[activeIndexState].current.ariaHidden = 'true';
-    // timelineNavItemRefs[activeIndexState].current.ariaSelected = 'false';
-    // timelineNavItemRefs[activeIndexState].current.ariaCurrent = 'false';
-    // timelineNavItemRefs[activeIndexState].current.remove();
-    // console.log(timelineNavItemRefs[activeIndexState].current);
+    timelineNavItemRefs[activeIndexState].current.tabIndex = '-1';
   };
+
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['timeline-nav__nav']}>

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -343,6 +343,16 @@ export const TimelineNav = ({
     timelineNavItemRefs[activeIndexState].current?.focus(); /* 2 */
     setIsActive(false); /* 3 */
   };
+
+  const onFocus = () => {
+    // document.activeElement.parentNode.hidden = true;
+    // console.log(document.activeElement.parentNode)
+    // timelineNavItemRefs[activeIndexState].current.ariaHidden = 'true';
+    // timelineNavItemRefs[activeIndexState].current.ariaSelected = 'false';
+    // timelineNavItemRefs[activeIndexState].current.ariaCurrent = 'false';
+    // timelineNavItemRefs[activeIndexState].current.remove();
+    // console.log(timelineNavItemRefs[activeIndexState].current);
+  };
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['timeline-nav__nav']}>
@@ -428,11 +438,17 @@ export const TimelineNav = ({
         <Button
           className={clsx(styles['timeline-nav__back'])}
           onClick={onClick}
+          onFocus={onFocus}
           ref={backRef}
           status="neutral"
           variant="link"
         >
-          <Icon name="arrow-back" purpose="informative" title="back" />
+          <Icon
+            id="back"
+            name="arrow-back"
+            purpose="informative"
+            title="back"
+          />
           Back
         </Button>
         {childrenWithProps[activeIndexState]}

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -512,7 +512,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="back"
+          id="18"
         >
           back
         </title>

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -512,7 +512,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="18"
+          id="back"
         >
           back
         </title>


### PR DESCRIPTION
### Summary:
This fixes an issue where a keyboard user who has focus on the  'Back' button could use alt-tab to put keyboard focus back on the menu, which is currently off-canvas. To prevent this unwanted behavior, we add an onFocus event listener to the 'Back' button that sets the currently active menu item's tabIndex to "-1", making it unable to receive focus via sequential keyboard navigation. The 'Back' button should be the only way users are able to return to the nav list, both visually and via sequential keyboard navigation.

### Test Plan:
Larger breakpoints should be unaffected by this work, since the 'Back' button is only visible on < lg breakpoints (and this ticket is adding a function to the Back button's `onFocus` listener).

Smaller breakpoints:

1. Open the browser's console and create a live expression to watch the value of `document.activeElement`. (This will show you what DOM element currently has focus.)
2. Using the Tab key, put keyboard focus on the nav list. 
3. With an item in the nav list focused, use the up and down arrows to focus on a nav item, then hit 'Enter' to select that item. The corresponding tab panel should slide into place, and in your browser you should see that the 'Back' button now has focus.
4. With the 'Back' button still focused, hit shift-tab. 
5. Focus should NOT go back to the currently active nav link, which is hidden off-screen. Instead it should step out of the TimelineNav component and go to the `body` DOM element. (This behavior matches what a keyboard user would experience in the version of this component for larger breakpoints. Since the 'Back' button is not used there, if a user shift-tabs while a nav menu item is selected, focus steps out of the component.)

The first clip shows the unwanted behavior. First the user selects a nav menu item. The nav panel becomes visible and the `activeElement` is the 'Back' button. With the 'Back' button active, the user hits shift-tab; the `activeElement` is now on the previously selected menu item, which is off-screen. This undesirable behavior allows the user to use up and down arrows to move up/down the hidden menu, causing the page to scroll. 

The second clip is using the work in this ticket. From the 'Back' button, shift-tab moves focus out of the component instead of focusing on the off-screen menu.

https://user-images.githubusercontent.com/24812780/181064881-12e9fcff-bbdf-4df2-b5b5-27bc58af5a1d.mov

https://user-images.githubusercontent.com/24812780/181064914-d13a74c5-9c7f-436f-ab13-d2e437be5e07.mov





