### PR TITLE
docs: remove beta tags and comments from mature components

### DIFF
--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Avatar } from './Avatar';
 export default {
   title: 'Atoms/Media/Avatar',
   component: Avatar,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Avatar>;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -10,8 +10,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Avatar} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/AvatarImage/AvatarImage.stories.tsx
+++ b/src/components/AvatarImage/AvatarImage.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { AvatarImage } from './AvatarImage';
 export default {
   title: 'Atoms/Media/AvatarImage',
   component: AvatarImage,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof AvatarImage>;

--- a/src/components/AvatarImage/AvatarImage.tsx
+++ b/src/components/AvatarImage/AvatarImage.tsx
@@ -10,8 +10,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {AvatarImage} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import { within } from '@storybook/testing-library';
 import React from 'react';
@@ -9,9 +8,6 @@ export default {
   title: 'Molecules/Navigation/Breadcrumbs',
   component: Breadcrumbs,
   subcomponents: { 'Breadcrumbs.Item': Breadcrumbs.Item },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -28,8 +28,6 @@ type Props = {
 };
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Breadcrumbs} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -33,8 +33,6 @@ type Props = {
 };
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {BreadcrumbsItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -64,8 +64,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * Contains the button and the dropdown
  */
 export const ButtonDropdown = ({

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -36,9 +36,6 @@ export interface Props {
 }
 
 /**
-
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Card} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/CardBody/CardBody.tsx
+++ b/src/components/CardBody/CardBody.tsx
@@ -15,7 +15,6 @@ export interface Props {
 
 /**
  * Primary UI component for user interaction
- * BETA: This component is still a work in progress and is subject to change.
  *
  * ```ts
  * import {CardBody} from "@chanzuckerberg/eds";

--- a/src/components/CardFooter/CardFooter.tsx
+++ b/src/components/CardFooter/CardFooter.tsx
@@ -15,7 +15,6 @@ export interface Props {
 
 /**
  * Primary UI component for user interaction
- * BETA: This component is still a work in progress and is subject to change.
  *
  * ```ts
  * import {CardFooter} from "@chanzuckerberg/eds";

--- a/src/components/DataBar/DataBar.stories.tsx
+++ b/src/components/DataBar/DataBar.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -29,9 +28,6 @@ export default {
       </div>
     ),
   ],
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof DataBar>;

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -43,8 +43,6 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DataBar} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DataBarSegment/DataBarSegment.tsx
+++ b/src/components/DataBarSegment/DataBarSegment.tsx
@@ -30,8 +30,6 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DataBarSegment} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { Story, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -9,9 +8,6 @@ export default {
   title: 'Molecules/Lists/DefinitionList',
   component: DefinitionList,
   subcomponents: { DefinitionListItem },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta;
 
 const Template: Story<Props> = (args) => (

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -24,8 +24,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DefinitionList} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DefinitionListItem/DefinitionListItem.tsx
+++ b/src/components/DefinitionListItem/DefinitionListItem.tsx
@@ -18,8 +18,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DefinitionListItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React, { ComponentProps } from 'react';
 import { DragDrop } from './DragDrop';
@@ -25,9 +24,6 @@ export default {
       </div>
     ),
   ],
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = ComponentProps<typeof DragDrop>;

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -48,8 +48,6 @@ type ContextRefs = {
 export const DropdownMenuContext = createContext<ContextRefs | null>(null);
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DropdownMenu} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem/DropdownMenuItem.tsx
@@ -50,8 +50,6 @@ export type DropdownMenuItemProps = {
 };
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {DropdownMenuItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -45,9 +44,6 @@ export default {
   },
   component: Grid,
   subcomponents: { GridItem },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Grid>;

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -38,8 +38,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Grid} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -14,8 +14,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {GridItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Header } from './Header';
 export default {
   title: 'Organisms/Global/Header',
   component: Header,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: <div className="fpo">Header children</div>,
   },

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -33,8 +33,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Header} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Hr/Hr.stories.tsx
+++ b/src/components/Hr/Hr.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Hr } from './Hr';
 export default {
   title: 'Atoms/Text/Hr',
   component: Hr,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Hr>;

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -20,8 +20,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Hr} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/InlineNotification/InlineNotification.stories.tsx
+++ b/src/components/InlineNotification/InlineNotification.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { InlineNotification, VARIANTS } from './InlineNotification';
@@ -17,9 +16,6 @@ export default {
       },
       options: VARIANTS,
     },
-  },
-  parameters: {
-    badges: [BADGE.BETA],
   },
 } as Meta<Args>;
 

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -64,8 +64,6 @@ type Props = {
 };
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {InlineNotification} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Label } from './Label';
 export default {
   title: 'Atoms/Forms/Label',
   component: Label,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Label>;

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -42,8 +42,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Label} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -38,8 +38,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Layout} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -12,7 +11,6 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
-    badges: [BADGE.BETA],
   },
   args: {
     children: <div className="fpo">Layout container</div>,

--- a/src/components/LayoutContainer/LayoutContainer.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.tsx
@@ -23,8 +23,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {LayoutContainer} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { LayoutLinelengthContainer } from './LayoutLinelengthContainer';
 export default {
   title: 'Molecules/Layout and Containers/Linelength Container',
   component: LayoutLinelengthContainer,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
@@ -14,8 +14,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {LayoutLinelengthContainer} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/LayoutSection/LayoutSection.tsx
+++ b/src/components/LayoutSection/LayoutSection.tsx
@@ -22,8 +22,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {LayoutSection} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/LinkList/LinkList.stories.tsx
+++ b/src/components/LinkList/LinkList.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,9 +7,6 @@ import LinkListItem from '../LinkListItem';
 export default {
   title: 'Molecules/Navigation/LinkList',
   component: LinkList,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/LinkList/LinkList.tsx
+++ b/src/components/LinkList/LinkList.tsx
@@ -34,8 +34,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {LinkList} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/LinkListItem/LinkListItem.tsx
+++ b/src/components/LinkListItem/LinkListItem.tsx
@@ -47,8 +47,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {LinkListItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Logo } from './Logo';
 export default {
   title: 'Molecules/Global/Logo',
   component: Logo,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <svg

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -29,8 +29,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Logo} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Main/Main.stories.tsx
+++ b/src/components/Main/Main.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -12,7 +11,6 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
-    badges: [BADGE.BETA],
   },
   args: {
     children: <div className="fpo">Main element</div>,

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -14,8 +14,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Main} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/ModalStepper/ModalStepper.tsx
+++ b/src/components/ModalStepper/ModalStepper.tsx
@@ -20,8 +20,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {ModalStepper} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/NavContainer/NavContainer.stories.tsx
+++ b/src/components/NavContainer/NavContainer.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -12,9 +11,6 @@ export default {
   title: 'Molecules/Global/NavContainer',
   component: NavContainer,
   subcomponents: { PrimaryNav, UtilityNav },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/NavContainer/NavContainer.tsx
+++ b/src/components/NavContainer/NavContainer.tsx
@@ -19,8 +19,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {NavContainer} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/NotificationList/NotificationList.stories.tsx
+++ b/src/components/NotificationList/NotificationList.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -11,9 +10,6 @@ export default {
   title: 'Molecules/Lists/NotificationList',
   component: NotificationList,
   subcomponents: { NotificationListItem },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = Props & NotificationListItemProps;

--- a/src/components/NotificationList/NotificationList.tsx
+++ b/src/components/NotificationList/NotificationList.tsx
@@ -15,8 +15,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {NotificationList} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/NotificationListItem/NotificationListItem.tsx
+++ b/src/components/NotificationListItem/NotificationListItem.tsx
@@ -40,8 +40,6 @@ interface State {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {NotificationListItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -36,8 +36,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {NumberIcon} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/OverflowList/OverflowList.stories.tsx
+++ b/src/components/OverflowList/OverflowList.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -8,9 +7,6 @@ import { OverflowListItem } from '../OverflowListItem/OverflowListItem';
 export default {
   title: 'Molecules/Lists/OverflowList',
   component: OverflowList,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof OverflowList>;

--- a/src/components/OverflowList/OverflowList.tsx
+++ b/src/components/OverflowList/OverflowList.tsx
@@ -22,8 +22,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {OverflowList} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/OverflowListItem/OverflowListItem.tsx
+++ b/src/components/OverflowListItem/OverflowListItem.tsx
@@ -14,8 +14,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {OverflowListItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PageHeader/PageHeader.stories.tsx
+++ b/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -10,9 +9,6 @@ import Text from '../Text';
 export default {
   title: 'Molecules/Text/PageHeader',
   component: PageHeader,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof PageHeader>;

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -65,8 +65,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PageHeader} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,9 +6,6 @@ import { Panel } from './Panel';
 export default {
   title: 'Molecules/Layout and Containers/Panel',
   component: Panel,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: 'A Panel is a generic bordered container for content.',
   },

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -29,8 +29,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Panel} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -9,7 +8,6 @@ export default {
   component: PopoverExample,
   parameters: {
     layout: 'centered',
-    badges: [BADGE.BETA],
   },
 } as Meta<Args>;
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -51,8 +51,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Popover} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PopoverBody/PopoverBody.tsx
+++ b/src/components/PopoverBody/PopoverBody.tsx
@@ -12,8 +12,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PopoverBody} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PopoverFooter/PopoverFooter.tsx
+++ b/src/components/PopoverFooter/PopoverFooter.tsx
@@ -14,8 +14,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PopoverFooter} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PopoverHeader/PopoverHeader.tsx
+++ b/src/components/PopoverHeader/PopoverHeader.tsx
@@ -22,8 +22,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PopoverHeader} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PrimaryNav/PrimaryNav.stories.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -9,9 +8,6 @@ export default {
   title: 'Molecules/Navigation/PrimaryNav',
   component: PrimaryNav,
   subcomponents: { PrimaryNavItem },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   decorators: [
     (Story) => (
       <div style={{ background: '#000' }}>

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -24,8 +24,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PrimaryNav} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -28,8 +28,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {PrimaryNavItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -22,6 +22,8 @@ export type RadioProps = RadioInputProps & {
 };
 
 /**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
  * ```ts
  * import {Radio} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Section/Section.stories.tsx
+++ b/src/components/Section/Section.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Section } from './Section';
@@ -10,9 +9,6 @@ import Text from '../Text';
 export default {
   title: 'Organisms/Sections/Section',
   component: Section,
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children:
       'This is the section body, where you can put any content or include other components.',

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -51,8 +51,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Section} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/ShowHide/ShowHide.stories.tsx
+++ b/src/components/ShowHide/ShowHide.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -14,7 +13,6 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
-    badges: [BADGE.BETA],
   },
   decorators: [
     (Story) => (

--- a/src/components/ShowHide/ShowHide.tsx
+++ b/src/components/ShowHide/ShowHide.tsx
@@ -43,8 +43,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {ShowHide} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -28,8 +28,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Tab} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -10,9 +9,6 @@ export default {
   title: 'Organisms/Interactive/Tabs',
   component: Tabs,
   subcomponents: { Tabs },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -93,8 +93,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Tabs} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -15,9 +14,6 @@ export default {
   title: 'Molecules/Navigation/TimelineNav',
   component: TimelineNav,
   subcomponents: { TimelineNavPanel },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     variant: 'ordered',
     children: (

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -93,8 +93,6 @@ export interface TimelineNavItem {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {TimelineNav} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -46,8 +46,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {TimelineNavPanel} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -14,7 +13,6 @@ export default {
       // TODO: re-enable when component is worked on
       skip: true,
     },
-    badges: [BADGE.BETA],
   },
   args: {
     children: (

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -26,8 +26,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {Toolbar} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/ToolbarItem/ToolbarItem.tsx
+++ b/src/components/ToolbarItem/ToolbarItem.tsx
@@ -20,8 +20,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {ToolbarItem} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/UtilityNav/UtilityNav.stories.tsx
+++ b/src/components/UtilityNav/UtilityNav.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -9,9 +8,6 @@ export default {
   title: 'Molecules/Navigation/UtilityNav',
   component: UtilityNav,
   subcomponents: { UtilityNavItem },
-  parameters: {
-    badges: [BADGE.BETA],
-  },
   args: {
     children: (
       <>

--- a/src/components/UtilityNav/UtilityNav.tsx
+++ b/src/components/UtilityNav/UtilityNav.tsx
@@ -28,8 +28,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {UtilityNav} from "@chanzuckerberg/eds";
  * ```

--- a/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -32,8 +32,6 @@ export interface Props {
 }
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
  * ```ts
  * import {UtilityNavItem} from "@chanzuckerberg/eds";
  * ```


### PR DESCRIPTION
### Summary:
This PR removes a bunch of beta tags from mature existing components. In https://github.com/chanzuckerberg/edu-design-system/pull/1267 I'm updating the documentation to include information about our new beta process.

I left the beta tags on components that have been made in the last ~6 weeks. Going forward, it should be easier to just look at the releases since we're only releasing a few components in each release.

The components I didn't remove the beta tags from are:
- plop file component templates
- Everything in `upcoming-components`
- `Drawer` (and `DrawerExample`, `DrawerBody`, `DrawerFooter`, and `DrawerHeader`)
- `FieldNote`
- `Filters` (and `FiltersCheckboxField` and `FiltersDrawer`)
- `InputField` (and `InputLabel`)
- `Radio`
- `Score`
- `SearchBar` (and `SearchButton` and `SearchField`)
- `StackedBlock`
- `Table` (and `TableBody`, `TableCell`, `TableFooter`, `TableHeader`, `TableHeaderCell`, `TableObject`, `TableObjectBody`, `TableObjectFooter`, `TableObjectHeader`, and `TableRow`)
- `Textfield`

### Summary shared between the two PRs
Almost all of our components have a beta tag (in storybook and also in the component docstring) even though some of them were completed months ago. This morning we discussed what should be the threshold for component graduation out of beta status, and it was decided that:
- when a component is in beta when it's first released/announced
- upon the following release, the component is no longer in beta
- releases will probably happen about once/month

### Test Plan:
Spot-checked some of the stories to verify the beta comment and badge are gone.