### PR TITLE
fix(projectcard): make numberAriaLabel optional but warn

### DIFF
--- a/src/components/ProjectCard/ProjectCard.test.tsx
+++ b/src/components/ProjectCard/ProjectCard.test.tsx
@@ -1,6 +1,20 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { ProjectCard } from './ProjectCard';
 import * as stories from './ProjectCard.stories';
+import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<ProjectCard />', () => {
+  const consoleWarnMock = consoleWarnMockHelper();
+
   generateSnapshots(stories);
+
+  it('should warn if number is passed without numberAriaLabel', () => {
+    render(<ProjectCard number={1} />);
+    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
+    expect(consoleWarnMock).toHaveBeenCalledWith(
+      'You must provide a "numberAriaLabel" for the number icon if a "number" has been passed',
+    );
+  });
 });

--- a/src/components/ProjectCard/ProjectCard.test.tsx
+++ b/src/components/ProjectCard/ProjectCard.test.tsx
@@ -3,18 +3,15 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { ProjectCard } from './ProjectCard';
 import * as stories from './ProjectCard.stories';
-import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
 describe('<ProjectCard />', () => {
-  const consoleWarnMock = consoleWarnMockHelper();
-
   generateSnapshots(stories);
 
   it('should warn if number is passed without numberAriaLabel', () => {
-    render(<ProjectCard number={1} />);
-    expect(consoleWarnMock).toHaveBeenCalledTimes(1);
-    expect(consoleWarnMock).toHaveBeenCalledWith(
-      'You must provide a "numberAriaLabel" for the number icon if a "number" has been passed',
+    expect(() => {
+      render(<ProjectCard number={1} />);
+    }).toThrow(
+      /You must provide a "numberAriaLabel" for the number icon if a "number" has been passed/,
     );
   });
 });

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -56,9 +56,9 @@ export interface Props {
    */
   number?: number;
   /**
-   * Number aria label
+   * Number aria label. Required if number prop is passed.
    */
-  numberAriaLabel: string;
+  numberAriaLabel?: string;
   /**
    * Property passed in to style draggable project card
    */
@@ -81,6 +81,11 @@ export const ProjectCard = ({
   isDragging,
   ...other
 }: Props) => {
+  if (number && !numberAriaLabel && process.env.NODE_ENV !== 'production') {
+    console.warn(
+      'You must provide a "numberAriaLabel" for the number icon if a "number" has been passed',
+    );
+  }
   const componentClassName = clsx(
     styles['project-card'],
     behavior === 'draggable' && styles['project-card--draggable'],

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -82,7 +82,7 @@ export const ProjectCard = ({
   ...other
 }: Props) => {
   if (number && !numberAriaLabel && process.env.NODE_ENV !== 'production') {
-    console.warn(
+    throw new Error(
       'You must provide a "numberAriaLabel" for the number icon if a "number" has been passed',
     );
   }


### PR DESCRIPTION
### Summary:
- `numberAriaLabel` should not be required if there is no `number`
- warns if doesn't exist if `number` is passed
### Test Plan:
- wrote unit test
- no visual regression
