### PR TITLE
feat(a11y): extending ahuth's original prototyped focus indicators

### DIFF
--- a/src/components/Button/focus.stories.tsx
+++ b/src/components/Button/focus.stories.tsx
@@ -1,60 +1,66 @@
-import type { StoryObj } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Button, ButtonProps } from './Button';
 import * as colors from '../../tokens-dist/ts/colors';
-import { STATUSES as buttonColors } from '../ClickableStyle/ClickableStyle';
+import { STATUSES } from '../ClickableStyle/ClickableStyle';
 
 export default {
   title: 'Focus Indicator',
   component: Button,
   argTypes: {
-    color: {
-      options: buttonColors,
+    status: {
       control: {
         type: 'radio',
       },
+      options: STATUSES,
     },
   },
-};
+} as Meta<Args>;
+
+type Args = React.ComponentProps<typeof Button>;
 
 export const Current: StoryObj<ButtonProps> = {
   render: (args) => (
     <div
       style={{
-        gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
         display: 'grid',
         gap: '1rem',
       }}
     >
-      {Object.keys(colors).map((colorName) => {
-        const color = colors[colorName];
-        return (
-          <div key={colorName}>
-            <div className="text-center">{colorName}</div>
-            <div
-              className="u-padding-xl u-width-100"
-              style={{
-                backgroundColor: color,
-                display: 'flex',
-                justifyContent: 'center',
-              }}
-            >
-              <Button
-                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                // @ts-ignore
-                state="focus"
-                {...args}
+      {Object.keys(colors)
+        .filter((colorName) => colorName.includes('Background'))
+        .map((colorName) => {
+          const color = colors[colorName];
+          return (
+            <div key={colorName}>
+              <div style={{ textAlign: 'center' }}>
+                {colorName.replace('EdsThemeColor', '')}
+              </div>
+              <div
+                className="u-padding-xl u-width-100"
+                style={{
+                  backgroundColor: color,
+                  display: 'flex',
+                  justifyContent: 'center',
+                }}
               >
-                Coffee
-              </Button>
+                <Button
+                  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                  // @ts-ignore
+                  state="focus"
+                  {...args}
+                >
+                  Coffee
+                </Button>
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
     </div>
   ),
   args: {
-    color: 'brand',
+    status: 'brand',
     size: 'lg',
     variant: 'primary',
   },
@@ -65,8 +71,9 @@ export const ProtoA: StoryObj<ButtonProps> = {
   args: {
     ...Current.args,
     style: {
-      '--tw-ring-offset-width': '2px',
-      '--tw-ring-color': 'black',
+      boxShadow: `0 0 0 2px white`,
+      outline: `2px black solid`,
+      outlineOffset: '2px',
     } as React.CSSProperties,
   },
   storyName: 'Proto A (black-white)',
@@ -77,10 +84,9 @@ export const ProtoB: StoryObj<ButtonProps> = {
   args: {
     ...Current.args,
     style: {
-      '--tw-ring-offset-width': '2px',
-      '--tw-ring-color': 'white',
-      outline: '3px solid black',
-      outlineOffset: '0',
+      boxShadow: `0 0 0 2px black`,
+      outline: `2px white solid`,
+      outlineOffset: '2px',
     } as React.CSSProperties,
   },
   storyName: 'Proto B (white-black)',
@@ -122,4 +128,43 @@ export const ProtoE: StoryObj<ButtonProps> = {
     },
   },
   storyName: 'Proto E (like Firefox)',
+};
+
+export const ProtoF: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: `0 0 0 2px white`,
+      outline: `2px ${colors.EdsColorBrandGrape700} solid`,
+      outlineOffset: '2px',
+    },
+  },
+  storyName: 'Proto F (purple-white)',
+};
+
+export const ProtoG: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: `0 0 0 2px white`,
+      outline: `2px ${colors.EdsColorBrandGrape500} solid`,
+      outlineOffset: '2px',
+    },
+  },
+  storyName: 'Proto G (light purple-white)',
+};
+
+export const ProtoH: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: `0 0 0 2px white`,
+      outline: `2px ${colors.EdsColorBrandGrape800} solid`,
+      outlineOffset: '2px',
+    },
+  },
+  storyName: 'Proto H (dark purple-white)',
 };

--- a/src/components/Button/focus.stories.tsx
+++ b/src/components/Button/focus.stories.tsx
@@ -1,0 +1,125 @@
+import type { StoryObj } from '@storybook/react';
+import React from 'react';
+import { Button, ButtonProps } from './Button';
+import * as colors from '../../tokens-dist/ts/colors';
+import { STATUSES as buttonColors } from '../ClickableStyle/ClickableStyle';
+
+export default {
+  title: 'Focus Indicator',
+  component: Button,
+  argTypes: {
+    color: {
+      options: buttonColors,
+      control: {
+        type: 'radio',
+      },
+    },
+  },
+};
+
+export const Current: StoryObj<ButtonProps> = {
+  render: (args) => (
+    <div
+      style={{
+        gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+        display: 'grid',
+        gap: '1rem',
+      }}
+    >
+      {Object.keys(colors).map((colorName) => {
+        const color = colors[colorName];
+        return (
+          <div key={colorName}>
+            <div className="text-center">{colorName}</div>
+            <div
+              className="u-padding-xl u-width-100"
+              style={{
+                backgroundColor: color,
+                display: 'flex',
+                justifyContent: 'center',
+              }}
+            >
+              <Button
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                state="focus"
+                {...args}
+              >
+                Coffee
+              </Button>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  ),
+  args: {
+    color: 'brand',
+    size: 'lg',
+    variant: 'primary',
+  },
+};
+
+export const ProtoA: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      '--tw-ring-offset-width': '2px',
+      '--tw-ring-color': 'black',
+    } as React.CSSProperties,
+  },
+  storyName: 'Proto A (black-white)',
+};
+
+export const ProtoB: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      '--tw-ring-offset-width': '2px',
+      '--tw-ring-color': 'white',
+      outline: '3px solid black',
+      outlineOffset: '0',
+    } as React.CSSProperties,
+  },
+  storyName: 'Proto B (white-black)',
+};
+
+export const ProtoC: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: '0 0 0 2px #F9F9D1, 0 0 0 4px #396196, 0 0 4px 8px #F9F9D1',
+      outline: '2px transparent solid',
+    },
+  },
+  storyName: 'Proto C (yellow-black-yellow shadow)',
+};
+
+export const ProtoD: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: '0 0 0 2px #6ef, 0 0 5px 3px #000',
+      outline: '2px rgba(0,0,0,0.4) solid',
+      outlineOffset: '-2px',
+    },
+  },
+  storyName: 'Proto D (shadow-teal-opaque)',
+};
+
+export const ProtoE: StoryObj<ButtonProps> = {
+  ...Current,
+  args: {
+    ...Current.args,
+    style: {
+      boxShadow: '0 0 0 2px midnightblue',
+      outline: '2px lightskyblue solid',
+      outlineOffset: '3px',
+    },
+  },
+  storyName: 'Proto E (like Firefox)',
+};


### PR DESCRIPTION
### Summary:

This is an exploratory PR to implement a two-tone focus indicator (see [RFC](https://docs.google.com/document/d/14su_YKybfaxC2sQMGC9KZQjHQPVzmVck8l2QXNnz1EQ/edit#heading=h.h595r9lnozn4)), which follows up https://github.com/chanzuckerberg/edu-design-system/pull/816. Some of this PR is bringing up to speed Andrew's changes with new CSS classes / file structures introduced since that PR was last opened.

I've also added three new prototypes, all a purple-on-white!

prior commit - [c6d6453](https://github.com/chanzuckerberg/edu-design-system/pull/1219/commits/c6d64534844b279a7f3103a5a3d7df5cb9e43663): [Chromatic](https://61313967cde49b003ae2a860-cucdszxoae.chromatic.com/?path=/story/focus-indicator--current)

### Test Plan:
