### PR TITLE
chore(score): rename neutral variant to table

### DIFF
--- a/src/components/Score/Score.module.css
+++ b/src/components/Score/Score.module.css
@@ -18,6 +18,6 @@
 .score--error {
   --tag-outline-color: var(--eds-theme-color-border-utility-error-default);
 }
-.score--neutral {
+.score--table {
   --tag-outline-color: transparent;
 }

--- a/src/components/Score/Score.stories.tsx
+++ b/src/components/Score/Score.stories.tsx
@@ -28,9 +28,17 @@ export const Error: StoryObj<Args> = {
   },
 };
 
-export const Neutral: StoryObj<Args> = {
+export const Table: StoryObj<Args> = {
   args: {
     text: '6 / 10',
-    variant: 'neutral',
+    variant: 'table',
   },
+  decorators: [
+    (Story) => (
+      <div>
+        <p>Score has transparent border for use in Table component</p>
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './Score.module.css';
 import Tag from '../Tag';
 
-export const VARIANTS = ['neutral', 'error', 'success'] as const;
+export const VARIANTS = ['table', 'error', 'success'] as const;
 
 export type Variant = typeof VARIANTS[number];
 

--- a/src/components/Score/__snapshots__/Score.test.tsx.snap
+++ b/src/components/Score/__snapshots__/Score.test.tsx.snap
@@ -12,18 +12,6 @@ exports[`<Score /> Error story renders snapshot 1`] = `
 </span>
 `;
 
-exports[`<Score /> Neutral story renders snapshot 1`] = `
-<span
-  class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--neutral"
->
-  <span
-    class="tag__body"
-  >
-    6 / 10
-  </span>
-</span>
-`;
-
 exports[`<Score /> Success story renders snapshot 1`] = `
 <span
   class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--success"
@@ -34,4 +22,21 @@ exports[`<Score /> Success story renders snapshot 1`] = `
     91 / 100
   </span>
 </span>
+`;
+
+exports[`<Score /> Table story renders snapshot 1`] = `
+<div>
+  <p>
+    Score has transparent border for use in Table component
+  </p>
+  <span
+    class="text text--sm text--bold-weight tag tag--neutral tag--outline score score--table"
+  >
+    <span
+      class="tag__body"
+    >
+      6 / 10
+    </span>
+  </span>
+</div>
 `;


### PR DESCRIPTION
### Summary:
[sc-213671]
- during design crit, discussed using the transparent border score variant advised for use in the Table component only
- decided on renaming variant to `table`
### Test Plan:
- unit tests pass
- no visual regression except change of `neutral` to `table` variant