### PR TITLE
chore: remove ordered lists in comments

### DIFF
--- a/.storybook/components/IconGrid/IconGrid.css
+++ b/.storybook/components/IconGrid/IconGrid.css
@@ -3,9 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) The icon grid is not for production and is meant solely to display
- *    a grid of icons within the pattern library. THerefore, it does not
- *    follow coding conventions
+ * The icon grid is not for production and is meant solely to display
+ * a grid of icons within the pattern library. THerefore, it does not
+ * follow coding conventions
  */
 
 .icon-grid {

--- a/.storybook/css/styleguide-only.css
+++ b/.storybook/css/styleguide-only.css
@@ -3,14 +3,14 @@
 \*------------------------------------*/
 
 /**
- * 1) Styleguide-only styles only ever show up inside of Storybook. 
- *    These styles will not be included in production or anywhere  
- *    outside Storybook
+ * Styleguide-only styles only ever show up inside of Storybook. 
+ * 
+ * These styles will not be included in production or anywhere outside Storybook.
  */
 
 /**
- * For Placement Only (FPO) Block
- * 1) A gray block that serves as a placeholder for a future component 
+ * For Placement Only (FPO) Block - a gray block that serves as a placeholder
+ * for a future component
  */
 .fpo {
   background: #e8f4f8;

--- a/.storybook/recipes/BaselineCard/BaselineCard.module.css
+++ b/.storybook/recipes/BaselineCard/BaselineCard.module.css
@@ -14,7 +14,8 @@
 
 /**
 * Baseline card container
-* 1) Used to pass the cardRef object to Card component
+*
+* Used to pass the cardRef object to Card component.
 */
 .baseline-card__container {
   @mixin reset;
@@ -43,7 +44,8 @@
 
 /**
 * Baseline card clickable 
-* 1) When an href prop is passed in, the card gets a :hover style to indicate
+*
+* When an href prop is passed in, the card gets a :hover style to indicate
 * that it is clickable.
 */
 .baseline-card--clickable {

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -123,7 +123,7 @@ export const BaselineCard = ({
   );
   return (
     /**
-     * 1) Wrapping the Card component in a container for attaching cardRef
+     * Wrapping the Card component in a container for attaching cardRef
      * to the card without adding a ref prop to <Card />
      */
 

--- a/.storybook/recipes/ButtonActionCalloutCard/ButtonActionCalloutCard.module.css
+++ b/.storybook/recipes/ButtonActionCalloutCard/ButtonActionCalloutCard.module.css
@@ -5,12 +5,13 @@
 \*------------------------------------*/
 
 /**
- * 1) Card elevated to drive attention and give an action
+ * Card elevated to drive attention and give an action.
  */
 
 /**
  * Button action callout card body inner
- * 1) Wrapper around the description and button
+ *
+ * Wrapper around the description and button.
  */
 .button-action-callout-card__body-inner {
   display: flex;

--- a/.storybook/recipes/CalendarCard/CalendarCard.module.css
+++ b/.storybook/recipes/CalendarCard/CalendarCard.module.css
@@ -65,8 +65,10 @@
 
 /**
 * Card calendar row which holds an icon and a combination of text strings.
-* 1) Keeps the icon positioned at the top of the cross-axis if the text strings expands to use multiple lines.
-* 2) The gap setting will maintain spacing between icon and text.
+* 
+* Keeps the icon positioned at the top of the cross-axis if the text strings expands to use multiple lines.
+* 
+* The gap setting will maintain spacing between icon and text.
 */
 .calendar-card__dates {
   display: flex;

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -4,7 +4,7 @@
     # GLOBAL HEADER
 \*------------------------------------*/
 /**
- * 1) Global navigation bar of site
+ * Global navigation bar of site
  */
 .global-header {
   position: relative;
@@ -27,7 +27,8 @@
 
 /**
  * Global header logo
- * 1) The SVG logo
+ *
+ * The SVG logo.
  */
 .global-header__logo {
   display: none;

--- a/.storybook/recipes/NumberIconList/NumberIconList.module.css
+++ b/.storybook/recipes/NumberIconList/NumberIconList.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Container recipe for the number icons to flex wrap them
+ * Container recipe for the number icons to flex wrap them.
  */
 .number-icon-list {
   display: flex;

--- a/.storybook/recipes/PageShell/PageShell.module.css
+++ b/.storybook/recipes/PageShell/PageShell.module.css
@@ -5,15 +5,14 @@
 \*------------------------------------*/
 
 /**
- * 1) 
+ * Primary shell around the entire page.
  */
 .page-shell {
   position: relative;
 }
 
 /**
- * Skip link
- * 1) The skip link 
+ * Skip link – allows the user to skip past the main navigation to the page content.
  */
 .page-shell__skip-link {
   position: absolute;

--- a/.storybook/recipes/TableCard/TableCard.module.css
+++ b/.storybook/recipes/TableCard/TableCard.module.css
@@ -5,12 +5,13 @@
 \*------------------------------------*/
 
 /**
- * 1) Card with a title, table, and button within
+ * Card with a title, table, and button within
  */
 
 /**
 * Table card table
-* 1) Actual table within the card
+*
+* Actual table within the card.
 */
 .table-card__table {
   color: var(--eds-theme-color-text-neutral-subtle);

--- a/src/components/AvatarImage/AvatarImage.module.css
+++ b/src/components/AvatarImage/AvatarImage.module.css
@@ -4,8 +4,8 @@
 
 /**
  * Avatar image SVG
- * 1) This component contains an outer wrapper
- *    and SVG fragments for avatars.
+ *
+ * This component contains an outer wrapper and SVG fragments for avatars.
  */
 .avatar-image {
   display: flex;

--- a/src/components/Banner/Banner.module.css
+++ b/src/components/Banner/Banner.module.css
@@ -18,8 +18,8 @@
   /**
    * Has a bottom margin to accommodate drop shadow
    */
-  box-shadow: var(--eds-box-shadow-md); 
-  margin-bottom: var(--eds-size-2); 
+  box-shadow: var(--eds-box-shadow-md);
+  margin-bottom: var(--eds-size-2);
 
   border-style: solid;
   border-radius: var(--eds-border-radius-md);
@@ -35,7 +35,7 @@
    * The thick border (left for horizontal and top for vertical orientation)
    * matches the icon color.
    */
-  border-top-color: var(--messaging-icon-color); 
+  border-top-color: var(--messaging-icon-color);
 }
 
 /**
@@ -60,8 +60,7 @@
 }
 
 /**
- * Banner close button
- * 1) Button used to dismiss dismissable banners
+ * Banner close button - button used to dismiss dismissable banners.
  */
 .banner__close-btn.banner__close-btn {
   position: absolute;
@@ -80,22 +79,22 @@
   .banner--horizontal {
     grid-template-columns: min-content 1fr;
     /* Everything is left-aligned */
-    text-align: left; 
+    text-align: left;
     justify-items: flex-start;
     /* Padding is reduced */
-    padding: 1rem; 
+    padding: 1rem;
     /* Left border is thick and dark instead of the top border */
-    border-top-width: var(--eds-theme-border-width); 
-    border-left-width: var(--eds-border-width-lg); 
+    border-top-width: var(--eds-theme-border-width);
+    border-left-width: var(--eds-border-width-lg);
     border-top-color: var(--messaging-border-color);
     border-left-color: var(--messaging-icon-color);
     /* Icon is smaller to match the heading line height */
     .banner__icon {
-      --icon-size-default: var(--eds-size-3); 
+      --icon-size-default: var(--eds-size-3);
     }
     /* Gap between text and action button is reduced */
     .banner__text-and-action {
-      gap: var(--eds-size-1); 
+      gap: var(--eds-size-1);
     }
 
     .banner__action {
@@ -160,13 +159,13 @@
  */
 .banner--flat {
   /* Has no drop shadow or visible border so it sits flat on the page */
-  box-shadow: none; 
+  box-shadow: none;
   /**
    * Instead of removing the border, we replace it with a transparent one.
    * On windows high contrast mode, the background color will be removed,
    * but this border will become 100% opacity black to retain visual separation
    */
-  --messaging-border-color: transparent; 
+  --messaging-border-color: transparent;
   /* Remove the bottom margin which is usually there to account for the drop shadow length */
-  margin-bottom: 0; 
+  margin-bottom: 0;
 }

--- a/src/components/Breadcrumbs/Breadcrumbs.module.css
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.css
@@ -5,9 +5,9 @@
 \*------------------------------------*/
 
 /**
- * 1) Breadcrumbs are a navigational component
- * 2) The outer wrapper for the breadcrumbs is a
- *    <nav> element
+ * Breadcrumbs are a navigational component
+ *
+ * The outer wrapper for the breadcrumbs is a <nav> element.
  */
 
 /**

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -105,7 +105,6 @@ export const LongTextMenu: StoryObj<Args> = {
       defaultViewport: 'tablet',
     },
     chromatic: { viewports: [834] },
-    /* 1 */
     axe: {
       skip: true,
     },

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -11,14 +11,14 @@
   @mixin eds-theme-typography-body-text-xs;
   max-width: 100%;
   /* Required for dropdown menu to absolutely position relative to this container. */
-  position: relative; 
+  position: relative;
 
   /* Hides all breadcrumbs except the last breadcrumb in smaller breakpoints. */
   display: none;
   flex-shrink: 0;
   &:last-of-type {
     display: flex;
-     /* Truncate last breadcrumb in smaller breakpoints */
+    /* Truncate last breadcrumb in smaller breakpoints */
     flex: 1 0 0%;
   }
 
@@ -28,10 +28,10 @@
 
   @media all and (min-width: $eds-bp-md) {
     /* Display breadcrumbs in larger breakpoints. */
-    display: flex; 
+    display: flex;
     &:last-of-type {
       /* Truncate last breadcrumb in smaller breakpoints */
-      flex: 0 0 auto; 
+      flex: 0 0 auto;
     }
   }
 }
@@ -44,12 +44,12 @@
   margin-right: var(--eds-size-1-and-half);
   @media all and (min-width: $eds-bp-md) {
     /* Hidden for larger breakpoints. */
-    display: none; 
+    display: none;
   }
 }
 .breadcrumbs__item-back > .breadcrumbs__separator {
   /* Hide the separator for the back variant. */
-  display: none; 
+  display: none;
 }
 
 /**
@@ -99,8 +99,7 @@
 }
 
 /**
- * Breadcrumbs Icon
- * 1) Separator between breadcrumb links
+ * Breadcrumbs Icon - a separator between breadcrumb links.
  */
 .breadcrumbs__separator {
   color: var(--eds-theme-color-icon-neutral-subtle);
@@ -114,7 +113,7 @@
  */
 .breadcrumbs__item:last-child .breadcrumbs__separator.breadcrumbs__separator {
   /*  A separator shouldn't be displayed after last link. */
-  display: none; 
+  display: none;
 }
 
 /**
@@ -122,7 +121,7 @@
  */
 .breadcrumbs__back-icon {
   color: var(--eds-theme-color-icon-neutral-subtle);
-   /* Transform over height due to icon being placed inside <a>. */
+  /* Transform over height due to icon being placed inside <a>. */
   transform: scale(1.5);
   position: relative;
   bottom: 0.125rem;

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -14,7 +14,8 @@
 
 /**
  * Primary disabled button styles
- * 1) Class is doubled to increase specificity
+ *
+ * Class is doubled to increase specificity.
  */
 .button--primary.button--primary {
   &:disabled,
@@ -27,7 +28,8 @@
 
 /**
  * Secondary disabled button styles
- * 1) Class is doubled to increase specificity
+ *
+ * Class is doubled to increase specificity.
  */
 .button--secondary.button--secondary {
   &:disabled,
@@ -44,7 +46,8 @@
 
 /**
  * Link disabled button styles
- * 1) Class is doubled to increase specificity
+ *
+ * Class is doubled to increase specificity.
  */
 .button--link.button--link {
   &:disabled,
@@ -56,7 +59,8 @@
 
 /**
  * Icon disabled button styles
- * 1) Class is doubled to increase specificity
+ *
+ * Class is doubled to increase specificity.
  */
 .button--icon.button--icon {
   &:disabled,

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -141,7 +141,8 @@ export const ButtonDropdown = ({
 
   /**
    * Handle keydown function
-   * 1) If the escape key is struck, close the panel
+   *
+   * If the escape key is struck, close the panel.
    */
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === ESCAPE_KEYCODE) {

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -3,8 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) A card is a block that typically contains a title, image,
- *    text, and/or calls to action
+ * A card is a block that typically contains a title, image, text, and/or calls to action.
  */
 .card {
   display: flex;
@@ -19,8 +18,7 @@
 }
 
 /**
- * Raised card
- * 1) Card that appears raised to show interactivity/emphasis
+ * Card that appears raised to show interactivity/emphasis.
  */
 .card--raised {
   box-shadow: var(--eds-box-shadow-md);
@@ -28,8 +26,9 @@
 }
 
 /**
- * Card that is being dragged in drag and drop
- * 1) Passed down to card to be reused. 
+ * Card that is being dragged in drag and drop.
+ * 
+ * Passed down to card to be reused.
  */
 .card.eds-is-dragging {
   box-shadow: var(--eds-box-shadow-xl);
@@ -40,7 +39,7 @@
  */
 .card--horizontal {
   /* Change the orientation to display header, body, and footer in a row. */
-  flex-direction: row; 
+  flex-direction: row;
 }
 
 /**
@@ -48,7 +47,7 @@
  */
 .card--center {
   /* Card where the content is centered. */
-  text-align: center; 
+  text-align: center;
 }
 
 /**
@@ -59,7 +58,7 @@
   /* Used on dark backgrounds to lighten the text color and remove a box shadow */
   background: transparent;
   border-color: var(--eds-theme-color-border-neutral-strong);
-  box-shadow: none; 
+  box-shadow: none;
 }
 
 /**
@@ -67,7 +66,7 @@
  */
 .card__header {
   /* Add spacing in between the header and body. */
-  margin-bottom: var(--eds-size-2); 
+  margin-bottom: var(--eds-size-2);
 
   /**
   * Card header within horizontal card

--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -5,8 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Styled clickable element that should look like a button or link.
- * 2) Defaults to primary variant.
+ * Styled clickable element that should look like a button or link.
  */
 .clickable-style {
   @mixin eds-theme-typography-button-label;
@@ -286,8 +285,10 @@
 
 /**
  * Icon brand clickable style
- * 1) A clickable style that strips out borders, backgrounds, etc
- * 2) Use for Close "X" buttons, tooltip icons, and other
+ * 
+ * A clickable style that strips out borders, backgrounds, etc.
+ *
+ * Use for Close "X" buttons, tooltip icons, and other.
  */
 .clickable-style--icon.clickable-style--brand {
   border-color: var(--eds-theme-color-button-icon-brand-border);
@@ -321,8 +322,10 @@
 
 /**
  * Icon neutral clickable style
- * 1) A clickable style that strips out borders, backgrounds, etc
- * 2) Use for Close "X" buttons, tooltip icons, and other
+ * 
+ * A clickable style that strips out borders, backgrounds, etc.
+ *
+ * Use for Close "X" buttons, tooltip icons, and other.
  */
 .clickable-style--icon.clickable-style--neutral {
   border-color: var(--eds-theme-color-button-icon-neutral-border);
@@ -358,8 +361,10 @@
 
 /**
  * Icon success clickable style
- * 1) A clickable style that strips out borders, backgrounds, etc
- * 2) Use for Close "X" buttons, tooltip icons, and other
+ * 
+ * A clickable style that strips out borders, backgrounds, etc.
+ *
+ * Use for Close "X" buttons, tooltip icons, and other.
  */
 .clickable-style--icon.clickable-style--success {
   border-color: var(--eds-theme-color-button-icon-success-border);
@@ -395,8 +400,10 @@
 
 /**
  * Icon warning clickable style
- * 1) A clickable style that strips out borders, backgrounds, etc
- * 2) Use for Close "X" buttons, tooltip icons, and other
+ * 
+ * A clickable style that strips out borders, backgrounds, etc.
+ *
+ * Use for Close "X" buttons, tooltip icons, and other.
  */
 .clickable-style--icon.clickable-style--warning {
   border-color: var(--eds-theme-color-button-icon-warning-border);
@@ -432,8 +439,10 @@
 
 /**
  * Icon error clickable style
- * 1) A clickable style that strips out borders, backgrounds, etc
- * 2) Use for Close "X" buttons, tooltip icons, and other
+ * 
+ * A clickable style that strips out borders, backgrounds, etc.
+ *
+ * Use for Close "X" buttons, tooltip icons, and other.
  */
 .clickable-style--icon.clickable-style--error {
   border-color: var(--eds-theme-color-button-icon-error-border);
@@ -482,8 +491,8 @@
 }
 
 /**
- * 1) Needs `:where` pseudoclass to reduce specificity so class overrides
- *    for margin can happen where used.
+ * Needs `:where` pseudoclass to reduce specificity so class overrides
+ * for margin can happen where used.
  */
 :where(.clickable-style--link) {
   /* 2px padding gives the text breathing room in the focus state */

--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -62,7 +62,7 @@
  */
 .drag-drop__inner {
   /* Uses a flex row to align containers. */
-  display: flex; 
+  display: flex;
   overflow: auto;
 }
 
@@ -71,25 +71,24 @@
  */
 .drag-drop__container {
   /* Set to display flex so empty state can span entire column. */
-  display: flex; 
+  display: flex;
   flex-shrink: 0;
   flex-direction: column;
   margin-left: var(--eds-size-2);
   width: 20rem;
   /* Padding added to the top to account for outline of button. */
-  padding-top: var(--eds-size-half); 
+  padding-top: var(--eds-size-half);
   /**
    * First drag drop container.
    */
   &:first-of-type {
     /* Don't add left margin to left align with the rest of the content. */
-    margin-left: 0; 
+    margin-left: 0;
   }
 }
 
 /**
- * 1) An area that can be dropped into.
- * 2) Explicitly giving container display type of 'block'. Avoid using flex; doing so may cause jumpy behavior when items are dropped.
+ * An area that can be dropped into.
  */
 .drag-drop__container-inner {
   display: flex;
@@ -110,7 +109,7 @@
   }
 
   /**
-   * 1) When there are more than two containers, apply a border
+   * When there are more than two containers, apply a border.
    */
   .drag-drop--multiple & {
     border: var(--eds-theme-border-width) solid
@@ -119,14 +118,15 @@
 }
 
 /**
- * 1) Container that holds droppable content. 
- * 2) DragDropItem styles are included here rather than in the /DragDropItem directory as a workaround to CSS Modules' locally scoped class names.
+ * Container that holds droppable content. 
+ *
+ * DragDropItem styles are included here rather than in the /DragDropItem directory as a workaround to CSS Modules' locally scoped class names.
  */
 
 .drag-drop__item {
   position: relative;
   /*  For best experience, use a margin on a single side of an item to add a gap between items. Using a margin on both top and bottom, or using flex or grid gap spacing in the drag-drop-container, cause jumpy behavior. */
-  margin-bottom: var(--eds-size-1); 
+  margin-bottom: var(--eds-size-1);
   background-color: var(--eds-color-neutral-100);
   border-radius: var(--eds-border-radius-lg);
   box-shadow: var(--eds-box-shadow-sm);

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -14,7 +14,8 @@ export interface Props {
   className?: string;
   /**
    * Column class names that can be appended to the component.
-   * 1) Used to add additional styles to the column
+   *
+   * Used to add additional styles to the column.
    */
   columnClassName?: string[];
   /**

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -49,7 +49,8 @@
 
 /**
  * Pinned sticky header
- * 1) Pins the sticky header to the top of the page. Transitions in from above the viewport.
+ *
+ * Pins the sticky header to the top of the page. Transitions in from above the viewport.
  */
 .header--sticky.eds-is-pinned {
   @media all and (max-width: $eds-bp-xl) {
@@ -60,7 +61,8 @@
 
 /**
  * Sticky header with scrolled class applied
- * 1) Class is applied when the sticky header gets pinned/unpinned and animation is needed
+ *
+ * Class is applied when the sticky header gets pinned/unpinned and animation is needed
  */
 .header--sticky.eds-is-scrolled {
   @media all and (max-width: $eds-bp-xl) {
@@ -75,6 +77,6 @@
   @media all and (max-width: $eds-bp-xl) {
     position: fixed;
     /* Tuck header above the viewport to be pulled down when the pinned class is applied. */
-    transform: translateY(-100%); 
+    transform: translateY(-100%);
   }
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,14 +6,18 @@ import styles from './Header.module.css';
 export interface Props {
   /**
    * Pinned stop property
-   * 1) Pixel value from the top of the page scrolled before the header goes away
-   * 2) Used only for `behavior="sticky"` header variant
+   *
+   * Pixel value from the top of the page scrolled before the header goes away.
+   *
+   * Used only for `behavior="sticky"` header variant.
    */
   pinnedStop?: number;
   /**
    * Unpinned property
-   * 1) Used to move the header offscreen but have it ready to move back in
-   * 2) Used only for `behavior="sticky"` header variant
+   *
+   * Used to move the header offscreen but have it ready to move back in.
+   *
+   * Used only for `behavior="sticky"` header variant.
    */
   unpinned?: boolean;
   /**
@@ -120,7 +124,8 @@ export const Header = ({
 
   /**
    * Use effect lifecycle hook
-   * 1) Add scroll and window resize event to adjust values
+   *
+   * Add scroll and window resize event to adjust values.
    */
   useEffect(() => {
     window.addEventListener('scroll', handleWindowScroll, false);

--- a/src/components/Hr/Hr.module.css
+++ b/src/components/Hr/Hr.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Line that acts as a separator of content
+ * Line that acts as a separator of content.
  * 
  */
 .hr {
@@ -18,16 +18,14 @@
 }
 
 /**
- * Hr Thick
- * 1) Horizontal rule with a thick border
+ * Horizontal rule with a thick border.
  */
 .hr--lg {
   border-width: var(--eds-border-width-lg);
 }
 
 /**
- * Hr Brand
- * 1) Branded horizontal rule
+ * Branded horizontal rule.
  */
 .hr--brand {
   border-color: var(--eds-theme-color-border-brand-primary-strong);

--- a/src/components/Icon/Icon.module.css
+++ b/src/components/Icon/Icon.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------ */
 
 /**
- * 1) Small graphic that represents functionality
+ * Small graphic that represents functionality.
  */
 .icon {
   display: inline-block;
@@ -15,14 +15,13 @@
    *
    * Inspired by https://www.youtube.com/watch?v=EDyiaDJJu-4
    */
-  width: var(--icon-size, var(--icon-size-default, 1em)); 
+  width: var(--icon-size, var(--icon-size-default, 1em));
   height: var(--icon-size, var(--icon-size-default, 1em));
 }
 
 /**
- * Full-width icon
- * 1) A block icon fills 100% of the width of its container
+ * A block icon fills 100% of the width of its container
  */
 .icon--full-width {
-  display: block; 
+  display: block;
 }

--- a/src/components/Label/Label.module.css
+++ b/src/components/Label/Label.module.css
@@ -6,7 +6,8 @@
 
 /**
  * Label
- * 1) Labels can sometimes be marked up as legends for field groups (i.e. radio field)
+ * 
+ * Labels can sometimes be marked up as legends for field groups (i.e. radio field).
  */
 .label {
   @mixin labelStyles;
@@ -14,9 +15,9 @@
 
 /**
  * Label flag
- * 1) A flag to mark whether or not a field is required
- *    or optional. Currently a flag is only present
- *    for optional fields
+ *
+ * A flag to mark whether or not a field is required or optional. Currently a flag
+ * is only present for optional fields.
  */
 .label__flag {
   @mixin eds-theme-typography-body-text-sm;
@@ -24,10 +25,9 @@
 
 /**
  * Label after
- * 1) An empty slot for additional element to appear
- *    to the right of the label text. Typically used
- *    to present tooltips by the labels
- * 2) Media query is for IE 11 browser only for label after alignment
+ *
+ * An empty slot for additional element to appear to the right of the label text.
+ * Typically used to present tooltips by the labels.
  */
 .label__after {
   display: inline-block;

--- a/src/components/Layout/Layout.module.css
+++ b/src/components/Layout/Layout.module.css
@@ -3,16 +3,18 @@
 \*------------------------------------*/
 
 /**
- * 1) Component that controls an overarching page layout. By default,
- *    the layout renders a fixed-position left sidebar on larger screens
- * 2) Left sidebar is the default
- * 3) minmax(0, 1fr) used to prevent content from overflowing the viewport
- * when items are stacked
+ * Component that controls an overarching page layout.
+ *
+ * By default, the layout renders a fixed-position left sidebar on larger screens.
  */
 .layout {
   display: grid;
   gap: var(--eds-size-3);
-  grid-template-columns: minmax(0, 1fr); 
+  /**
+   * minmax(0, 1fr) used to prevent content from overflowing the viewport
+   * when items are stacked
+   */
+  grid-template-columns: minmax(0, 1fr);
 
   @media all and (min-width: $eds-bp-xl) {
     grid-template-columns: auto 1fr;
@@ -74,7 +76,8 @@
 
 /**
  * Sidebar layout section region
- * 1) Contains the global header and site navigation
+ * 
+ * Contains the global header and site navigation.
  */
 .layout__section--sidebar {
   @media all and (min-width: $eds-bp-xl) {
@@ -113,7 +116,8 @@
 
 /**
  * Sidebar layout section region within wide sidebar variant
- * 1) Width should be larger than the default
+ *
+ * Width should be larger than the default.
  */
 .layout--sidebar-wide > .layout__section--sidebar {
   @media all and (min-width: $eds-bp-xl) {
@@ -123,7 +127,8 @@
 
 /**
  * Main layout section region 
- * 1) Contains the main page content
+ *
+ * Contains the main page content.
  */
 .layout__section--main {
   @media all and (min-width: $eds-bp-xl) {
@@ -134,9 +139,10 @@
 
 /**
  * Main layout section region within right sidebar
- * 1) Place below the right sidebar on small screens.
+ *
+ * Place below the right sidebar on small screens..
  */
 .layout--right-sidebar > .layout__section--main {
   /* Place to the left of the sidebar on large screens. */
-  order: 1; 
+  order: 1;
 }

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -18,17 +18,20 @@ export interface Props {
   className?: string;
   /**
    * Expandable layout sections
-   * 1) Used for hover/focus states showing/hiding extra content
+   *
+   * Used for hover/focus states showing/hiding extra content
    */
   expandable?: boolean;
   /**
    * Sidebar property
-   * 1) Adjust the gap between layout sections.
+   *
+   * Adjust the gap between layout sections.
    */
   gap?: 'none' | 'lg-xl';
   /**
    * Sidebar property
-   * 1) Adjust the size of the sidebar
+   *
+   * Adjust the size of the sidebar:
    * - **right-sidebar** renders a main section with a fixed width right sidebar
    * - **67-33** renders a 66.66% main section, 33.33% right sidebar section
    * - **50-50** renders a 50% main section, 50% sidebar section

--- a/src/components/LayoutContainer/LayoutContainer.module.css
+++ b/src/components/LayoutContainer/LayoutContainer.module.css
@@ -4,15 +4,15 @@
 
 /**
  * Layout Container
- * 1) Caps the width of the content to the maximum width
- *    and centers the container.
+ *
+ * Caps the width of the content to the maximum width and centers the container.
  */
 .layout-container {
   /**
   * Uses calc to account for the addition of padding around the layout container
   * to ensure content doesn't butt up against viewport edge.
   */
-  max-width: calc(var(--eds-l-max-width) + var(--eds-size-6)); 
+  max-width: calc(var(--eds-l-max-width) + var(--eds-size-6));
   margin-left: auto;
   margin-right: auto;
   padding-left: var(--eds-size-2);
@@ -26,7 +26,8 @@
 
 /**
  * Layout container centered
- * 1) Used for pages that don't contain the header or the footer
+ *
+ * Used for pages that don't contain the header or the footer.
  */
 .eds-l-container--center {
   display: flex;

--- a/src/components/NavContainer/NavContainer.module.css
+++ b/src/components/NavContainer/NavContainer.module.css
@@ -3,19 +3,19 @@
 \*------------------------------------*/
 
 /**
- * 1) Container that houses navigation to be toggled on and off on small screens.
+ * Container that houses navigation to be toggled on and off on small screens.
  */
 .nav-container {
-  position: absolute; 
-  top: 100%; 
-  left: 0; 
+  position: absolute;
+  top: 100%;
+  left: 0;
   /* Hide by default on small screens. */
-  visibility: hidden; 
-  opacity: 0; 
+  visibility: hidden;
+  opacity: 0;
   height: 0;
-  width: 100%; 
+  width: 100%;
   padding: var(--eds-size-1);
-  z-index: var(--eds-z-index-bottom); 
+  z-index: var(--eds-z-index-bottom);
   transition: all var(--eds-anim-move-quick) var(--eds-anim-ease);
 
   @media screen and (prefers-reduced-motion) {
@@ -27,9 +27,9 @@
   */
   @media all and (min-width: $eds-bp-xl) {
     /* Un-hide navcontainer to display nav by default on larger screens. */
-    display: flex; 
+    display: flex;
     /* Display children as horizontal flex items. */
-    justify-content: space-between; 
+    justify-content: space-between;
     position: static;
     visibility: visible;
     opacity: 1;
@@ -41,7 +41,8 @@
 
 /**
 * Active nav container
-* 1) Open state on small screens
+*
+* Open state on small screens.
 */
 .nav-container.is-active {
   display: block;

--- a/src/components/NavContainer/NavContainer.tsx
+++ b/src/components/NavContainer/NavContainer.tsx
@@ -13,7 +13,8 @@ export interface Props {
   className?: string;
   /**
    * is Active
-   * 1) Panel is open when set to true. Close when set to false
+   *
+   * Panel is open when set to true. Close when set to false.
    */
   isActive?: boolean;
 }

--- a/src/components/NotificationList/NotificationList.module.css
+++ b/src/components/NotificationList/NotificationList.module.css
@@ -25,7 +25,8 @@
 
 /**
 * Notification List- is read 
-* 1) When a list item is marked as read, this class is added to enable "is read" styles
+* 
+* When a list item is marked as read, this class is added to enable "is read" styles.
 */
 
 .notification-list__is-read {
@@ -33,7 +34,8 @@
 }
 /* 
 * Notification list item content
-* 1) The wrapper for the text
+* 
+* The wrapper for the text.
 */
 .notification-list__content {
   color: var(--eds-theme-color-text-neutral-default);
@@ -42,7 +44,8 @@
 
 /*
 * Notification list item title link
-* 1) Main text title of the notification
+* 
+* Main text title of the notification.
 */
 .notification-list__link {
   color: var(--eds-theme-color-text-link-brand);
@@ -51,7 +54,8 @@
 
   /**
   *  Notification List Item (is read)
-  * 1) When isRead === true, the title link text changes to grey
+  * 
+  * When isRead === true, the title link text changes to grey.
   */
   .notification-list__is-read & {
     color: var(--eds-theme-color-text-neutral-default);
@@ -60,12 +64,13 @@
 
 /*
 * Notification list item subtitle
-* 1) Contains the created date (relative) and the originating source of the notification
+* 
+* Contains the created date (relative) and the originating source of the notification.
 
 * Notification list item button
-* 1) Indicator that displays the item's read/not read status in
-* a <button> element; when clicked, it toggles between read/not
-* read statuses
+* 
+* Indicator that displays the item's read/not read status in a <button> element;
+* when clicked, it toggles between read/not read statuses.
 */
 .notification-list__button {
   position: relative;
@@ -93,7 +98,6 @@
 
   /*
     * Notification List Item (is read)
-    * 1) When isRead === true, button's background and border are changed to neutral
     */
   .notification-list__is-read & {
     background-color: var(--eds-theme-color-background-neutral-default);

--- a/src/components/NotificationListItem/NotificationListItem.tsx
+++ b/src/components/NotificationListItem/NotificationListItem.tsx
@@ -18,7 +18,8 @@ export interface NotificationListItemProps {
   href?: string;
   /**
    * Marked as read
-   * 1) If notification is marked as read using 'Mark All Seen', this gets set to true
+   *
+   * If notification is marked as read using 'Mark All Seen', this gets set to true.
    */
   markedAsRead?: boolean;
   /**

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -5,12 +5,13 @@
 
 /**
  * Number Icon displays a number enclosed in a circle.
- * 1) Centers the number text in the circle.
+ * 
+ * Centers the number text in the circle.
  */
 .number-icon {
   @mixin eds-theme-typography-body-text-sm;
   /* Line height set to 1 here since this should only ever be on 1 line and it evens out padding in circle. */
-  line-height: 1; 
+  line-height: 1;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -38,9 +39,9 @@
 .number-icon--sm {
   @mixin eds-theme-typography-body-text-xs;
   /* Line height set to 1 here since this should only ever be on 1 line and it evens out padding in circle. */
-  line-height: 1; 
+  line-height: 1;
   /* Height and width should be the same to make the icon a circle and not oblong. */
-  height: var(--eds-size-2-and-half); 
+  height: var(--eds-size-2-and-half);
   width: var(--eds-size-2-and-half);
   min-width: var(--eds-size-2-and-half);
 }

--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -46,16 +46,20 @@
  */
 .page-header__left {
   /* Flex 1 added so the right content doesn't wrap. */
-  flex: 1; 
+  flex: 1;
   /* Push page header right all the way to the right. */
   @media all and (min-width: $eds-bp-md) {
-    margin-right: auto; 
+    margin-right: auto;
   }
 }
 
 /**
  * Page header right
- * 1) On larger viewports, add margin-left to keep space between title and header-right content. If additional margin needs to be added (i.e. margin-top on smaller viewports), add a spacing utility class to the contents of header-right.
+ * 
+ * On larger viewports, add margin-left to keep space between title and
+ * header-right content. If additional margin needs to be added (i.e.
+ * margin-top on smaller viewports), add a spacing utility class to the
+ * contents of header-right.
  */
 .page-header__right {
   @media all and (min-width: $eds-bp-md) {
@@ -76,13 +80,12 @@
 
 /**
  * Page title after
- * 1) An optional container that lives inside
  */
 .page-header__title-after {
   display: inline-block;
   margin-left: var(--eds-size-1-and-half);
   position: relative;
-  top: -1rem; /* TODO */
+  top: -1rem;
 }
 
 /**

--- a/src/components/PageLevelBanner/PageLevelBanner.module.css
+++ b/src/components/PageLevelBanner/PageLevelBanner.module.css
@@ -9,11 +9,11 @@
  */
 .banner {
   /* Position is relative to allow for absolute-positioned close button. */
-  position: relative; 
+  position: relative;
   /* Grid is used to separate the icon from the text with correct spacing. */
-  display: grid; 
-  gap: var(--eds-size-2); 
-  grid-template-columns: min-content 1fr; 
+  display: grid;
+  gap: var(--eds-size-2);
+  grid-template-columns: min-content 1fr;
   padding: var(--eds-size-2) var(--eds-size-4);
   background-color: var(--eds-theme-color-neutral-subtle-background);
   border-bottom: var(--eds-border-width-md) solid var(--messaging-border-color);
@@ -21,16 +21,18 @@
 
 /**
  * PageLevelBanner informational icon
- * 1) Icon color matches the thick bottom border
+ *
+ * Icon color matches the thick bottom border.
  */
 .banner__icon {
-  color: var(--messaging-icon-color); 
+  color: var(--messaging-icon-color);
   --icon-size-default: var(--eds-size-3);
 }
 
 /**
  * PageLevelBanner close button
- * 1) Button used to dismiss dismissable banners
+ *
+ * Button used to dismiss dismissable banners.
  */
 .banner__close-btn.banner__close-btn {
   position: absolute;
@@ -40,10 +42,11 @@
 
 /**
  * Dismissable banner
- * 1) Add extra right padding to account for close button
+ *
+ * Add extra right padding to account for close button.
  */
 .banner--dismissable {
-  padding-right: var(--eds-size-9); 
+  padding-right: var(--eds-size-9);
 }
 
 /*------------------------------------*\

--- a/src/components/Panel/Panel.module.css
+++ b/src/components/Panel/Panel.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) A container for content
+ * A container for content.
  */
 .panel {
   background: var(--eds-theme-color-background-neutral-default);

--- a/src/components/PrimaryNav/PrimaryNav.module.css
+++ b/src/components/PrimaryNav/PrimaryNav.module.css
@@ -5,15 +5,15 @@
 \*------------------------------------*/
 
 /**
- * Primary navigation existing in the header and maybe the footer
- * 1) The outer <nav> wrapper of the primary navigation
- * 2) Normally margin-top should not be used to space elements, but
- *    the primary navigation is
+ * Primary navigation existing in the header and maybe the footer.
+ * 
+ * The outer <nav> wrapper of the primary navigation.
  */
 
 /**
  * Primary nav list
- * 1) The actual list of nav items
+ * 
+ The actual list of nav items.
  */
 .primary-nav__list {
   @mixin reset;

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -6,7 +6,8 @@
 
 /**
  * Primary nav link
- * 1) Individual link within each primary nav item
+ *
+ * Individual link within each primary nav item.
  */
 .primary-nav__link {
   display: flex;

--- a/src/components/ProjectCard/ProjectCard.module.css
+++ b/src/components/ProjectCard/ProjectCard.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Primary UI components acts as container for card components.
+ * Primary UI components acts as container for card components.
  */
 .project-card {
   position: relative;
@@ -24,7 +24,7 @@
   */
   .project-card--draggable & {
     /* Allows room for the handle to show on hover without overlaying content. */
-    min-width: var(--eds-size-2-and-half); 
+    min-width: var(--eds-size-2-and-half);
   }
 }
 

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -23,7 +23,8 @@ export interface Props {
   behavior?: 'draggable';
   /**
    * Button dropdown items
-   * 1) If not declared, the button dropdown does not render
+   *
+   * If not declared, the button dropdown does not render.
    */
   buttonDropdownItems?: ReactNode;
   /**

--- a/src/components/Section/Section.module.css
+++ b/src/components/Section/Section.module.css
@@ -4,7 +4,8 @@
 
 /**
  * Section
- * 1) A section is a discrete section of a web page
+ * 
+ * A section is a discrete section of a web page.
  */
 .section {
   padding-top: var(--eds-size-4);
@@ -13,7 +14,8 @@
 
 /**
  * Section header
- * 1) contains section header inner, left, and right elements
+ * 
+ * contains section header inner, left, and right elements.
  */
 .section__header {
   display: flex;
@@ -32,14 +34,15 @@
 
 /**
 * Section header inner
-* 1) Contains the titleBefore, title-inner, and titleAfter.
+* 
+* Contains the titleBefore, title-inner, and titleAfter..
 */
 .section__header-inner {
   /**
    * Flex grow only has an effect if there is content in the section__right slot;
    * section_right gets forced to the right edge of the header 
    */
-  flex-grow: 1; 
+  flex-grow: 1;
   display: flex;
   flex-direction: row;
   gap: var(--eds-size-1);
@@ -51,7 +54,8 @@
 
 /**
 * Section title inner
-* 1) Contains the section title, overline, and description in a column.
+* 
+* Contains the section title, overline, and description in a column..
 */
 .section__title-inner {
   display: flex;
@@ -61,9 +65,9 @@
 
   .section--center & {
     /* When variant === center, the title inner container gets centered in the header inner container */
-    justify-self: center; 
+    justify-self: center;
     /* When variant === center, the title inner container's contents get center aligned on the cross-axis */
-    align-items: center; 
+    align-items: center;
   }
 }
 
@@ -78,8 +82,10 @@
 
 /**
 * Section title before, after
-* 1) Slots for node(s) to appear to the left (before) and right (after) of the title. 
-* 2) The title after slot is vertically aligned to the top of the title, similar to the positioning of a superscript
+* 
+* Slots for node(s) to appear to the left (before) and right (after) of the title.
+*
+* The title after slot is vertically aligned to the top of the title, similar to the positioning of a superscript.
 */
 .section__title-before,
 .section__title-after {
@@ -91,7 +97,8 @@
 
 /**
 * overline 
-* 1) Optional string that appears above the section title
+* 
+* Optional string that appears above the section title.
 */
 .section__overline {
   margin-top: 0;
@@ -100,7 +107,8 @@
 
 /**
  * Section description
- * 1) Optional string that appears beneath the section title
+ * 
+ * Optional string that appears beneath the section title.
  */
 .section__description {
   margin-top: var(--eds-size-half);
@@ -109,7 +117,8 @@
 
 /**
 * Section right
-* 1) Optional area to put right-aligned content after section title
+* 
+* Optional area to put right-aligned content after section title.
 **/
 .section__right {
   display: flex;

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -55,8 +55,10 @@ export interface Props {
  * import {Section} from "@chanzuckerberg/eds";
  * ```
  *
- * 1) Section component contains a section header and body
- * 2) The Heading component requires a value for "size", so this headingAs prop is provided a default value of "h2" to allow it to remain optional on Section component
+ * Section component contains a section header and body.
+ *
+ * The Heading component requires a value for "size", so this headingAs prop is provided
+ * a default value of "h2" to allow it to remain optional on Section component.
  */
 export const Section = ({
   align,

--- a/src/components/ShowHide/ShowHide.module.css
+++ b/src/components/ShowHide/ShowHide.module.css
@@ -3,14 +3,14 @@
 \*------------------------------------*/
 
 /**
- * 1) Button that toggles open and closes a panel
+ * Button that toggles open and closes a panel.
  */
 
 .show-hide__panel {
   display: none;
 
   /**
-   * 1) Button that toggles open and closes a panel
+   * Button that toggles open and closes a panel.
    */
   .show-hide.eds-is-active & {
     margin-top: var(--eds-size-1);
@@ -23,7 +23,7 @@
  */
 .show-hide svg {
   /* Add transition for icon flip when activated. */
-  transition: transform var(--eds-anim-fade-long) var(--eds-anim-ease); 
+  transition: transform var(--eds-anim-fade-long) var(--eds-anim-ease);
 
   @media screen and (prefers-reduced-motion) {
     transition: none;
@@ -35,5 +35,5 @@
  */
 .show-hide.eds-is-active svg {
   /* Rotate icon 180 deg when show hide component is open. */
-  transform: rotate(90deg); 
+  transform: rotate(90deg);
 }

--- a/src/components/StackedBlock/StackedBlock.module.css
+++ b/src/components/StackedBlock/StackedBlock.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Container for the stacked blocks items vertically aligned with hyperlinked.
+ * Container for the stacked blocks items vertically aligned with hyperlinked.
  */
 .stacked-block__description {
   margin-top: var(--eds-size-1);

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Data Table
+ * Data Table
  */
 .table {
   border-collapse: collapse;
@@ -41,7 +41,8 @@
 
 /**
  * Table Header
- * 1) First row of a table that contains the table header cells
+ * 
+ * First row of a table that contains the table header cells.
  */
 .table__header {
   /**
@@ -52,14 +53,15 @@
 
     @media all and (min-width: $eds-bp-md) {
       /* Hide on small screens */
-      display: table-header-group; 
+      display: table-header-group;
     }
   }
 }
 
 /**
  * Table body
- * 1) <tbody> tag, contains the table rows in the body of the table
+ * 
+ * <tbody> tag, contains the table rows in the body of the table.
  */
 .table__body {
   .table--stacked > & {
@@ -128,12 +130,11 @@
  */
 .table__row--bare {
   /* Removes border. */
-  border-bottom: none; 
+  border-bottom: none;
 }
 
 /**
  * Clickable table row
- * 1) Indicates a clickable table row
  */
 .table__row--clickable {
   cursor: pointer;
@@ -145,7 +146,8 @@
 
 /**
 * Table header cell and table header cell button
-* 1) On table header cells that are not sortable, the container is a div.
+* 
+* On table header cells that are not sortable, the container is a div.
 */
 .table__header-cell,
 /**
@@ -164,7 +166,8 @@
 .table__header-cell {
   /**
   * Table header cell within table body
-  * 1) Adjust the padding to match the table__cell padding for alignment
+  *
+  * Adjust the padding to match the table__cell padding for alignment.
   */
   .table__body & {
     padding: var(--eds-size-2) var(--eds-size-1);
@@ -173,7 +176,8 @@
 
 /**
 * Table header cell button
-* 1) On table header cells that are sortable, the container is a button.
+*
+* On table header cells that are sortable, the container is a button.
 */
 .table__header-cell-button {
   display: inline-flex;
@@ -197,7 +201,9 @@
 
 /**
  * Table header cell contents
- * 1) A wrapper for the title and sort icon. Uses a flex row so that icon remains at the bottom when one or more titles breaks into multiple lines 
+ *
+ * A wrapper for the title and sort icon. Uses a flex row so that icon remains at
+ * the bottom when one or more titles breaks into multiple lines .
  */
 .table__header-cell-contents {
   display: flex;
@@ -219,7 +225,7 @@
    * Condensed table.
    */
   .table--condensed & {
-     /*  shrinks padding between table rows. */
+    /*  shrinks padding between table rows. */
     padding: var(--eds-size-1) var(--eds-size-1);
   }
 
@@ -272,12 +278,12 @@
     padding-right: 0;
 
     &:before {
-    /**
+      /**
      * Take data-heading attribute and display
      * that value as a block-level title above
      * each table cell.
      */
-      content: attr(data-heading); 
+      content: attr(data-heading);
       display: block;
       margin-right: auto;
       @mixin eds-theme-typography-body-text-sm-bold;
@@ -288,7 +294,7 @@
          * Hide data-heading on large screens since
          * table header cells become visible 
          */
-        content: none; 
+        content: none;
       }
     }
 
@@ -366,7 +372,7 @@
        * cells stack on top of each other and are displayed
        * as a single cluster with headings
        */
-      border: 0; 
+      border: 0;
     }
   }
 
@@ -386,13 +392,14 @@
    * Table cell inside a clickable table row.
    */
   .table__row--clickable & {
-     /* Mimic clickable link styles. */
+    /* Mimic clickable link styles. */
     @mixin textLink;
   }
 
   /**
    * Lists inside table
-   * 1) If text wraps onto a new line, it gets indented
+   *
+   * If text wraps onto a new line, it gets indented.
    */
   > ul,
   > ol {
@@ -400,8 +407,8 @@
     list-style: none;
 
     > li {
-      margin-left: 1rem; 
-      text-indent: -1rem; 
+      margin-left: 1rem;
+      text-indent: -1rem;
     }
   }
 }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -33,7 +33,8 @@ export interface Props {
   hideCaption?: boolean;
   /**
    * Highlight first cell
-   * 1) Make the first cell more prominent on smaller screens in stacked variant
+   *
+   * Make the first cell more prominent on smaller screens in stacked variant.
    */
   highlightFirstCell?: boolean;
   /**

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -67,7 +67,8 @@ export const TableHeaderCell = ({
 }: Props) => {
   /**
    * Sort status
-   * 1) State variable to hold current sort direction. Initialized with value in sortDirection prop.
+   *
+   * State variable to hold current sort direction. Initialized with value in sortDirection prop.
    */
   const [sortStatus, setSortStatus] = useState<SortOptions>(sortDirection);
 

--- a/src/components/TableObject/TableObject.module.css
+++ b/src/components/TableObject/TableObject.module.css
@@ -3,9 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) A table object is a container for a data table
- * and toolbars either above or below the table
- * 2) Important for uses like filtering and pagination
+ * A table object is a container for a data table and toolbars either above or below the table.
+ *
+ * Important for uses like filtering and pagination.
  */
 .table-object {
   width: 100%;
@@ -26,7 +26,8 @@
 
 /**
  * Overflow table object body
- * 1) Used to create a scrollable table on small screens
+ *
+ * Used to create a scrollable table on small screens.
  */
 .table-object__body--overflow {
   /**
@@ -84,5 +85,5 @@
 .table-object__body-inner {
   width: 100%;
   /* Overflow auto to allow scrolling when too much content. */
-  overflow: auto; 
+  overflow: auto;
 }

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -17,7 +17,8 @@
 
 /**
  * Tabs header
- * 1) Contains the tab list.
+ *
+ * Contains the tab list.
  */
 .tabs__header {
   /* Tab overflow behavior*/
@@ -32,7 +33,8 @@
 
 /**
  * Fade scrollable indicators to display if there is scrollable area on either side.
- * 1) The color "white" is arbitrary and any non transparent color can be used here.
+ *
+ * The color "white" is arbitrary and any non transparent color can be used here.
  */
 .tabs--scrollable-left {
   -webkit-mask-image: -webkit-linear-gradient(
@@ -58,7 +60,8 @@
 
 /**
  * Tabs list
- * 1) Actual unordered list of tabs.
+ *
+ * Actual unordered list of tabs.
  */
 .tabs__list {
   @mixin reset;
@@ -72,9 +75,11 @@
 
 /**
  * Tabs item
- * 1) Flex shrink 0 keeps tabs from expanding to fill up the space of the container
  */
 .tabs__item {
+  /**
+   * Flex shrink 0 keeps tabs from expanding to fill up the space of the container.
+   */
   flex-shrink: 0;
 }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -141,7 +141,8 @@ export const Tabs = ({
 
   /**
    * Get previous prop
-   * 1) This is used to compare the previous prop to the current prop
+   *
+   * This is used to compare the previous prop to the current prop.
    */
   function usePrevious(activeIndex: number) {
     useEffect(() => {

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -98,7 +98,7 @@
 }
 
 /**
- * 1) A passage of text, including various components (i.e. article, blog post)
+ * sA passage of text, including various components (i.e. article, blog post)
  */
 .text-passage {
   /**

--- a/src/components/TextField/TextField.module.css
+++ b/src/components/TextField/TextField.module.css
@@ -28,10 +28,10 @@
 
 /**
  * Text Field Within
- * 1) A slot to put arbitrary content that appears within
- *    the text field border to the right. 
- * 2) Typically used for buttons and icon buttons to enable
- *    things like show/hide password buttons 
+ *
+ * A slot to put arbitrary content that appears within the text field border to the right. 
+ *
+ * Typically used for buttons and icon buttons to enable things like show/hide password buttons .
  */
 .text-field__input-within {
   position: absolute;

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) List of of links where each link toggles open associated information
+ * List of of links where each link toggles open associated information
  */
 .timeline-nav {
   display: flex;
@@ -42,8 +42,10 @@
 
 /**
  * Timeline nav
- * 1) Contains the tab list
- * 2) Tab overflow behavior
+ *
+ * Contains the tab list.
+ * 
+ * Tab overflow behavior.
  */
 .timeline-nav__nav {
   display: block;
@@ -62,8 +64,6 @@
 
 /**
  * Timeline nav body 
- * TODO: Tokenize the box shadow
- * 1) Take up the rest of the space
  */
 .timeline-nav__body {
   display: block;
@@ -87,7 +87,7 @@
     visibility: visible;
     transform: translateX(0);
     padding: var(--eds-size-5) var(--eds-size-8);
-    box-shadow: 0px 2px 8px var(--eds-theme-color-border-neutral-subtle); /* 1 */
+    box-shadow: 0px 2px 8px var(--eds-theme-color-border-neutral-subtle); /* TODO: Tokenize the box shadow */
   }
 }
 
@@ -120,8 +120,8 @@
 
 /**
  * Timeline nav list
- * 1) Actual unordered list of timeline-nav
- * 2) Set to display flex to place timeline-nav side by side
+ *
+ * Actual unordered list of timeline-nav.
  */
 .timeline-nav__list {
   @mixin reset;
@@ -136,7 +136,8 @@
 
 /**
  * Timeline nav item
- * 1) Flex shrink 0 keeps timeline-nav from expanding to fill up the space of the container
+ *
+ * Flex shrink 0 keeps timeline-nav from expanding to fill up the space of the container.
  */
 .timeline-nav__item {
   position: relative;
@@ -162,7 +163,7 @@
     * list item; a value of 0 would position the line at the top of the current list item; 100% would position it at the bottom of
     * the current list item. We want a small visual gap between the bullet/icon and the top of the line 
     */
-    left: 0.75rem; 
+    left: 0.75rem;
     /**
     * This sets the height of the vertical line relative to the height of the current list item.
     * We want a small visual gap between the bottom of the line and the next bullet/icon.
@@ -184,7 +185,8 @@
 
     /**
       * List Timeline nav item after
-      * 1) Don't add a line after the last list item
+      *
+      * Don't add a line after the last list item.
       */
     &:after {
       content: none;
@@ -194,8 +196,10 @@
 
 /**
  * Timeline nav link
- * 1) Base style for each link in the list
- * 2) Using disabled text color here because all links are "inactive" until selected and this color is overridden
+ * 
+ * Base style for each link in the list.
+ *
+ * Using disabled text color here because all links are "inactive" until selected and this color is overridden.
  */
 .timeline-nav__link {
   position: relative;
@@ -253,7 +257,7 @@
   left: -4px;
   /* Since this will display as a cirlce, keep height and width equal; should be wide enough to fit a two-digit number */
   width: 1.5rem;
-  height: 1.5rem; 
+  height: 1.5rem;
   /* Using a percentage here instead of --eds-border-radius-md because this must always render as a circle */
   border-radius: 50%;
   /* Used on list items using number variant; provides a cosmetic cicular border */
@@ -264,7 +268,7 @@
   background: var(--eds-theme-color-background-neutral-default);
   /* Make the border dark when li is active */
   .timeline-nav__item.eds-is-active & {
-    border: 1px solid var(--eds-theme-color-text-neutral-default); 
+    border: 1px solid var(--eds-theme-color-text-neutral-default);
   }
 }
 /**
@@ -281,8 +285,12 @@
 
 /**
   * Timeline- nav link title
-  * 1) Wrapped in a div so that it doesn't affect the position of the arrow if the title is long and breaks onto multiple lines
-  * 2) In the case of a long text string with no breaking spaces and/or a browser with text-only-zoom, we don't want the text to overflow; truncate with an ellipsis instead
+  *
+  * Wrapped in a div so that it doesn't affect the position of the arrow if the
+  * title is long and breaks onto multiple lines.
+  *
+  * In the case of a long text string with no breaking spaces and/or a browser
+  * with text-only-zoom, we don't want the text to overflow; truncate with an ellipsis instead.
   */
 .timeline-nav__link-title {
   display: block;
@@ -291,7 +299,8 @@
 }
 
 /**Timeline nav title after
-  * 1) Optional content that will be positioned to the right of title
+  *
+  * Optional content that will be positioned to the right of title
   */
 .timeline-nav__link-title-after {
   display: inline-block;
@@ -300,9 +309,11 @@
 
 /**
   * Timeline nav link arrow
-  * 1) (Only used on smaller screens) - an arrow icon at the right 
+  *
+  * (Only used on smaller screens) - an arrow icon at the right 
   * end of each item.
-  * 2) Must be used to prevent icon from shrinking to fit space
+  *
+  * Must be used to prevent icon from shrinking to fit space.
   */
 .timeline-nav__link-arrow {
   margin-left: auto;
@@ -316,7 +327,8 @@
 
 /**
   * Timeline nav icon
-  * 1) Used so the transparent icon doesn't show the line behind. 
+  *
+  * Used so the transparent icon doesn't show the line behind. 
   */
 .timeline-nav__icon {
   --icon-size: var(--eds-size-3);

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -98,7 +98,9 @@ export interface TimelineNavItem {
  * ```
  *
  * Timeline nav Component
- * 1) Provides a list-view pane for item labels/titles, and a details pane for each item's content. When an item in the list is selected, the details pane is updated.
+ *
+ * Provides a list-view pane for item labels/titles, and a details pane for each item's content.
+ * When an item in the list is selected, the details pane is updated.
  */
 export const TimelineNav = ({
   activeIndex = 0,
@@ -139,7 +141,8 @@ export const TimelineNav = ({
 
   /**
    * Get previous prop
-   * 1) This is used to compare the previous prop to the current prop
+   *
+   * This is used to compare the previous prop to the current prop.
    */
   function usePrevious(activeIndex: number) {
     useEffect(() => {
@@ -347,7 +350,8 @@ export const TimelineNav = ({
 
   /**
    * resetTabIndex (used by 'Back' button on <lg viewports)
-   * 1) This fixes an issue where a keyboard user who has focus on the
+   *
+   * This fixes an issue where a keyboard user who has focus on the
    * 'Back' button could use shift-tab to put keyboard focus back
    * on the menu, which is currently off-canvas. To prevent this
    * unwanted behavior, we set the currently active menu item's

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -5,9 +5,10 @@
 \*------------------------------------*/
 
 /**
-  * 1) Message of information, success, caution, or warning to the user
-  * 2) Container for the toast content, to provide background styling
-  */
+ * Message of information, success, caution, or warning to the user.
+ *
+ * Container for the toast content, to provide background styling.
+ */
 .toast {
   width: 100%;
   max-width: 25rem;
@@ -26,13 +27,13 @@
    * The thick left border operates as a foreground band of color, 
    * so foreground rather than border is used
    */
-  border-left-width: var(--eds-border-width-lg); 
+  border-left-width: var(--eds-border-width-lg);
   border-radius: var(--eds-size-half);
   /**
    * The border CSS variables are defined in the messaging mixins    
    */
   border-color: var(--messaging-border-color);
-  border-left-color: var(--border-dark-color); 
+  border-left-color: var(--border-dark-color);
 
   box-shadow: var(--eds-box-shadow-sm);
 }
@@ -46,8 +47,8 @@
 }
 
 /**
-* The toast content, usually an icon and text message. Does not include the optional close button
-*/
+ * The toast content, usually an icon and text message. Does not include the optional close button
+ */
 .toast__content {
   padding-top: var(--eds-size-2);
   padding-bottom: var(--eds-size-2);

--- a/src/components/Toolbar/Toolbar.module.css
+++ b/src/components/Toolbar/Toolbar.module.css
@@ -3,8 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) A toolbar is a container that houses form controls for uses
- *    things like filtering a data table
+ * A toolbar is a container that houses form controls for uses things like filtering a data table.
  */
 .toolbar {
   display: flex;
@@ -26,16 +25,14 @@
 }
 
 /**
- * Vertical align top
- * 1) Veritcally aligns toolbar items to the top of the toolbar
+ * Veritcally aligns toolbar items to the top of the toolbar.
  */
 .toolbar--vertical-align-top {
   align-items: flex-start;
 }
 
 /**
- * Vertical align bottom
- * 1) Veritcally aligns toolbar items to the bottom of the toolbar
+ * Veritcally aligns toolbar items to the bottom of the toolbar.
  */
 .toolbar--vertical-align-bottom {
   align-items: flex-end;
@@ -43,21 +40,23 @@
 
 /**
  * Center-aligned toolbar item
- * 1) since the toolbar is set to display: flex, 
- *    using margin: auto will push item away from  
- *    other items
  */
 .toolbar__item--align-center {
+  /**
+   * Since the toolbar is set to display: flex, using margin: auto will
+   * push item away from other items.
+   */
   margin-left: auto;
   margin-right: auto;
 }
 
 /**
- * Center-aligned toolbar item
- * 1) since the toolbar is set to display: flex, 
- *    using margin: auto will push item away from
- *    other items  
+ * Right-aligned toolbar item
  */
 .toolbar__item--align-right {
+  /**
+   * Since the toolbar is set to display: flex, using margin: auto will
+   * push item away from other items.
+   */
   margin-left: auto;
 }

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -3,8 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) Tippyjs provides .tippy-box, which has two child elements: .tippy-content and .tippy-arrow
- * 2) Tippyjs also attaches data-attribute `data-placement` depending on how the tooltip is aligned
+ * Tippyjs provides .tippy-box, which has two child elements: .tippy-content and .tippy-arrow.
+ *
+ * Tippyjs also attaches data-attribute `data-placement` depending on how the tooltip is aligned.
  */
 
 .tooltip {
@@ -19,7 +20,7 @@
 }
 
 /**
- * 1) Enables opacity fade animation 
+ * Enables opacity fade animation 
  */
 .tooltip[data-state='hidden'] {
   opacity: 0;
@@ -33,7 +34,7 @@
 }
 
 /**
- * 1) Color Variants
+ * Color Variants
  */
 .tooltip--light {
   border-color: var(--eds-color-neutral-300);
@@ -50,7 +51,7 @@
 }
 
 /**
- * 1) Add arrows
+ * Add arrows
  */
 .tooltip :global(.tippy-arrow) {
   position: absolute;

--- a/src/components/Utilities/Alignment.css
+++ b/src/components/Utilities/Alignment.css
@@ -4,7 +4,8 @@
 
 /** 
  * Left align text
- * 1) Forces text-align to left
+ *
+ * Forces text-align to left
  */
 .u-text-align-left {
   text-align: left !important;
@@ -12,7 +13,8 @@
 
 /** 
  * center align text
- * 1) Forces text-align to center
+ *
+ * Forces text-align to center
  */
 .u-text-align-center {
   text-align: center !important;
@@ -20,7 +22,8 @@
 
 /** 
  * Right align text
- * 1) Forces text-align to right
+ *
+ * Forces text-align to right
  */
 .u-text-align-right {
   text-align: right !important;
@@ -28,7 +31,8 @@
 
 /** 
  * Maximizes space between content
- * 1) Forces justify-content to space-between.
+ *
+ * Forces justify-content to space-between.
  */
 .u-justify-content-space-between {
   justify-content: space-between !important;
@@ -36,7 +40,8 @@
 
 /** 
  * Pushes content to the end
- * 1) Forces justify-content to flex-end.
+ *
+ * Forces justify-content to flex-end.
  */
 .u-justify-content-flex-end {
   justify-content: flex-end !important;
@@ -44,7 +49,8 @@
 
 /** 
  * Centers content
- * 1) Forces justify-content to center.
+ *
+ * Forces justify-content to center.
  */
 .u-justify-content-center {
   justify-content: center !important;
@@ -52,7 +58,8 @@
 
 /** 
  * Aligns content to the center
- * 1) Forces align-items to center.
+ *
+ * Forces align-items to center.
  */
 .u-align-items-center {
   align-items: center !important;
@@ -60,7 +67,8 @@
 
 /**
  * Aligns self to the start
- * 1) Forces align-self to flex-start.
+ *
+ * Forces align-self to flex-start.
  */
 .u-align-self-flex-start {
   align-self: flex-start !important;

--- a/src/components/Utilities/Colors.css
+++ b/src/components/Utilities/Colors.css
@@ -4,7 +4,8 @@
 
 /**
  * Success utility
- * 1) Forces color of text to be the success variable
+ *
+ * Forces color of text to be the success variable.
  */
 .u-color-utility-success {
   color: var(--eds-theme-color-text-utility-success) !important;
@@ -12,7 +13,8 @@
 
 /**
  * Error utility
- * 1) Forces color of text to be the error variable
+ *
+ * Forces color of text to be the error variable.
  */
 .u-color-utility-error {
   color: var(--eds-theme-color-text-utility-error) !important;
@@ -20,7 +22,8 @@
 
 /**
  * Warning utility
- * 1) Forces color of text to be the Warning variable
+ *
+ * Forces color of text to be the Warning variable.
  */
 .u-color-utility-warning {
   color: var(--eds-theme-color-text-utility-warning) !important;
@@ -28,7 +31,8 @@
 
 /**
  * Info utility
- * 1) Forces color of text to be the Info variable
+ *
+ * Forces color of text to be the Info variable.
  */
 .u-color-utility-info {
   color: var(--eds-theme-color-text-utility-info) !important;

--- a/src/components/Utilities/Display.css
+++ b/src/components/Utilities/Display.css
@@ -3,7 +3,8 @@
 \*------------------------------------*/
 /**
  * Display block utility
- * 1) Forces display property to block
+ *
+ * Forces display property to block.
  */
 .u-display-block {
   display: block !important;
@@ -11,7 +12,8 @@
 
 /**
  * Display inline block utility
- * 1) Forces display property to inline-block
+ *
+ * Forces display property to inline-block.
  */
 .u-display-inline-block {
   display: inline-block !important;
@@ -19,7 +21,8 @@
 
 /**
  * Display inline utility
- * 1) Forces display property to inline
+ *
+ * Forces display property to inline.
  */
 .u-display-inline {
   display: inline !important;
@@ -27,7 +30,8 @@
 
 /**
  * Display flex utility
- * 1) Forces display property to flex
+ *
+ * Forces display property to flex.
  */
 .u-display-flex {
   display: flex !important;

--- a/src/components/Utilities/Heights.css
+++ b/src/components/Utilities/Heights.css
@@ -3,8 +3,7 @@
 \*------------------------------------*/
 
 /** 
- * Height 100%
- * 1) Forces height to 100%
+ * Forces height to 100%.
  */
 .u-height-100 {
   height: 100% !important;

--- a/src/components/Utilities/Shadows.css
+++ b/src/components/Utilities/Shadows.css
@@ -4,7 +4,8 @@
 
 /**
  * Box shadow small
- * 1) Forces box shadow to box-shadow-sm variable
+ *
+ * Forces box shadow to box-shadow-sm variable.
  */
 .u-box-shadow-sm {
   box-shadow: var(--eds-box-shadow-sm) !important;
@@ -12,7 +13,8 @@
 
 /**
  * Box shadow medium
- * 1) Forces box shadow to box-shadow-md variable
+ *
+ * Forces box shadow to box-shadow-md variable.
  */
 .u-box-shadow-md {
   box-shadow: var(--eds-box-shadow-md) !important;

--- a/src/components/Utilities/Spacing.css
+++ b/src/components/Utilities/Spacing.css
@@ -4,7 +4,8 @@
 
 /**
  * Margin none
- * 1) Forces margin to 0rem
+ * 
+ * Forces margin to 0rem.
  */
 .u-margin-none {
   margin: 0 !important;
@@ -12,7 +13,8 @@
 
 /**
  * Margin small
- * 1) Forces margin to 0.5rem
+ * 
+ * Forces margin to 0.5rem.
  */
 .u-margin-sm {
   margin: var(--eds-size-1) !important;
@@ -20,7 +22,8 @@
 
 /**
  * Margin
- * 1) Forces margin to 1rem
+ * 
+ * Forces margin to 1rem.
  */
 .u-margin-md {
   margin: var(--eds-size-2) !important;
@@ -28,7 +31,8 @@
 
 /**
  * Margin large
- * 1) Forces margin to 1.5rem
+ * 
+ * Forces margin to 1.5rem.
  */
 .u-margin-lg {
   margin: var(--eds-size-3) !important;
@@ -36,7 +40,8 @@
 
 /**
  * Margin xl
- * 1) Forces margin to 2rem
+ * 
+ * Forces margin to 2rem.
  */
 .u-margin-xl {
   margin: var(--eds-size-4) !important;
@@ -44,7 +49,8 @@
 
 /**
  * Margin top none
- * 1) Forces margin top to 0rem
+ * 
+ * Forces margin top to 0rem.
  */
 .u-margin-top-none {
   margin-top: 0 !important;
@@ -52,7 +58,8 @@
 
 /**
  * Margin top small
- * 1) Forces margin top to 0.5rem
+ * 
+ * Forces margin top to 0.5rem.
  */
 .u-margin-top-sm {
   margin-top: var(--eds-size-1) !important;
@@ -60,7 +67,8 @@
 
 /**
  * Margin top
- * 1) Forces margin top to 1rem
+ * 
+ * Forces margin top to 1rem.
  */
 .u-margin-top-md {
   margin-top: var(--eds-size-2) !important;
@@ -68,7 +76,8 @@
 
 /**
  * Margin top large
- * 1) Forces margin top to 1.5rem
+ * 
+ * Forces margin top to 1.5rem.
  */
 .u-margin-top-lg {
   margin-top: var(--eds-size-3) !important;
@@ -76,7 +85,8 @@
 
 /**
  * Margin top xl
- * 1) Forces margin top to 2rem
+ * 
+ * Forces margin top to 2rem.
  */
 .u-margin-top-xl {
   margin-top: var(--eds-size-4) !important;
@@ -84,7 +94,8 @@
 
 /**
  * Margin top xl mobile
- * 1) Forces margin top to 2rem (on smaller viewports only)
+ * 
+ * Forces margin top to 2rem (on smaller viewports only).
  */
 .u-margin-top-xl-mobile {
   margin-top: var(--eds-size-4) !important;
@@ -96,7 +107,8 @@
 
 /**
  * Margin top xxl
- * 1) Forces margin top to 3rem
+ * 
+ * Forces margin top to 3rem.
  */
 .u-margin-top-xxl {
   margin-top: var(--eds-size-6) !important;
@@ -104,7 +116,8 @@
 
 /**
  * Margin bottom xxxL
- * 1) Forces bottom margin to 6rem
+ * 
+ * Forces bottom margin to 6rem.
  */
 .u-margin-top-xxxl {
   margin-top: var(--eds-size-12) !important;
@@ -112,7 +125,8 @@
 
 /**
  * Margin right
- * 1) Forces right margin to 0rem
+ * 
+ * Forces right margin to 0rem.
  */
 .u-margin-right-none {
   margin-right: 0 !important;
@@ -120,7 +134,8 @@
 
 /**
  * Margin right small
- * 1) Forces right margin to 0.5rem
+ * 
+ * Forces right margin to 0.5rem.
  */
 .u-margin-right-sm {
   margin-right: var(--eds-size-1) !important;
@@ -128,7 +143,8 @@
 
 /**
  * Margin right
- * 1) Forces right margin to 1rem
+ * 
+ * Forces right margin to 1rem.
  */
 .u-margin-right-md {
   margin-right: var(--eds-size-2) !important;
@@ -136,7 +152,8 @@
 
 /**
  * Margin right large
- * 1) Forces margin right to 1.5rem
+ * 
+ * Forces margin right to 1.5rem.
  */
 .u-margin-right-lg {
   margin-right: var(--eds-size-3) !important;
@@ -144,7 +161,8 @@
 
 /**
  * Margin right xl
- * 1) Forces right margin to 2rem
+ * 
+ * Forces right margin to 2rem.
  */
 .u-margin-right-xl {
   margin-right: var(--eds-size-4) !important;
@@ -152,7 +170,8 @@
 
 /**
  * Margin bottom
- * 1) Forces bottom margin to 0rem
+ * 
+ * Forces bottom margin to 0rem.
  */
 .u-margin-bottom-none {
   margin-bottom: 0 !important;
@@ -160,7 +179,8 @@
 
 /**
  * Margin bottom small
- * 1) Forces bottom margin to 0.5rem
+ * 
+ * Forces bottom margin to 0.5rem.
  */
 .u-margin-bottom-sm {
   margin-bottom: var(--eds-size-1) !important;
@@ -168,7 +188,8 @@
 
 /**
  * Margin bottom
- * 1) Forces bottom margin to 1rem
+ * 
+ * Forces bottom margin to 1rem.
  */
 .u-margin-bottom-md {
   margin-bottom: var(--eds-size-2) !important;
@@ -176,7 +197,8 @@
 
 /**
  * Margin bottom large
- * 1) Forces margin bottom to 1.5rem
+ * 
+ * Forces margin bottom to 1.5rem.
  */
 .u-margin-bottom-lg {
   margin-bottom: var(--eds-size-3) !important;
@@ -184,7 +206,8 @@
 
 /**
  * Margin bottom xl
- * 1) Forces bottom margin to 2rem
+ * 
+ * Forces bottom margin to 2rem.
  */
 .u-margin-bottom-xl {
   margin-bottom: var(--eds-size-4) !important;
@@ -192,7 +215,8 @@
 
 /**
  * Margin bottom extra large
- * 1) Forces bottom margin to 3rem
+ * 
+ * Forces bottom margin to 3rem.
  */
 .u-margin-bottom-xxl {
   margin-bottom: var(--eds-size-6) !important;
@@ -200,7 +224,8 @@
 
 /**
  * Margin bottom XXL
- * 1) Forces bottom margin to 6rem
+ * 
+ * Forces bottom margin to 6rem.
  */
 .u-margin-bottom-xxxl {
   margin-bottom: var(--eds-size-12) !important;
@@ -208,7 +233,8 @@
 
 /**
  * Margin left
- * 1) Forces left margin to 0rem
+ * 
+ * Forces left margin to 0rem.
  */
 .u-margin-left-none {
   margin-left: 0 !important;
@@ -216,7 +242,8 @@
 
 /**
  * Margin left small
- * 1) Forces left margin to 0.5rem
+ * 
+ * Forces left margin to 0.5rem.
  */
 .u-margin-left-sm {
   margin-left: var(--eds-size-1) !important;
@@ -224,7 +251,8 @@
 
 /**
  * Margin left
- * 1) Forces left margin to 1rem
+ * 
+ * Forces left margin to 1rem.
  */
 .u-margin-left-md {
   margin-left: var(--eds-size-2) !important;
@@ -232,7 +260,8 @@
 
 /**
  * Margin left large
- * 1) Forces left margin to 1.5rem
+ * 
+ * Forces left margin to 1.5rem.
  */
 .u-margin-left-lg {
   margin-left: var(--eds-size-3) !important;
@@ -240,7 +269,8 @@
 
 /**
  * Margin left xl
- * 1) Forces left margin to 2rem
+ * 
+ * Forces left margin to 2rem.
  */
 .u-margin-left-xl {
   margin-left: var(--eds-size-4) !important;
@@ -252,7 +282,8 @@
 
 /**
  * Padding none
- * 1) Forces padding to 0rem
+ * 
+ * Forces padding to 0rem.
  */
 .u-padding-none {
   padding: 0 !important;
@@ -260,7 +291,8 @@
 
 /**
  * Padding small
- * 1) Forces padding to 0.5rem
+ * 
+ * Forces padding to 0.5rem.
  */
 .u-padding-sm {
   padding: var(--eds-size-1) !important;
@@ -268,7 +300,8 @@
 
 /**
  * Padding
- * 1) Forces padding to 1rem
+ * 
+ * Forces padding to 1rem.
  */
 .u-padding-md {
   padding: var(--eds-size-2) !important;
@@ -276,7 +309,8 @@
 
 /**
  * Padding
- * 1) Forces padding to 1.5rem
+ * 
+ * Forces padding to 1.5rem.
  */
 .u-padding-lg {
   padding: var(--eds-size-3) !important;
@@ -284,7 +318,8 @@
 
 /**
  * Padding xl
- * 1) Forces padding to 2rem
+ * 
+ * Forces padding to 2rem.
  */
 .u-padding-xl {
   padding: var(--eds-size-4) !important;
@@ -292,7 +327,8 @@
 
 /**
  * Padding top none
- * 1) Forces padding top to 0rem
+ * 
+ * Forces padding top to 0rem.
  */
 .u-padding-top-none {
   padding-top: 0 !important;
@@ -300,7 +336,8 @@
 
 /**
  * Padding top small
- * 1) Forces padding top to 0.5rem
+ * 
+ * Forces padding top to 0.5rem.
  */
 .u-padding-top-sm {
   padding-top: var(--eds-size-1) !important;
@@ -308,7 +345,8 @@
 
 /**
  * Padding top
- * 1) Forces padding top to 1rem
+ * 
+ * Forces padding top to 1rem.
  */
 .u-padding-top-md {
   padding-top: var(--eds-size-2) !important;
@@ -316,7 +354,8 @@
 
 /**
  * Padding top large
- * 1) Forces padding top to 1.5rem
+ * 
+ * Forces padding top to 1.5rem.
  */
 .u-padding-top-lg {
   padding: var(--eds-size-3) !important;
@@ -324,7 +363,8 @@
 
 /**
  * Padding top xl
- * 1) Forces padding top to 2rem
+ * 
+ * Forces padding top to 2rem.
  */
 .u-padding-top-xl {
   padding-top: var(--eds-size-4) !important;
@@ -332,7 +372,8 @@
 
 /**
  * Padding right
- * 1) Forces right padding to 0rem
+ * 
+ * Forces right padding to 0rem.
  */
 .u-padding-right-none {
   padding-right: 0 !important;
@@ -340,7 +381,8 @@
 
 /**
  * Padding right small
- * 1) Forces right padding to 0.5rem
+ * 
+ * Forces right padding to 0.5rem.
  */
 .u-padding-right-sm {
   padding-right: var(--eds-size-1) !important;
@@ -348,7 +390,8 @@
 
 /**
  * Padding right
- * 1) Forces right padding to 1rem
+ * 
+ * Forces right padding to 1rem.
  */
 .u-padding-right-md {
   padding-right: var(--eds-size-2) !important;
@@ -356,7 +399,8 @@
 
 /**
  * Padding right large
- * 1) Forces padding right to 1.5rem
+ * 
+ * Forces padding right to 1.5rem.
  */
 .u-padding-right-lg {
   padding: var(--eds-size-3) !important;
@@ -364,7 +408,8 @@
 
 /**
  * Padding right xl
- * 1) Forces right padding to 2rem
+ * 
+ * Forces right padding to 2rem.
  */
 .u-padding-right-xl {
   padding-right: var(--eds-size-4) !important;
@@ -372,7 +417,8 @@
 
 /**
  * Padding bottom
- * 1) Forces bottom padding to 0rem
+ * 
+ * Forces bottom padding to 0rem.
  */
 .u-padding-bottom-none {
   padding-bottom: 0 !important;
@@ -380,7 +426,8 @@
 
 /**
  * Padding bottom small
- * 1) Forces bottom padding to 0.5rem
+ * 
+ * Forces bottom padding to 0.5rem.
  */
 .u-padding-bottom-sm {
   padding-bottom: var(--eds-size-1) !important;
@@ -388,7 +435,8 @@
 
 /**
  * Padding bottom
- * 1) Forces bottom padding to 1rem
+ * 
+ * Forces bottom padding to 1rem.
  */
 .u-padding-bottom-md {
   padding-bottom: var(--eds-size-2) !important;
@@ -396,7 +444,8 @@
 
 /**
  * Padding bottom large
- * 1) Forces bottom padding to 1.5rem
+ * 
+ * Forces bottom padding to 1.5rem.
  */
 .u-padding-bottom-lg {
   padding-bottom: var(--eds-size-3) !important;
@@ -404,7 +453,8 @@
 
 /**
  * Padding bottom xl
- * 1) Forces bottom padding to 2rem
+ * 
+ * Forces bottom padding to 2rem.
  */
 .u-padding-bottom-xl {
   padding-bottom: var(--eds-size-4) !important;
@@ -412,7 +462,8 @@
 
 /**
  * Padding left
- * 1) Forces left padding to 0rem
+ * 
+ * Forces left padding to 0rem.
  */
 .u-padding-left-none {
   padding-left: 0 !important;
@@ -420,7 +471,8 @@
 
 /**
  * Padding left small
- * 1) Forces left padding to 0.5rem
+ * 
+ * Forces left padding to 0.5rem.
  */
 .u-padding-left-sm {
   padding-left: var(--eds-size-1) !important;
@@ -428,7 +480,8 @@
 
 /**
  * Padding left
- * 1) Forces left padding to 1rem
+ * 
+ * Forces left padding to 1rem.
  */
 .u-padding-left-md {
   padding-left: var(--eds-size-2) !important;
@@ -436,7 +489,8 @@
 
 /**
  * Padding left large
- * 1) Forces left padding to 1.5rem
+ * 
+ * Forces left padding to 1.5rem.
  */
 .u-padding-left-lg {
   padding-left: var(--eds-size-3) !important;
@@ -444,7 +498,8 @@
 
 /**
  * Padding left xl
- * 1) Forces left padding to 2rem
+ * 
+ * Forces left padding to 2rem.
  */
 .u-padding-left-xl {
   padding-left: var(--eds-size-4) !important;

--- a/src/components/Utilities/Visibility.css
+++ b/src/components/Utilities/Visibility.css
@@ -5,8 +5,7 @@
 \*------------------------------------*/
 
 /**
- * Is Hidden
- * 1) Completely remove from the flow and screen readers.
+ * Completely remove from the flow and screen readers.
  */
 .u-is-hidden {
   display: none !important;
@@ -14,16 +13,14 @@
 }
 
 /**
- * Is Visibly Hidden
- * 1) Hides from screens but leaves content available to assitive technologies.
+ * Hides from screens but leaves content available to assitive technologies.
  */
 .u-is-vishidden {
   @mixin visuallyHide;
 }
 
 /**
- * Mobile Visibly Hidden 
- * 1) Hides (on smaller screens only) but leaves content available to assitive technologies.
+ * Hides (on smaller screens only) but leaves content available to assitive technologies.
  */
 .u-mobile-hidden {
   @mixin visuallyHide;

--- a/src/components/UtilityNav/UtilityNav.module.css
+++ b/src/components/UtilityNav/UtilityNav.module.css
@@ -9,10 +9,9 @@
  */
 
 /**
- * Utility navigation existing in the header and maybe the footer
- * 1) The outer <nav> wrapper of the utility navigation
- * 2) Normally margin-top should not be used to space elements, but
- *    the utility navigation is
+ * Utility navigation existing in the header and maybe the footer.
+ *
+ * The outer <nav> wrapper of the utility navigation.
  */
 
 .utility-nav {
@@ -24,7 +23,8 @@
 
 /**
  * Utility nav list
- * 1) The actual list of nav items
+ * 
+ * The actual list of nav items.
  */
 .utility-nav__list {
   @mixin reset;

--- a/src/components/UtilityNavItem/UtilityNavItem.module.css
+++ b/src/components/UtilityNavItem/UtilityNavItem.module.css
@@ -6,7 +6,8 @@
 
 /**
  * Utility nav item
- * 1) Individual list item
+ *
+ * Individual list item
  */
 .utility-nav__item {
   position: relative;

--- a/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -6,7 +6,8 @@ import { useMergedRefs } from '../../hooks';
 export interface Props {
   /**
    * Aria label
-   * 1) Use aria label for icon-only utility nav item
+   *
+   * Use aria label for icon-only utility nav item.
    */
   'aria-label'?: string;
   /**

--- a/src/design-tokens/css/base/media.css
+++ b/src/design-tokens/css/base/media.css
@@ -4,7 +4,8 @@
 
 /**
  * Responsive image styling
- * 1) Allows for images to flex with varying screen size
+ *
+ * Allows for images to flex with varying screen size.
  */
 img {
   max-width: 100%;

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -8,7 +8,11 @@
 
 /**
 * Reset all
-* 1) The 'all' shorthand CSS property resets all of an element's properties except unicode-bidi, direction, and CSS Custom Properties. The value 'unset' specifies that all of an element's properties should be changed to their inherited values if they inherit by default, or to their initial values if not.
+*
+* The 'all' shorthand CSS property resets all of an element's properties except unicode-bidi,
+* direction, and CSS Custom Properties. The value 'unset' specifies that all of an element's
+* properties should be changed to their inherited values if they inherit by default, or to their
+* initial values if not.
 */
 @define-mixin resetAll {
   all: unset !important;

--- a/src/upcoming-components/Accordion/Accordion.module.css
+++ b/src/upcoming-components/Accordion/Accordion.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) A list of buttons that contain additional content that toggle open/close when link is selected
+ * A list of buttons that contain additional content that toggle open/close when link is selected.
  */
 .accordion {
   margin: 0;

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.module.css
@@ -38,7 +38,8 @@
 
 /**
  * Accordion Button
- * 1) The accordion trigger marked up as a <button>
+ * 
+ * The accordion trigger marked up as a <button>.
  */
 .accordion__panel-button {
   all: inherit;
@@ -57,7 +58,6 @@
 
 /**
  * Accordion panel button focus visible
- * 1) Show focus ring when focused only with keyboard
  */
 .accordion__panel-button:focus-visible {
   @mixin focus;
@@ -71,7 +71,8 @@
 
 /**
  * Accordion panel button within inverted accordion
- * 1) The wrapper for the text
+ *
+ * The wrapper for the text
  */
 .accordion--inverted .accordion__panel-button {
   color: var(--eds-theme-color-text-neutral-default-inverse);
@@ -79,7 +80,8 @@
 
 /**
  * Accordion body
- * 1) Set max height to 0 and overflow to hidden to get smoother transition when activated
+ *
+ * Set max height to 0 and overflow to hidden to get smoother transition when activated.
  */
 .accordion__panel-body {
   display: block;
@@ -116,7 +118,8 @@
 
 /**
  * Accordion panel left
- * 1) Section that contains the title and other text of the accordion
+ *
+ * Section that contains the title and other text of the accordion.
  */
 .accordion__panel-left {
   flex: 1;
@@ -131,8 +134,10 @@
 
 /**
  * Accordion Icon
- * 1) The icon that indicates the accordion
- * 2) Double up on the classname to override default `icon` height and width
+ *
+ * The icon that indicates the accordion.
+ * 
+ * Double up on the classname to override default `icon` height and width.
  */
 .accordion__panel-icon.accordion__panel-icon {
   margin-left: auto;

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.tsx
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.tsx
@@ -34,7 +34,8 @@ export interface Props {
   className?: string;
   /**
    * is Active
-   * 1) Panel is open when set to true. Close when set to false
+   *
+   * Panel is open when set to true. Close when set to false.
    */
 
   isActive?: boolean;

--- a/src/upcoming-components/CheckboxField/CheckboxField.module.css
+++ b/src/upcoming-components/CheckboxField/CheckboxField.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Consists of a label, form control, and an optional note about the field.
+ * Consists of a label, form control, and an optional note about the field.
  */
 .checkbox-field {
   @mixin fieldsetStyles;
@@ -21,7 +21,8 @@
 
 /**
  * Checkbox field body
- * 1) Contains the list of checkbox options
+ * 
+ * Contains the list of checkbox options
  */
 .checkbox-field__body {
   position: relative;
@@ -68,8 +69,10 @@
 
 /**
  * Checkbox field control
- * 1) The actual checkbox form control
- * 2) Align control to label
+ * 
+ * The actual checkbox form control.
+ * 
+ * Align control to label.
  */
 .checkbox-field__item-control {
   position: relative;

--- a/src/upcoming-components/Counter/Counter.module.css
+++ b/src/upcoming-components/Counter/Counter.module.css
@@ -3,10 +3,10 @@
 \*------------------------------------*/
 
 /**
- * 1) A counter is a form control that consists of a 
- *    numeric input and + - buttons to increment the 
- *    value on either side of the input 
- * 2) Cap the width of the input
+ * A counter is a form control that consists of a  numeric input and
+ * + - buttons to increment the  value on either side of the input .
+ *
+ * Cap the width of the input.
  */
 
 /**
@@ -48,9 +48,8 @@
 
 /**
  * Counter +/- button styles
- * 1) Instance of icon button variant, and then rebuilds
- *    styles to match text input styles
- * 2) Margin left and margin right 0 added to remove margin in Safari from these 
+ *
+ * Instance of icon button variant, and then rebuilds styles to match text input styles.
  */
 .counter__btn {
   padding-top: var(--eds-size-1-and-half);

--- a/src/upcoming-components/Feature/Feature.module.css
+++ b/src/upcoming-components/Feature/Feature.module.css
@@ -5,8 +5,8 @@
 \*------------------------------------*/
 
 /**
- * 1) A Feature is a prominent marketing block that contains
- *    Side by side information and an image
+ * A Feature is a prominent marketing block that contains and image
+ * and information side by side.
  */
 .feature {
   display: flex; /* 2 */
@@ -23,8 +23,8 @@
 
 /**
  * Feature body
- * 1) Container within feature that usually contains an excerpt of text
- * 2) Take up the remaining space on medr screens
+ *
+ * Container within feature that usually contains an excerpt of text.
  */
 .feature__body {
   margin-bottom: var(--eds-size-4);
@@ -40,7 +40,6 @@
 
 /**
  * Feature title
- * 1) Feature headline
  */
 .feature__title {
   @mixin reset;

--- a/src/upcoming-components/FileUploadField/FileUploadField.module.css
+++ b/src/upcoming-components/FileUploadField/FileUploadField.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Consists of a label, form control, and an optional note about the field.
+ * Consists of a label, form control, and an optional note about the field.
  */
 .file-upload-field {
   position: relative;
@@ -19,8 +19,8 @@
 
 /**
  * Hit area
- * 1) the area where users can drag files onto or click
- *    to bring up the file explorer
+ *
+ * The area where users can drag files onto or click to bring up the file explorer.
  */
 .file-upload-field__hit-area {
   border: var(--eds-theme-border-width) dashed
@@ -67,7 +67,8 @@
 
 /**
  * Label after
- * 1) Slot after the label that can be used to place components like a tooltip
+ *
+ * Slot after the label that can be used to place components like a tooltip.
  */
 .file-upload-field__label-after {
   display: inherit;
@@ -76,7 +77,8 @@
 
 /**
  * Text field input
- * 1) The actual form control
+ *
+ * The actual form control.
  */
 .file-upload-field__input {
   position: absolute;
@@ -96,7 +98,8 @@
 .file-upload-field--error > .file-upload-field__note {
   /**
    * file-upload-field note within error state
-   * 1) Set to display flex to place icon next to the fieldnote
+   *
+   * Set to display flex to place icon next to the fieldnote.
    */
   display: inline-flex;
 }
@@ -112,7 +115,8 @@
 
 /**
  * file-upload-field icon
- * 1) Icon that can be placed at the end of the text input
+ *
+ * Icon that can be placed at the end of the text input.
  */
 .file-upload-field__icon {
   position: absolute;

--- a/src/upcoming-components/FooterNav/FooterNav.module.css
+++ b/src/upcoming-components/FooterNav/FooterNav.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Navigation within the footer that contains auxiliary links
+ * Navigation within the footer that contains auxiliary links.
  */
 .footer-nav {
   padding: var(--eds-size-1) 0;
@@ -14,7 +14,8 @@
 
 /**
  * Footer nav listItems
- * 1) Actual list of the footer nav
+ *
+ * Actual list of the footer nav.
  */
 .footer-nav__list {
   @mixin reset;
@@ -25,7 +26,8 @@
 
 /**
  * Footer nav items
- * 1) Nav item within the footer nav list
+ *
+ * Nav item within the footer nav list.
  */
 .footer-nav__item {
   margin: var(--eds-size-1) var(--eds-size-2);

--- a/src/upcoming-components/Hero/Hero.module.css
+++ b/src/upcoming-components/Hero/Hero.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) A hero is a pronounced block typically situated at the top of a page layout
+ * A hero is a pronounced block typically situated at the top of a page layout.
  */
 .hero {
   position: relative;
@@ -48,7 +48,8 @@
 
 /**
  * Hero layout container
- * 1) Instance of LayoutContainer that sets left gutter 
+ * 
+ * Instance of LayoutContainer that sets left gutter.
  */
 .hero__layout-container {
   position: relative;
@@ -58,7 +59,8 @@
 
 /**
  * Hero body
- * 1) Contains the hero text, call to action, and other things
+ *
+ * Contains the hero text, call to action, and other things.
  */
 .hero__body {
   @media all and (min-width: $eds-bp-sm) {
@@ -69,7 +71,8 @@
 
 /**
  * Hero title
- * 1) Note: this typography needs to be addressed at a system level
+ *
+ * Note: this typography needs to be addressed at a system level.
  */
 .hero__title {
   @mixin reset;

--- a/src/upcoming-components/InlineForm/InlineForm.module.css
+++ b/src/upcoming-components/InlineForm/InlineForm.module.css
@@ -3,8 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) An inline form displays an input and a button side-by-side.
- * 2) Can be used for search, email newsletter signup, and other one-field forms
+ * An inline form displays an input and a button side-by-side.
+ *
+ * Can be used for search, email newsletter signup, and other one-field forms.
  */
 .inline-form {
   display: flex;

--- a/src/upcoming-components/KeyValueTable/KeyValueTable.module.css
+++ b/src/upcoming-components/KeyValueTable/KeyValueTable.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Data table that always consists of 2 columns (i.e. a list of items and prices with total)
+ * Data table that always consists of 2 columns (i.e. a list of items and prices with total)
  */
 .key-value-table {
   border-collapse: collapse;

--- a/src/upcoming-components/KeyValueTableRow/KeyValueTableRow.tsx
+++ b/src/upcoming-components/KeyValueTableRow/KeyValueTableRow.tsx
@@ -5,12 +5,14 @@ import styles from '../KeyValueTable/KeyValueTable.module.css';
 export interface Props {
   /**
    * Row key
-   * 1) The key in the key value pair that sits on the left
+   *
+   * The key in the key value pair that sits on the left.
    */
   rowKey?: ReactNode;
   /**
    * Row value
-   * 1) The value in the key value pair that sits on the right
+   *
+   * The value in the key value pair that sits on the right.
    */
   rowValue?: ReactNode;
   /**

--- a/src/upcoming-components/LoadingIndicator/LoadingIndicator.module.css
+++ b/src/upcoming-components/LoadingIndicator/LoadingIndicator.module.css
@@ -3,7 +3,7 @@
 \*------------------------------------*/
 
 /**
- * 1) 
+ * A spinner that indicates content is loadaing.
  */
 /* stylelint-disable-next-line block-no-empty */
 .loading-indicator {

--- a/src/upcoming-components/MediaBlock/MediaBlock.module.css
+++ b/src/upcoming-components/MediaBlock/MediaBlock.module.css
@@ -19,7 +19,8 @@
 
 /**
  * Media Container
- * 1) This is the container that holds the image (or media)
+ *
+ * This is the container that holds the image (or media).
  */
 .media-block__media {
   width: 100%;
@@ -49,7 +50,8 @@
 
 /**
  * Media Block Headline
- * 1) This is the headline of the media block
+ *
+ * This is the headline of the media block.
  */
 .media-block__title {
   @mixin eds-theme-typography-heading-3;

--- a/src/upcoming-components/SkeletonBar/SkeletonBar.module.css
+++ b/src/upcoming-components/SkeletonBar/SkeletonBar.module.css
@@ -3,8 +3,9 @@
 \*------------------------------------*/
 
 /**
- * 1) Skeleton bar used to indicate a loading state
- *    Used within table cells and other loading components
+ * Skeleton bar used to indicate a loading state
+ *
+ * Used within table cells and other loading components.
  */
 .skeleton-bar {
   position: relative;
@@ -39,7 +40,8 @@
 
 /**
  * Continuous rotation animation
- * 1) Used for loading spinner animation
+ *
+ * Used for loading spinner animation.
  */
 @keyframes pulse {
   0% {

--- a/src/upcoming-components/TextList/TextList.module.css
+++ b/src/upcoming-components/TextList/TextList.module.css
@@ -5,7 +5,7 @@
 \*------------------------------------*/
 
 /**
- * 1) Basic list of lines of text that can contain optional inline items afterwards
+ * Basic list of lines of text that can contain optional inline items afterwards
  */
 .text-list {
   @mixin reset;


### PR DESCRIPTION
### Summary:
As part of the work to clean up the old code patterns we don't really want anymore, I'm waging a just (imo) war against numbered lists in code comments. This PR removes numbered lists in descriptions where the number isn't pointing to a specific line of code; it's just listing out details about the block of code below (usually a CSS block).

I also tried to remove some comments I thought were redundant but I didn't want to spend too much time nit-picking these comments because there are a lot of them.

### Test Plan:
All  automated tests pass and the comments look a little better...