### PR TITLE
chore(clickable-style): center content horitontally

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -14,6 +14,7 @@
 .clickable-style {
   @mixin eds-theme-typography-button-label;
   display: inline-flex;
+  justify-content: center;
   align-items: center;
   gap: 0.75rem; /* 3 */
   border-width: var(--eds-theme-border-width);


### PR DESCRIPTION
### Summary:
I just noticed that `ClickableStyle` content isn't horizontally centered, which normally doesn't matter because we determine the component width using padding, but buttons using the `fullWidth` prop have their content on the left side, which looks weird. (This prop isn't being used in `traject` yet.)

### Screenshots
#### Before
<img width="1434" alt="button component full width story in storybook before this change" src="https://user-images.githubusercontent.com/7761701/181752810-f9c74cd7-9095-46a1-ab33-e570e28ff4fc.png">

#### After
<img width="1434" alt="button component full width story in storybook after this change" src="https://user-images.githubusercontent.com/7761701/181752825-3acef0bc-bb70-4e26-9a66-ef20a4369280.png">

### Test Plan:
Verify the text is now horizontally centered in the "full width" story for the `Button` and `Link` components.