### PR TITLE
chore(clickable-style, button, link): set display to inline on link variant

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -454,21 +454,25 @@
 
 /**
  * Link button styles
+ * 1) Override default Clickable styles
+ * 2) Smaller gap between text and icon in link button style
  */
 .clickable-style--link {
   @mixin textLink;
 
-  border-radius: 0;
+  /* 1 */
   border: 0;
+  border-radius: 0;
   background-color: transparent;
+
+  gap: 0.25em; /* 2 */
 }
 
 /**
- * Margin 0 added becuase Safari has margin on buttons.
  * 1) Needs `:where` pseudoclass to reduce specificity so class overrides
  *    for margin can happen where used.
  * 2) 2px padding gives the text breathing room in the focus state
- * 3) 2px margin compensates for the padding so the link doesn't have too much space between it
+ * 3) -2px margin compensates for the padding so the link doesn't have too much space between it
  *    and surrounding text
  */
 :where(.clickable-style--link) {
@@ -478,6 +482,8 @@
 
 /**
  * Link neutral clickable style
+ * 1) Overrides the default background color on focus. Often used when the default
+ *    focus background color doesn't mesh well with the surrounding colors.
  */
 .clickable-style--link.clickable-style--neutral {
   text-decoration-color: var(--eds-theme-color-icon-neutral-strong);
@@ -485,15 +491,10 @@
   &:hover {
     text-decoration-color: var(--eds-theme-color-border-neutral-strong);
   }
-}
 
-/**
- * Link neutral clickable style pseudo element for the focus background state.
- * Overrides the default background color on focus. Often used when the default
- * focus background color doesn't mesh well with the surrounding colors.
- */
-.clickable-style--link.clickable-style--neutral::before {
-  background-color: var(--eds-theme-color-icon-neutral-strong);
+  &:focus {
+    background-color: var(--eds-theme-color-icon-neutral-strong); /* 1 */
+  }
 }
 
 /**

--- a/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
+++ b/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
@@ -32,7 +32,7 @@ exports[`<FieldNote /> WithText story renders snapshot 1`] = `
       <li>
         Even 
         <a
-          class="clickable-style clickable-style--link clickable-style--brand"
+          class="clickable-style clickable-style--link clickable-style--brand link--link"
           data-bootstrap-override="clickable-style-link"
           href="#"
         >

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -1,0 +1,13 @@
+@import '../../design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # LINK
+\*------------------------------------*/
+
+/**
+ * Link button with link variant styles
+ * 1) Override display: inline-flex from ClickableStyle
+ */
+.link--link {
+  display: inline; /* 1 */
+}

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -347,3 +347,24 @@ export const IconError: StoryObj<Args> = {
     variant: 'icon',
   },
 };
+
+export const LinkInParagraphContext = {
+  render: () => (
+    <div>
+      Lorem ipsum dolor sit amet,{' '}
+      <Link href={getRandomUrl()}>consectetur adipiscing elit</Link>. Morbi
+      porta at ante quis molestie. Nam scelerisque id diam at iaculis. Nullam
+      sit amet iaculis erat. Nulla id tellus ante.{' '}
+      <Link href={getRandomUrl()}>
+        Aliquam pellentesque ipsum sagittis, commodo neque at, ornare est.
+        Maecenas a malesuada sem, vitae euismod erat. Nullam molestie nunc non
+        dui dignissim fermentum.
+      </Link>{' '}
+      Aliquam id volutpat nulla, sed auctor orci. Fusce cursus leo nisi. Fusce
+      vehicula vitae nisl nec ultricies. Cras ut enim nec magna semper egestas.
+      Sed sed quam id nisl bibendum convallis. Proin suscipit, odio{' '}
+      <Link href={getRandomUrl()}>vel pulvinar</Link> euismod, risus eros
+      ullamcorper lectus, non blandit nulla dui eget massa.
+    </div>
+  ),
+};

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,6 @@
+import clsx from 'clsx';
 import React, { ReactNode, forwardRef } from 'react';
+import styles from './Link.module.css';
 import ClickableStyle from '../ClickableStyle';
 import type { ClickableStyleProps } from '../ClickableStyle';
 
@@ -40,11 +42,20 @@ export type LinkProps = LinkHTMLElementProps & {
  * components are exactly the same.
  */
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ variant = 'link', status = 'brand', size = 'lg', ...rest }, ref) => {
+  (
+    { className, variant = 'link', status = 'brand', size = 'lg', ...rest },
+    ref,
+  ) => {
+    const componentClassName = clsx(
+      variant === 'link' && styles['link--link'],
+      className,
+    );
+
     return (
       <ClickableStyle
         {...rest}
         as="a"
+        className={componentClassName}
         ref={ref}
         size={size}
         status={status}

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<Link /> Default story renders snapshot 1`] = `
 <a
-  class="clickable-style clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand link--link"
   data-bootstrap-override="clickable-style-link"
   href="/"
 >
@@ -258,9 +258,43 @@ exports[`<Link /> IconWarning story renders snapshot 1`] = `
 </a>
 `;
 
+exports[`<Link /> LinkInParagraphContext story renders snapshot 1`] = `
+<div>
+  Lorem ipsum dolor sit amet,
+   
+  <a
+    class="clickable-style clickable-style--link clickable-style--brand link--link"
+    data-bootstrap-override="clickable-style-link"
+    href="/"
+  >
+    consectetur adipiscing elit
+  </a>
+  . Morbi porta at ante quis molestie. Nam scelerisque id diam at iaculis. Nullam sit amet iaculis erat. Nulla id tellus ante.
+   
+  <a
+    class="clickable-style clickable-style--link clickable-style--brand link--link"
+    data-bootstrap-override="clickable-style-link"
+    href="/"
+  >
+    Aliquam pellentesque ipsum sagittis, commodo neque at, ornare est. Maecenas a malesuada sem, vitae euismod erat. Nullam molestie nunc non dui dignissim fermentum.
+  </a>
+   
+  Aliquam id volutpat nulla, sed auctor orci. Fusce cursus leo nisi. Fusce vehicula vitae nisl nec ultricies. Cras ut enim nec magna semper egestas. Sed sed quam id nisl bibendum convallis. Proin suscipit, odio
+   
+  <a
+    class="clickable-style clickable-style--link clickable-style--brand link--link"
+    data-bootstrap-override="clickable-style-link"
+    href="/"
+  >
+    vel pulvinar
+  </a>
+   euismod, risus eros ullamcorper lectus, non blandit nulla dui eget massa.
+</div>
+`;
+
 exports[`<Link /> LinkNeutral story renders snapshot 1`] = `
 <a
-  class="clickable-style clickable-style--link clickable-style--neutral"
+  class="clickable-style clickable-style--link clickable-style--neutral link--link"
   data-bootstrap-override="clickable-style-link"
   href="/"
 >
@@ -270,7 +304,7 @@ exports[`<Link /> LinkNeutral story renders snapshot 1`] = `
 
 exports[`<Link /> LinkRightIcon story renders snapshot 1`] = `
 <a
-  class="clickable-style clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand link--link"
   data-bootstrap-override="clickable-style-link"
   href="/"
 >
@@ -535,7 +569,7 @@ exports[`<Link /> TertiarySmall story renders snapshot 1`] = `
 
 exports[`<Link /> passes class names down properly 1`] = `
 <a
-  class="clickable-style clickable-style--link clickable-style--brand exampleClassName"
+  class="clickable-style clickable-style--link clickable-style--brand link--link exampleClassName"
   data-bootstrap-override="clickable-style-link"
   data-testid="example-class-name"
   href="/"
@@ -546,7 +580,7 @@ exports[`<Link /> passes class names down properly 1`] = `
 
 exports[`<Link /> passes test ids down properly 1`] = `
 <a
-  class="clickable-style clickable-style--link clickable-style--brand"
+  class="clickable-style clickable-style--link clickable-style--brand link--link"
   data-bootstrap-override="clickable-style-link"
   data-testid="example-test-id"
   href="/"

--- a/src/components/StackedBlock/__snapshots__/StackedBlock.test.tsx.snap
+++ b/src/components/StackedBlock/__snapshots__/StackedBlock.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<StackedBlock /> Default story renders snapshot 1`] = `
   class="stacked-block"
 >
   <a
-    class="clickable-style clickable-style--link clickable-style--brand"
+    class="clickable-style clickable-style--link clickable-style--brand link--link"
     data-bootstrap-override="clickable-style-link"
   >
     This is a link

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -16,11 +16,6 @@
 
 /**
  * Link button styles
- * 1) display: inline-flex allows us to manage icon placement and the focus background animation
- * 2) Smaller gap between text and icon in link button style
- * 3) Has position relative to support the background color pseudo element
- * 4) We hide overflow so the pseudo element can be pushed out of site
- * 5) z-index 0 required for the background to appear correctly on focus
  * 6) Has smaller icons than other button styles
  * 7) Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
       color, but it will also make borders 100% opacity black
@@ -29,25 +24,12 @@
   font-size: inherit;
   font-weight: var(--eds-font-weight-medium);
   line-height: inherit;
-  text-align: left;
-  display: inline-flex; /* 1 */
-  gap: 0.25em; /* 2 */
 
   color: var(--eds-theme-color-text-link-default);
   text-decoration: underline;
   text-decoration-color: var(--eds-theme-color-background-brand-primary-strong);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
-
-  position: relative; /* 3 */
-  overflow: hidden; /* 4 */
-  z-index: var(--eds-z-index-0); /* 5 */
-  transition: color var(--eds-anim-move-medium) var(--eds-anim-ease),
-    text-decoration-color var(--eds-anim-move-medium) var(--eds-anim-ease);
-
-  @media screen and (prefers-reduced-motion) {
-    transition: none;
-  }
 
   svg {
     --icon-size-default: 1.25em; /* 6 */
@@ -64,44 +46,12 @@
     text-decoration-color: var(
       --eds-theme-color-text-neutral-default-inverse
     ) !important;
+    background-color: var(--eds-theme-color-background-brand-primary-strong);
   }
 
   &:visited {
     color: var(--eds-theme-color-text-neutral-subtle);
     text-decoration-color: var(--eds-theme-color-text-neutral-subtle);
-  }
-
-  /**
-   * Pseudo element with background color for focus state
-   * 1) Uses an absolutely-positioned pseudo element with a background color to animate it up and down
-   * 2) The pseudo element has a negative z-index to position it behind the text
-   * 3) The element is pushed down out of sight to hide it. Needs to be 101%, not 100%, to or the very top
-   *    will be visible
-   * 4) We set transform-origin: to bottom so it animates up from the bottom, not out from the middle
-   * 5) And we pull it back up on focus so it's visible
-   */
-  &::before {
-    /* 1 */
-    content: '';
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: var(--eds-z-index-bottom); /* 2 */
-    background-color: var(--eds-theme-color-background-brand-primary-strong);
-
-    transform: translateY(101%); /* 3 */
-    transform-origin: bottom; /* 4 */
-    transition: transform var(--eds-anim-move-medium) var(--eds-anim-ease);
-
-    @media screen and (prefers-reduced-motion) {
-      transition: none;
-    }
-  }
-
-  &:focus::before {
-    transform: translateY(0); /* 5 */
   }
 }
 


### PR DESCRIPTION
### Summary:
We got a comment about how links aren't wrapping well in paragraphs – if the link text is in a paragraph that wraps but the link text itself does not wrap it's fine; but if the link text is situated in such a way that the link text wraps, it will break away from the rest of the text and sit on its own line. This is because we have `display: inline-flex` on the link styles.

We were aware of this behavior, but it had been like that for a long time and no one had commented on it – *until now*. And since we're pushing for more mobile-friendly designs and less ultra-short link text (ie "here" and "learn more"), I think it's going to keep coming up.

There are 2 side effects from removing `display: inline-flex`:
- the animation for the focus state won't work (which is fine; that was just a fun little thing I wanted to throw in)
- the `gap` style we're using to add space between text and icons (is an icon is present) in links won't work anymore

**Also**, we're not able to fix this for `button` elements that are styled to look like links – the text can wrap within the button, but it doesn't look like (from my exploration) that it's possible to get the button text to wrap *with* paragraph text. So the `Button` component might as well keep `display: inline-flex` and the gap between the text and icon (if an icon is present). I'm going to remove the focus animation though because I think it's too messy from a code and UX point of view to have that only some of the time when it's not really important.

### Screenshots
#### Before
<img width="1018" alt="the new link in paragraph context story but without the other changes from this pr" src="https://user-images.githubusercontent.com/7761701/183938274-272247a0-4ae6-42b6-8575-383cdc2715f6.png">

#### After
<img width="1022" alt="the new link in paragraph context story with the other changes from this pr" src="https://user-images.githubusercontent.com/7761701/183938282-78d21984-20ec-4dde-abb3-36dc8a6a4d90.png">

### Test Plan:
Verify that:
- buttons styled like links and all links (regardless of style) in the system are unchanged
- the focus state for buttons and links styled like links still works (but with a quick fade animation instead of a vertical slide)
- the link text wraps with the paragraph text in the new `LinkInParagraphContext` story