### PR TITLE
chore(modal-body): pass down extra props to wrapper div

### DIFF
--- a/src/components/ModalBody/ModalBody.tsx
+++ b/src/components/ModalBody/ModalBody.tsx
@@ -20,15 +20,19 @@ export type Props = {
   isFocusable?: boolean;
 };
 
-export const ModalBody = (props: Props) => {
-  return (
-    <div
-      className={clsx(styles['modal-body'], props.className)}
-      // This element is tabbable to allow keyboard users to scroll long content.
-      // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-      tabIndex={props.isFocusable ? 0 : undefined}
-    >
-      {props.children}
-    </div>
-  );
-};
+export const ModalBody = ({
+  children,
+  className,
+  isFocusable,
+  ...other
+}: Props) => (
+  <div
+    className={clsx(styles['modal-body'], className)}
+    // This element is tabbable to allow keyboard users to scroll long content.
+    // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+    tabIndex={isFocusable ? 0 : undefined}
+    {...other}
+  >
+    {children}
+  </div>
+);


### PR DESCRIPTION
### Summary:
The `ModalBody` component isn't passing down extra props, which means you can't put a `data-testid` on it for end-to-end tests. This PR just passes extra props down onto the wrapper `div`.

### Test Plan:
I temporarily added a `data-testid` to a `Modal.Body` in the `Modal.stories.tsx` file and verified in the browser that the attribute is being passed down.

<img width="1746" alt="modal story with the chrome dev tools open, inspecting the modal body, with a test id visible in the dom tree" src="https://user-images.githubusercontent.com/7761701/189460472-b0c739ad-fb42-4662-be19-3e49b452ad22.png">