### PR TITLE
chore(clickable-style): make transition target more specific

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -22,10 +22,17 @@
   border-radius: var(--eds-border-radius-md);
   cursor: pointer;
   text-decoration: none; /* 4 */
-  transition: all var(--eds-anim-fade-quick) var(--eds-anim-ease);
+  transition-property: color, background-color, border-color;
+  transition-duration: var(--eds-anim-fade-quick);
+  transition-timing-function: var(--eds-anim-ease);
 
   svg {
     --icon-size-default: 2em; /* 5 */
+    transition: color var(--eds-anim-fade-quick) var(--eds-anim-ease);
+
+    @media screen and (prefers-reduced-motion) {
+      transition: none;
+    }
   }
 
   &:focus {


### PR DESCRIPTION
### Summary:
Currently our buttons don't have visible focus outlines in Safari. Through process of elimination, I found that the source of the issue is the `transition` styling. The `transition` is targeting `all`, not specific CSS properties (which is considered best practice). I don't know exactly what's going on, but making the transition specific, which I was planning to do anyway at some point, fixes this.

### Test Plan:
Open storybook in Safari,
navigate to either the `Button` component and a component that uses it (like the dismissable `PageLevelBanner` stories),
tab to the button with your keyboard,
and verify the focus outline is visible.

(Please note that you need to have turned on the "Press Tab to highlight each item on a webpage" accessibility setting in Safari to see this functionality.)