### PR TITLE
chore: rename disabled and error classes conventionally

### DIFF
--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -75,9 +75,9 @@ export const GlobalHeader = ({
   const toggleMenu = () => {
     setisActive(!isActive);
     if (isActive) {
-      document.body.classList.remove('eds-is-disabled');
+      document.body.classList.remove('body--disabled');
     } else {
-      document.body.classList.add('eds-is-disabled');
+      document.body.classList.add('body--disabled');
     }
   };
 

--- a/src/components/FieldNote/FieldNote.module.css
+++ b/src/components/FieldNote/FieldNote.module.css
@@ -12,29 +12,28 @@
   @mixin eds-theme-typography-body-text-xs;
   margin-top: var(--eds-size-half);
   color: var(--eds-theme-color-text-neutral-subtle);
-
-  /**
-     * Field note inside a field that has an error 
-     */
-  &.eds-is-error {
-    color: var(--eds-theme-color-text-utility-error);
-  }
 }
 
 /**
   * Fieldnote icon
   */
-.field-note__icon.field-note__icon {
+.field-note__icon {
   height: var(--eds-size-2);
   width: var(--eds-size-2);
   position: relative;
   bottom: 1px;
+}
 
-  .eds-is-error & {
-    display: inline-block;
-    position: relative;
-    margin-right: var(--eds-size-1);
-  }
+/**
+ * Error variant
+ */
+.field-note--error {
+  color: var(--eds-theme-color-text-utility-error);
+}
+.field-note--error > .field-note__icon {
+  display: inline-block;
+  position: relative;
+  margin-right: var(--eds-size-1);
 }
 
 /**

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -50,7 +50,7 @@ export const FieldNote = ({
     styles['field-note'],
     className,
     inverted && styles['field-note--inverted'],
-    isError && styles['eds-is-error'],
+    isError && styles['field-note--error'],
   );
   return (
     <div

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -192,8 +192,6 @@ export const TextField = ({
     styles['text-field'],
     className,
     inverted && styles['text-field--inverted'],
-    isError && styles['eds-is-error'],
-    disabled && styles['eds-is-disabled'],
   );
 
   return (

--- a/src/components/TextField/__snapshots__/TextField.test.ts.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.ts.snap
@@ -36,7 +36,7 @@ exports[`<TextField /> Default story renders snapshot 1`] = `
 
 exports[`<TextField /> Disabled story renders snapshot 1`] = `
 <div
-  class="text-field eds-is-disabled"
+  class="text-field"
 >
   <label
     class="label text-field__label"
@@ -50,7 +50,7 @@ exports[`<TextField /> Disabled story renders snapshot 1`] = `
   >
     <input
       aria-invalid="false"
-      class="text-input text-field__input eds-is-disabled"
+      class="text-input text-field__input"
       data-bootstrap-override="textinput"
       disabled=""
       id="8"
@@ -63,7 +63,7 @@ exports[`<TextField /> Disabled story renders snapshot 1`] = `
 
 exports[`<TextField /> Error story renders snapshot 1`] = `
 <div
-  class="text-field eds-is-error"
+  class="text-field"
 >
   <label
     class="label text-field__label"
@@ -78,7 +78,7 @@ exports[`<TextField /> Error story renders snapshot 1`] = `
     <input
       aria-describedby="6"
       aria-invalid="true"
-      class="text-input text-field__input eds-is-error"
+      class="text-input error text-field__input"
       data-bootstrap-override="textinput"
       id="5"
       type="text"
@@ -87,7 +87,7 @@ exports[`<TextField /> Error story renders snapshot 1`] = `
   </div>
   <div
     aria-live="assertive"
-    class="field-note text-field__note eds-is-error"
+    class="field-note text-field__note field-note--error"
     id="6"
   >
     <svg

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -65,7 +65,7 @@ export interface Props {
    */
   onChange?: ChangeEventHandler;
   /**
-   * Input pattern
+   * Defines a regular expression that the input's value must match in order for the value to pass constraint validation.
    */
   pattern?: string;
   /**
@@ -120,58 +120,23 @@ export interface Props {
  * ```
  */
 export const TextInput = ({
-  accept,
-  'aria-describedby': ariaDescribedBy,
   className,
   disabled,
   id,
-  inputMode,
   isError,
-  min,
-  max,
-  maxLength,
-  multiple,
-  name,
-  pattern,
-  onChange,
-  placeholder,
-  readOnly,
-  required,
-  type,
-  title,
-  value,
-  defaultValue,
   ...other
 }: Props) => {
   const componentClassName = clsx(
     styles['text-input'],
+    isError && styles['error'],
     className,
-    disabled && styles['eds-is-disabled'],
-    isError && styles['eds-is-error'],
   );
 
   return (
     <input
-      accept={accept}
-      aria-describedby={ariaDescribedBy}
       className={componentClassName}
-      defaultValue={defaultValue}
       disabled={disabled}
       id={id}
-      inputMode={inputMode}
-      max={max}
-      maxLength={maxLength}
-      min={min}
-      multiple={multiple}
-      name={name}
-      onChange={onChange}
-      pattern={pattern}
-      placeholder={placeholder}
-      readOnly={readOnly}
-      required={required}
-      title={title}
-      type={type}
-      value={value}
       {...other}
     />
   );

--- a/src/components/TextInput/__snapshots__/TextInput.test.ts.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.ts.snap
@@ -3,6 +3,5 @@
 exports[`<TextInput /> Default story renders snapshot 1`] = `
 <input
   class="text-input"
-  value=""
 />
 `;

--- a/src/design-tokens/css/base/body.css
+++ b/src/design-tokens/css/base/body.css
@@ -9,12 +9,13 @@ body {
   margin: 0;
   color: var(--eds-theme-color-text-neutral-default);
   background: var(--eds-theme-color-background-neutral-subtle);
+}
 
-  &.eds-is-disabled {
-    overflow: hidden;
-    width: 100%;
-    min-height: 100%;
-  }
+/* Body disabled variant */
+.body--disabled {
+  overflow: hidden;
+  width: 100%;
+  min-height: 100%;
 }
 
 /* Body with light background on small screens */

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -116,29 +116,21 @@
   /**
    * Input error state
    */
-  &.eds-is-error {
+  &.error {
     border-color: var(--eds-theme-color-border-utility-error-strong);
   }
 
   /**
    * Disabled state
    */
-  &.eds-is-disabled {
+  &:disabled {
     background-color: var(--eds-theme-color-background-disabled);
     border-color: var(--eds-theme-color-border-disabled);
     color: var(--eds-theme-color-text-disabled);
     cursor: not-allowed;
   }
 
-  &::-webkit-input-placeholder {
-    @mixin placeholderStyles;
-  }
-
-  &::-moz-placeholder {
-    @mixin placeholderStyles;
-  }
-
-  &:-ms-input-placeholder {
+  &::placeholder {
     @mixin placeholderStyles;
   }
 }
@@ -150,7 +142,6 @@
 }
 
 @define-mixin placeholderStyles {
-  font-style: italic;
   color: var(--eds-theme-color-text-neutral-subtle);
 }
 

--- a/src/upcoming-components/CheckboxField/CheckboxField.tsx
+++ b/src/upcoming-components/CheckboxField/CheckboxField.tsx
@@ -97,8 +97,6 @@ export const CheckboxField = ({
     variant === 'inline' && styles['checkbox-field--inline'],
     size === 'sm' && styles['checkbox-field--sm'],
     inverted && styles['checkbox-field--inverted'],
-    isError && styles['eds-is-error'],
-    disabled && styles['eds-is-disabled'],
   );
   return (
     <Fieldset className={componentClassName} id={id} {...other}>

--- a/src/upcoming-components/CheckboxField/CheckboxField.tsx
+++ b/src/upcoming-components/CheckboxField/CheckboxField.tsx
@@ -23,6 +23,7 @@ export interface Props {
   className?: string;
   /**
    * Disables the field and prevents editing the contents
+   * TODO: disabled variant needs to be styled. Checkbox components themselves already support disabled styling.
    */
   disabled?: boolean;
   /**
@@ -79,7 +80,6 @@ export const CheckboxField = ({
   label,
   isError,
   fieldNote,
-  disabled,
   'aria-describedby': ariaDescribedBy,
   children,
   optionalLabel,
@@ -91,6 +91,7 @@ export const CheckboxField = ({
     ? ariaDescribedBy || generatedId
     : undefined;
 
+  // TODO: disabled variant styling
   const componentClassName = clsx(
     styles['checkbox-field'],
     className,

--- a/src/upcoming-components/Counter/Counter.module.css
+++ b/src/upcoming-components/Counter/Counter.module.css
@@ -24,10 +24,10 @@
   border-style: solid;
   border-color: var(--eds-theme-color-form-border);
   border-radius: var(--eds-theme-form-border-radius);
+}
 
-  .eds-is-error & {
-    border-color: var(--eds-theme-color-border-utility-error-strong);
-  }
+.counter--error > .counter__body {
+  border-color: var(--eds-theme-color-border-utility-error-strong);
 }
 
 /**

--- a/src/upcoming-components/Counter/Counter.tsx
+++ b/src/upcoming-components/Counter/Counter.tsx
@@ -154,9 +154,8 @@ export const Counter = ({
 
   const componentClassName = clsx(
     styles['counter'],
+    isError && styles['counter--error'],
     className,
-    isError && styles['eds-is-error'],
-    disabled && styles['eds-is-disabled'],
   );
   return (
     <div className={componentClassName} {...other}>

--- a/src/upcoming-components/FileUploadField/FileUploadField.module.css
+++ b/src/upcoming-components/FileUploadField/FileUploadField.module.css
@@ -45,36 +45,26 @@
   &.file-upload-field__hit-area--drag-over {
     border-color: var(--eds-theme-color-form-input-border-focus);
   }
-
-  /**
-   * Hit area within error state
-   */
-  .eds-is-error & {
-    border-color: var(--eds-theme-color-border-utility-error-strong);
-  }
-
-  /**
-   * Hit area within disabled field
-   */
-  .eds-is-disabled & {
-    border-color: var(--eds-theme-color-border-disabled);
-    background: var(--eds-theme-color-background-disabled);
-    color: var(--eds-theme-color-text-disabled);
-    cursor: not-allowed;
-
-    &.file-upload-field__hit-area--drag-over {
-      border-color: var(--eds-theme-color-disabled-border);
-    }
-  }
+}
+.file-upload-field--error > .file-upload-field__hit-area {
+  border-color: var(--eds-theme-color-border-utility-error-strong);
+}
+.file-upload-field--disabled > .file-upload-field__hit-area {
+  border-color: var(--eds-theme-color-border-disabled);
+  background: var(--eds-theme-color-background-disabled);
+  color: var(--eds-theme-color-text-disabled);
+  cursor: not-allowed;
+}
+.file-upload-field--disabled
+  > .file-upload-field__hit-area.file-upload-field__hit-area--drag-over {
+  border-color: var(--eds-theme-color-disabled-border);
 }
 
 /**
- * Label 
+ * Label, disabled variant
  */
-.file-upload-field__label {
-  .eds-is-disabled & {
-    color: var(--eds-theme-color-text-disabled);
-  }
+.file-upload-field--disabled > .file-upload-field__label {
+  color: var(--eds-theme-color-text-disabled);
 }
 
 /**
@@ -100,23 +90,17 @@
   outline: none;
   opacity: 0;
   cursor: pointer;
-
-  .eds-is-disabled & {
-    cursor: not-allowed;
-  }
 }
 
 /**
  * file-upload-field note
  */
-.file-upload-field__note {
+.file-upload-field--error > .file-upload-field__note {
   /**
-     * file-upload-field note within error state
-     * 1) Set to display flex to place icon next to the fieldnote
-     */
-  .eds-is-error & {
-    display: inline-flex;
-  }
+   * file-upload-field note within error state
+   * 1) Set to display flex to place icon next to the fieldnote
+   */
+  display: inline-flex;
 }
 
 /**

--- a/src/upcoming-components/FileUploadField/FileUploadField.tsx
+++ b/src/upcoming-components/FileUploadField/FileUploadField.tsx
@@ -311,9 +311,9 @@ export const FileUploadField = ({
 
   const componentClassName = clsx(
     styles['file-upload-field'],
+    isErrorState && styles['file-upload-field--error'],
+    isDisabled && styles['file-upload-field--disabled'],
     className,
-    isErrorState && styles['eds-is-error'],
-    isDisabled && styles['eds-is-disabled'],
   );
 
   const hitAreaClassName = clsx(

--- a/src/upcoming-components/RadioField/RadioField.module.css
+++ b/src/upcoming-components/RadioField/RadioField.module.css
@@ -92,11 +92,10 @@
   .radio-field--inverted & {
     color: var(--eds-theme-color-text-neutral-default-inverse);
   }
-
-  .radio-field.eds-is-disabled & {
-    color: var(--eds-theme-color-text-disabled);
-    cursor: not-allowed;
-  }
+}
+.radio-field--disabled > .radio-field__item-label {
+  color: var(--eds-theme-color-text-disabled);
+  cursor: not-allowed;
 }
 
 .radio-field__item-after {

--- a/src/upcoming-components/RadioField/RadioField.tsx
+++ b/src/upcoming-components/RadioField/RadioField.tsx
@@ -147,12 +147,11 @@ export const RadioField = ({
 
   const componentClassName = clsx(
     styles['radio-field'],
-    className,
     variant === 'inline' && styles['radio-field--inline'],
     size === 'sm' && styles['radio-field--sm'],
     inverted && styles['radio-field--inverted'],
-    isError && styles['eds-is-error'],
-    disabled && styles['eds-is-disabled'],
+    disabled && styles['radio-field--disabed'],
+    className,
   );
   return (
     <Fieldset className={componentClassName} id={id} {...other}>

--- a/src/upcoming-components/RadioField/RadioField.tsx
+++ b/src/upcoming-components/RadioField/RadioField.tsx
@@ -150,7 +150,7 @@ export const RadioField = ({
     variant === 'inline' && styles['radio-field--inline'],
     size === 'sm' && styles['radio-field--sm'],
     inverted && styles['radio-field--inverted'],
-    disabled && styles['radio-field--disabed'],
+    disabled && styles['radio-field--disabled'],
     className,
   );
   return (

--- a/src/upcoming-components/Textarea/Textarea.tsx
+++ b/src/upcoming-components/Textarea/Textarea.tsx
@@ -96,7 +96,11 @@ export const Textarea = ({
   defaultValue,
   ...other
 }: Props) => {
-  const componentClassName = clsx(styles['textarea'], className);
+  const componentClassName = clsx(
+    styles['textarea'],
+    isError && styles['error'],
+    className,
+  );
 
   return (
     <textarea

--- a/src/upcoming-components/Textarea/Textarea.tsx
+++ b/src/upcoming-components/Textarea/Textarea.tsx
@@ -96,12 +96,7 @@ export const Textarea = ({
   defaultValue,
   ...other
 }: Props) => {
-  const componentClassName = clsx(
-    styles['textarea'],
-    className,
-    disabled && styles['eds-is-disabled'],
-    isError && styles['eds-is-error'],
-  );
+  const componentClassName = clsx(styles['textarea'], className);
 
   return (
     <textarea

--- a/src/upcoming-components/TextareaField/TextareaField.tsx
+++ b/src/upcoming-components/TextareaField/TextareaField.tsx
@@ -165,8 +165,6 @@ export const TextareaField = ({
     styles['textarea-field'],
     className,
     inverted && styles['textarea-field--inverted'],
-    isError && styles['eds-is-error'],
-    disabled && styles['eds-is-disabled'],
   );
 
   return (


### PR DESCRIPTION
### Summary:
- motivation 
  - for input field migration, error and disabled handling is better styled more conventionally to our repo
- execution
  - this renames `eds-is-error` and `eds-is-disabled` which are BM remnants to `--error` and `--disabled` or the psuedoclass`:disabled` and unnests those classes from their stylesheets
  - also un-italicizes placeholder mixin to match mocks
### Test Plan:
- new unit snaps
- no visual regressions