### PR TITLE
feat(score): add score component

### DIFF
--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -2,9 +2,7 @@ import clsx from 'clsx';
 import React, { MutableRefObject, ReactNode, useEffect, useRef } from 'react';
 import styles from './BaselineCard.module.css';
 
-import { Card, CardBody, CardFooter, CardHeader, Tag } from '../../../src';
-
-import { Variant } from '../../../src/components/Tag/Tag';
+import { Card, CardBody, CardFooter, CardHeader, Score } from '../../../src';
 
 interface Metadata {
   /**
@@ -20,9 +18,9 @@ interface Metadata {
    */
   deadline: string;
   /**
-   * Tag variant for the score. For coloring outline since background and fonts are fixed.
+   * Score variant. For coloring outline since background and fonts are fixed.
    */
-  variant?: Variant;
+  variant: 'success' | 'error' | 'neutral';
 }
 
 export interface Props {
@@ -158,9 +156,8 @@ export const BaselineCard = ({
                     Score
                   </th>
                   <td>
-                    <Tag
+                    <Score
                       className={styles['baseline-card__score']}
-                      hasOutline
                       text={metadata.score}
                       variant={metadata.variant}
                     />

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -3,6 +3,7 @@ import React, { MutableRefObject, ReactNode, useEffect, useRef } from 'react';
 import styles from './BaselineCard.module.css';
 
 import { Card, CardBody, CardFooter, CardHeader, Score } from '../../../src';
+import { Variant } from '../../../src/components/Score/Score';
 
 interface Metadata {
   /**
@@ -20,7 +21,7 @@ interface Metadata {
   /**
    * Score variant. For coloring outline since background and fonts are fixed.
    */
-  variant: 'success' | 'error' | 'neutral';
+  variant: Variant;
 }
 
 export interface Props {

--- a/src/components/Score/Score.module.css
+++ b/src/components/Score/Score.module.css
@@ -1,0 +1,25 @@
+@import '../../design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # SCORE
+\*------------------------------------*/
+
+/**
+ * Rounded rectangle container that houses a score.
+ */
+.score {
+  background-color: transparent;
+}
+
+/**
+ * Color variants
+ */
+.score--success {
+  --tag-secondary-color: var(--eds-theme-color-border-utility-success-strong);
+}
+.score--error {
+  --tag-secondary-color: var(--eds-theme-color-border-utility-error-default);
+}
+.score--neutral {
+  --tag-secondary-color: transparent;
+}

--- a/src/components/Score/Score.module.css
+++ b/src/components/Score/Score.module.css
@@ -8,18 +8,18 @@
  * Rounded rectangle container that houses a score.
  */
 .score {
-  background-color: transparent;
+  --tag-secondary-color: transparent;
 }
 
 /**
  * Color variants
  */
 .score--success {
-  --tag-secondary-color: var(--eds-theme-color-border-utility-success-strong);
+  --tag-outline-color: var(--eds-theme-color-border-utility-success-strong);
 }
 .score--error {
-  --tag-secondary-color: var(--eds-theme-color-border-utility-error-default);
+  --tag-outline-color: var(--eds-theme-color-border-utility-error-default);
 }
 .score--neutral {
-  --tag-secondary-color: transparent;
+  --tag-outline-color: transparent;
 }

--- a/src/components/Score/Score.stories.tsx
+++ b/src/components/Score/Score.stories.tsx
@@ -1,0 +1,36 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import { StoryObj, Meta } from '@storybook/react';
+import React from 'react';
+
+import { Score } from './Score';
+
+export default {
+  title: 'PleaseUpdateThisToADifferentFolder/Score',
+  component: Score,
+  parameters: {
+    badges: [BADGE.BETA],
+  },
+} as Meta<Args>;
+
+type Args = React.ComponentProps<typeof Score>;
+
+export const Success: StoryObj<Args> = {
+  args: {
+    text: '91 / 100',
+    variant: 'success',
+  },
+};
+
+export const Error: StoryObj<Args> = {
+  args: {
+    text: '6 / 10',
+    variant: 'error',
+  },
+};
+
+export const Neutral: StoryObj<Args> = {
+  args: {
+    text: '6 / 10',
+    variant: 'neutral',
+  },
+};

--- a/src/components/Score/Score.test.tsx
+++ b/src/components/Score/Score.test.tsx
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as stories from './Score.stories';
+
+describe('<Score />', () => {
+  generateSnapshots(stories);
+});

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+import React from 'react';
+import styles from './Score.module.css';
+import Tag from '../Tag';
+
+export interface Props {
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
+   * The color variant of the score.
+   */
+  variant: 'success' | 'error' | 'neutral';
+  /**
+   * The score value text.
+   */
+  text: string;
+}
+
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * ```ts
+ * import {Score} from "@chanzuckerberg/eds";
+ * ```
+ *
+ * TODO: update this comment with a description of the component.
+ */
+export const Score = ({ className, variant, ...other }: Props) => {
+  const componentClassName = clsx(
+    styles['score'],
+    styles[`score--${variant}`],
+    className,
+  );
+
+  return <Tag className={componentClassName} {...other} />;
+};

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -34,5 +34,5 @@ export const Score = ({ className, variant, ...other }: Props) => {
     className,
   );
 
-  return <Tag className={componentClassName} {...other} />;
+  return <Tag className={componentClassName} hasOutline {...other} />;
 };

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import styles from './Score.module.css';
 import Tag from '../Tag';
 
+export const VARIANTS = ['neutral', 'error', 'success'] as const;
+
+export type Variant = typeof VARIANTS[number];
+
 export interface Props {
   /**
    * CSS class names that can be appended to the component.
@@ -11,7 +15,7 @@ export interface Props {
   /**
    * The color variant of the score.
    */
-  variant: 'success' | 'error' | 'neutral';
+  variant: Variant;
   /**
    * The score value text.
    */
@@ -25,7 +29,7 @@ export interface Props {
  * import {Score} from "@chanzuckerberg/eds";
  * ```
  *
- * TODO: update this comment with a description of the component.
+ * A (pill shaped badge) wrapper intended for use with scores.
  */
 export const Score = ({ className, variant, ...other }: Props) => {
   const componentClassName = clsx(

--- a/src/components/Score/__snapshots__/Score.test.tsx.snap
+++ b/src/components/Score/__snapshots__/Score.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Score /> Error story renders snapshot 1`] = `
+<span
+  class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--error"
+>
+  <span
+    class="tag__body"
+  >
+    6 / 10
+  </span>
+</span>
+`;
+
+exports[`<Score /> Neutral story renders snapshot 1`] = `
+<span
+  class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--neutral"
+>
+  <span
+    class="tag__body"
+  >
+    6 / 10
+  </span>
+</span>
+`;
+
+exports[`<Score /> Success story renders snapshot 1`] = `
+<span
+  class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--success"
+>
+  <span
+    class="tag__body"
+  >
+    91 / 100
+  </span>
+</span>
+`;

--- a/src/components/Score/index.ts
+++ b/src/components/Score/index.ts
@@ -1,0 +1,1 @@
+export { Score as default } from './Score';

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -11,8 +11,10 @@
  */
 .tag {
   width: max-content;
+  height: var(--eds-size-3);
   max-width: 20rem;
-  padding: var(--eds-size-half) var(--eds-size-1-and-half);
+  padding-left: var(--eds-size-1-and-half);
+  padding-right: var(--eds-size-1-and-half);
 
   display: inline-flex;
   align-items: center;
@@ -22,7 +24,7 @@
 
   background-color: var(--tag-secondary-color); /* 1 */
   color: var(--tag-primary-color);
-  --icon-size-default: 1.25rem;
+  --icon-size-default: 0.875rem;
 }
 
 /**
@@ -41,42 +43,44 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @mixin eds-theme-typography-tag;
 }
 
 /**
  * Color variants.
  */
-.tag--neutral {
+:where(.tag--neutral) {
   --tag-primary-color: var(--eds-theme-color-text-neutral-default);
   --tag-secondary-color: var(--eds-theme-color-background-neutral-subtle);
   --tag-outline-color: var(--eds-theme-color-border-neutral-default);
 }
 
-.tag--error {
+:where(.tag--error) {
   --tag-primary-color: var(--eds-theme-color-text-utility-error);
   --tag-secondary-color: var(--eds-theme-color-background-utility-error);
   --tag-outline-color: var(--eds-theme-color-border-utility-error-default);
 }
 
-.tag--success {
+:where(.tag--success) {
   --tag-primary-color: var(--eds-theme-color-text-utility-success);
   --tag-secondary-color: var(--eds-theme-color-background-utility-success);
   --tag-outline-color: var(--eds-theme-color-border-utility-success-default);
 }
 
-.tag--warning {
+:where(.tag--warning) {
   --tag-primary-color: var(--eds-theme-color-text-utility-warning);
   --tag-secondary-color: var(--eds-theme-color-background-utility-warning);
   --tag-outline-color: var(--eds-theme-color-border-utility-warning-default);
 }
 
-.tag--yield {
+:where(.tag--yield) {
   --tag-primary-color: var(--eds-theme-color-text-grade-revise);
   --tag-secondary-color: var(--eds-theme-color-background-grade-revise-subtle);
   --tag-outline-color: var(--eds-theme-color-border-grade-revise-default);
 }
 
-.tag--brand {
+:where(.tag--brand) {
   --tag-primary-color: var(--eds-theme-color-text-brand-primary);
   --tag-secondary-color: var(
     --eds-theme-color-background-brand-primary-default

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -54,10 +54,10 @@ export const Tag = ({
   hasOutline = false,
 }: Props) => {
   const componentClassName = clsx(
-    className,
     styles['tag'],
     styles[`tag--${variant}`],
     hasOutline && styles['tag--outline'],
+    className,
   );
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { default as PageHeader } from './components/PageHeader';
 export { default as PageLevelBanner } from './components/PageLevelBanner';
 export { default as Panel } from './components/Panel';
 export { default as ProjectCard } from './components/ProjectCard';
+export { default as Score } from './components/Score';
 export { default as Section } from './components/Section';
 export { default as StackedBlock } from './components/StackedBlock';
 export { default as Tab } from './components/Tab';


### PR DESCRIPTION
### Summary:
[sc-209039]
- Motivation
  - a score is needed for Cards and Tables in the Student Refinement Pilot
  - Tag needed styles update to align with UI Kit
  - Arguably, score component itself may not be needed but this incorporates multiple styles overrides and keeps scores components consistent
- Execution
  - <Score> component wraps <Tag>
  - Wraps <Tag> variant styles in `:where()` to allow classname styling
  - Uses tag typography token
### Test Plan:
- No visual regression except for Tag styles changes
- Score snaps written

![Screen Shot 2022-08-16 at 4 21 46 PM](https://user-images.githubusercontent.com/86632227/185001770-3ce2f5de-7fc0-4780-9cfd-ed423bda6ea9.png)
![Screen Shot 2022-08-16 at 4 21 50 PM](https://user-images.githubusercontent.com/86632227/185001771-e620f8d1-f807-4ca5-8e38-abe5d1daa0f1.png)
![Screen Shot 2022-08-16 at 4 21 52 PM](https://user-images.githubusercontent.com/86632227/185001772-251cd7fd-1ed0-408a-94d6-e14107918343.png)

