### PR TITLE
fix(fieldnote): match error icon color to mocks

### DIFF
--- a/src/components/FieldNote/FieldNote.module.css
+++ b/src/components/FieldNote/FieldNote.module.css
@@ -22,15 +22,19 @@
 }
 
 /**
+ * Disabled variant
+ */
+.field-note--disabled {
+  color: var(--eds-theme-color-text-disabled);
+}
+
+/**
  * Error variant
  */
 .field-note--error {
   color: var(--eds-theme-color-text-utility-error);
 }
-.field-note--disabled {
-  color: var(--eds-theme-color-text-disabled);
-}
-.field-note--error.field-note__icon {
+.field-note--error > .field-note__icon {
   color: var(--eds-theme-color-icon-utility-error);
 }
 


### PR DESCRIPTION
### Summary:
- icon was not properly receiving color token
- fixes css selection to receive color token
### Test Plan:
- unit tests pass
- visual regression on error icon color only

![image](https://user-images.githubusercontent.com/86632227/187496604-9202feab-1641-4533-ac4f-91033727bbb6.png)
