### PR TITLE
chore(clickable-style): only show focus state for keyboard users

### DIFF
--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -35,8 +35,14 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focus;
+    }
   }
 
   @media screen and (prefers-reduced-motion) {
@@ -497,8 +503,14 @@
     text-decoration-color: var(--eds-theme-color-text-link-strong);
   }
 
-  &:focus {
+  &:focus-visible {
     background-color: var(--eds-theme-color-text-link-default); /* 1 */
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      background-color: var(--eds-theme-color-text-link-default); /* 1 */
+    }
   }
 }
 

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -40,13 +40,24 @@
     text-decoration-color: var(--eds-theme-color-text-link-strong);
   }
 
-  &:focus {
+  &:focus-visible {
     outline: 1px solid transparent; /* 7 */
     color: var(--eds-theme-color-text-neutral-default-inverse) !important;
     text-decoration-color: var(
       --eds-theme-color-text-neutral-default-inverse
     ) !important;
     background-color: var(--eds-theme-color-text-link-strong);
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      outline: 1px solid transparent; /* 7 */
+      color: var(--eds-theme-color-text-neutral-default-inverse) !important;
+      text-decoration-color: var(
+        --eds-theme-color-text-neutral-default-inverse
+      ) !important;
+      background-color: var(--eds-theme-color-text-link-strong);
+    }
   }
 }
 


### PR DESCRIPTION
### Summary
This is part of the work for https://app.shortcut.com/czi-edu/story/191861/consider-using-focus-visible-in-button-styles

#### The Problem
It was brought to our attention that the focus style for links looks like a bug to mouse users because it's so prominent. As users, we mostly ignore focus outlines on buttons when clicking around, but the link style (white text on a flat dark background) really catches the user's attention. We would like to move towards removing focus states on mouse interaction for most interactive components (input fields are one exception we're aware of but there may be more we'll decide on later). Technically we could just remove it for links right now, but I would like for us to be consistent about it or else it will look like links are buggy in a different way.

#### General thoughts on removing focus states for mouse interactions
Along already has this, and we're pretty comfortable with it from an accessibility point of view as long as keyboard users can see the focus states.

I tried to think of reasons to not remove focus states for mouse users, and the only one I can come up with is that we might be more likely to notice if an interactive element does not have a focus state (because we primarily test via mouse/trackpad). But I can't personally remember ever noticing "hey this doesn't have a focus state when I click on it; that's a bug"—I can only remember noticing it's missing a focus state when testing with a keyboard.

#### Implementation ideas
The Big Medium group was using [:focus-visible](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible) instead of `:focus ` to implement focus states, which would cause the focus states to only appear on keyboard interaction (which is what we want). Unfortunately, the browser versions we support don't all quite support this CSS feature yet (there are >=2 versions for several browsers that are missing it). So we want to find a different method for the meantime.

We can also explore using the [focus-visible npm package](https://github.com/WICG/focus-visible) to remove focus states on mouse interaction across the board. This is already in the Along codebase, and we could add it to LP and/or EDS.

#### This PR
In this PR, I'm using `:focus-visible` in the button and link in EDS and supplementing it with a fallback block for browsers that don't support it yet. (When all our supported browsers do support it, we can can just remove the fallback blocks. In the meantime, there will be a bit of duplication.) I'm only adding it to the buttons and links 1) to get initial feedback and 2) because the problem people have is with links specifically. (As stated above, I would like to remove it across the board so it's consistent, but the more pressing concern is links because that's the one people think looks broken.)

### Test Plan
I'm having trouble getting Sauce Labs to tunnel on my machine, so I installed Chrome 84 on a backup laptop I have and verified that the focus states for buttons and links appear on mouse click for that computer (but they only appear on keyboard interaction on my main machine which is using Chrome 105).