### PR TITLE
chore: use focus-visible instead of focus

### DIFF
--- a/.storybook/components/TokenSpecimen/TokenSpecimen.css
+++ b/.storybook/components/TokenSpecimen/TokenSpecimen.css
@@ -74,7 +74,7 @@
   transition: all 0.15s ease;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     opacity: 0.2;
   }
 }
@@ -83,7 +83,7 @@
   transition: all 0.15s ease;
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     transform: translateX(-3rem);
   }
 }

--- a/.storybook/recipes/BaselineCard/BaselineCard.module.css
+++ b/.storybook/recipes/BaselineCard/BaselineCard.module.css
@@ -86,7 +86,7 @@
   word-wrap: normal !important; /* 4 */
 }
 
-.baseline-card__link:focus {
+.baseline-card__link:focus-visible {
   @mixin eds-theme-typography-body-text-sm;
   background-color: var(--eds-theme-color-background-neutral-default);
   clip: auto !important; /* 5 */

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -49,7 +49,7 @@
   color: var(--eds-theme-color-text-neutral-default-inverse);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(
       --eds-theme-color-button-primary-brand-background-hover
     ); /* TODO */

--- a/.storybook/recipes/PageShell/PageShell.module.css
+++ b/.storybook/recipes/PageShell/PageShell.module.css
@@ -23,7 +23,7 @@
   transform: translateY(-100%);
   transition: transform var(--eds-anim-fade-quick);
 
-  &:focus {
+  &:focus-visible {
     transform: translateY(0%);
   }
 

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -113,7 +113,7 @@ EDS uses [PostCSS Nested](https://github.com/postcss/postcss-nested) to provide 
   background: var(--eds-theme-color-background-brand-primary-strong);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-background-brand-primary-strong-hover);
   }
 
@@ -269,6 +269,30 @@ Use:
 import { EdsThemeColorUtilitySuccessForeground } from 'src/tokens-dist/ts/colors';
 
 <Icon color={EdsThemeColorUtilitySuccessForeground} />;
+```
+
+- Use `:focus-visible` instead of `:focus`
+
+This allows focus indicators to appear for keyboard users while remaining hidden from mouse-only users.
+
+Instead of:
+
+```scss
+.button--primary {
+  &:focus {
+    @mixin focus;
+  }
+}
+```
+
+Use:
+
+```scss
+.button--primary {
+  &:focus-visible {
+    @mixin focus;
+  }
+}
 ```
 
 ## Utility classes <a name="utility-classes"></a>

--- a/docs/TOKENS.md
+++ b/docs/TOKENS.md
@@ -145,7 +145,7 @@ Additional branded values ("secondary", "tertiary", "accent", "supports", etc) c
 
 #### Focus colors
 
-- `focus-ring` defines the focus ring color used for component `:focus` state
+- `focus-ring` defines the focus ring color used for component `:focus-visible` state
 
 #### Link colors
 

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -80,7 +80,7 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     text-decoration: underline;
   }
 

--- a/src/components/CheckboxInput/CheckboxInput.module.css
+++ b/src/components/CheckboxInput/CheckboxInput.module.css
@@ -47,7 +47,7 @@
 .checkbox__icon {
   color: var(--eds-theme-color-icon-brand-primary);
 }
-.checkbox__input:focus + .checkbox__icon {
+.checkbox__input:focus-visible + .checkbox__icon {
   @mixin focus; /* 1 */
   outline-offset: -2px;
 }

--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -28,7 +28,7 @@
     --icon-size-default: 2em; /* 5 */
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
   }
 
@@ -492,7 +492,7 @@
     text-decoration-color: var(--eds-theme-color-border-neutral-strong);
   }
 
-  &:focus {
+  &:focus-visible {
     background-color: var(--eds-theme-color-icon-neutral-strong); /* 1 */
   }
 }

--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -196,8 +196,8 @@
   }
 
   .drag-drop__item--hover:hover &,
-  .drag-drop__item--hover:focus &,
-  &:focus {
+  .drag-drop__item--hover:focus-visible &,
+  &:focus-visible {
     opacity: 1;
   }
 }

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -72,7 +72,7 @@
   transition: background var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-background-neutral-subtle);
   }
 

--- a/src/components/ModalBody/ModalBody.module.css
+++ b/src/components/ModalBody/ModalBody.module.css
@@ -12,6 +12,6 @@
   flex: 1;
 }
 
-.modal-body:focus {
+.modal-body:focus-visible {
   @mixin focusInside;
 }

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -18,7 +18,7 @@
   transition: background var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-button-primary-brand-background-hover);
   }
 

--- a/src/components/RadioInput/RadioInput.module.css
+++ b/src/components/RadioInput/RadioInput.module.css
@@ -45,7 +45,7 @@
   color: var(--eds-theme-color-icon-brand-primary);
   border: var(--eds-border-width-sm) solid transparent; /* 1 */
 }
-.radio__input:focus + .radio__icon {
+.radio__input:focus-visible + .radio__icon {
   border: var(--eds-border-width-sm) solid var(--eds-theme-color-focus-ring);
   border-radius: 9999px;
 }

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -201,7 +201,7 @@
     background-color var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: var(--eds-theme-color-text-neutral-default);
   }
 

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -40,7 +40,7 @@
     text-decoration-color: var(--eds-theme-color-border-brand-primary);
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 1px solid transparent; /* 7 */
     color: var(--eds-theme-color-text-neutral-default-inverse) !important;
     text-decoration-color: var(

--- a/src/upcoming-components/FileUploadField/FileUploadField.module.css
+++ b/src/upcoming-components/FileUploadField/FileUploadField.module.css
@@ -35,7 +35,7 @@
     border-color: var(--eds-theme-color-form-input-border-hover);
   }
 
-  &:focus,
+  &:focus-visible,
   &:focus-within {
     border-color: var(--eds-theme-color-form-input-border-focus);
   }


### PR DESCRIPTION
### Summary:
We got a comment that link focus styles seem "sticky" because after you click on them as a mouse user, the link stays focused until you click on something else. This didn't really bother people until we added the link focus style, which is a solid purple background. But if we're going to change that, we should just change all interactive elements to work the same way.

So in this PR, I'm changing `&:focus` styles to instead use `&:focus-visible`. We already have a few instances of this in the codebase, but now it will be universal. I also added a line to the documentation to this effect.

### Test Plan:
I went through all of the interactive components and recipes (but not pages) and verified that interactive elements shows a focus styles on keyboard interaction and no focus styles when clicked with mouse/trackpad.

(I didn't test pages because they're made up of components I'd already tested. I probably didn't need to test recipes either but I wanted to try to be thorough.)