### PR TITLE
chore(clickable-style): update sm button styles

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -506,35 +506,39 @@
 
 /**
  * Small clickable style
- * 1) Height is used instead of vertical padding because the icon size we use would
- *    cause the height to expand
  */
 .clickable-style--sm {
-  height: var(--eds-size-3); /* 1 */
-  padding-left: var(--eds-size-half);
-  padding-right: var(--eds-size-half);
+  @mixin eds-theme-typography-button-label-sm;
+  /**
+   * Height is used instead of vertical padding because the icon size we use would
+   * cause the height to expand
+   */
+  height: var(--eds-size-3);
+  padding: 0 var(--eds-size-1);
 }
 
 /**
  * Medium clickable style
- * 1) Height is used instead of vertical padding because the icon size we use would
- *    cause the height to expand
  */
 .clickable-style--md {
-  height: var(--eds-size-4); /* 1 */
-  padding-left: var(--eds-size-1);
-  padding-right: var(--eds-size-1);
+  /**
+   * Height is used instead of vertical padding because the icon size we use would
+   * cause the height to expand
+   */
+  height: var(--eds-size-4);
+  padding: 0 var(--eds-size-1);
 }
 
 /**
  * Large clickable style
- * 1) Height is used instead of vertical padding because the icon size we use would
- *    cause the height to expand
  */
 .clickable-style--lg {
-  height: var(--eds-size-5); /* 1 */
-  padding-left: var(--eds-size-2);
-  padding-right: var(--eds-size-2);
+  /**
+   * Height is used instead of vertical padding because the icon size we use would
+   * cause the height to expand
+   */
+  height: var(--eds-size-5);
+  padding: 0 var(--eds-size-2);
 }
 
 /**

--- a/src/design-tokens/tier-2-usage/typography-usage.css
+++ b/src/design-tokens/tier-2-usage/typography-usage.css
@@ -72,6 +72,10 @@
   @mixin eds-typography-preset-006 $important;
 }
 
+@define-mixin eds-theme-typography-button-label-sm $important {
+  @mixin eds-typography-preset-008-bold $important;
+}
+
 @define-mixin eds-theme-typography-form-label $important {
   @mixin eds-typography-preset-006 $important;
 }


### PR DESCRIPTION
### Summary:
The "sm" `Button` styles are being updated to make the text smaller and horizontal padding bigger.

- font size: 14px => 12px
- line height: 24px => 20px
- height: unchanged (24px)
- left/right padding: 4px => 8px

### Screenshots
#### Before
##### Figma
<img width="902" alt="Screen Shot 2022-09-09 at 4 27 08 PM" src="https://user-images.githubusercontent.com/7761701/189458879-5b8044e7-3ef1-465b-8ff4-73e3ac728e1a.png">

##### Storybook
<img width="1583" alt="Screen Shot 2022-09-09 at 4 33 21 PM" src="https://user-images.githubusercontent.com/7761701/189458889-48f552f0-636b-4f2a-beb7-edda2e1ae1f9.png">

#### After
##### Figma
<img width="780" alt="Screen Shot 2022-09-09 at 4 26 07 PM" src="https://user-images.githubusercontent.com/7761701/189458903-1afc8621-cc91-4b9c-889c-95f02fb03e80.png">

##### Storybook
<img width="1583" alt="Screen Shot 2022-09-09 at 4 28 46 PM" src="https://user-images.githubusercontent.com/7761701/189458916-0bbadaa3-e22e-4d5e-97aa-55d7dd652277.png">

### Test Plan:
Verify "sm" `Button` styles reflect new size properties.