### PR TITLE
chore: remove unused commitizen config from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,10 +188,5 @@
       "stylelint --fix"
     ]
   },
-  "packageManager": "yarn@3.1.1",
-  "config": {
-    "commitizen": {
-      "path": "./node_modules/cz-conventional-changelog"
-    }
-  }
+  "packageManager": "yarn@3.1.1"
 }


### PR DESCRIPTION
### Summary:

- We removed the dependency for cz-conventional-commit in the last 6 months. This PR removes the lingering configuration in package.json, which references that dependency. Conventional commits are still enforced by linting rules (commitlint/config-conventional)

### Test Plan:

- ensure CI passes and `install` works as expected
