### PR TITLE
fix(notification-list): add focus state to button

### DIFF
--- a/src/components/NotificationList/NotificationList.module.css
+++ b/src/components/NotificationList/NotificationList.module.css
@@ -81,6 +81,10 @@
   background-color: var(--eds-theme-color-text-link-strong);
   cursor: pointer;
 
+  &:focus {
+    @mixin focus;
+  }
+
   /*
     * Notification List Item (is read)
     * 1) When isRead === true, button's background and border are changed to neutral


### PR DESCRIPTION
### Summary:
@jinlee93 flagged that the button in notification list items does not currently have a visual state change on focus. (This button serves as the "read" indicator, and the user can trigger it to flip the "read" state.)

This PR just adds the regular focus outline on focus.

<img width="1280" alt="before and after comparison showing the notification dot button now has an outline on focus" src="https://user-images.githubusercontent.com/7761701/188944347-9662095d-d494-4b4b-8a91-a3650b0ec321.png">

#### After

### Test Plan:
- navigated to http://localhost:9009/?path=/story/molecules-lists-notificationlist--default
- verified I could tab through the notification text and buttons
- verified there's now a focus outline on the buttons when focused
- verified I can flip the "read" status on the buttons with the keyboard