### PR TITLE
chore: use focus instead of focus-visible

### DIFF
--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -56,7 +56,7 @@
     border-color: transparent; /* TODO */
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focusInverted;
   }
 

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -84,7 +84,7 @@
     text-decoration: underline;
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 }

--- a/src/components/Drawer/Drawer.module.css
+++ b/src/components/Drawer/Drawer.module.css
@@ -22,7 +22,7 @@
   background-color: transparent;
 }
 
-.drawer__container:focus-visible {
+.drawer__container:focus {
   @mixin focus;
 }
 
@@ -55,7 +55,7 @@
     transition: none;
   }
 }
-.drawer:focus-visible {
+.drawer:focus {
   @mixin focus;
 }
 

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -76,7 +76,7 @@
     background: var(--eds-theme-color-background-neutral-subtle);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 

--- a/src/components/LinkList/LinkList.module.css
+++ b/src/components/LinkList/LinkList.module.css
@@ -45,7 +45,7 @@
   display: flex;
   @mixin textLink;
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 
@@ -71,7 +71,7 @@
     color: var(--eds-theme-color-text-neutral-default-inverse);
     text-decoration: none;
 
-    &:focus-visible {
+    &:focus {
       @mixin focusInverted;
     }
   }

--- a/src/components/Logo/Logo.module.css
+++ b/src/components/Logo/Logo.module.css
@@ -17,7 +17,7 @@
   display: block;
   width: fit-content; /* 1 */
 
-  &:focus-visible {
+  &:focus {
     @mixin focusInverted;
   }
 }

--- a/src/components/Popover/Popover.module.css
+++ b/src/components/Popover/Popover.module.css
@@ -28,7 +28,7 @@
   overscroll-behavior-y: contain;
   z-index: var(--eds-z-index-bottom);
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -26,7 +26,7 @@
     background: var(--eds-theme-color-button-primary-brandbackground-active);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focusInverted;
   }
 

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -94,7 +94,7 @@
     box-shadow var(--eds-anim-fade-quick) var(--eds-anim-ease),
     background-color var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -205,7 +205,7 @@
     color: var(--eds-theme-color-text-neutral-default);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -59,7 +59,7 @@
   @mixin textLink;
   color: var(--eds-theme-color-text-neutral-default-inverse);
 
-  &:focus-visible {
+  &:focus {
     @mixin focusInverted;
   }
 }
@@ -104,7 +104,7 @@
     border-color: var(--eds-theme-color-form-border-hover);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
     border-color: var(--eds-theme-color-border-brand-primary-strong);
   }

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
@@ -59,7 +59,7 @@
  * Accordion panel button focus visible
  * 1) Show focus ring when focused only with keyboard
  */
-.accordion__panel-button:focus-visible {
+.accordion__panel-button:focus {
   @mixin focus;
 }
 

--- a/src/upcoming-components/Tags/Tags.module.css
+++ b/src/upcoming-components/Tags/Tags.module.css
@@ -38,7 +38,7 @@
   line-height: 1;
   cursor: pointer;
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
   }
 }


### PR DESCRIPTION
### Summary:
When discussion https://github.com/chanzuckerberg/edu-design-system/pull/1250 we realized that the browser versions we support don't all support the `focus-visible` CSS feature, which we're currently using in a few places in the codebase.

This PR just replaces `:focus-visible` with `:focus`.

### Test Plan:
Spot check that these now show focus on both mouse and keyboard interaction.