### PR TITLE
test(notification-list-popover): skip chromatic snapshots

### DIFF
--- a/.storybook/recipes/NotificationListPopover/NotificationListPopover.stories.tsx
+++ b/.storybook/recipes/NotificationListPopover/NotificationListPopover.stories.tsx
@@ -1,6 +1,4 @@
 import { StoryObj, Meta } from '@storybook/react';
-import { within } from '@storybook/testing-library';
-import isChromatic from 'chromatic/isChromatic';
 import React from 'react';
 
 import { NotificationListPopover } from './NotificationListPopover';
@@ -8,6 +6,13 @@ import { NotificationListPopover } from './NotificationListPopover';
 export default {
   title: 'Recipes/NotificationListPopover',
   component: NotificationListPopover,
+  parameters: {
+    chromatic: {
+      // These stories are very flaky, though we're not sure why.
+      // We tried delaying the snapshot just in case there's a timing issue at play here, which was not successful.
+      disableSnapshot: true,
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof NotificationListPopover>;
@@ -29,11 +34,4 @@ export const Default: StoryObj<Args> = {
       </div>
     ),
   ],
-  play: async ({ canvasElement }) => {
-    if (isChromatic()) {
-      const canvas = within(canvasElement);
-      const filtersTrigger = await canvas.findByRole('button');
-      filtersTrigger.click();
-    }
-  },
 };

--- a/src/components/DataBar/DataBar.stories.tsx
+++ b/src/components/DataBar/DataBar.stories.tsx
@@ -131,7 +131,7 @@ export const InteractiveExample: StoryObj<Args> = {
   parameters: {
     /* 1 */
     chromatic: {
-      skip: true,
+      disableSnapshot: true,
     },
     snapshot: {
       skip: true,

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -10,7 +10,11 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
-    chromatic: { disableSnapshot: true },
+    chromatic: {
+      // These stories are very flaky, though we're not sure why.
+      // We tried delaying the snapshot just in case there's a timing issue at play here, which was not successful.
+      disableSnapshot: true,
+    },
   },
   args: {
     children: (


### PR DESCRIPTION
### Summary:
Follow-up to https://github.com/chanzuckerberg/edu-design-system/pull/1288 in which I turned off the chromatic snapshots for the `Popover` component.

The `NotificationListPopover` chromatic snapshots are also flaky because that component uses the `Popover`, so I'm disabling this one as well. Here's an example of a build where the snapshot appeared changed even though the code couldn't possibly have caused the change: https://www.chromatic.com/build?appId=61313967cde49b003ae2a860&number=2621

### Test Plan:
No chromatic changes triggered for the `NotificationListPopover`.