### PR TITLE
chore(release): v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.1.1](https://github.com/chanzuckerberg/edu-design-system/compare/v3.1.0...v3.1.1) (2022-08-12)
+
+
+### Bug Fixes
+
+* **drawerheader:** correctly refer to color token ([a92c92b](https://github.com/chanzuckerberg/edu-design-system/commit/a92c92b1df000737839bb2473cc60c8563549b1e))
+* **drawerheader:** correctly refer to color token ([84409b3](https://github.com/chanzuckerberg/edu-design-system/commit/84409b372e2c0c84014bae52747a336b167eb1c1))
+
 ## [3.1.0](https://github.com/chanzuckerberg/edu-design-system/compare/v1.5.1...v3.1.0) (2022-08-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",


### PR DESCRIPTION
From changelog:
* **drawerheader:** correctly refer to color token ([a92c92b](https://github.com/chanzuckerberg/edu-design-system/commit/a92c92b1df000737839bb2473cc60c8563549b1e))
(this double committed for some reason, probably because I fumbled the tags (is why this branch is `-b` but is correct now), but is correct in the source)

A patch release as a followup to fix #1226