### PR TITLE
chore(textfield): remove optional indicator

### DIFF
--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -594,7 +594,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="22"
+      id="21"
     >
       Active Step 1
     </title>
@@ -612,7 +612,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="23"
+      id="22"
     >
       Step 2
     </title>
@@ -630,7 +630,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="24"
+      id="23"
     >
       Step 3
     </title>
@@ -882,7 +882,7 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="19"
+          id="18"
         >
           close modal
         </title>
@@ -980,7 +980,7 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="20"
+          id="19"
         >
           close modal
         </title>
@@ -1240,7 +1240,7 @@ exports[`Modal WithoutHeaderAndFooter story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="21"
+          id="20"
         >
           close modal
         </title>

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -594,7 +594,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="21"
+      id="22"
     >
       Active Step 1
     </title>
@@ -612,7 +612,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="22"
+      id="23"
     >
       Step 2
     </title>
@@ -630,7 +630,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     xmlns="http://www.w3.org/2000/svg"
   >
     <title
-      id="23"
+      id="24"
     >
       Step 3
     </title>
@@ -882,7 +882,7 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="18"
+          id="19"
         >
           close modal
         </title>
@@ -980,7 +980,7 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="19"
+          id="20"
         >
           close modal
         </title>
@@ -1240,7 +1240,7 @@ exports[`Modal WithoutHeaderAndFooter story renders snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <title
-          id="20"
+          id="21"
         >
           close modal
         </title>

--- a/src/components/TextField/TextField.stories.tsx
+++ b/src/components/TextField/TextField.stories.tsx
@@ -51,19 +51,11 @@ export const Disabled: StoryObj<Args> = {
   },
 };
 
-export const RequiredIndicator: StoryObj<Args> = {
+export const Required: StoryObj<Args> = {
   args: {
     label: 'Text field with fieldNote',
     required: true,
     fieldNote: 'This is a fieldnote for a required text field.',
-  },
-};
-
-export const OptionalIndicator: StoryObj<Args> = {
-  args: {
-    label: 'Text field with fieldNote',
-    optionalIndicator: true,
-    fieldNote: 'This is a fieldnote for an optional text field.',
   },
 };
 
@@ -158,7 +150,7 @@ export const DisabledVariants: StoryObj<Args> = {
   },
 };
 
-export const RequiredIndicatorVariants: StoryObj<Args> = {
+export const RequiredVariants: StoryObj<Args> = {
   args: {
     required: true,
   },
@@ -236,20 +228,6 @@ export const RequiredIndicatorVariants: StoryObj<Args> = {
       </div>
     </>
   ),
-  parameters: {
-    axe: {
-      // Disabled input does not need to meet color contrast
-      disabledRules: ['color-contrast'],
-    },
-  },
-};
-
-export const OptionalIndicatorVariants: StoryObj<Args> = {
-  ...RequiredIndicatorVariants,
-  args: {
-    optionalIndicator: true,
-    required: false,
-  },
   parameters: {
     axe: {
       // Disabled input does not need to meet color contrast

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -73,10 +73,6 @@ export interface Props {
    */
   onChange?: ChangeEventHandler;
   /**
-   * Used to show 'Optional' description on top of input field if input is not required.
-   */
-  optionalIndicator?: boolean;
-  /**
    * Placeholder attribute for input. Note: placeholder should be used sparingly
    */
   placeholder?: string;
@@ -138,7 +134,6 @@ export const TextField = ({
   inputWithin,
   isError,
   label,
-  optionalIndicator,
   required,
   type = 'text',
   ...other
@@ -147,12 +142,7 @@ export const TextField = ({
     throw new Error('You must provide a visible label or aria-label');
   }
 
-  const indicator = required
-    ? 'Required'
-    : optionalIndicator
-    ? 'Optional'
-    : null;
-  const shouldRenderOverline = !!(label || indicator);
+  const shouldRenderOverline = !!(label || required);
   const overlineClassName = clsx(
     styles['text-field__overline'],
     !label && styles['text-field__overline--no-label'],
@@ -172,9 +162,9 @@ export const TextField = ({
       {shouldRenderOverline && (
         <div className={overlineClassName}>
           {label && <Label htmlFor={idVar} text={label} />}
-          {indicator && (
+          {required && (
             <Text as="p" size="sm">
-              {indicator}
+              Required
             </Text>
           )}
         </div>

--- a/src/components/TextField/__snapshots__/TextField.test.ts.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.ts.snap
@@ -100,6 +100,39 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
+          for="50"
+        >
+          Label text
+           
+        </label>
+      </div>
+      <div
+        class="text-field__body"
+      >
+        <input
+          aria-describedby="51"
+          aria-invalid="false"
+          class="input-field"
+          data-bootstrap-override="inputfield"
+          disabled=""
+          id="50"
+          placeholder="placeholder"
+          type="text"
+        />
+      </div>
+      <div
+        class="field-note field-note--disabled"
+        id="51"
+      >
+        fieldNote text
+      </div>
+    </div>
+    <div>
+      <div
+        class="text-field__overline text-field__overline--disabled"
+      >
+        <label
+          class="label"
           for="52"
         >
           Label text
@@ -116,7 +149,6 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           data-bootstrap-override="inputfield"
           disabled=""
           id="52"
-          placeholder="placeholder"
           type="text"
         />
       </div>
@@ -127,6 +159,9 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         fieldNote text
       </div>
     </div>
+    <p>
+      no fieldNote, label
+    </p>
     <div>
       <div
         class="text-field__overline text-field__overline--disabled"
@@ -143,25 +178,16 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="55"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
           id="54"
+          placeholder="placeholder"
           type="text"
         />
       </div>
-      <div
-        class="field-note field-note--disabled"
-        id="55"
-      >
-        fieldNote text
-      </div>
     </div>
-    <p>
-      no fieldNote, label
-    </p>
     <div>
       <div
         class="text-field__overline text-field__overline--disabled"
@@ -183,32 +209,6 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           data-bootstrap-override="inputfield"
           disabled=""
           id="56"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--disabled"
-      >
-        <label
-          class="label"
-          for="58"
-        >
-          Label text
-           
-        </label>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          disabled=""
-          id="58"
           type="text"
         />
       </div>
@@ -221,20 +221,20 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="61"
+          aria-describedby="59"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="60"
+          id="58"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="61"
+        id="59"
       >
         fieldNote text
       </div>
@@ -244,19 +244,19 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="63"
+          aria-describedby="61"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="62"
+          id="60"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="63"
+        id="61"
       >
         fieldNote text
       </div>
@@ -274,7 +274,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="64"
+          id="62"
           placeholder="placeholder"
           type="text"
         />
@@ -290,7 +290,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="66"
+          id="64"
           type="text"
         />
       </div>
@@ -378,7 +378,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="32"
+          for="30"
         >
           Label text
            
@@ -388,18 +388,18 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="33"
+          aria-describedby="31"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="32"
+          id="30"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="33"
+        id="31"
       >
         <svg
           class="icon field-note__icon"
@@ -411,7 +411,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="34"
+            id="32"
           >
             error
           </title>
@@ -428,7 +428,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="35"
+          for="33"
         >
           Label text
            
@@ -438,17 +438,17 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="36"
+          aria-describedby="34"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="35"
+          id="33"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="36"
+        id="34"
       >
         <svg
           class="icon field-note__icon"
@@ -460,7 +460,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="37"
+            id="35"
           >
             error
           </title>
@@ -474,6 +474,31 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
     <p>
       no fieldNote, label
     </p>
+    <div>
+      <div
+        class="text-field__overline"
+      >
+        <label
+          class="label"
+          for="36"
+        >
+          Label text
+           
+        </label>
+      </div>
+      <div
+        class="text-field__body"
+      >
+        <input
+          aria-invalid="true"
+          class="input-field error"
+          data-bootstrap-override="inputfield"
+          id="36"
+          placeholder="placeholder"
+          type="text"
+        />
+      </div>
+    </div>
     <div>
       <div
         class="text-field__overline"
@@ -494,31 +519,6 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           class="input-field error"
           data-bootstrap-override="inputfield"
           id="38"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="40"
-        >
-          Label text
-           
-        </label>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="true"
-          class="input-field error"
-          data-bootstrap-override="inputfield"
-          id="40"
           type="text"
         />
       </div>
@@ -531,19 +531,19 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="43"
+          aria-describedby="41"
           aria-invalid="true"
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="42"
+          id="40"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="43"
+        id="41"
       >
         <svg
           class="icon field-note__icon"
@@ -555,7 +555,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="44"
+            id="42"
           >
             error
           </title>
@@ -571,18 +571,18 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="46"
+          aria-describedby="44"
           aria-invalid="true"
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="45"
+          id="43"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="46"
+        id="44"
       >
         <svg
           class="icon field-note__icon"
@@ -594,7 +594,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="47"
+            id="45"
           >
             error
           </title>
@@ -617,7 +617,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="48"
+          id="46"
           placeholder="placeholder"
           type="text"
         />
@@ -632,7 +632,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="50"
+          id="48"
           type="text"
         />
       </div>
@@ -651,7 +651,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
     >
       <label
         class="label"
-        for="14"
+        for="12"
       >
         Input field with button inside
          
@@ -664,7 +664,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
         aria-invalid="false"
         class="input-field"
         data-bootstrap-override="inputfield"
-        id="14"
+        id="12"
         type="text"
       />
       <div
@@ -706,6 +706,38 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
+          for="14"
+        >
+          Label text
+           
+        </label>
+      </div>
+      <div
+        class="text-field__body"
+      >
+        <input
+          aria-describedby="15"
+          aria-invalid="false"
+          class="input-field"
+          data-bootstrap-override="inputfield"
+          id="14"
+          placeholder="placeholder"
+          type="text"
+        />
+      </div>
+      <div
+        class="field-note"
+        id="15"
+      >
+        fieldNote text
+      </div>
+    </div>
+    <div>
+      <div
+        class="text-field__overline"
+      >
+        <label
+          class="label"
           for="16"
         >
           Label text
@@ -721,7 +753,6 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           id="16"
-          placeholder="placeholder"
           type="text"
         />
       </div>
@@ -732,6 +763,9 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         fieldNote text
       </div>
     </div>
+    <p>
+      no fieldNote, label
+    </p>
     <div>
       <div
         class="text-field__overline"
@@ -748,24 +782,15 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="19"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           id="18"
+          placeholder="placeholder"
           type="text"
         />
       </div>
-      <div
-        class="field-note"
-        id="19"
-      >
-        fieldNote text
-      </div>
     </div>
-    <p>
-      no fieldNote, label
-    </p>
     <div>
       <div
         class="text-field__overline"
@@ -786,31 +811,6 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           id="20"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="22"
-        >
-          Label text
-           
-        </label>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="22"
           type="text"
         />
       </div>
@@ -823,19 +823,19 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="25"
+          aria-describedby="23"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="24"
+          id="22"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="25"
+        id="23"
       >
         fieldNote text
       </div>
@@ -845,18 +845,18 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="27"
+          aria-describedby="25"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="26"
+          id="24"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="27"
+        id="25"
       >
         fieldNote text
       </div>
@@ -873,7 +873,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="28"
+          id="26"
           placeholder="placeholder"
           type="text"
         />
@@ -888,7 +888,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="30"
+          id="28"
           type="text"
         />
       </div>
@@ -915,56 +915,13 @@ exports[`<TextField /> NoVisibleLabel story renders snapshot 1`] = `
       class="text-field__body"
     >
       <input
-        aria-describedby="13"
+        aria-describedby="11"
         aria-invalid="false"
         aria-label="Input for no visible label"
         class="input-field"
         data-bootstrap-override="inputfield"
-        id="12"
-        required=""
-        type="text"
-      />
-    </div>
-    <div
-      class="field-note"
-      id="13"
-    >
-      This text field has no visible label
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<TextField /> OptionalIndicator story renders snapshot 1`] = `
-<div
-  style="padding: 0.5rem; background-color: white;"
->
-  <div>
-    <div
-      class="text-field__overline"
-    >
-      <label
-        class="label"
-        for="10"
-      >
-        Text field with fieldNote
-         
-      </label>
-      <p
-        class="text text--sm"
-      >
-        Optional
-      </p>
-    </div>
-    <div
-      class="text-field__body"
-    >
-      <input
-        aria-describedby="11"
-        aria-invalid="false"
-        class="input-field"
-        data-bootstrap-override="inputfield"
         id="10"
+        required=""
         type="text"
       />
     </div>
@@ -972,473 +929,13 @@ exports[`<TextField /> OptionalIndicator story renders snapshot 1`] = `
       class="field-note"
       id="11"
     >
-      This is a fieldnote for an optional text field.
+      This text field has no visible label
     </div>
   </div>
 </div>
 `;
 
-exports[`<TextField /> OptionalIndicatorVariants story renders snapshot 1`] = `
-<div
-  style="padding: 0.5rem; background-color: white;"
->
-  <div
-    style="display: grid; grid-template-columns: 1fr 2fr 2fr; gap: 2rem;"
-  >
-    <div />
-    <p>
-      Placeholder
-    </p>
-    <p>
-      No Placeholder
-    </p>
-    <p>
-      fieldNote, label
-    </p>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="94"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="95"
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="94"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note"
-        id="95"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="96"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="97"
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="96"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note"
-        id="97"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <p>
-      no fieldNote, label
-    </p>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="98"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="98"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="100"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="100"
-          type="text"
-        />
-      </div>
-    </div>
-    <p>
-      fieldNote, no label
-    </p>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--no-label"
-      >
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="103"
-          aria-invalid="false"
-          aria-label="Label text"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="102"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note"
-        id="103"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--no-label"
-      >
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="105"
-          aria-invalid="false"
-          aria-label="Label text"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="104"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note"
-        id="105"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <p>
-      no fieldNote, no label
-    </p>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--no-label"
-      >
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          aria-label="Label text"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="106"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--no-label"
-      >
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          aria-label="Label text"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="108"
-          type="text"
-        />
-      </div>
-    </div>
-    <p>
-      fieldNote, label, isError
-    </p>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="110"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="111"
-          aria-invalid="true"
-          class="input-field error"
-          data-bootstrap-override="inputfield"
-          id="110"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note field-note--error"
-        id="111"
-      >
-        <svg
-          class="icon field-note__icon"
-          fill="currentColor"
-          height="1rem"
-          role="img"
-          style="--icon-size: 1rem;"
-          width="1rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title
-            id="112"
-          >
-            error
-          </title>
-          <use
-            xlink:href="test-file-stub#dangerous"
-          />
-        </svg>
-        fieldNote text
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="113"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="114"
-          aria-invalid="true"
-          class="input-field error"
-          data-bootstrap-override="inputfield"
-          id="113"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note field-note--error"
-        id="114"
-      >
-        <svg
-          class="icon field-note__icon"
-          fill="currentColor"
-          height="1rem"
-          role="img"
-          style="--icon-size: 1rem;"
-          width="1rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title
-            id="115"
-          >
-            error
-          </title>
-          <use
-            xlink:href="test-file-stub#dangerous"
-          />
-        </svg>
-        fieldNote text
-      </div>
-    </div>
-    <p>
-      fieldNote, label, disabled
-    </p>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--disabled"
-      >
-        <label
-          class="label"
-          for="116"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="117"
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          disabled=""
-          id="116"
-          placeholder="placeholder"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note field-note--disabled"
-        id="117"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--disabled"
-      >
-        <label
-          class="label"
-          for="118"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Optional
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="119"
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          disabled=""
-          id="118"
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note field-note--disabled"
-        id="119"
-      >
-        fieldNote text
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<TextField /> RequiredIndicator story renders snapshot 1`] = `
+exports[`<TextField /> Required story renders snapshot 1`] = `
 <div
   style="padding: 0.5rem; background-color: white;"
 >
@@ -1482,7 +979,7 @@ exports[`<TextField /> RequiredIndicator story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
+exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
 <div
   style="padding: 0.5rem; background-color: white;"
 >
@@ -1499,6 +996,44 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
     <p>
       fieldNote, label
     </p>
+    <div>
+      <div
+        class="text-field__overline"
+      >
+        <label
+          class="label"
+          for="66"
+        >
+          Label text
+           
+        </label>
+        <p
+          class="text text--sm"
+        >
+          Required
+        </p>
+      </div>
+      <div
+        class="text-field__body"
+      >
+        <input
+          aria-describedby="67"
+          aria-invalid="false"
+          class="input-field"
+          data-bootstrap-override="inputfield"
+          id="66"
+          placeholder="placeholder"
+          required=""
+          type="text"
+        />
+      </div>
+      <div
+        class="field-note"
+        id="67"
+      >
+        fieldNote text
+      </div>
+    </div>
     <div>
       <div
         class="text-field__overline"
@@ -1525,7 +1060,6 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           id="68"
-          placeholder="placeholder"
           required=""
           type="text"
         />
@@ -1537,6 +1071,9 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         fieldNote text
       </div>
     </div>
+    <p>
+      no fieldNote, label
+    </p>
     <div>
       <div
         class="text-field__overline"
@@ -1558,25 +1095,16 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="71"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           id="70"
+          placeholder="placeholder"
           required=""
           type="text"
         />
       </div>
-      <div
-        class="field-note"
-        id="71"
-      >
-        fieldNote text
-      </div>
     </div>
-    <p>
-      no fieldNote, label
-    </p>
     <div>
       <div
         class="text-field__overline"
@@ -1602,37 +1130,6 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           id="72"
-          placeholder="placeholder"
-          required=""
-          type="text"
-        />
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline"
-      >
-        <label
-          class="label"
-          for="74"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Required
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          id="74"
           required=""
           type="text"
         />
@@ -1655,12 +1152,12 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="77"
+          aria-describedby="75"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="76"
+          id="74"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1668,7 +1165,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note"
-        id="77"
+        id="75"
       >
         fieldNote text
       </div>
@@ -1687,19 +1184,19 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="79"
+          aria-describedby="77"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="78"
+          id="76"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="79"
+        id="77"
       >
         fieldNote text
       </div>
@@ -1725,7 +1222,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="80"
+          id="78"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1750,7 +1247,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="82"
+          id="80"
           required=""
           type="text"
         />
@@ -1765,7 +1262,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="84"
+          for="82"
         >
           Label text
            
@@ -1780,11 +1277,11 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="85"
+          aria-describedby="83"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="84"
+          id="82"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1792,7 +1289,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note field-note--error"
-        id="85"
+        id="83"
       >
         <svg
           class="icon field-note__icon"
@@ -1804,7 +1301,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="86"
+            id="84"
           >
             error
           </title>
@@ -1821,7 +1318,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="87"
+          for="85"
         >
           Label text
            
@@ -1836,18 +1333,18 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="88"
+          aria-describedby="86"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="87"
+          id="85"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="88"
+        id="86"
       >
         <svg
           class="icon field-note__icon"
@@ -1859,7 +1356,7 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           xmlns="http://www.w3.org/2000/svg"
         >
           <title
-            id="89"
+            id="87"
           >
             error
           </title>
@@ -1873,6 +1370,45 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
     <p>
       fieldNote, label, disabled
     </p>
+    <div>
+      <div
+        class="text-field__overline text-field__overline--disabled"
+      >
+        <label
+          class="label"
+          for="88"
+        >
+          Label text
+           
+        </label>
+        <p
+          class="text text--sm"
+        >
+          Required
+        </p>
+      </div>
+      <div
+        class="text-field__body"
+      >
+        <input
+          aria-describedby="89"
+          aria-invalid="false"
+          class="input-field"
+          data-bootstrap-override="inputfield"
+          disabled=""
+          id="88"
+          placeholder="placeholder"
+          required=""
+          type="text"
+        />
+      </div>
+      <div
+        class="field-note field-note--disabled"
+        id="89"
+      >
+        fieldNote text
+      </div>
+    </div>
     <div>
       <div
         class="text-field__overline text-field__overline--disabled"
@@ -1900,7 +1436,6 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
           data-bootstrap-override="inputfield"
           disabled=""
           id="90"
-          placeholder="placeholder"
           required=""
           type="text"
         />
@@ -1908,44 +1443,6 @@ exports[`<TextField /> RequiredIndicatorVariants story renders snapshot 1`] = `
       <div
         class="field-note field-note--disabled"
         id="91"
-      >
-        fieldNote text
-      </div>
-    </div>
-    <div>
-      <div
-        class="text-field__overline text-field__overline--disabled"
-      >
-        <label
-          class="label"
-          for="92"
-        >
-          Label text
-           
-        </label>
-        <p
-          class="text text--sm"
-        >
-          Required
-        </p>
-      </div>
-      <div
-        class="text-field__body"
-      >
-        <input
-          aria-describedby="93"
-          aria-invalid="false"
-          class="input-field"
-          data-bootstrap-override="inputfield"
-          disabled=""
-          id="92"
-          required=""
-          type="text"
-        />
-      </div>
-      <div
-        class="field-note field-note--disabled"
-        id="93"
       >
         fieldNote text
       </div>


### PR DESCRIPTION
### Summary:
[sc-213670]
- during design crit, discussed need of the optional indicator
- if optional, just don't passed required was decided
- no usage of optional indicator in platform
### Test Plan:
- unit tests pass
- no visual regression except removal of optional variant textfields