### PR TITLE
Csnizik/208576 feedback punchlist

### DIFF
--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -486,7 +486,7 @@ export const CoursePlannerEdit = () => {
             headingSize="title-sm"
             orientation="2up"
             right={
-              <ButtonGroup>
+              <ButtonGroup className="u-margin-top-xl">
                 <Button>
                   <Icon name="arrow-narrow-left" purpose="decorative" />
                   Back

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -486,6 +486,13 @@ export const CoursePlannerEdit = () => {
             headingSize="title-sm"
             orientation="2up"
             right={
+              // The parent class of this ButtonGroup is .page-header,
+              // which uses flex-direction:column, with a media query
+              // that changes flex-direction to row at the medium
+              // breakpoint. This ButtonGroup needs to have a margin
+              // above it only when the flex-direction is column, so
+              // this utility class was written with a media query
+              // that matches the behavior of .page-header
               <ButtonGroup className="u-margin-top-xl-mobile">
                 <Button>
                   <Icon name="arrow-narrow-left" purpose="decorative" />

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -486,7 +486,7 @@ export const CoursePlannerEdit = () => {
             headingSize="title-sm"
             orientation="2up"
             right={
-              <ButtonGroup className="u-margin-top-xl">
+              <ButtonGroup className="u-margin-top-xl-mobile">
                 <Button>
                   <Icon name="arrow-narrow-left" purpose="decorative" />
                   Back

--- a/.storybook/pages/CoursePlannerStep1/CoursePlannerStep1.tsx
+++ b/.storybook/pages/CoursePlannerStep1/CoursePlannerStep1.tsx
@@ -36,7 +36,7 @@ export const CoursePlannerStep1 = () => (
           headingSize="title-md"
           orientation="2up"
           right={
-            <ButtonGroup>
+            <ButtonGroup className="u-margin-top-xl">
               <Button>Return to Course</Button>
               <Button variant="primary">
                 Next <Icon name="arrow-narrow-right" purpose="decorative" />

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -103,11 +103,9 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                         <TableHeaderCell>Checkpoints Status</TableHeaderCell>
                         <TableHeaderCell>Final Product</TableHeaderCell>
                       </TableRow>
-                    </TableHeader>
-                    <TableBody>
                       <TableRow>
-                        <TableCell></TableCell>
-                        <TableCell>
+                        <TableHeaderCell></TableHeaderCell>
+                        <TableHeaderCell>
                           <NumberIconList>
                             <NumberIcon
                               aria-label="Item 1"
@@ -168,9 +166,11 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                               size="sm"
                             />
                           </NumberIconList>
-                        </TableCell>
-                        <TableCell></TableCell>
+                        </TableHeaderCell>
+                        <TableHeaderCell></TableHeaderCell>
                       </TableRow>
+                    </TableHeader>
+                    <TableBody>
                       <TableRow>
                         <TableCell data-heading="Student">
                           Araya, Raquel

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -194,7 +194,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -206,7 +206,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -218,7 +218,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -230,7 +230,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -242,7 +242,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -254,7 +254,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -266,7 +266,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -278,7 +278,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -290,7 +290,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -302,7 +302,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -351,7 +351,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -363,7 +363,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -375,7 +375,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -387,7 +387,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -399,7 +399,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -448,7 +448,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -460,7 +460,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -472,7 +472,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -484,7 +484,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -496,7 +496,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -508,7 +508,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -520,7 +520,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -532,7 +532,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -544,7 +544,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -556,7 +556,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -605,7 +605,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -617,7 +617,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -629,7 +629,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -641,7 +641,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -653,7 +653,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -665,7 +665,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -677,7 +677,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -689,7 +689,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -701,7 +701,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -713,7 +713,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -762,7 +762,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -774,7 +774,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -786,7 +786,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -798,7 +798,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -810,7 +810,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -822,7 +822,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -834,7 +834,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -846,7 +846,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -858,7 +858,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -870,7 +870,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -919,7 +919,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -931,7 +931,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -943,7 +943,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -955,7 +955,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -967,7 +967,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -979,7 +979,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -991,7 +991,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1003,7 +1003,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1015,7 +1015,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1027,7 +1027,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -1076,7 +1076,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1088,7 +1088,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1100,7 +1100,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1112,7 +1112,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1124,7 +1124,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1136,7 +1136,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1148,7 +1148,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1160,7 +1160,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1172,7 +1172,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1184,7 +1184,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -1233,7 +1233,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1245,7 +1245,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1257,7 +1257,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1269,7 +1269,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1281,7 +1281,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1293,7 +1293,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1305,7 +1305,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1317,7 +1317,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1329,7 +1329,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1341,7 +1341,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>
@@ -1388,7 +1388,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              1
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1400,7 +1400,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              2
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1412,7 +1412,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              3
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1424,7 +1424,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              4
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1436,7 +1436,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              5
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1448,7 +1448,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              6
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1460,7 +1460,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              7
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1472,7 +1472,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              8
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1484,7 +1484,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              9
+                              &nbsp;
                             </div>
                             <div
                               className="fpo"
@@ -1496,7 +1496,7 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
                                 flexShrink: 0,
                               }}
                             >
-                              10
+                              &nbsp;
                             </div>
                           </div>
                         </TableCell>

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -47,10 +47,10 @@ export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
       <BreadcrumbsItem href="#" text="Modern World 2" />
     </Breadcrumbs>
     <PageHeader
-      className="u-margin-bottom-xl"
+      className="u-margin-bottom-xl u-flex-direction-row"
       right={
         <Button status="neutral" variant="icon">
-          More options
+          <div className="u-mobile-hidden">More options</div>
           <Icon name="dots-vertical" purpose="decorative" />
         </Button>
       }

--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -56,7 +56,7 @@
 
 /**
  * Page header right
- * 1) On larger viewports, add margin-left to keep space between title and header-right content. If additional margin needs to be added, add a spacing utility class to the contents of header-right.
+ * 1) On larger viewports, add margin-left to keep space between title and header-right content. If additional margin needs to be added (i.e. margin-top on smaller viewports), add a spacing utility class to the contents of header-right.
  */
  .page-header__right {
   

--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -56,13 +56,12 @@
 
 /**
  * Page header right
+ * 1) On larger viewports, add margin-left to keep space between title and header-right content. If additional margin needs to be added, add a spacing utility class to the contents of header-right.
  */
-.page-header__right {
-  margin-top: var(--eds-size-4); /* 1 */
-
+ .page-header__right {
+  
   @media all and (min-width: $eds-bp-md) {
-    margin-top: 0;
-    margin-left: var(--eds-size-4); /* 1 */
+    margin-left: var(--eds-size-4); 
   }
 }
 

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -21,6 +21,7 @@ import {
   R_ARROW_KEYCODE,
   D_ARROW_KEYCODE,
   ENTER_KEYCODE,
+  SPACEBAR_KEYCODE,
 } from '../../util/keycodes';
 import Button from '../Button';
 import Icon from '../Icon';
@@ -207,7 +208,7 @@ export const TimelineNav = ({
    * 2) Set active tab, next tab, and previous tab.
    * 3) If right or down arrow key keyed, focus on next tab.
    * 4) If left or up arrow key keyed, focus on the previous tab.
-   * 5) If enter keyed, set focus to the 'Back' button. This is wrapped in a setTimeout() method to ensure that document.activeElement gets set properly. TODO: determine why backRef.current?.focus() needs to be in a callback
+   * 5) If enter or spacebar keyed, set focus to the 'Back' button. This is wrapped in a setTimeout() method to ensure that document.activeElement gets set properly. TODO: determine why backRef.current?.focus() needs to be in a callback
    *
    * TODO: improve `any` type
    */
@@ -235,7 +236,7 @@ export const TimelineNav = ({
     } else if ([L_ARROW_KEYCODE, U_ARROW_KEYCODE].includes(e.key)) {
       /* 4 */
       timelineNavItemRefs[prev].current.focus();
-    } else if (e.key === ENTER_KEYCODE) {
+    } else if (e.key === ENTER_KEYCODE || e.key === SPACEBAR_KEYCODE) {
       setTimeout(() => {
         backRef.current?.focus(); /* 5 */
       }, 500);

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -20,6 +20,7 @@ import {
   U_ARROW_KEYCODE,
   R_ARROW_KEYCODE,
   D_ARROW_KEYCODE,
+  ENTER_KEYCODE,
 } from '../../util/keycodes';
 import Button from '../Button';
 import Icon from '../Icon';
@@ -188,18 +189,14 @@ export const TimelineNav = ({
   /**
    * On open
    * 1) On click of a tab, set activeIndexState to index of tab being clicked
-   * 2) Set focus to the 'Back' button. This is wrapped in a setTimeout() method to ensure that document.activeElement gets set properly. TODO: determine why backRef.current?.focus() needs to be in a callback
-   * 3) If function is passed into onChange prop, run that on click
+   * 2) If function is passed into onChange prop, run that on click
    */
   function onOpen(index: number) {
     setActiveIndexState(index); /* 1 */
     setIsActive(true);
-    setTimeout(() => {
-      backRef.current?.focus(); /* 2 */
-    }, 500);
 
     if (onChange) {
-      /* 3 */
+      /* 2 */
       onChange(index);
     }
   }
@@ -210,6 +207,7 @@ export const TimelineNav = ({
    * 2) Set active tab, next tab, and previous tab.
    * 3) If right or down arrow key keyed, focus on next tab.
    * 4) If left or up arrow key keyed, focus on the previous tab.
+   * 5) If enter keyed, set focus to the 'Back' button. This is wrapped in a setTimeout() method to ensure that document.activeElement gets set properly. TODO: determine why backRef.current?.focus() needs to be in a callback
    *
    * TODO: improve `any` type
    */
@@ -237,6 +235,10 @@ export const TimelineNav = ({
     } else if ([L_ARROW_KEYCODE, U_ARROW_KEYCODE].includes(e.key)) {
       /* 4 */
       timelineNavItemRefs[prev].current.focus();
+    } else if (e.key === ENTER_KEYCODE) {
+      setTimeout(() => {
+        backRef.current?.focus(); /* 5 */
+      }, 500);
     }
   }
 

--- a/src/components/Utilities/Display.css
+++ b/src/components/Utilities/Display.css
@@ -36,9 +36,14 @@
 }
 
 /**
- * Flex direction utility
+ * Flex direction utility classes
  * 1) Forces display direction to column
+ * 2) Forces display direction to row. Useful for overriding columnar display at specific breakpoints only
  */
-.u-flex-direction-column {
-  flex-direction: column !important;
+ .u-flex-direction-column {
+  flex-direction: column !important /* 1 */;
+}
+
+.u-flex-direction-row {
+  flex-direction: row !important /* 2 */;
 }

--- a/src/components/Utilities/Spacing.css
+++ b/src/components/Utilities/Spacing.css
@@ -85,6 +85,18 @@
 }
 
 /**
+ * Margin top xl mobile
+ * 1) Forces margin top to 2rem (on smaller viewports only)
+ */
+.u-margin-top-xl-mobile {
+  margin-top: var(--eds-size-4) !important;
+
+  @media all and (min-width: $eds-bp-md) {
+    margin-top: unset !important;
+  }
+}
+
+/**
  * Margin top xxl
  * 1) Forces margin top to 3rem
  */

--- a/src/components/Utilities/Visibility.css
+++ b/src/components/Utilities/Visibility.css
@@ -20,3 +20,15 @@
 .u-is-vishidden {
   @mixin visuallyHide;
 }
+
+/**
+ * Mobile Visibly Hidden 
+ * 1) Hides (on smaller screens only) but leaves content available to assitive technologies.
+ */
+.u-mobile-hidden {
+  @mixin visuallyHide;
+
+  @media all and (min-width: $eds-bp-lg) {
+    @mixin resetAll;
+  }
+}

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -6,6 +6,10 @@
   padding: 0;
 }
 
+@define-mixin resetAll {
+  all: unset !important;
+}
+
 /**
  * Link button styles
  * 1) display: inline-flex allows us to manage icon placement and the focus background animation

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -6,6 +6,10 @@
   padding: 0;
 }
 
+/**
+* Reset all
+* 1) The 'all' shorthand CSS property resets all of an element's properties except unicode-bidi, direction, and CSS Custom Properties. The value 'unset' specifies that all of an element's properties should be changed to their inherited values if they inherit by default, or to their initial values if not.
+*/
 @define-mixin resetAll {
   all: unset !important;
 }


### PR DESCRIPTION
### Summary

The work in this PR covers https://app.shortcut.com/czi-edu/story/208576/feedback-overview-styling-punch-list

### Test Plan

All work can be viewed in Storybook: **Pages > Projects > Feedback > Overview**

---
1) **Hide the first row (legend) on mobile**

**Testing step:** on mobile view, select the first item in the Timeline, "Overview".

**Before:**
<img width="473" alt="Screen Shot 2022-07-28 at 11 06 34 AM" src="https://user-images.githubusercontent.com/24812780/181585595-dcad53b6-93fc-4e5a-919b-35fd678154a1.png">

**After:**
<img width="472" alt="Screen Shot 2022-07-28 at 11 07 47 AM" src="https://user-images.githubusercontent.com/24812780/181585759-e1803ffa-39b2-4018-b71d-d372b073cf32.png">

**IMPORTANT:** On desktop view, the 'legend' row should still be visible. The border beneath it is changed to a heavier line due to this content being into the Table Header; this matches the Figma design.

Figma design:
<img width="754" alt="Screen Shot 2022-07-28 at 11 32 53 AM" src="https://user-images.githubusercontent.com/24812780/181591185-59a94e1e-2ae3-4941-9e53-4ca579ce5cb0.png">

Desktop view after the work in this PR:
<img width="694" alt="Screen Shot 2022-07-28 at 11 38 05 AM" src="https://user-images.githubusercontent.com/24812780/181591754-5842fc3e-eadf-417e-8a14-13faa6382c59.png">

---

2) **Back button link focus should only be visible on keyboard interaction, not mouse click**

**Testing step:** on mobile view, using a mouse, click on any item from the Timeline so that the "Back" button becomes visible.

**Before:**
<img width="468" alt="Screen Shot 2022-07-28 at 11 14 20 AM" src="https://user-images.githubusercontent.com/24812780/181587522-1a924c9b-187a-462e-bcfe-d669f8765de0.png">

**After:**
<img width="474" alt="Screen Shot 2022-07-28 at 11 17 04 AM" src="https://user-images.githubusercontent.com/24812780/181587685-99c9b740-b800-4192-8952-224ad5bdd0fb.png">

**IMPORTANT:** the Back button should still be active, with the active background animating in, when a Timeline nav item is selected using a keyboard.

---

3) **Update the FPO icons to `&nbsp;`**

**Testing step:** on either mobile or desktop view, click the first Timeline item, "Overview".

**Before:**
<img width="628" alt="Screen Shot 2022-07-28 at 11 21 51 AM" src="https://user-images.githubusercontent.com/24812780/181588775-9b7b71a4-4daa-4bb6-93a1-dc4fc5d25167.png">

**After:**
<img width="612" alt="Screen Shot 2022-07-28 at 11 23 18 AM" src="https://user-images.githubusercontent.com/24812780/181588923-82a802d3-32c8-4b18-a0c1-1ad6fcdce548.png">

---

4) **"More Options" button becomes icon-only on mobile; button remains in same flex row as page title text**

**Testing step 1:** In mobile view, check the display and placement of the 3 vertical dot icon to the right of the page title.

**Before:**
<img width="530" alt="Screen Shot 2022-07-28 at 11 44 10 AM" src="https://user-images.githubusercontent.com/24812780/181592902-88191240-2557-4704-8c91-e01f92c8fad5.png">

**After:**
<img width="526" alt="Screen Shot 2022-07-28 at 11 46 15 AM" src="https://user-images.githubusercontent.com/24812780/181593222-a25c0f5e-be11-4ed2-943d-cc05d5100da4.png">

**Testing step 2:** In desktop view, check that "More options" is visible and the button is at the right end of the row. (This should remain unaffected by the work in this PR.

<img width="933" alt="Screen Shot 2022-07-28 at 11 47 59 AM" src="https://user-images.githubusercontent.com/24812780/181594079-92e51806-a984-4f89-952c-8270062d3127.png">

---

### Regression testing

The work in this PR touches other Storybook pages, which will need to be checked to make sure there are no regressions.

**What to look for**
In `PageHeader.module.css`, the style definition for `.page-header__right` was setting `margin-top: var(--eds-size-4);` on smaller breakpoints. This was having the unwanted effect of making the "More options" button lower than the page title (on smaller vp). To correct this, the `margin-top` property was removed from `.page-header__right`. 

Removing the `margin-top` property here had the unwanted side effect of removing `margin-top` from the header-right contents on 3 other Storybook pages. To compensate for this, a new utility class was created, `.u-margin-top-xl-mobile`, which adds `margin-top: var(--eds-size-4) !important;` on < md bp, and removes it on >= md bp with `margin-top: unset !important;`. 

**Potential regression #1 - Storybook > Pages > Course Planner > Edit > Default**
Desktop: the button group ("Back" and "Next") in the header-right slot should not move from their current position.

**Desktop** (red outline shows edges of `header.PageHeader-module__page-header`)

<img width="861" alt="Screen Shot 2022-07-28 at 1 11 45 PM" src="https://user-images.githubusercontent.com/24812780/181608105-e4046e71-947e-4108-a5c5-85844c1b3c94.png">

<img width="866" alt="Screen Shot 2022-07-28 at 1 12 43 PM" src="https://user-images.githubusercontent.com/24812780/181608254-8e0f366c-60cc-4061-bd66-f737dbab25b7.png">

**Mobile** 

<img width="545" alt="Screen Shot 2022-07-28 at 1 09 50 PM" src="https://user-images.githubusercontent.com/24812780/181607868-fc82b990-8f08-4818-b1b8-454e2ffc1cb4.png">

<img width="543" alt="Screen Shot 2022-07-28 at 1 07 44 PM" src="https://user-images.githubusercontent.com/24812780/181607915-5e4a5da3-2904-4488-ab0d-d11b71adff4c.png">

**Potential regression #2 - Storybook > Pages > Course Planner > Step 1 > Default**
(Same as #1 above; buttons "Return to Course" and "Next")

**Potential regression #3 - Storybook > Pages > Projects > Project > Student View**
(Same as #1 above; button "View plan")