### PR TITLE
chore(dropdown): ts error

### DIFF
--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -117,18 +117,22 @@ export const DropdownMenu: React.FC<Props> = ({
       if (React.isValidElement(child)) {
         if (isReactFragment(child)) {
           const newChildren = child.props.children;
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           return newChildren.map((item: ReactNode, i: number) => {
-            // @ts-expect-error TODO: fix "No overload matches this call" error
-            return React.cloneElement<Props>(item, {
-              ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
-            });
+            console.log({ item: item });
+            return React.cloneElement<Props>(
+              item as any,
+              {
+                ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
+              } as any,
+            );
           });
         } else {
-          // @ts-expect-error TODO: fix "No overload matches this call" error
-          return React.cloneElement<Props>(child, {
-            ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
-          });
+          return React.cloneElement<Props>(
+            child as any,
+            {
+              ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
+            } as any,
+          );
         }
       }
     },

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -105,12 +105,11 @@ export const DropdownMenu: React.FC<Props> = ({
 
   /**
    * Pass props down to children
-   * 1) Cycle through children and pass down ref
-   * 2) If fragment is used for children (ProjectCardDropdown)
+   * 1) Using type 'any' here because TS requires typechecking at this point, but these elements have already been typechecked
+   * 2) Cycle through children and pass down ref
    */
   const childrenWithProps = React.Children.map(
     children,
-    // TODO: improve `any` type
     (child: ReactNode, i: number) => {
       // Checking isValidElement is the safe way and avoids a typescript
       // error too.
@@ -119,18 +118,18 @@ export const DropdownMenu: React.FC<Props> = ({
           const newChildren = child.props.children;
           return newChildren.map((item: ReactNode, i: number) => {
             return React.cloneElement<Props>(
-              item as any,
+              item as any /* 1 */,
               {
-                ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
-              } as any,
+                ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 2 */,
+              } as any /* 1 */,
             );
           });
         } else {
           return React.cloneElement<Props>(
-            child as any,
+            child as any /* 1 */,
             {
-              ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 1 */,
-            } as any,
+              ref: (el: HTMLLIElement) => (childRefs.current[i] = el) /* 2 */,
+            } as any /* 1 */,
           );
         }
       }

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -118,7 +118,6 @@ export const DropdownMenu: React.FC<Props> = ({
         if (isReactFragment(child)) {
           const newChildren = child.props.children;
           return newChildren.map((item: ReactNode, i: number) => {
-            console.log({ item: item });
             return React.cloneElement<Props>(
               item as any,
               {


### PR DESCRIPTION
### Summary:
Clears TS error, "No overload matches this call" in DropdownMenu.tsx

If this solution is accepted, it can also be applied to:
ButtonDropdown.tsx:172
Tabs.tsx:306
TimelineNav.tsx:252

### Test Plan:
`yarn types` should run without errors.