### PR TITLE
chore(tooltip): remove disply: inline-flex from non-interactive wrapper

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -50,14 +50,6 @@
 }
 
 /**
- * 1) When childNotInteractive is true and alignment is top or bottom
- */
-.tooltip__child-not-interactive-wrapper--vertical {
-  /* Needed for the top and bottom alignment to work properly */
-  display: inline-flex;
-}
-
-/**
  * 1) Add arrows
  */
 .tooltip :global(.tippy-arrow) {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -144,10 +144,6 @@ export const Tooltip = ({
   if (childNotInteractive) {
     children = (
       <span
-        className={clsx(
-          (align === 'bottom' || align === 'top') &&
-            styles['tooltip__child-not-interactive-wrapper--vertical'],
-        )}
         data-testid="disabled-child-tooltip-wrapper"
         // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
         tabIndex={0}

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -118,7 +118,6 @@ exports[`<Tooltip /> DisabledButton story renders snapshot 1`] = `
     >
       <span
         aria-describedby="tippy-8"
-        class="tooltip__child-not-interactive-wrapper--vertical"
         data-testid="disabled-child-tooltip-wrapper"
         tabindex="0"
       >
@@ -207,7 +206,6 @@ exports[`<Tooltip /> InteractiveDisabledButton story renders snapshot 1`] = `
         class="trigger--spacing-top trigger--spacing-left"
       >
         <span
-          class="tooltip__child-not-interactive-wrapper--vertical"
           data-testid="disabled-child-tooltip-wrapper"
           tabindex="0"
         >
@@ -453,7 +451,6 @@ exports[`<Tooltip /> TextChild story renders snapshot 1`] = `
     >
       <span
         aria-describedby="tippy-9"
-        class="tooltip__child-not-interactive-wrapper--vertical"
         data-testid="disabled-child-tooltip-wrapper"
         tabindex="0"
       >


### PR DESCRIPTION
### Summary:
I recently added `childNotInteractive` prop to `Tooltip` for cases where the `children` passed into the tooltip is, as you might guess, not interactive (e.g. an icon, some text, or a disabled button). In order for the tooltip to work on non-interactive elements, the child needs to be wrapped in a `span` or `div` with `tabIndex=0`, so this prop allows us to add the wrapper for the consumer.

I also added `display: inline-flex` to the wrapper if the tooltip's placement is `top` or `bottom` because otherwise the tooltip arrow isn't in quite the right position. But when I tried to use this in `traject`, some of the elements didn't appear at all, which I didn't notice (and then [someone else had to go revert the commit](https://github.com/FB-PLP/traject/pull/12244)). Since it's much worse for something to accidentally not appear at all than having the arrow slightly off-center, I'm removing that styling. Consumers can add it on themselves if they really want to and it's safe.

### Test Plan:
I tested one of the problem areas in `traject` with the existing tooltip functionality and verified that just turning off `display: inline-flex` solved the issue (though, again, the arrow is still slightly off.