### PR TITLE
test(popover): skip chromatic testing

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
-    chromatic: { delay: 300 },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     children: (


### PR DESCRIPTION
### Summary:
I'm sadly still seeing flaky `Popover` snapshots in chromatic even after a delay was added 😞 I think this may be related to the issue with `Tooltip`, but I don't know what that is, so I'm just disabling the tests for now so they don't get in devs' way.

For an example of the issue, I have a [PR that just updated some documentation](https://github.com/chanzuckerberg/edu-design-system/pull/1287), but it still managed to trigger [5 Popover snapshot changes in chromatic](https://www.chromatic.com/build?appId=61313967cde49b003ae2a860&number=2608).

There's already a [shortcut story for investigating the Tooltip chromatic issue](https://app.shortcut.com/czi-edu/story/200684/fix-tooltip-chromatic-issues).

### Test Plan:
Verify there are no chromatic changes for this PR.