### PR TITLE
chore(popover): add delay to reduce chromatic flakiness

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -10,6 +10,7 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
+    chromatic: { delay: 300 },
   },
   args: {
     children: (


### PR DESCRIPTION
Like the overlay component that relies on Headless (*cough* Dropdown *cough*) Popover seems to have Chromatic flakiness. This introduces Chromatic delay to attempt to resolve said flakiness.