### PR TITLE
fix(drawerheader): correctly refer to color token

### DIFF
--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React, { MouseEventHandler, ReactNode } from 'react';
-import { EdsThemeColorIconNeutralSubtle } from '../../../src/tokens-dist/ts/colors';
 import Button from '../../components/Button';
 import Icon from '../../components/Icon';
+import { EdsThemeColorIconNeutralSubtle } from '../../tokens-dist/ts/colors';
 import styles from '../Drawer/Drawer.module.css';
 
 export type Props = {


### PR DESCRIPTION
### Summary:
- need to refer to the correct color token as the DrawerHeader no longer lives in `upcoming-components`
- will follow up with an eds patch fix
### Test Plan:
- built file refers to correct token
![image](https://user-images.githubusercontent.com/86632227/184419213-c343bdbb-3d27-4b57-b361-70f308e685c2.png)
