### PR TITLE
fix(baseline-card): stop clicks outside visible card area

### DIFF
--- a/.storybook/recipes/BaselineCard/BaselineCard.module.css
+++ b/.storybook/recipes/BaselineCard/BaselineCard.module.css
@@ -22,6 +22,17 @@
 }
 
 /**
+ * Inner wrapper that is also clickable
+ *
+ * This is needed because the outermost div may extend beyond the visible card,
+ * which means the user could click on empty space and still activate the click
+ * handler.
+ */
+.baseline-card__clickable-wrapper {
+  width: max-content;
+}
+
+/**
  * Baseline card label.
  */
 .baseline-card__label {

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -127,70 +127,72 @@ export const BaselineCard = ({
      * to the card without adding a ref prop to <Card />
      */
 
-    <div className={styles['baseline-card__container']} ref={cardRef}>
-      <Card className={componentClassName} {...other}>
-        <CardHeader className={styles['baseline-card__label']}>
-          {label}
-        </CardHeader>
-        <CardBody className={styles['baseline-card__body']}>
-          {body}
-          {linkProps && (
-            <a
-              className={styles['baseline-card__link']}
-              href={linkProps.href}
-              ref={linkRef}
-              target={linkProps.target ? linkProps.target : '_self'}
-            >
-              {linkProps.text}
-            </a>
+    <div className={styles['baseline-card__container']}>
+      <div className={styles['baseline-card__clickable-wrapper']} ref={cardRef}>
+        <Card className={componentClassName} {...other}>
+          <CardHeader className={styles['baseline-card__label']}>
+            {label}
+          </CardHeader>
+          <CardBody className={styles['baseline-card__body']}>
+            {body}
+            {linkProps && (
+              <a
+                className={styles['baseline-card__link']}
+                href={linkProps.href}
+                ref={linkRef}
+                target={linkProps.target ? linkProps.target : '_self'}
+              >
+                {linkProps.text}
+              </a>
+            )}
+          </CardBody>
+          {metadata && (
+            <CardFooter className={styles['baseline-card__footer']}>
+              <table className={styles['baseline-card__table']}>
+                <tbody className={styles['baseline-card__table-body']}>
+                  <tr className={styles['baseline-card__table-row']}>
+                    <th
+                      className={styles['baseline-card__table-label']}
+                      scope="row"
+                    >
+                      Score
+                    </th>
+                    <td>
+                      <Score
+                        className={styles['baseline-card__score']}
+                        text={metadata.score}
+                        variant={metadata.variant}
+                      />
+                    </td>
+                  </tr>
+                  <tr className={styles['baseline-card__table-row']}>
+                    <th
+                      className={styles['baseline-card__table-label']}
+                      scope="row"
+                    >
+                      Attempts
+                    </th>
+                    <td className={styles['baseline-card__table-data']}>
+                      {metadata.attempts}
+                    </td>
+                  </tr>
+                  <tr className={styles['baseline-card__table-row']}>
+                    <th
+                      className={styles['baseline-card__table-label']}
+                      scope="row"
+                    >
+                      Line Passes On
+                    </th>
+                    <td className={styles['baseline-card__table-data']}>
+                      {metadata.deadline}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </CardFooter>
           )}
-        </CardBody>
-        {metadata && (
-          <CardFooter className={styles['baseline-card__footer']}>
-            <table className={styles['baseline-card__table']}>
-              <tbody className={styles['baseline-card__table-body']}>
-                <tr className={styles['baseline-card__table-row']}>
-                  <th
-                    className={styles['baseline-card__table-label']}
-                    scope="row"
-                  >
-                    Score
-                  </th>
-                  <td>
-                    <Score
-                      className={styles['baseline-card__score']}
-                      text={metadata.score}
-                      variant={metadata.variant}
-                    />
-                  </td>
-                </tr>
-                <tr className={styles['baseline-card__table-row']}>
-                  <th
-                    className={styles['baseline-card__table-label']}
-                    scope="row"
-                  >
-                    Attempts
-                  </th>
-                  <td className={styles['baseline-card__table-data']}>
-                    {metadata.attempts}
-                  </td>
-                </tr>
-                <tr className={styles['baseline-card__table-row']}>
-                  <th
-                    className={styles['baseline-card__table-label']}
-                    scope="row"
-                  >
-                    Line Passes On
-                  </th>
-                  <td className={styles['baseline-card__table-data']}>
-                    {metadata.deadline}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </CardFooter>
-        )}
-      </Card>
+        </Card>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Summary:
I noticed while working on something else that in the baseline card that is clickable, if you click in the empty space to the right of the card, it still activates the link and navigates you to another page. This PR moves the `onClick` handler to an inner wrapper that is constrained to the card content.

### Video of the bug
https://user-images.githubusercontent.com/7761701/191122393-43acc8f7-be5a-4d37-8aaf-2c1166fec591.mp4

### Test Plan:
Navigate to the `Clickable` story for the `BaselineCard` in storybook,
click in the empty space to the right of the card,
and verify that you're not navigated to another page.