### PR TITLE
fix(pageheader): remove wrapping div for overline

### DIFF
--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -58,20 +58,10 @@
  * Page header right
  * 1) On larger viewports, add margin-left to keep space between title and header-right content. If additional margin needs to be added (i.e. margin-top on smaller viewports), add a spacing utility class to the contents of header-right.
  */
- .page-header__right {
-  
+.page-header__right {
   @media all and (min-width: $eds-bp-md) {
-    margin-left: var(--eds-size-4); 
+    margin-left: var(--eds-size-4);
   }
-}
-
-/**
- * Page header overline
- * 1) overline is an optional element that appears above the header
- */
-.page-header__overline {
-  margin-top: 0;
-  margin-bottom: var(--eds-size-1);
 }
 
 /**

--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -3,6 +3,7 @@ import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { PageHeader } from './PageHeader';
+import Breadcrumbs from '../Breadcrumbs';
 import Tag from '../Tag';
 import Text from '../Text';
 
@@ -34,6 +35,20 @@ export const WithOverline: StoryObj<Args> = {
       <Text as="div" size="overline">
         Overline above title
       </Text>
+    ),
+    title: 'Page header title',
+    description:
+      'This is a description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+  },
+};
+
+export const WithBreadcrumbs: StoryObj<Args> = {
+  args: {
+    overline: (
+      <Breadcrumbs>
+        <Breadcrumbs.Item href="#" text="My Courses" />
+        <Breadcrumbs.Item href="#" text="(2023) Modern World 1" />
+      </Breadcrumbs>
     ),
     title: 'Page header title',
     description:

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -97,9 +97,7 @@ export const PageHeader = ({
   return (
     <header className={componentClassName} {...other}>
       <div className={styles['page-header__left']}>
-        {overline && (
-          <div className={styles['page-header__overline']}>{overline}</div>
-        )}
+        {overline}
         <Heading
           as={as}
           className={styles['page-header__title']}

--- a/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
+++ b/src/components/PageHeader/__snapshots__/PageHeader.test.tsx.snap
@@ -97,6 +97,99 @@ exports[`<PageHeader /> TwoUp story renders snapshot 1`] = `
 </header>
 `;
 
+exports[`<PageHeader /> WithBreadcrumbs story renders snapshot 1`] = `
+<header
+  class="page-header"
+>
+  <div
+    class="page-header__left"
+  >
+    <nav
+      aria-label="breadcrumbs links"
+      class="breadcrumbs"
+      id="1"
+    >
+      <ul
+        class="breadcrumbs__list"
+      >
+        <li
+          class="breadcrumbs__item breadcrumbs__item-back"
+        >
+          <a
+            class="breadcrumbs__link"
+            href="#"
+          >
+            <svg
+              class="icon breadcrumbs__back-icon"
+              fill="currentColor"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title
+                id="2"
+              >
+                My Courses
+              </title>
+              <use
+                xlink:href="test-file-stub#chevron-left"
+              />
+            </svg>
+          </a>
+          <span
+            aria-hidden="true"
+            class="breadcrumbs__separator"
+          >
+            /
+          </span>
+        </li>
+        <li
+          class="breadcrumbs__item"
+        >
+          <a
+            class="breadcrumbs__link"
+            href="#"
+          >
+            My Courses
+          </a>
+          <span
+            aria-hidden="true"
+            class="breadcrumbs__separator"
+          >
+            /
+          </span>
+        </li>
+        <li
+          class="breadcrumbs__item"
+        >
+          <a
+            class="breadcrumbs__link"
+            href="#"
+          >
+            (2023) Modern World 1
+          </a>
+          <span
+            aria-hidden="true"
+            class="breadcrumbs__separator"
+          >
+            /
+          </span>
+        </li>
+      </ul>
+    </nav>
+    <h1
+      class="page-header__title heading heading--size-headline-lg heading--neutral-strong"
+    >
+      Page header title
+    </h1>
+    <div
+      class="page-header__description"
+    >
+      This is a description Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    </div>
+  </div>
+</header>
+`;
+
 exports[`<PageHeader /> WithDescription story renders snapshot 1`] = `
 <header
   class="page-header"
@@ -126,13 +219,9 @@ exports[`<PageHeader /> WithOverline story renders snapshot 1`] = `
     class="page-header__left"
   >
     <div
-      class="page-header__overline"
+      class="layout-linelength-container text text--overline text-passage text-passage--overline"
     >
-      <div
-        class="layout-linelength-container text text--overline text-passage text-passage--overline"
-      >
-        Overline above title
-      </div>
+      Overline above title
     </div>
     <h1
       class="page-header__title heading heading--size-headline-lg heading--neutral-strong"


### PR DESCRIPTION
### Summary:
- Motivation:
  - There was a request to add an area above the pageheader title for components like breadcrumbs
  - Turned out the area exists, but is wrapped with a div with some set margins
- Execution:
  - Removes the div wrapper
### Test Plan:
- unit tests pass, pageheader snap updated
- no visual regressions except for pageheader overline story

![image](https://user-images.githubusercontent.com/86632227/185005924-b241b60d-460b-4f1a-b403-68cfcc06f161.png)
