### PR TITLE
chore(page-shell): add focus outline

### DIFF
--- a/.storybook/recipes/PageShell/PageShell.module.css
+++ b/.storybook/recipes/PageShell/PageShell.module.css
@@ -25,6 +25,7 @@
 
   &:focus {
     transform: translateY(0%);
+    @mixin focusInverted;
   }
 
   @media screen and (prefers-reduced-motion) {


### PR DESCRIPTION
### Summary:
I happened to notice while working on something else that the `SkipLink` doesn't have an outline when focused. It is normally hidden and appears on focus, but I think it needs the outline to make it clear that that's where the user's focus is when it appears.

### Before
<img width="1617" alt="page shell recipe with the skip link visible, the skip link does not have a white outline" src="https://user-images.githubusercontent.com/7761701/191118272-e8117574-7c98-4fc4-82a5-69e11571a537.png">

### After
<img width="1617" alt="page shell recipe with the skip link visible, the skip link does have a white outline" src="https://user-images.githubusercontent.com/7761701/191118292-6f45bf8b-92c7-481a-95b0-33d76f098c83.png">

### Test Plan:
Navigate to the page shell recipe,
tab to the skip link,
and verify there's a white outline around the link.