### PR TITLE
chore(link): update colors for default and hover states

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -489,18 +489,16 @@
 
 /**
  * Link neutral clickable style
- * 1) Overrides the default background color on focus. Often used when the default
- *    focus background color doesn't mesh well with the surrounding colors.
  */
 .clickable-style--link.clickable-style--neutral {
-  text-decoration-color: var(--eds-theme-color-icon-neutral-strong);
+  text-decoration-color: var(--eds-theme-color-text-link-default);
 
   &:hover {
-    text-decoration-color: var(--eds-theme-color-border-neutral-strong);
+    text-decoration-color: var(--eds-theme-color-text-link-strong);
   }
 
   &:focus {
-    background-color: var(--eds-theme-color-icon-neutral-strong); /* 1 */
+    background-color: var(--eds-theme-color-text-link-default); /* 1 */
   }
 }
 

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -27,7 +27,7 @@
 
   color: var(--eds-theme-color-text-link-default);
   text-decoration: underline;
-  text-decoration-color: var(--eds-theme-color-background-brand-primary-strong);
+  text-decoration-color: var(--eds-theme-color-text-link-strong);
   text-decoration-thickness: 2px;
   text-underline-offset: 2px;
 
@@ -36,8 +36,8 @@
   }
 
   &:hover {
-    color: var(--eds-theme-color-text-link-default-hover);
-    text-decoration-color: var(--eds-theme-color-border-brand-primary);
+    color: var(--eds-theme-color-text-link-strong);
+    text-decoration-color: var(--eds-theme-color-text-link-strong);
   }
 
   &:focus {
@@ -46,7 +46,7 @@
     text-decoration-color: var(
       --eds-theme-color-text-neutral-default-inverse
     ) !important;
-    background-color: var(--eds-theme-color-background-brand-primary-strong);
+    background-color: var(--eds-theme-color-text-link-strong);
   }
 }
 


### PR DESCRIPTION
### Summary:
The link styles for both variants (brand and neutral) are being nicely simplified to only use 2 colors:
- neutral 800
  - brand and neutral variant text in default state
  - neutral variant underline in default state
  - neutral variant background in focus state
- brand 700
  - brand variant underline in default state
  - brand and neutral variant text in hover state
  - brand variant background in focus state

I'm intentionally avoiding updating tokens for this PR because I'm waiting for design to decide what naming convention they would like to use. Instead, I'm just using 2 existing tokens for links that have these 2 colors and leaving a few tokens now-unused. [Shortcut ticket for updating the tokens.](https://app.shortcut.com/czi-edu/story/214834/update-link-color-tokens-in-code)

### Test Plan:
Verify the "link" `variant` (in both the `Button` and `Link` components) match the new styles in all states.