### PR TITLE
chore: use focus-visible instead of focus everywhere

### DIFF
--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -49,15 +49,29 @@
   color: var(--eds-theme-color-text-neutral-default-inverse);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(
       --eds-theme-color-button-primary-brand-background-hover
     ); /* TODO */
     border-color: transparent; /* TODO */
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focusInverted;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:hover,
+    &:focus {
+      background: var(
+        --eds-theme-color-button-primary-brand-background-hover
+      ); /* TODO */
+      border-color: transparent; /* TODO */
+    }
+
+    &:focus {
+      @mixin focusInverted;
+    }
   }
 
   @media all and (min-width: $eds-bp-xl) {

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -50,10 +50,8 @@
 
   &:hover,
   &:focus-visible {
-    background: var(
-      --eds-theme-color-button-primary-brand-background-hover
-    ); /* TODO */
-    border-color: transparent; /* TODO */
+    background: var(--eds-theme-color-button-primary-brand-background-hover);
+    border-color: transparent;
   }
 
   &:focus-visible {
@@ -63,10 +61,8 @@
   @supports not selector(:focus-visible) {
     &:hover,
     &:focus {
-      background: var(
-        --eds-theme-color-button-primary-brand-background-hover
-      ); /* TODO */
-      border-color: transparent; /* TODO */
+      background: var(--eds-theme-color-button-primary-brand-background-hover);
+      border-color: transparent;
     }
 
     &:focus {

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -106,6 +106,26 @@ EDS uses [PostCSS Nested](https://github.com/postcss/postcss-nested) to provide 
 }
 ```
 
+#### Focus states
+
+We use focus-visible for most focus states. This ensures that the focus state will appear when the user is interacting with an element using a keyboard, but the focus state will not be present if the user if interacting with the element using a mouse. Exceptions to this rule include situations where the focus state also communicates to users that they are in some sort of edit state, e.g. when typing in an input field.
+
+However, we currently support some browser versions that do not support the focus-visible CSS feature, so we also use a fallback block in conjunciton with focus-visible.
+
+```scss
+.button--primary {
+  &:focus-visible {
+    @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focus;
+    }
+  }
+}
+```
+
 #### States and pseudo-selectors
 
 ```scss
@@ -113,8 +133,14 @@ EDS uses [PostCSS Nested](https://github.com/postcss/postcss-nested) to provide 
   background: var(--eds-theme-color-background-brand-primary-strong);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-background-brand-primary-strong-hover);
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      background: var(--eds-theme-color-background-brand-primary-strong-hover);
+    }
   }
 
   &:after {

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -133,14 +133,8 @@ However, we currently support some browser versions that do not support the focu
   background: var(--eds-theme-color-background-brand-primary-strong);
 
   &:hover,
-  &:focus-visible {
+  &:active {
     background: var(--eds-theme-color-background-brand-primary-strong-hover);
-  }
-
-  @supports not selector(:focus-visible) {
-    &:focus {
-      background: var(--eds-theme-color-background-brand-primary-strong-hover);
-    }
   }
 
   &:after {

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -80,12 +80,23 @@
   }
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:hover,
+    &:focus {
+      text-decoration: underline;
+    }
+
+    &:focus {
+      @mixin focus;
+    }
   }
 }
 

--- a/src/components/CheckboxInput/CheckboxInput.module.css
+++ b/src/components/CheckboxInput/CheckboxInput.module.css
@@ -47,9 +47,16 @@
 .checkbox__icon {
   color: var(--eds-theme-color-icon-brand-primary);
 }
-.checkbox__input:focus + .checkbox__icon {
+.checkbox__input:focus-visible + .checkbox__icon {
   @mixin focus; /* 1 */
   outline-offset: -2px;
+}
+
+@supports not selector(:focus-visible) {
+  .checkbox__input:focus + .checkbox__icon {
+    @mixin focus; /* 1 */
+    outline-offset: -2px;
+  }
 }
 
 /**

--- a/src/components/Drawer/Drawer.module.css
+++ b/src/components/Drawer/Drawer.module.css
@@ -51,8 +51,14 @@
     transition: none;
   }
 }
-.drawer:focus {
+.drawer:focus-visible {
   @mixin focusInside;
+}
+
+@supports not selector(:focus-visible) {
+  .drawer:focus {
+    @mixin focusInside;
+  }
 }
 
 /**

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -72,12 +72,23 @@
   transition: background var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-background-neutral-subtle);
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:hover,
+    &:focus {
+      background: var(--eds-theme-color-background-neutral-subtle);
+    }
+
+    &:focus {
+      @mixin focus;
+    }
   }
 
   @media screen and (prefers-reduced-motion) {

--- a/src/components/LinkList/LinkList.module.css
+++ b/src/components/LinkList/LinkList.module.css
@@ -45,8 +45,14 @@
   display: flex;
   @mixin textLink;
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focus;
+    }
   }
 
   /**

--- a/src/components/Logo/Logo.module.css
+++ b/src/components/Logo/Logo.module.css
@@ -17,7 +17,13 @@
   display: block;
   width: fit-content; /* 1 */
 
-  &:focus {
+  &:focus-visible {
     @mixin focusInverted;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focusInverted;
+    }
   }
 }

--- a/src/components/ModalBody/ModalBody.module.css
+++ b/src/components/ModalBody/ModalBody.module.css
@@ -12,6 +12,12 @@
   flex: 1;
 }
 
-.modal-body:focus {
+.modal-body:focus-visible {
   @mixin focusInside;
+}
+
+@supports not selector(:focus-visible) {
+  .modal-body:focus {
+    @mixin focusInside;
+  }
 }

--- a/src/components/NotificationList/NotificationList.module.css
+++ b/src/components/NotificationList/NotificationList.module.css
@@ -81,8 +81,14 @@
   background-color: var(--eds-theme-color-text-link-strong);
   cursor: pointer;
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focus;
+    }
   }
 
   /*

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -18,7 +18,7 @@
   transition: background var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     background: var(--eds-theme-color-button-primary-brand-background-hover);
   }
 
@@ -26,8 +26,19 @@
     background: var(--eds-theme-color-button-primary-brandbackground-active);
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focusInverted;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:hover,
+    &:focus {
+      background: var(--eds-theme-color-button-primary-brand-background-hover);
+    }
+
+    &:focus {
+      @mixin focusInverted;
+    }
   }
 
   /**

--- a/src/components/RadioInput/RadioInput.module.css
+++ b/src/components/RadioInput/RadioInput.module.css
@@ -45,9 +45,16 @@
   color: var(--eds-theme-color-icon-brand-primary);
   border: var(--eds-border-width-sm) solid transparent; /* 1 */
 }
-.radio__input:focus + .radio__icon {
+.radio__input:focus-visible + .radio__icon {
   border: var(--eds-border-width-sm) solid var(--eds-theme-color-focus-ring);
   border-radius: 9999px;
+}
+
+@supports not selector(:focus-visible) {
+  .radio__input:focus + .radio__icon {
+    border: var(--eds-border-width-sm) solid var(--eds-theme-color-focus-ring);
+    border-radius: 9999px;
+  }
 }
 
 /**

--- a/src/components/RadioInput/RadioInput.module.css
+++ b/src/components/RadioInput/RadioInput.module.css
@@ -47,13 +47,13 @@
 }
 .radio__input:focus-visible + .radio__icon {
   border: var(--eds-border-width-sm) solid var(--eds-theme-color-focus-ring);
-  border-radius: 9999px;
+  border-radius: var(--eds-border-radius-full);
 }
 
 @supports not selector(:focus-visible) {
   .radio__input:focus + .radio__icon {
     border: var(--eds-border-width-sm) solid var(--eds-theme-color-focus-ring);
-    border-radius: 9999px;
+    border-radius: var(--eds-border-radius-full);
   }
 }
 

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -94,8 +94,14 @@
     box-shadow var(--eds-anim-fade-quick) var(--eds-anim-ease),
     background-color var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      @mixin focus;
+    }
   }
 
   @media screen and (prefers-reduced-motion) {

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -201,12 +201,23 @@
     background-color var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
   &:hover,
-  &:focus {
+  &:focus-visible {
     color: var(--eds-theme-color-text-neutral-default);
   }
 
-  &:focus {
+  &:focus-visible {
     @mixin focus;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:hover,
+    &:focus {
+      color: var(--eds-theme-color-text-neutral-default);
+    }
+
+    &:focus {
+      @mixin focus;
+    }
   }
 
   @media screen and (prefers-reduced-motion) {

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
@@ -59,8 +59,14 @@
  * Accordion panel button focus visible
  * 1) Show focus ring when focused only with keyboard
  */
-.accordion__panel-button:focus {
+.accordion__panel-button:focus-visible {
   @mixin focus;
+}
+
+@supports not selector(:focus-visible) {
+  .accordion__panel-button:focus {
+    @mixin focus;
+  }
 }
 
 /**


### PR DESCRIPTION
### Summary:
In https://github.com/chanzuckerberg/edu-design-system/pull/1290 I updated the buttons and links to only show the focus state when the user interacts with them using a keyboard (as opposed to with a mouse/trackpad). The implementation method was done using `focus-visible` along with a fallback block for browsers that don't support it yet. (I added a [ticket to remove the fallback blocks](https://app.shortcut.com/czi-edu/story/215843/remove-focus-fallback-css) once we're only supporting browser versions that support `focus-visible`.)

In this PR, I'm expanding to use this method on almost all `:focus` states. Exceptions include:
- `inputStyles` mixin and `SearchField` component
  - I talked to design and we determined that we want mouse users to see the focus state so they know that typing on their keyboard will add text in the input field.
- `BaselineCard` and `SkipLink`
  - In both of these cases, the link only appears on keyboard interaction already, so there's nothing to hide for mouse users.
- inverted states
  - Because we're going to remove that stuff anyway; there's no point updating it.
- `FileUploadField`
  - Because it's also using `focus-within`, and I don't want there to be a discrepancy where sometimes the focus state appears for mouse users and sometimes it doesn't.

### Test Plan:
In any of the supported browser versions (e.g. the latest version of Chrome), verify that:
- the focus state does not appear on mouse click
- the focus state does appear when tabbing to it using a keyboard

In any of the *unsupported* browser versions (e.g. Chrome 84), verify that:
- the focus state appears on both mouse click and when tabbing to it using a keyboard