### PR TITLE
chore(layout): remove expandable prop options

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -7,7 +7,6 @@ export interface Props {
    * Behavior
    */
   behavior?: 'fixed-sidebar';
-
   /**
    * Child node(s) that can be nested inside component
    */
@@ -16,12 +15,6 @@ export interface Props {
    * CSS class names that can be appended to the component.
    */
   className?: string;
-  /**
-   * Expandable layout sections
-   *
-   * Used for hover/focus states showing/hiding extra content
-   */
-  expandable?: boolean;
   /**
    * Sidebar property
    *

--- a/src/components/LayoutSection/LayoutSection.tsx
+++ b/src/components/LayoutSection/LayoutSection.tsx
@@ -4,10 +4,6 @@ import styles from '../Layout/Layout.module.css';
 
 export interface Props {
   /**
-   * Behavioral variations
-   */
-  behavior?: 'expandable';
-  /**
    * Child node(s) that can be nested inside component
    */
   children: ReactNode;


### PR DESCRIPTION
### Summary:
I happened to notice some "expandable" prop thingies in `Layout` and `LayoutSection` that don't seem to be used, and I don't think we have any plans to make these things expandable, so I'm removing them.

### Test Plan:
All automated tests pass and there are no visual changes detected by chromatic.