### PR TITLE
feat(datasummarycard): adds DataSummaryCard recipe

### DIFF
--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.module.css
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.module.css
@@ -1,0 +1,106 @@
+@import '../../../src/design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # DATA SUMMARY CARD
+\*------------------------------------*/
+
+/**
+ * Data Summary Card centers and wraps header, data, and footnote.
+ */
+.data-summary-card {
+  width: 12.75rem;
+  height: 9.25rem;
+  position: relative;
+  overflow: hidden;
+
+  border: 0;
+  box-shadow: var(--eds-box-shadow-sm);
+
+  align-items: center;
+}
+.data-summary-card:hover {
+  border: var(--eds-border-width-sm) solid
+    var(--eds-theme-color-border-neutral-default);
+}
+
+/**
+ * The header wraps the title.
+ */
+.data-summary-card__header {
+  margin-top: var(--eds-size-2);
+  margin-bottom: var(--eds-size-half);
+}
+
+/**
+ * Prevents jitter of the card components when hovering due to border spawning.
+ * Transparent border can't be used due to off-track variant indicator needing full width.
+ */
+.data-summary-card:hover > .data-summary-card__header {
+  margin-top: calc(var(--eds-size-2) - var(--eds-border-width-sm));
+}
+
+/**
+ * The title communicates card organization.
+ */
+.data-summary-card__title {
+  @mixin eds-theme-typography-overline-sm;
+}
+
+/**
+ * The body wraps data and description text.
+ */
+.data-summary-card__body {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/**
+ * The data is the main content for the card.
+ */
+.data-summary-card__data {
+  @mixin eds-theme-typography-headline-lg;
+
+  display: flex;
+  align-items: center;
+  gap: var(--eds-size-half);
+
+  margin-bottom: var(--eds-size-half);
+}
+
+/**
+ * The data unit provides a unit of measurement for the data to make it relevant.
+ */
+.data-summary-card__data-unit {
+  @mixin eds-theme-typography-headline-sm;
+}
+
+/**
+ * The Description provides more elucidation for the data.
+ */
+.data-summary-card__description {
+  @mixin eds-theme-typography-caption-text-sm;
+  font-weight: var(--eds-font-weight-light);
+}
+
+/**
+ * Off track variant, bottom orange border indicates off track status.
+ */
+.data-summary-card__indicator--off-track {
+  width: 100%;
+  height: 8px;
+
+  position: absolute;
+  bottom: 0;
+  left: 0;
+
+  background-color: var(--eds-theme-color-icon-utility-warning);
+}
+
+/**
+ * Prevents jitter of the card components when hovering due to border spawning.
+ * Transparent border can't be used due to off-track variant indicator needing full width.
+ */
+.data-summary-card:hover > .data-summary-card__indicator--off-track {
+  height: 7px;
+}

--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.stories.tsx
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.stories.tsx
@@ -1,0 +1,37 @@
+import { StoryObj, Meta } from '@storybook/react';
+import React from 'react';
+
+import { DataSummaryCard } from './DataSummaryCard';
+
+export default {
+  title: 'Recipes/DataSummaryCard',
+  component: DataSummaryCard,
+  args: {
+    title: 'students',
+    data: 'XXX',
+    dataUnit: '/ XXX',
+    description: 'Off Track',
+  },
+} as Meta<Args>;
+
+type Args = React.ComponentProps<typeof DataSummaryCard>;
+
+export const Default: StoryObj<Args> = {};
+export const OffTrack: StoryObj<Args> = {
+  args: {
+    variant: 'off-track',
+  },
+};
+
+export const NoDataUnit: StoryObj<Args> = {
+  args: {
+    data: '30',
+    dataUnit: undefined,
+  },
+};
+
+export const NoDescription: StoryObj<Args> = {
+  args: {
+    description: undefined,
+  },
+};

--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.stories.tsx
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.stories.tsx
@@ -7,10 +7,10 @@ export default {
   title: 'Recipes/DataSummaryCard',
   component: DataSummaryCard,
   args: {
-    title: 'students',
-    data: 'XXX',
+    title: 'title',
+    dataAmount: 'XXX',
     dataUnit: '/ XXX',
-    description: 'Off Track',
+    description: 'Description',
   },
 } as Meta<Args>;
 
@@ -25,13 +25,15 @@ export const OffTrack: StoryObj<Args> = {
 
 export const NoDataUnit: StoryObj<Args> = {
   args: {
-    data: '30',
+    dataAmount: '30',
     dataUnit: undefined,
   },
 };
 
 export const NoDescription: StoryObj<Args> = {
   args: {
+    dataAmount: '50',
+    dataUnit: '%',
     description: undefined,
   },
 };

--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
@@ -12,7 +12,7 @@ export interface Props {
   /**
    * Main data text of the card.
    */
-  data?: string;
+  dataAmount: string;
   /**
    * Text that provides a unit of measurement for the data.
    */
@@ -20,10 +20,9 @@ export interface Props {
   /**
    * Text to provide more context for the data.
    */
-
   description?: string;
   /**
-   * Title text of the data to represented.
+   * Title text of the data represented.
    */
   title: string;
   /**
@@ -37,7 +36,7 @@ export interface Props {
  */
 export const DataSummaryCard = ({
   className,
-  data,
+  dataAmount,
   dataUnit,
   description,
   title,
@@ -54,11 +53,10 @@ export const DataSummaryCard = ({
       </Card.Header>
       <Card.Body className={styles['data-summary-card__body']}>
         <Text
-          as="p"
           className={styles['data-summary-card__data']}
           variant="neutral-medium"
         >
-          {data}
+          {dataAmount}
           {dataUnit && (
             <Text
               as="span"
@@ -71,7 +69,6 @@ export const DataSummaryCard = ({
         </Text>
         {description && (
           <Text
-            as="p"
             className={styles['data-summary-card__description']}
             variant="neutral-subtle"
           >

--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
@@ -1,0 +1,91 @@
+import clsx from 'clsx';
+import React from 'react';
+import styles from './DataSummaryCard.module.css';
+
+import { Card, Heading, Text } from '../../../src';
+
+export interface Props {
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
+   * Main data text of the card.
+   */
+  data?: string;
+  /**
+   * Text that provides a unit of measurement for the data.
+   */
+  dataUnit?: string;
+  /**
+   * Text to provide more context for the data.
+   */
+
+  description?: string;
+  /**
+   * Title text of the data to represented.
+   */
+  title: string;
+  /**
+   * Off track variant to indicate status.
+   */
+  variant?: 'off-track';
+}
+
+/**
+ * Recipe for a Card component to showcase categorical statistics.
+ */
+export const DataSummaryCard = ({
+  className,
+  data,
+  dataUnit,
+  description,
+  title,
+  variant,
+  ...other
+}: Props) => {
+  const componentClassName = clsx(styles['data-summary-card'], className);
+  return (
+    <Card className={componentClassName} {...other}>
+      <Card.Header className={styles['data-summary-card__header']}>
+        <Heading className={styles['data-summary-card__title']} size="h3">
+          {title}
+        </Heading>
+      </Card.Header>
+      <Card.Body className={styles['data-summary-card__body']}>
+        <Text
+          as="p"
+          className={styles['data-summary-card__data']}
+          variant="neutral-medium"
+        >
+          {data}
+          {dataUnit && (
+            <Text
+              as="span"
+              className={styles['data-summary-card__data-unit']}
+              variant="neutral-subtle"
+            >
+              {dataUnit}
+            </Text>
+          )}
+        </Text>
+        {description && (
+          <Text
+            as="p"
+            className={styles['data-summary-card__description']}
+            variant="neutral-subtle"
+          >
+            {description}
+          </Text>
+        )}
+      </Card.Body>
+      {variant === 'off-track' && (
+        <div
+          aria-label="off track"
+          className={styles['data-summary-card__indicator--off-track']}
+          role="img"
+        />
+      )}
+    </Card>
+  );
+};

--- a/.storybook/recipes/DataSummaryCard/index.ts
+++ b/.storybook/recipes/DataSummaryCard/index.ts
@@ -1,0 +1,1 @@
+export { DataSummaryCard as default } from './DataSummaryCard';

--- a/plop-templates/Recipe/Recipe.tsx.hbs
+++ b/plop-templates/Recipe/Recipe.tsx.hbs
@@ -1,5 +1,5 @@
-import React from 'react';
 import clsx from 'clsx';
+import React from 'react';
 import styles from './{{pascalCase name}}.module.css';
 
 export interface Props {
@@ -16,8 +16,7 @@ export const {{pascalCase name}} = ({
   className,
   ...other
 }: Props) => {
-  const componentClassName = clsx(styles['{{dashCase name}}'], className, {
-  });
+  const componentClassName = clsx(styles['{{dashCase name}}'], className);
   return (
     <div
       className={componentClassName}

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,7 +11,7 @@ const defaultArgs = {
 };
 
 export default {
-  title: 'Molecules/Forms/Checkbox',
+  title: 'Atoms/Forms/Checkbox',
   component: Checkbox,
   args: defaultArgs,
   argTypes: {


### PR DESCRIPTION
### Summary:
[sc-211849]
- motivation
  - Data Summary Card is used in the school and district tools pilot
  - Data Summary Card displays simple data of students to provide status at a quick glance
    - Communicates 'off-track' status if necessary
- execution
  - Wraps the `Card` component
  - Relevant mocks: [Recipe](https://www.figma.com/file/CQu6m6sxvFO0zYSrWq6jsH/Data-Summary-Card---Creation-Exploration?node-id=5961%3A12067), [usage in poc](https://www.figma.com/file/PJ6pnQy2J68vLiYJwTCy2y/SDT-Course-%3E-Students-Proof-of-Concept-Pilot?node-id=158%3A20107)
### Test Plan:
- unit tests pass
- no visual regressions
![Screen Shot 2022-08-30 at 8 30 19 PM](https://user-images.githubusercontent.com/86632227/187586586-6a5f2c8e-4736-40c0-9249-0c5e08d2e37f.png)
![Screen Shot 2022-08-30 at 8 30 21 PM](https://user-images.githubusercontent.com/86632227/187586587-b563ab02-788b-4f06-ad2c-887d9ce69485.png)
![Screen Shot 2022-08-30 at 8 30 23 PM](https://user-images.githubusercontent.com/86632227/187586588-a755189e-f287-478f-bddb-ec909b83c2d7.png)
![Screen Shot 2022-08-30 at 8 30 25 PM](https://user-images.githubusercontent.com/86632227/187586589-5f7edfe3-a968-4cd1-aecb-ef90383224a6.png)
