### PR TITLE
chore(tooltip)!: rename childDisabled to childNotInteractive

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -50,9 +50,9 @@
 }
 
 /**
- * 1) When childDisabled is true and alignment is top or bottom
+ * 1) When childNotInteractive is true and alignment is top or bottom
  */
-.tooltip__child-disabled-wrapper--vertical {
+.tooltip__child-not-interactive-wrapper--vertical {
   /* Needed for the top and bottom alignment to work properly */
   display: inline-flex;
 }

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -143,7 +143,7 @@ export const Disabled: StoryObj<Args> = {
     >
       <Tooltip
         align="top"
-        childDisabled={true}
+        childNotInteractive={true}
         text={defaultArgs.text}
         visible={true}
       >
@@ -189,7 +189,7 @@ export const InteractiveDisabled: StoryObj<Args> = {
     >
       <Tooltip
         align="top"
-        childDisabled={true}
+        childNotInteractive={true}
         duration={args.duration}
         text={defaultArgs.text}
       >

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -133,7 +133,7 @@ export const LongButtonText: StoryObj<Args> = {
   },
 };
 
-export const Disabled: StoryObj<Args> = {
+export const DisabledButton: StoryObj<Args> = {
   render: () => (
     <div
       className={clsx(
@@ -150,6 +150,26 @@ export const Disabled: StoryObj<Args> = {
         <Button disabled variant="primary">
           Tooltip trigger
         </Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const TextChild: StoryObj<Args> = {
+  render: () => (
+    <div
+      className={clsx(
+        styles['trigger--spacing-top'],
+        styles['trigger--spacing-left'],
+      )}
+    >
+      <Tooltip
+        align="top"
+        childNotInteractive={true}
+        text={defaultArgs.text}
+        visible={true}
+      >
+        <>Tooltip trigger</>
       </Tooltip>
     </div>
   ),
@@ -176,7 +196,7 @@ export const Interactive: StoryObj<Args> = {
   ],
 };
 
-export const InteractiveDisabled: StoryObj<Args> = {
+export const InteractiveDisabledButton: StoryObj<Args> = {
   args: {
     duration: undefined,
   },

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -6,7 +6,8 @@ import React from 'react';
 import * as TooltipStoryFile from './Tooltip.stories';
 import consoleWarnMockHelper from '../../../jest/helpers/consoleWarnMock';
 
-const { Interactive, InteractiveDisabled } = composeStories(TooltipStoryFile);
+const { Interactive, InteractiveDisabledButton } =
+  composeStories(TooltipStoryFile);
 
 describe('<Tooltip />', () => {
   const warnMock = consoleWarnMockHelper();
@@ -31,7 +32,7 @@ describe('<Tooltip />', () => {
 
   it('should close tooltip via escape key for disabled buttons', async () => {
     // disable animation for test
-    render(<InteractiveDisabled duration={0} />);
+    render(<InteractiveDisabledButton duration={0} />);
     const trigger = await screen.findByTestId('disabled-child-tooltip-wrapper');
     expect(screen.queryByTestId('tooltip-content')).not.toBeInTheDocument();
     await userEvent.hover(trigger);

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -23,13 +23,13 @@ type TooltipProps = {
    */
   children?: React.ReactElement;
   /**
-   * If the child being passed into the Tooltip via the `children` prop is disabled (e.g. a disabled button).
+   * If the child being passed into the Tooltip via the `children` prop is not interactive (e.g. a disabled button or an icon).
    *
    * Please note that spacing and placement styling will need to be added to a wrapper around the Tooltip,
-   * not on the button child inside the Tooltip, because there will be a wrapper around the button child. Example:
+   * not on the child component inside the Tooltip, because there will be a wrapper around the child. Example:
    * <div className="spacing-goes-here"><Tooltip text="Tooltip text"><Button disabled>Button text</Button></Tooltip></div>
    */
-  childDisabled?: boolean;
+  childNotInteractive?: boolean;
   /**
    * Custom classname for additional styles.
    *
@@ -104,7 +104,7 @@ type Plugin = Plugins[number];
 export const Tooltip = ({
   variant = 'light',
   align = 'top',
-  childDisabled,
+  childNotInteractive,
   className,
   duration = 200,
   text,
@@ -141,12 +141,12 @@ export const Tooltip = ({
   let children = rest.children;
   // Tippy only works on elements with a tabindex. If the child is disabled, we need to
   // wrap it in an element with a tabindex in order for it to work.
-  if (childDisabled) {
+  if (childNotInteractive) {
     children = (
       <span
         className={clsx(
           (align === 'bottom' || align === 'top') &&
-            styles['tooltip__child-disabled-wrapper--vertical'],
+            styles['tooltip__child-not-interactive-wrapper--vertical'],
         )}
         data-testid="disabled-child-tooltip-wrapper"
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`<Tooltip /> Disabled story renders snapshot 1`] = `
     >
       <span
         aria-describedby="tippy-8"
-        class="tooltip__child-disabled-wrapper--vertical"
+        class="tooltip__child-not-interactive-wrapper--vertical"
         data-testid="disabled-child-tooltip-wrapper"
         tabindex="0"
       >
@@ -207,7 +207,7 @@ exports[`<Tooltip /> InteractiveDisabled story renders snapshot 1`] = `
         class="trigger--spacing-top trigger--spacing-left"
       >
         <span
-          class="tooltip__child-disabled-wrapper--vertical"
+          class="tooltip__child-not-interactive-wrapper--vertical"
           data-testid="disabled-child-tooltip-wrapper"
           tabindex="0"
         >

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
 </body>
 `;
 
-exports[`<Tooltip /> Disabled story renders snapshot 1`] = `
+exports[`<Tooltip /> DisabledButton story renders snapshot 1`] = `
 <body>
   <div>
     <div
@@ -196,7 +196,7 @@ exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
 </body>
 `;
 
-exports[`<Tooltip /> InteractiveDisabled story renders snapshot 1`] = `
+exports[`<Tooltip /> InteractiveDisabledButton story renders snapshot 1`] = `
 <body>
   <div>
     <div>
@@ -439,6 +439,65 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
       <div
         class="tippy-arrow"
         style="position: absolute; top: 0px; transform: translate(0px, 3px);"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<Tooltip /> TextChild story renders snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="trigger--spacing-top trigger--spacing-left"
+    >
+      <span
+        aria-describedby="tippy-9"
+        class="tooltip__child-not-interactive-wrapper--vertical"
+        data-testid="disabled-child-tooltip-wrapper"
+        tabindex="0"
+      >
+        Tooltip trigger
+      </span>
+    </div>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-9"
+    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
+  >
+    <div
+      class="tippy-box tooltip tooltip--light"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="top"
+      data-reference-hidden=""
+      data-state="visible"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 200ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 200ms;"
+      >
+        <div>
+          <span
+            data-testid="tooltip-content"
+          >
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+             
+            <b>
+              Donec a erat eu augue consequat eleifend non vel sem.
+            </b>
+             Praesent efficitur mauris ac leo semper accumsan.
+          </span>
+        </div>
+      </div>
+      <div
+        class="tippy-arrow"
+        style="position: absolute; left: 0px; transform: translate(3px, 0px);"
       />
     </div>
   </div>


### PR DESCRIPTION
### Summary:
We're seeing `Tooltip` usage in `traject` where the child is not an interactive element (like an icon that's not a button). We just added the `childDisabled` prop so the `Tooltip` supports disabled buttons and such as `children`. This prop also works for other non-interactive children, but the prop name is a little confusing to use in those situations. To make this usage clearer, I'm renaming the `childDisabled` prop to `childNotInteractive`.

### Test Plan:
I added a story that has text in a react fragment to verify the prop works for that situation.

<img width="895" alt="tooltip story with plain text as the child" src="https://user-images.githubusercontent.com/7761701/188734212-8114bfa6-4b9d-4c09-9518-49b50f13d882.png">
