### PR TITLE
feat(tooltip): add childDisabled prop

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -53,7 +53,7 @@
  * 1) When childDisabled is true and alignment is top or bottom
  */
 .tooltip__child-disabled-wrapper--vertical {
-  /* Needed for the bottom alignment to work properly */
+  /* Needed for the top and bottom alignment to work properly */
   display: inline-flex;
 }
 

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -50,6 +50,14 @@
 }
 
 /**
+ * 1) When childDisabled is true and alignment is top or bottom
+ */
+.tooltip__child-disabled-wrapper--vertical {
+  /* Needed for the bottom alignment to work properly */
+  display: inline-flex;
+}
+
+/**
  * 1) Add arrows
  */
 .tooltip :global(.tippy-arrow) {

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -184,7 +184,12 @@ export const InteractiveDisabled: StoryObj<Args> = {
         styles['trigger--spacing-left'],
       )}
     >
-      <Tooltip align="top" childDisabled={true} text={defaultArgs.text}>
+      <Tooltip
+        align="top"
+        childDisabled={true}
+        duration={0}
+        text={defaultArgs.text}
+      >
         <Button disabled variant="primary">
           Tooltip trigger
         </Button>

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -177,7 +177,10 @@ export const Interactive: StoryObj<Args> = {
 };
 
 export const InteractiveDisabled: StoryObj<Args> = {
-  render: () => (
+  args: {
+    duration: undefined,
+  },
+  render: (args) => (
     <div
       className={clsx(
         styles['trigger--spacing-top'],
@@ -187,7 +190,7 @@ export const InteractiveDisabled: StoryObj<Args> = {
       <Tooltip
         align="top"
         childDisabled={true}
-        duration={0}
+        duration={args.duration}
         text={defaultArgs.text}
       >
         <Button disabled variant="primary">

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -134,6 +134,19 @@ export const LongButtonText: StoryObj<Args> = {
   },
 };
 
+export const Disabled: StoryObj<Args> = {
+  args: {
+    children: (
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+      <span className={clsx(styles['trigger--spacing'])} tabIndex={0}>
+        <Button disabled variant="primary">
+          Tooltip trigger
+        </Button>
+      </span>
+    ),
+  },
+};
+
 export const Interactive: StoryObj<Args> = {
   args: {
     // reset prop values defined in defaultArgs

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,6 +1,5 @@
 import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { Meta, Story, StoryObj } from '@storybook/react';
-import { within, userEvent } from '@storybook/testing-library';
 import clsx from 'clsx';
 import React from 'react';
 import { Tooltip } from './Tooltip';
@@ -135,16 +134,25 @@ export const LongButtonText: StoryObj<Args> = {
 };
 
 export const Disabled: StoryObj<Args> = {
-  args: {
-    children: (
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      <span className={clsx(styles['trigger--spacing'])} tabIndex={0}>
+  render: () => (
+    <div
+      className={clsx(
+        styles['trigger--spacing-top'],
+        styles['trigger--spacing-left'],
+      )}
+    >
+      <Tooltip
+        align="top"
+        childDisabled={true}
+        text={defaultArgs.text}
+        visible={true}
+      >
         <Button disabled variant="primary">
           Tooltip trigger
         </Button>
-      </span>
-    ),
-  },
+      </Tooltip>
+    </div>
+  ),
 };
 
 export const Interactive: StoryObj<Args> = {
@@ -161,17 +169,34 @@ export const Interactive: StoryObj<Args> = {
   decorators: [
     (Story: Story) => (
       <div>
-        <p>
-          Click somewhere in this area to dismiss the tooltip, then hover over
-          the button to make it reappear.
-        </p>
+        <p>Hover over the button to make the tooltip appear.</p>
         <Story />
       </div>
     ),
   ],
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const trigger = await canvas.findByRole('button');
-    await userEvent.hover(trigger);
-  },
+};
+
+export const InteractiveDisabled: StoryObj<Args> = {
+  render: () => (
+    <div
+      className={clsx(
+        styles['trigger--spacing-top'],
+        styles['trigger--spacing-left'],
+      )}
+    >
+      <Tooltip align="top" childDisabled={true} text={defaultArgs.text}>
+        <Button disabled variant="primary">
+          Tooltip trigger
+        </Button>
+      </Tooltip>
+    </div>
+  ),
+  decorators: [
+    (Story: Story) => (
+      <div>
+        <p>Hover over the button to make the tooltip appear.</p>
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -162,7 +162,7 @@ export const Interactive: StoryObj<Args> = {
     visible: undefined,
     children: (
       <Button className={clsx(styles['trigger--spacing'])} variant="primary">
-        Hover here to see tooltip after clicking somewhere outside.
+        Tooltip trigger
       </Button>
     ),
   },

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -36,9 +36,8 @@ describe('<Tooltip />', () => {
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
     await userEvent.hover(trigger);
     expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
-    // TODO: make worky
-    // await userEvent.keyboard('{esc}');
-    // expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
+    await userEvent.keyboard('{esc}');
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
   });
 
   it('should display warning message when attempting to use dark variant', () => {

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import * as TooltipStoryFile from './Tooltip.stories';
 import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
-const { Interactive } = composeStories(TooltipStoryFile);
+const { Interactive, InteractiveDisabled } = composeStories(TooltipStoryFile);
 
 describe('<Tooltip />', () => {
   const warnMock = consoleWarnMockHelper();
@@ -27,6 +27,18 @@ describe('<Tooltip />', () => {
     expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
     await userEvent.keyboard('{esc}');
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
+  });
+
+  it('should close tooltip via escape key for disabled buttons', async () => {
+    // disable animation for test
+    render(<InteractiveDisabled duration={0} />);
+    const trigger = await screen.findByTestId('disabled-child-tooltip-wrapper');
+    expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
+    await userEvent.hover(trigger);
+    expect(screen.getByTestId('tooltip-content')).toBeInTheDocument();
+    // TODO: make worky
+    // await userEvent.keyboard('{esc}');
+    // expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
   });
 
   it('should display warning message when attempting to use dark variant', () => {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -24,6 +24,10 @@ type TooltipProps = {
   children?: React.ReactElement;
   /**
    * If the child being passed into the Tooltip via the `children` prop is disabled (e.g. a disabled button).
+   *
+   * Please note that spacing and placement styling will need to be added to a wrapper around the Tooltip,
+   * not on the button child inside the Tooltip, because there will be a wrapper around the button child. Example:
+   * <div className="spacing-goes-here"><Tooltip text="Tooltip text"><Button disabled>Button text</Button></Tooltip></div>
    */
   childDisabled?: boolean;
   /**

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -82,6 +82,32 @@ type Plugin = Plugins[number];
  *
  * https://atomiks.github.io/tippyjs/
  * https://github.com/atomiks/tippyjs-react
+ *
+ * Example usage:
+ *
+ * ```tsx
+ * <Tooltip>
+ *   <Button className={clsx(styles['trigger--spacing'])} variant="primary">
+ *     Tooltip trigger
+ *   </Button>
+ * </Tooltip>
+ * ```
+ *
+ * If the tooltip trigger is a disabled button, you'll need to wrap the button in a span with tabIndex={0}.
+ *
+ * https://atomiks.github.io/tippyjs/v5/creating-tooltips/#disabled-elements
+ *
+ * Example:
+ *
+ * ```tsx
+ * <Tooltip>
+ *   <span tabIndex={0}>
+ *     <Button className={clsx(styles['trigger--spacing'])} variant="primary">
+ *       Tooltip trigger
+ *     </Button>
+ *   </span>
+ * </Tooltip>
+ * ```
  */
 export const Tooltip = ({
   variant = 'light',

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -23,6 +23,10 @@ type TooltipProps = {
    */
   children?: React.ReactElement;
   /**
+   * If the child being passed into the Tooltip via the `children` prop is disabled (e.g. a disabled button).
+   */
+  childDisabled?: boolean;
+  /**
    * Custom classname for additional styles.
    *
    * These styles will only affect the tooltip bubble.
@@ -87,31 +91,16 @@ type Plugin = Plugins[number];
  *
  * ```tsx
  * <Tooltip>
- *   <Button className={clsx(styles['trigger--spacing'])} variant="primary">
+ *   <Button variant="primary">
  *     Tooltip trigger
  *   </Button>
- * </Tooltip>
- * ```
- *
- * If the tooltip trigger is a disabled button, you'll need to wrap the button in a span with tabIndex={0}.
- *
- * https://atomiks.github.io/tippyjs/v5/creating-tooltips/#disabled-elements
- *
- * Example:
- *
- * ```tsx
- * <Tooltip>
- *   <span tabIndex={0}>
- *     <Button className={clsx(styles['trigger--spacing'])} variant="primary">
- *       Tooltip trigger
- *     </Button>
- *   </span>
  * </Tooltip>
  * ```
  */
 export const Tooltip = ({
   variant = 'light',
   align = 'top',
+  childDisabled,
   className,
   duration = 200,
   text,
@@ -122,6 +111,7 @@ export const Tooltip = ({
       'The dark variant is deprecated and will be removed in an upcoming release. Please use the default light variant instead.',
     );
   }
+
   // Hides tooltip when escape key is pressed, following:
   // https://atomiks.github.io/tippyjs/v6/plugins/#hideonesc
   const hideOnEsc: Plugin = {
@@ -143,6 +133,26 @@ export const Tooltip = ({
       };
     },
   };
+
+  let children = rest.children;
+  // Tippy only works on elements with a tabindex. If the child is disabled, we need to
+  // wrap it in an element with a tabindex in order for it to work.
+  if (childDisabled) {
+    children = (
+      <span
+        className={clsx(
+          (align === 'bottom' || align === 'top') &&
+            styles['tooltip__child-disabled-wrapper--vertical'],
+        )}
+        data-testid="disabled-child-tooltip-wrapper"
+        // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+        tabIndex={0}
+      >
+        {rest.children}
+      </span>
+    );
+  }
+
   return (
     <Tippy
       {...rest}
@@ -156,6 +166,8 @@ export const Tooltip = ({
       duration={duration}
       placement={align}
       plugins={[hideOnEsc]}
-    />
+    >
+      {children}
+    </Tippy>
   );
 };

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -113,92 +113,37 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
 exports[`<Tooltip /> Disabled story renders snapshot 1`] = `
 <body>
   <div>
-    <span
-      aria-describedby="tippy-8"
-      class="trigger--spacing"
-      tabindex="0"
+    <div
+      class="trigger--spacing-top trigger--spacing-left"
     >
-      <button
-        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary button--disabled"
-        data-bootstrap-override="clickable-style-primary"
-        disabled=""
-        tabindex="-1"
-        type="button"
+      <span
+        aria-describedby="tippy-8"
+        class="tooltip__child-disabled-wrapper--vertical"
+        data-testid="disabled-child-tooltip-wrapper"
+        tabindex="0"
       >
-        Tooltip trigger
-      </button>
-    </span>
+        <button
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary button--disabled"
+          data-bootstrap-override="clickable-style-primary"
+          disabled=""
+          tabindex="-1"
+          type="button"
+        >
+          Tooltip trigger
+        </button>
+      </span>
+    </div>
   </div>
   <div
     data-tippy-root=""
     id="tippy-8"
-    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
+    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
   >
     <div
       class="tippy-box tooltip tooltip--light"
       data-animation="fade"
       data-escaped=""
-      data-placement="right"
-      data-reference-hidden=""
-      data-state="visible"
-      role="tooltip"
-      style="max-width: 350px; transition-duration: 0ms;"
-      tabindex="-1"
-    >
-      <div
-        class="tippy-content"
-        data-state="visible"
-        style="transition-duration: 0ms;"
-      >
-        <div>
-          <span
-            data-testid="tooltip-content"
-          >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
-          </span>
-        </div>
-      </div>
-      <div
-        class="tippy-arrow"
-        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
-      />
-    </div>
-  </div>
-</body>
-`;
-
-exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
-<body>
-  <div>
-    <div>
-      <p>
-        Click somewhere in this area to dismiss the tooltip, then hover over the button to make it reappear.
-      </p>
-      <button
-        aria-describedby="tippy-9"
-        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary trigger--spacing"
-        data-bootstrap-override="clickable-style-primary"
-        type="button"
-      >
-        Hover here to see tooltip after clicking somewhere outside.
-      </button>
-    </div>
-  </div>
-  <div
-    data-tippy-root=""
-    id="tippy-9"
-    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
-  >
-    <div
-      class="tippy-box tooltip tooltip--light"
-      data-animation="fade"
-      data-escaped=""
-      data-placement="right"
+      data-placement="top"
       data-reference-hidden=""
       data-state="visible"
       role="tooltip"
@@ -225,8 +170,58 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
       </div>
       <div
         class="tippy-arrow"
-        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
+        style="position: absolute; left: 0px; transform: translate(3px, 0px);"
       />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
+<body>
+  <div>
+    <div>
+      <p>
+        Hover over the button to make the tooltip appear.
+      </p>
+      <button
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary trigger--spacing"
+        data-bootstrap-override="clickable-style-primary"
+        type="button"
+      >
+        Hover here to see tooltip after clicking somewhere outside.
+      </button>
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<Tooltip /> InteractiveDisabled story renders snapshot 1`] = `
+<body>
+  <div>
+    <div>
+      <p>
+        Hover over the button to make the tooltip appear.
+      </p>
+      <div
+        class="trigger--spacing-top trigger--spacing-left"
+      >
+        <span
+          class="tooltip__child-disabled-wrapper--vertical"
+          data-testid="disabled-child-tooltip-wrapper"
+          tabindex="0"
+        >
+          <button
+            class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary button--disabled"
+            data-bootstrap-override="clickable-style-primary"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Tooltip trigger
+          </button>
+        </span>
+      </div>
     </div>
   </div>
 </body>

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -110,6 +110,68 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
 </body>
 `;
 
+exports[`<Tooltip /> Disabled story renders snapshot 1`] = `
+<body>
+  <div>
+    <span
+      aria-describedby="tippy-8"
+      class="trigger--spacing"
+      tabindex="0"
+    >
+      <button
+        class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary button--disabled"
+        data-bootstrap-override="clickable-style-primary"
+        disabled=""
+        tabindex="-1"
+        type="button"
+      >
+        Tooltip trigger
+      </button>
+    </span>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-8"
+    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
+  >
+    <div
+      class="tippy-box tooltip tooltip--light"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="right"
+      data-reference-hidden=""
+      data-state="visible"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 0ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 0ms;"
+      >
+        <div>
+          <span
+            data-testid="tooltip-content"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             
+            <b>
+              Donec a erat eu augue consequat eleifend non vel sem.
+            </b>
+             Praesent efficitur mauris ac leo semper accumsan.
+          </span>
+        </div>
+      </div>
+      <div
+        class="tippy-arrow"
+        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
+      />
+    </div>
+  </div>
+</body>
+`;
+
 exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
 <body>
   <div>
@@ -118,7 +180,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
         Click somewhere in this area to dismiss the tooltip, then hover over the button to make it reappear.
       </p>
       <button
-        aria-describedby="tippy-8"
+        aria-describedby="tippy-9"
         class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary trigger--spacing"
         data-bootstrap-override="clickable-style-primary"
         type="button"
@@ -129,7 +191,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
   </div>
   <div
     data-tippy-root=""
-    id="tippy-8"
+    id="tippy-9"
     style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
   >
     <div

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -189,7 +189,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
         data-bootstrap-override="clickable-style-primary"
         type="button"
       >
-        Hover here to see tooltip after clicking somewhere outside.
+        Tooltip trigger
       </button>
     </div>
   </div>


### PR DESCRIPTION
### Summary:
Our `Tooltip` component currently doesn't work on disabled buttons (which is a relatively common pattern). The reason is, `Tippy` only worked on elements that have a `tabIndex`, which disabled elements don't have. The solution is to wrap the children in a `span` with a `tabIndex` of 0.

I was originally going to add documentation and a story to this effect, but then I noticed the `react-bootstrap` `OverlayTrigger` component has a `childDisabled` prop. If we use a prop like that, we can wrap the children in a `span` with a `tabIndex` so our users don't have to. (I also noticed some weirdness around needing a different `display` styling for top and bottom alignment, so we can bake that in too.

### Test Plan:
I verified the tooltip looked okay with all 4 alignments in storybook.