### PR TITLE
docs(components): add information about beta status

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -43,6 +43,12 @@ Each EDS component is documented in Storybook, which surfaces each component's A
 4. Edit component source code in accordance with [EDS's code guidelines](./CODE_GUIDELINES.md)
 5. Create relevant stories for all component variants
 
+### Beta status
+
+When components are first created using the `plop` feature, they're given a beta tag in the `.stories` file and a line is added to the component docstring stating that the component is in beta. When the component is first officially released/announced internally, the component will be in beta, but it will leave beta in the following release. We expect these releases to happen about once/month, and the removal of the beta information will happen as part of the release process.
+
+Exceptions can be made for components that are still fluctuating and experiencing a lot of changes when the second release comes around.
+
 ---
 
 ## Working with pages


### PR DESCRIPTION
### Summary:
This PR updates the component documentation to describe our new beta process. In https://github.com/chanzuckerberg/edu-design-system/pull/1266 I'm removing a bunch of beta tags from mature existing components.

### Summary shared between the two PRs:
Almost all of our components have a beta tag (in storybook and also in the component docstring) even though some of them were completed months ago. This morning we discussed what should be the threshold for component graduation out of beta status, and it was decided that:
- when a component is in beta when it's first released/announced
- upon the following release, the component is no longer in beta
- releases will probably happen about once/month

### Test Plan:
Verify the new documentation looks okay in the visual studio preview.
<img width="677" alt="component documentation with the new section visible" src="https://user-images.githubusercontent.com/7761701/188750336-f28d5cd6-3c9a-443e-aa3e-55df0cd72b22.png">