### PR TITLE
fix(tag): allow data attributes on tag and remove max-width

### DIFF
--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -10,16 +10,16 @@
 .tag {
   width: max-content;
   height: var(--eds-size-3);
-  max-width: 20rem;
   padding-left: var(--eds-size-1-and-half);
   padding-right: var(--eds-size-1-and-half);
 
   display: inline-flex;
   align-items: center;
-   /* Grabs colors from whichever variant is selected. */
+
+  /* Grabs colors from whichever variant is selected. */
   border: var(--tag-secondary-color) solid var(--eds-theme-border-width);
   /* Rounds the corners of the tag. */
-  border-radius: var(--eds-border-radius-full); 
+  border-radius: var(--eds-border-radius-full);
 
   background-color: var(--tag-secondary-color);
   color: var(--tag-primary-color);

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -29,7 +29,15 @@ export const ColorVariants: StoryObj<Args> = {
   render: (args) => (
     <div className={styles.tagList}>
       {VARIANTS.map((variant) => {
-        return <Tag key={variant} {...args} text={variant} variant={variant} />;
+        return (
+          <Tag
+            data-testid="test"
+            key={variant}
+            {...args}
+            text={variant}
+            variant={variant}
+          />
+        );
       })}
     </div>
   ),

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -52,6 +52,7 @@ export const Tag = ({
   icon,
   text,
   hasOutline = false,
+  ...other
 }: Props) => {
   const componentClassName = clsx(
     styles['tag'],
@@ -61,7 +62,13 @@ export const Tag = ({
   );
 
   return (
-    <Text as="span" className={componentClassName} size="sm" weight="bold">
+    <Text
+      as="span"
+      className={componentClassName}
+      size="sm"
+      weight="bold"
+      {...other}
+    >
       {icon}
       {text && <span className={styles['tag__body']}>{text}</span>}
     </Text>

--- a/src/components/Tag/__snapshots__/Tag.test.ts.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.ts.snap
@@ -6,6 +6,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
 >
   <span
     class="text text--sm text--bold-weight tag tag--neutral"
+    data-testid="test"
   >
     <span
       class="tag__body"
@@ -15,6 +16,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--error"
+    data-testid="test"
   >
     <span
       class="tag__body"
@@ -24,6 +26,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--success"
+    data-testid="test"
   >
     <span
       class="tag__body"
@@ -33,6 +36,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--warning"
+    data-testid="test"
   >
     <span
       class="tag__body"
@@ -42,6 +46,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--yield"
+    data-testid="test"
   >
     <span
       class="tag__body"
@@ -51,6 +56,7 @@ exports[`<Tag /> ColorVariants story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--brand"
+    data-testid="test"
   >
     <span
       class="tag__body"


### PR DESCRIPTION
### Summary:
Addresses #686, #794
These issues are a little old but still valid
- Passes `other` props for broad data attributes for Tag
- Removes `max-width` for tag
### Test Plan:
- added `data-testid` to a story
  - no errors and seen in storybook
![Screen Shot 2022-09-22 at 9 20 29 AM](https://user-images.githubusercontent.com/86632227/191800999-59e0292d-8f3c-4e72-a1e2-8e21866de966.png)
  - snap updated including `data-testid`
- no other unit test failures
- no visual regressions 