### PR TITLE
Add back tailwind utilities for stories & recipes

### DIFF
--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -31,7 +31,6 @@ import {
 } from '../../../src/tokens-dist/ts/colors';
 import NumberIconList from '../../recipes/NumberIconList';
 import { PageShell } from '../../recipes/PageShell/PageShell';
-import '../../../src/components/Utilities/Spacing.css';
 
 export interface Props {
   /**
@@ -42,15 +41,15 @@ export interface Props {
 
 export const FeedbackOverview = ({ activeIndex = 0 }: Props) => (
   <PageShell className="body--alternate">
-    <Breadcrumbs className="u-margin-bottom-md">
+    <Breadcrumbs className="mb-4">
       <BreadcrumbsItem href="#" text="My Courses" />
       <BreadcrumbsItem href="#" text="Modern World 2" />
     </Breadcrumbs>
     <PageHeader
-      className="u-margin-bottom-xl u-flex-direction-row"
+      className="!mb-8 !flex-row"
       right={
         <Button status="neutral" variant="icon">
-          <div className="u-mobile-hidden">More options</div>
+          <div className="sr-only lg:not-sr-only">More options</div>
           <Icon name="dots-vertical" purpose="decorative" />
         </Button>
       }

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 // Import base-level styles
 import '../src/design-tokens/css/base/reset.css';
+import '../src/design-tokens/css/base/tailwind.css';
 import '../src/design-tokens/css/base/body.css';
 import '../src/design-tokens/css/base/media.css';
 

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,7 +4,7 @@
     "at-rule-no-unknown": [
       true,
       {
-        "ignoreAtRules": ["define-mixin", "mixin"]
+        "ignoreAtRules": ["define-mixin", "mixin", "tailwind"]
       }
     ],
     "custom-property-empty-line-before": "never",

--- a/package.json
+++ b/package.json
@@ -17,19 +17,20 @@
     "url": "https://github.com/chanzuckerberg/edu-design-system/issues"
   },
   "files": [
-    "/lib"
+    "/lib",
+    "tailwind.config.js"
   ],
   "scripts": {
     "build": "yarn build:clean && yarn build:tokens && yarn build:js && yarn build:styles && yarn copy-to-lib",
     "build:clean": "rm -rf lib/",
-    "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js",
+    "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn copy-tokens-to-lib",
     "build:icons": "svg-sprite-generate -d src/icons/ -o src/icons/spritemap/spritemap.svg && yarn generate-icon-types",
     "build:js": "tsc --project tsconfig.build.json",
     "build:storybook": "build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",
     "build:styles": "postcss \"src/components/**/*.css\" --dir lib/ --base src/ --verbose",
     "chromatic": "chromatic",
     "commit": "./node_modules/.bin/cz",
-    "copy-to-lib": "yarn copy-icons-to-lib && yarn copy-tokens-to-lib && yarn copy-fonts-to-lib",
+    "copy-to-lib": "yarn copy-icons-to-lib && yarn copy-fonts-to-lib",
     "copy-fonts-to-lib": "copyfiles -u 3 src/design-tokens/tier-1-definitions/fonts.css src/design-tokens/tier-1-definitions/fonts/**/* lib/tokens",
     "copy-icons-to-lib": "copyfiles -u 1 src/icons/spritemap/**/* lib",
     "copy-tokens-to-lib": "copyfiles -u 2 src/tokens-dist/**/* lib/tokens",
@@ -168,6 +169,7 @@
     "stylelint-config-recommended": "^7.0.0",
     "svg-sprite-generator": "^0.0.7",
     "svg-spritemap-webpack-plugin": "^3.9.1",
+    "tailwindcss": "^3.1.8",
     "ts-jest": "^27.1.3",
     "typescript": "^4.6.2",
     "web-vitals": "^2.1.4"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,12 +1,15 @@
 const breakpoints = require('./src/design-tokens/tier-1-definitions/breakpoints');
 
 module.exports = {
-  plugins: [
-    require('postcss-import')({
+  plugins: {
+    'postcss-import': {
       addModulesDirectories: ['node_modules'],
-    }),
-    require('postcss-mixins'),
-    require('postcss-nested'),
-    require('postcss-simple-vars')({ variables: breakpoints }),
-  ],
+    },
+    'postcss-mixins': {},
+    'postcss-simple-vars': { variables: breakpoints },
+    // TODO: replace with tailwindcss/nesting (https://tailwindcss.com/docs/using-with-preprocessors#nesting)
+    // to silence warnings; for some reason this is not working currently.
+    'postcss-nested': {},
+    tailwindcss: {},
+  },
 };

--- a/src/components/Drawer/DrawerExample.tsx
+++ b/src/components/Drawer/DrawerExample.tsx
@@ -31,7 +31,7 @@ export const DrawerExample = () => {
     setDrawerOpen(false);
   }
   return (
-    <div style={{ padding: '1rem', minHeight: '500px' }}>
+    <div className="p-4 min-h-[500px]">
       <Button onClick={openDrawerExample} ref={drawerButton} variant="primary">
         Open Drawer
       </Button>

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.module.css
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.module.css
@@ -1,6 +1,0 @@
-/**
- * Caps dividing line to 120px width.
- */
-.capped-line {
-  max-width: 120px;
-}

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
@@ -2,7 +2,6 @@ import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { HorizontalStepper } from './HorizontalStepper';
-import styles from './HorizontalStepper.stories.module.css';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import HorizontalStep from '../HorizontalStep';
@@ -17,11 +16,8 @@ export default {
   },
   decorators: [
     (Story) => (
-      <div
-        style={{
-          margin: '1rem', // Pushes contents away from storybook borders.
-        }}
-      >
+      // Pushes contents away from storybook borders.
+      <div className="m-4">
         <Story />
       </div>
     ),
@@ -88,7 +84,7 @@ export const Interactive: StoryObj<Args> = {
 
 export const HorizontalSteps: StoryObj<Args> = {
   render: () => (
-    <ol style={{ padding: 0 }}>
+    <ol className="p-0">
       <HorizontalStep
         stepNumber={1}
         text="Horizontal step"
@@ -106,7 +102,7 @@ export const HorizontalSteps: StoryObj<Args> = {
 
 export const HorizontalStepsDifferentNumbers: StoryObj<Args> = {
   render: () => (
-    <ol style={{ padding: 0 }}>
+    <ol className="p-0">
       <HorizontalStep stepNumber={1} text="Horizontal step" variant="active" />
       <HorizontalStep stepNumber={2} text="Horizontal step" variant="active" />
       <HorizontalStep stepNumber={3} text="Horizontal step" variant="active" />
@@ -128,6 +124,6 @@ export const HorizontalStepsDifferentNumbers: StoryObj<Args> = {
 
 export const CappedLine: StoryObj<Args> = {
   args: {
-    linesClassName: styles['capped-line'],
+    linesClassName: 'max-w-[120px]',
   },
 };

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
     class="horizontal-stepper"
@@ -25,7 +25,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     </li>
     <hr
       aria-hidden="true"
-      class="horizontal-stepper__line capped-line"
+      class="horizontal-stepper__line max-w-[120px]"
     />
     <li
       class="horizontal-step horizontal-step--incomplete"
@@ -62,7 +62,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     </li>
     <hr
       aria-hidden="true"
-      class="horizontal-stepper__line capped-line"
+      class="horizontal-stepper__line max-w-[120px]"
     />
     <li
       class="horizontal-step horizontal-step--incomplete"
@@ -99,7 +99,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     </li>
     <hr
       aria-hidden="true"
-      class="horizontal-stepper__line capped-line"
+      class="horizontal-stepper__line max-w-[120px]"
     />
     <li
       class="horizontal-step horizontal-step--incomplete"
@@ -136,7 +136,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
     </li>
     <hr
       aria-hidden="true"
-      class="horizontal-stepper__line capped-line"
+      class="horizontal-stepper__line max-w-[120px]"
     />
     <li
       class="horizontal-step horizontal-step--incomplete"
@@ -177,7 +177,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
 
 exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
     class="horizontal-stepper"
@@ -339,10 +339,10 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
 
 exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
-    style="padding: 0px;"
+    class="p-0"
   >
     <li
       class="horizontal-step horizontal-step--incomplete"
@@ -426,10 +426,10 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
 
 exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
-    style="padding: 0px;"
+    class="p-0"
   >
     <li
       class="horizontal-step horizontal-step--active"
@@ -677,7 +677,7 @@ exports[`<HorizontalStepper /> HorizontalStepsDifferentNumbers story renders sna
 
 exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
     class="horizontal-stepper"
@@ -852,7 +852,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
 
 exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
     class="horizontal-stepper"
@@ -1003,7 +1003,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
 
 exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <ol
     class="horizontal-stepper"

--- a/src/design-tokens/css/base/tailwind.css
+++ b/src/design-tokens/css/base/tailwind.css
@@ -1,0 +1,15 @@
+/**
+ * This injects Tailwind's base styles and any base styles registered by
+ * plugins.
+ */
+@tailwind base;
+/**
+* This injects Tailwind's component classes and any component classes
+* registered by plugins.
+*/
+@tailwind components;
+/**
+* This injects Tailwind's utility classes and any utility classes registered
+* by plugins.
+*/
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,6 +12,17 @@ module.exports = {
     './src/components/**/*Example.tsx',
     './.storybook/**/*.{js,jsx,ts,tsx}',
   ],
+  corePlugins: {
+    /**
+     * Disable Tailwind's preflight (CSS reset) styles.
+     * We're only using Tailwind for stories/recipes, and some of those
+     * (esp. documentation pages) depend on browser default styles.
+     *
+     * Remove this setting if we are turning on Tailwind for component styles,
+     * so we will better match consuming apps.
+     */
+    preflight: false,
+  },
   theme: {
     colors: {
       transparent: 'transparent',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,50 @@
+const variableTokens = require('./lib/tokens/json/css-variables-nested.json');
+const staticTokens = require('./lib/tokens/json/variables-nested.json');
+
+module.exports = {
+  /**
+   * The main value in TW utility classes is for Storybook stories & recipes.
+   * We avoid using them in component styles to reduce chance of conflict with other libraries.
+   * Please configure downstream Tailwind config purge to include app files if necessary.
+   */
+  content: [
+    './src/components/**/*.stories.{ts,tsx}',
+    './src/components/**/*Example.tsx',
+    './.storybook/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    colors: {
+      transparent: 'transparent',
+      ...variableTokens.eds.color,
+    },
+    fontSize: {
+      // provide values for both font-size and line-height
+      // sync with src/design-tokens/tier-1-definitions/typography-presets.css
+      body: [staticTokens.eds['font-size']['16'], '1.5'],
+      h1: [staticTokens.eds['font-size']['40'], '1.2'],
+      h2: [staticTokens.eds['font-size']['32'], '1.25'],
+      h3: [staticTokens.eds['font-size']['24'], '1.333'],
+      h4: [staticTokens.eds['font-size']['18'], '1.333'],
+      h5: [staticTokens.eds['font-size']['16'], '1.5'],
+      h6: [staticTokens.eds['font-size']['14'], '1.57'],
+      h7: [staticTokens.eds['font-size']['12'], '1.666'],
+      sm: [staticTokens.eds['font-size']['14'], '1.57'],
+      xs: [staticTokens.eds['font-size']['12'], '1.666'],
+      caption: [staticTokens.eds['font-size']['12'], '1.666'],
+    },
+    fontWeight: {
+      normal: staticTokens.eds['font-weight'].light,
+      medium: staticTokens.eds['font-weight'].medium,
+      bold: staticTokens.eds['font-weight'].bold,
+    },
+    // sync with src/design-tokens/tier-1-definitions/breakpoints.js
+    screens: {
+      xs: '375px',
+      sm: '560px',
+      md: '768px',
+      lg: '960px',
+      xl: '1200px',
+      xxl: '1400px',
+    },
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1889,6 +1889,7 @@ __metadata:
     svg-sprite-generator: ^0.0.7
     svg-spritemap-webpack-plugin: ^3.9.1
     svg4everybody: ^2.1.9
+    tailwindcss: ^3.1.8
     ts-jest: ^27.1.3
     typescript: ^4.6.2
     web-vitals: ^2.1.4
@@ -5683,7 +5684,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^7.1.1, acorn-walk@npm:^7.2.0":
+"acorn-node@npm:^1.8.2":
+  version: 1.8.2
+  resolution: "acorn-node@npm:1.8.2"
+  dependencies:
+    acorn: ^7.0.0
+    acorn-walk: ^7.0.0
+    xtend: ^4.0.2
+  checksum: 02e1564a1ccf8bd1fcefcd01235398af4a9effaf032c5397994ddd275590a72894cb3e26e4b82579ccdda1e48ade7486aef61e771ddae3563ca452b927f443d8
+  languageName: node
+  linkType: hard
+
+"acorn-walk@npm:^7.0.0, acorn-walk@npm:^7.1.1, acorn-walk@npm:^7.2.0":
   version: 7.2.0
   resolution: "acorn-walk@npm:7.2.0"
   checksum: 9252158a79b9d92f1bc0dd6acc0fcfb87a67339e84bcc301bb33d6078936d27e35d606b4d35626d2962cd43c256d6f27717e70cbe15c04fff999ab0b2260b21f
@@ -5706,7 +5718,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^7.1.1, acorn@npm:^7.4.1":
+"acorn@npm:^7.0.0, acorn@npm:^7.1.1, acorn@npm:^7.4.1":
   version: 7.4.1
   resolution: "acorn@npm:7.4.1"
   bin:
@@ -6019,6 +6031,13 @@ __metadata:
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 544af8dd3f60546d3e4aff084d451b96961d2267d668670199692f8d054f0415d86fc5497d0e641e91546f0aa920e7c29e5250e99fc89f5552a34b5d93b77f43
+  languageName: node
+  linkType: hard
+
+"arg@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "arg@npm:5.0.2"
+  checksum: 6c69ada1a9943d332d9e5382393e897c500908d91d5cb735a01120d5f71daf1b339b7b8980cbeaba8fd1afc68e658a739746179e4315a26e8a28951ff9930078
   languageName: node
   linkType: hard
 
@@ -7415,7 +7434,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:3.5.3, chokidar@npm:^3.3.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.1":
+"chokidar@npm:3.5.3, chokidar@npm:^3.3.0, chokidar@npm:^3.4.1, chokidar@npm:^3.4.2, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -7781,7 +7800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.1.4, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: b0445859521eb4021cd0fb0cc1a75cecf67fceecae89b63f62b201cca8d345baf8b952c966862a9d9a2632987d4f6581f0ec8d957dfacece86f0a7919316f610
@@ -8996,6 +9015,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"defined@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "defined@npm:1.0.0"
+  checksum: 77672997c5001773371c4dbcce98da0b3dc43089d6da2ad87c4b800adb727633cea8723ea3889fe0c2112a2404e2fd07e3bfd0e55f7426aa6441d8992045dbd5
+  languageName: node
+  linkType: hard
+
 "del@npm:^6.0.0":
   version: 6.0.0
   resolution: "del@npm:6.0.0"
@@ -9123,6 +9149,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"detective@npm:^5.2.1":
+  version: 5.2.1
+  resolution: "detective@npm:5.2.1"
+  dependencies:
+    acorn-node: ^1.8.2
+    defined: ^1.0.0
+    minimist: ^1.2.6
+  bin:
+    detective: bin/detective.js
+  checksum: dc4601bbc6be850edb3c2dab7a0eaf5a6169a15ad201679c66d40ea1986df816eeaecd590047f15b0780285f3eeea13b82dca0d4c52a47e744a571e326a72dc9
+  languageName: node
+  linkType: hard
+
+"didyoumean@npm:^1.2.2":
+  version: 1.2.2
+  resolution: "didyoumean@npm:1.2.2"
+  checksum: d5d98719d58b3c2fa59663c4c42ba9716f1fd01245c31d5fce31915bd3aa26e6aac149788e007358f778ebbd68a2256eb5973e8ca6f221df221ba060115acf2e
+  languageName: node
+  linkType: hard
+
 "diff-sequences@npm:^26.6.2":
   version: 26.6.2
   resolution: "diff-sequences@npm:26.6.2"
@@ -9177,6 +9223,13 @@ __metadata:
   dependencies:
     path-type: ^4.0.0
   checksum: fa05e18324510d7283f55862f3161c6759a3f2f8dbce491a2fc14c8324c498286c54282c1f0e933cb930da8419b30679389499b919122952a4f8592362ef4615
+  languageName: node
+  linkType: hard
+
+"dlv@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "dlv@npm:1.1.3"
+  checksum: d7381bca22ed11933a1ccf376db7a94bee2c57aa61e490f680124fa2d1cd27e94eba641d9f45be57caab4f9a6579de0983466f620a2cd6230d7ec93312105ae7
   languageName: node
   linkType: hard
 
@@ -11271,7 +11324,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-parent@npm:^6.0.1":
+"glob-parent@npm:^6.0.1, glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
@@ -12501,6 +12554,15 @@ __metadata:
   dependencies:
     has: ^1.0.3
   checksum: b27034318b4b462f1c8f1dfb1b32baecd651d891a4e2d1922135daeff4141dfced2b82b07aef83ef54275c4a3526aa38da859223664d0868ca24182badb784ce
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.9.0":
+  version: 2.10.0
+  resolution: "is-core-module@npm:2.10.0"
+  dependencies:
+    has: ^1.0.3
+  checksum: 0f3f77811f430af3256fa7bbc806f9639534b140f8ee69476f632c3e1eb4e28a38be0b9d1b8ecf596179c841b53576129279df95e7051d694dac4ceb6f967593
   languageName: node
   linkType: hard
 
@@ -14142,6 +14204,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lilconfig@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "lilconfig@npm:2.0.6"
+  checksum: 40a3cd72f103b1be5975f2ac1850810b61d4053e20ab09be8d3aeddfe042187e1ba70b4651a7e70f95efa1642e7dc8b2ae395b317b7d7753b241b43cef7c0f7d
+  languageName: node
+  linkType: hard
+
 "lines-and-columns@npm:^1.1.6":
   version: 1.2.4
   resolution: "lines-and-columns@npm:1.2.4"
@@ -15233,7 +15302,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.1.23, nanoid@npm:^3.3.1, nanoid@npm:^3.3.3":
+"nanoid@npm:^3.1.23, nanoid@npm:^3.3.1, nanoid@npm:^3.3.3, nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
   bin:
@@ -15593,6 +15662,13 @@ __metadata:
     define-property: ^0.2.5
     kind-of: ^3.0.3
   checksum: a9e35f07e3a2c882a7e979090360d1a20ab51d1fa19dfdac3aa8873b328a7c4c7683946ee97c824ae40079d848d6740a3788fa14f2185155dab7ed970a72c783
+  languageName: node
+  linkType: hard
+
+"object-hash@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "object-hash@npm:3.0.0"
+  checksum: 80b4904bb3857c52cc1bfd0b52c0352532ca12ed3b8a6ff06a90cd209dfda1b95cee059a7625eb9da29537027f68ac4619363491eedb2f5d3dddbba97494fd6c
   languageName: node
   linkType: hard
 
@@ -16656,7 +16732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-import@npm:^14.0.2":
+"postcss-import@npm:^14.0.2, postcss-import@npm:^14.1.0":
   version: 14.1.0
   resolution: "postcss-import@npm:14.1.0"
   dependencies:
@@ -16680,7 +16756,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-load-config@npm:^3.0.0":
+"postcss-load-config@npm:^3.0.0, postcss-load-config@npm:^3.1.4":
   version: 3.1.4
   resolution: "postcss-load-config@npm:3.1.4"
   dependencies:
@@ -16894,7 +16970,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss-nested@npm:^5.0.6":
+"postcss-nested@npm:5.0.6, postcss-nested@npm:^5.0.6":
   version: 5.0.6
   resolution: "postcss-nested@npm:5.0.6"
   dependencies:
@@ -17134,6 +17210,17 @@ __metadata:
     picocolors: ^1.0.0
     source-map-js: ^1.0.2
   checksum: 514fb3552805a5d039a2d6b4df3e73f657001716ca93c0d57e6067b0473abdea70276d80afc96005c9aaff82ed5d98062bd97724d3f47ca400fba0b5e9e436ed
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.14":
+  version: 8.4.16
+  resolution: "postcss@npm:8.4.16"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 10eee25efd77868036403858577da0cefaf2e0905feeaba5770d5438ccdddba3d01cba8063e96b8aac4c6daa0ed413dd5ae0554a433a3c4db38df1d134cffc1f
   languageName: node
   linkType: hard
 
@@ -18386,6 +18473,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve@npm:^1.22.1":
+  version: 1.22.1
+  resolution: "resolve@npm:1.22.1"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^2.0.0-next.3":
   version: 2.0.0-next.3
   resolution: "resolve@npm:2.0.0-next.3"
@@ -18406,6 +18506,19 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: c79ecaea36c872ee4a79e3db0d3d4160b593f2ca16e031d8283735acd01715a203607e9ded3f91f68899c2937fa0d49390cddbe0fb2852629212f3cda283f4a7
+  languageName: node
+  linkType: hard
+
+"resolve@patch:resolve@^1.22.1#~builtin<compat/resolve>":
+  version: 1.22.1
+  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=07638b"
+  dependencies:
+    is-core-module: ^2.9.0
+    path-parse: ^1.0.7
+    supports-preserve-symlinks-flag: ^1.0.0
+  bin:
+    resolve: bin/resolve
+  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
   languageName: node
   linkType: hard
 
@@ -20075,6 +20188,41 @@ __metadata:
     string-width: ^4.2.3
     strip-ansi: ^6.0.1
   checksum: 5b07fe462ee03d2e1fac02cbb578efd2e0b55ac07e3d3db2e950aa9570ade5a4a2b8d3c15e9f25c89e4e50b646bc4269934601ee1eef4ca7968ad31960977690
+  languageName: node
+  linkType: hard
+
+"tailwindcss@npm:^3.1.8":
+  version: 3.1.8
+  resolution: "tailwindcss@npm:3.1.8"
+  dependencies:
+    arg: ^5.0.2
+    chokidar: ^3.5.3
+    color-name: ^1.1.4
+    detective: ^5.2.1
+    didyoumean: ^1.2.2
+    dlv: ^1.1.3
+    fast-glob: ^3.2.11
+    glob-parent: ^6.0.2
+    is-glob: ^4.0.3
+    lilconfig: ^2.0.6
+    normalize-path: ^3.0.0
+    object-hash: ^3.0.0
+    picocolors: ^1.0.0
+    postcss: ^8.4.14
+    postcss-import: ^14.1.0
+    postcss-js: ^4.0.0
+    postcss-load-config: ^3.1.4
+    postcss-nested: 5.0.6
+    postcss-selector-parser: ^6.0.10
+    postcss-value-parser: ^4.2.0
+    quick-lru: ^5.1.1
+    resolve: ^1.22.1
+  peerDependencies:
+    postcss: ^8.0.9
+  bin:
+    tailwind: lib/cli.js
+    tailwindcss: lib/cli.js
+  checksum: 86480301fc6ae1e392c2aba8264ab425bd919078176b010fda724518a7c265e950da5f4120c69c9041509c318207985fa9d680b6f5021e23f8214135a61a54b6
   languageName: node
   linkType: hard
 
@@ -21961,7 +22109,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:^4.0.2, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a


### PR DESCRIPTION
### Summary:
[ch213288]

Tailwind utilities are easier to use than the BM-defined ones, and especially for reference pages & recipes, are easier for app developers to copy & paste in.

Note that this matches our behavior before BM -- it's a separate question whether & how to use utilities in component styles themselves.

### Test Plan:
This PR has 5 commits:
1: Adds back all the necessary config stuff to get Tailwind working again
2-4: Converts styles in each of the types of files we want to support Tailwind utilities in to make sure it's working.
5: Turn off preflight reset styles to ensure no visual changes

I'd also expect to see no changes in chromatic