### PR TITLE
chore: remove remaining numbered lists in comments

### DIFF
--- a/.storybook/recipes/BaselineCard/BaselineCard.module.css
+++ b/.storybook/recipes/BaselineCard/BaselineCard.module.css
@@ -72,37 +72,45 @@
 
 /**
 * Baseline card link (based on WordPress' .screen-reader-text class)
-* 1) On a clickable card, the link should be visually hidden but still
+* 
+* On a clickable card, the link should be visually hidden but still
 * accessible to screen readers. It should also become visible when it 
 * receives keyboard focus, i.e. using the Tab key
-* 2) Set width and height to 1px; some screen readers don't announce 
-* an element with a size of 0 px
-* 3) Hide the link
-* 4) Prevent screen readers reading the text letter for letter, as the
-* text is placed in a 1 pixel wide space. Many screen reader and browser
-* combinations announce broken words as they would appear visually.
-* 5) Clip is deprecated, but is added to support older browsers that don't support clip-path yet.
-* 
-* See https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
 */
-
 .baseline-card__link {
   border: 0;
+  /**
+   * Clip is deprecated, but is added to support older browsers that don't support clip-path yet.
+   * 
+   * See https://make.wordpress.org/accessibility/handbook/markup/the-css-class-screen-reader-text/
+   */
   clip: rect(1px, 1px, 1px, 1px);
   clip-path: inset(50%);
-  width: 1px; /* 2 */
+  /**
+   * Set width and height to 1px; some screen readers don't announce 
+   * an element with a size of 0 px
+   */
+  width: 1px;
   height: 1px;
-  margin: -1px; /* 3 */
+  /**
+   * Hide the link
+   */
+  margin: -1px;
   padding: 0;
   position: absolute;
   overflow: hidden;
-  word-wrap: normal !important; /* 4 */
+  /**
+   * Prevent screen readers reading the text letter for letter, as the
+   * text is placed in a 1 pixel wide space. Many screen reader and browser
+   * combinations announce broken words as they would appear visually.
+   */
+  word-wrap: normal !important;
 }
 
 .baseline-card__link:focus {
   @mixin eds-theme-typography-body-text-sm;
   background-color: var(--eds-theme-color-background-neutral-default);
-  clip: auto !important; /* 5 */
+  clip: auto !important;
   clip-path: none;
   color: var(--eds-theme-color-text-neutral-default);
   display: block;
@@ -114,7 +122,7 @@
   text-decoration: none;
   top: var(--eds-size-half);
   width: auto;
-  z-index: var(--eds-z-index-top); /* 1 */
+  z-index: var(--eds-z-index-top);
 }
 
 /**

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -49,15 +49,15 @@ export interface Props {
 
 /*
  * Clickable card: link properties
- * 1) Href and text are required attributes
- * 2) Text will be used by screen readers; it will only be visible when the
- * link is focused by a keyboard
- * 3) Target attribute is optional
  */
 export type LinkType = {
-  href: string /* 1 */;
-  text: ReactNode /* 2 */;
-  target?: '_blank' | '_parent' | '_self' | '_top' /* 3 */;
+  href: string;
+  /**
+   * Text will be used by screen readers; it will only be visible when the
+   * link is focused by a keyboard.
+   */
+  text: ReactNode;
+  target?: '_blank' | '_parent' | '_self' | '_top';
 };
 
 /**
@@ -82,14 +82,7 @@ export const BaselineCard = ({
   const linkRef = useRef() as MutableRefObject<HTMLAnchorElement>;
 
   /**
-   * useEffect hook
-   * 1) On component load or update, check for both a cardRef and a linkRef.
-   * The presence of both means this card has a clickable link.
-   * 2) Attach click handler to the card.
-   * 3) Check to see if text is selected; if so, do not call .click() on the
-   * linkRef
-   * 4) Pass the click to the linkRef.
-   * 5) Cleanup.
+   * Hook up the link functionality on component mount if a link is present
    *
    * TODO: If the visible text of the card also contains links, these will
    * need to have an event listener added to them to stop propagation of the
@@ -97,20 +90,23 @@ export const BaselineCard = ({
    * links.
    */
   useEffect(() => {
+    /**
+     * On component load or update, check for both a cardRef and a linkRef.
+     * The presence of both means this card has a clickable link.
+     */
     if (!cardRef.current || !linkRef.current) {
-      /* 1 */
       return;
     }
     const curr = cardRef.current;
-    curr.addEventListener('click', handleClick); /* 2 */
+    curr.addEventListener('click', handleClick);
 
     function handleClick() {
-      const isTextSelected = window.getSelection()?.toString(); /* 3 */
+      const isTextSelected = window.getSelection()?.toString();
       if (!isTextSelected) {
-        linkRef.current.click(); /* 4 */
+        linkRef.current.click();
       }
     }
-    /* 5 */
+
     return () => {
       curr.removeEventListener('click', handleClick, false);
     };

--- a/.storybook/recipes/CalendarCard/CalendarCard.module.css
+++ b/.storybook/recipes/CalendarCard/CalendarCard.module.css
@@ -11,32 +11,32 @@
   background-color: var(--eds-theme-color-background-neutral-default-hover);
 }
 /**
-* Brand variant (default): brand colored left border
-*/
+ * Brand variant (default): brand colored left border
+ */
 .calendar-card--brand {
   border-left: var(--eds-border-width-lg) solid
     var(--eds-theme-color-border-brand-primary-strong);
 }
 
 /**
-* Revise variant
-*/
+ * Revise variant
+ */
 .calendar-card--revise {
   border-left: var(--eds-border-width-lg) solid
     var(--eds-theme-color-border-grade-revise-strong);
 }
 
 /** 
-* Success variant
-*/
+ * Success variant
+ */
 .calendar-card--success {
   border-left: var(--eds-border-width-lg) solid
     var(--eds-theme-color-border-utility-success-strong);
 }
 
 /**
-* Stack the card's contents in a flex column.
-*/
+ * Stack the card's contents in a flex column.
+ */
 .calendar-card__body {
   display: flex;
   flex-direction: column;
@@ -45,31 +45,35 @@
 }
 
 /**
-* Card title row which holds an optional icon and a text string.
-* 1) Keeps the icon positioned at the top of the cross-axis if the text string expands to use multiple lines.
-* 2) If icon is used, the gap setting will maintain spacing between icon and text.
-*/
+ * Card title row which holds an optional icon and a text string.
+ */
 .calendar-card__title {
   display: flex;
   align-items: flex-start;
-  justify-content: flex-start; /* 1 */
-  gap: var(--eds-size-1); /* 2 */
+  /**
+   * Keeps the icon positioned at the top of the cross-axis if the text string expands to use multiple lines.
+   */
+  justify-content: flex-start;
+  /**
+   * If icon is used, the gap setting will maintain spacing between icon and text.
+   */
+  gap: var(--eds-size-1);
 }
 
 /** 
-* Span to hold optional icon.
-*/
+ * Span to hold optional icon.
+ */
 .calendar-card__title-icon {
   min-width: 1.2rem;
 }
 
 /**
-* Card calendar row which holds an icon and a combination of text strings.
-* 
-* Keeps the icon positioned at the top of the cross-axis if the text strings expands to use multiple lines.
-* 
-* The gap setting will maintain spacing between icon and text.
-*/
+ * Card calendar row which holds an icon and a combination of text strings.
+ * 
+ * Keeps the icon positioned at the top of the cross-axis if the text strings expands to use multiple lines.
+ * 
+ * The gap setting will maintain spacing between icon and text.
+ */
 .calendar-card__dates {
   display: flex;
   align-items: flex-start;
@@ -78,15 +82,15 @@
 }
 
 /* 
-* Span to hold icon before calendar text
-*/
+ * Span to hold icon before calendar text
+ */
 .calendar-card__dates-icon {
   min-width: 1.2rem;
 }
 
 /*
-* Keeps tags evenly spaced in rows, wrapping when needed
-*/
+ * Keeps tags evenly spaced in rows, wrapping when needed
+ */
 .calendar-card__tags {
   display: flex;
   flex-wrap: wrap;

--- a/.storybook/recipes/CardWithNotification/CardWithNotification.module.css
+++ b/.storybook/recipes/CardWithNotification/CardWithNotification.module.css
@@ -6,17 +6,19 @@
 
 /**
  * Card recipe with a bottom notification.
- * 1) Add a border around the entire card and notification.
- * 2) Remove the redundant border that existed on the card component.
  */
 .card-with-notification {
-  /* 1 */
+  /**
+   * Add a border around the entire card and notification.
+   */
   border-radius: var(--eds-border-radius-md);
   border: var(--eds-theme-color-border-neutral-subtle) solid
     var(--eds-theme-border-width);
 }
 .card-with-notification__card {
-  /* 2 */
+  /**
+   * Remove the redundant border that existed on the card component.
+   */
   border: 0;
   border-radius: 0;
 }

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.module.css
@@ -41,9 +41,6 @@
 
 /**
  * Menu Button 
- * 1) Menu button triggers the navigation container
- *    on small screens, but is hidden when the nav
- *    can be exposed
  */
 .global-header__menu-button.global-header__menu-button {
   padding: var(--eds-size-half);
@@ -72,7 +69,12 @@
   }
 
   @media all and (min-width: $eds-bp-xl) {
-    display: none; /* 1 */
+    /**
+     * Menu button triggers the navigation container
+     * on small screens, but is hidden when the nav
+     * can be exposed
+     */
+    display: none;
   }
 }
 
@@ -91,12 +93,14 @@
 
 /**
  * Utility nav popover
- * 1) On small screens, create a max width so that the popover flexes to accommodate small screens
  */
 .global-header__popover {
   max-height: 28rem;
   width: max-content;
-  max-width: calc(100vw - 2rem); /* 1 */
+  /**
+   * On small screens, create a max width so that the popover flexes to accommodate small screens
+   */
+  max-width: calc(100vw - 2rem);
 
   @media all and (min-width: $eds-bp-xl) {
     max-width: initial;

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -54,7 +54,6 @@ export interface Props {
 
 /**
  * Primary UI component for user interaction
- * 1) Use the xl breakpoint to match the CSS breakpoint for the popover position change
  */
 export const GlobalHeader = ({
   className,
@@ -69,7 +68,10 @@ export const GlobalHeader = ({
 }: Props) => {
   const [isActive, setisActive] = useState(false);
   const [isLarge, setIsLarge] = useState(false);
-  const popoverBreakpoint = parseInt(breakpoint['eds-bp-xl']) * 16; /* 1 */
+  /**
+   * Use the xl breakpoint to match the CSS breakpoint for the popover position change
+   */
+  const popoverBreakpoint = parseInt(breakpoint['eds-bp-xl']) * 16;
 
   const toggleMenu = () => {
     setisActive(!isActive);

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -74,12 +74,12 @@ export const Breadcrumbs = ({
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
-   * 1) Flattens breadcrumb items that may be wrapped in React.Fragment into an array so they can be manipulated easily
-   * 2) Finds the second to last breadcrumb item for mobile Breadcrumbs back icon
-   * 3) Finds all the breadcrumb items between the first and last breadcrumb items so they can be placed in the dropdown.
+   * Flattens breadcrumb items that may be wrapped in React.Fragment into an array so they can be manipulated easily.
    */
-  const breadcrumbsItems = flattenBreadcrumbsItems(children); /* 1 */
-  /* 2 */
+  const breadcrumbsItems = flattenBreadcrumbsItems(children);
+  /**
+   * Finds the second to last breadcrumb item for mobile Breadcrumbs back icon.
+   */
   const backBreadCrumb =
     breadcrumbsItems.length > 1
       ? React.cloneElement(
@@ -91,7 +91,9 @@ export const Breadcrumbs = ({
           },
         )
       : null;
-  /* 3 */
+  /**
+   * Finds all the breadcrumb items between the first and last breadcrumb items so they can be placed in the dropdown.
+   */
   const dropdownMenuItems = breadcrumbsItems
     .slice(1, breadcrumbsItems.length - 1)
     .map((breadcrumbItem, index) => {
@@ -117,15 +119,14 @@ export const Breadcrumbs = ({
       id={breadcrumbsId}
       {...other}
     >
-      {/**
-       * 1) Back icon breadcrumb always exists, just hidden via css depending on breakpoint to increase performance
-       * 2) The ellipsis breadcrumb with dropdown only exists if there would be overflow and there are 3 or more breadcrumb items
-       * 3) If (2) conditions aren't met, display all breadcrumbs
-       */}
       <ul className={styles['breadcrumbs__list']} ref={ref}>
-        {/* 1 */}
+        {/**
+         * Back icon breadcrumb always exists, just hidden via css depending on breakpoint to increase performance
+         */}
         {backBreadCrumb}
-        {/* 2 */}
+        {/**
+         * The ellipsis breadcrumb with dropdown only exists if there would be overflow and there are 3 or more breadcrumb items.
+         */}
         {shouldTruncate && breadcrumbsItems.length > 2 ? (
           <>
             {breadcrumbsItems[0]}
@@ -137,7 +138,9 @@ export const Breadcrumbs = ({
             {breadcrumbsItems[breadcrumbsItems.length - 1]}
           </>
         ) : (
-          /* 3 */
+          /**
+           * If the above conditions aren't met, display all breadcrumbs.
+           */
           breadcrumbsItems
         )}
       </ul>

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -87,7 +87,6 @@ export const ButtonDropdown = ({
 
   /**
    * On component load/updated
-   * * 1) Handle click outside panel event handling for both tap and mouse events
    */
   React.useEffect(() => {
     if (isActiveVar) {
@@ -95,47 +94,44 @@ export const ButtonDropdown = ({
       const el = ref.current.querySelector<HTMLElement>('.sparky-c-dropdown');
       if (el) el.focus();
     }
-    document.addEventListener('mousedown', handleOnClickOutside, false); /* 1 */
-    document.addEventListener(
-      'touchstart',
-      handleOnClickOutside,
-      false,
-    ); /* 1 */
+    /**
+     * Handle click outside panel event handling for both tap and mouse events
+     */
+    document.addEventListener('mousedown', handleOnClickOutside, false);
+    document.addEventListener('touchstart', handleOnClickOutside, false);
     return () => {
-      document.removeEventListener(
-        'mousedown',
-        handleOnClickOutside,
-        false,
-      ); /* 1 */
-      document.removeEventListener(
-        'touchstart',
-        handleOnClickOutside,
-        false,
-      ); /* 1 */
+      document.removeEventListener('mousedown', handleOnClickOutside, false);
+      document.removeEventListener('touchstart', handleOnClickOutside, false);
     };
   });
 
   /**
    * Handle click outside function
-   * 1) If the event isn't inside to the dropdown button itself or the entire
-   * component, then close the panel
    */
   const handleOnClickOutside = (event: MouseEvent | TouchEvent) => {
     if (ref.current && !ref.current.contains(event.target as HTMLElement)) {
-      closePanel(); /* 1 */
+      /**
+       * If the event isn't inside to the dropdown button itself or the entire
+       * component, then close the panel
+       */
+      closePanel();
     }
   };
 
   /**
    * Close the panel
-   * 1) Set active state to false
-   * 2) Return the focus to the button that triggered the dropdown when closed
    */
   function closePanel() {
-    setIsActive(false); /* 1 */
+    /**
+     * Set active state to false
+     */
+    setIsActive(false);
 
     if (isActiveVar && buttonRef.current) {
-      buttonRef.current.focus(); /* 2 */
+      /**
+       * Return the focus to the button that triggered the dropdown when closed
+       */
+      buttonRef.current.focus();
     }
   }
 

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -58,12 +58,14 @@
   margin-bottom: var(--eds-size-2);
 
   /**
-  * Card header within horizontal card
-  * 1) Remove default spacing for vertical card. Add margin right for spacing between header and body
-  */
+   * Card header within horizontal card
+   */
   .card--horizontal & {
-    margin-bottom: 0; /* 1 */
-    margin-right: var(--eds-size-2); /* 1 */
+    /**
+     * Remove default spacing for vertical card. Add margin right for spacing between header and body
+     */
+    margin-bottom: 0;
+    margin-right: var(--eds-size-2);
   }
 }
 
@@ -76,20 +78,22 @@
 
 /**
  * Card footer
- * 1) Using margin-top since card__footer is
- *    optional and may not always exist. Putting
- *    margin-bottom on card__body would result in
- *    a gap if card__footer does not exist
  */
 .card__footer {
-  margin-top: var(--eds-size-2); /* 1 */
+  /**
+   * Using margin-top since card__footer is optional and may not always exist. Putting
+   * margin-bottom on card__body would result in a gap if card__footer does not exist.
+   */
+  margin-top: var(--eds-size-2);
 
   /**
-  * Card footer within horizontal card
-  * 1) Using margin left to space away from card body. Zero out margin top.
-  */
+   * Card footer within horizontal card
+   */
   .card--horizontal & {
-    margin-top: 0; /* 1 */
-    margin-left: var(--eds-size-2); /* 1 */
+    /**
+     * Using margin left to space away from card body. Zero out margin top.
+     */
+    margin-top: 0;
+    margin-left: var(--eds-size-2);
   }
 }

--- a/src/components/CheckboxInput/CheckboxInput.module.css
+++ b/src/components/CheckboxInput/CheckboxInput.module.css
@@ -10,10 +10,10 @@
 .input__wrapper {
   position: relative;
   /* Centers the checkbox icon in the wrapper. */
-  display: inline-flex; 
+  display: inline-flex;
   align-items: center;
   /* Aligns the checkbox with the first line of the label. */
-  align-self: flex-start; 
+  align-self: flex-start;
 }
 /**
  * The visually hidden input element for the checkbox. The visual checkmark is provided by an svg element.
@@ -21,12 +21,12 @@
 .checkbox__input {
   cursor: pointer;
   /* Removes default margins placed by browser for checkboxes. */
-  margin: 0; 
+  margin: 0;
   /* Remove the checkbox from the page flow, positioning it on top of the SVG. */
-  position: absolute; 
+  position: absolute;
   left: 0.25rem;
   /* Set same dimensions as the CheckboxSvg element. */
-  height: var(--eds-size-2); 
+  height: var(--eds-size-2);
   width: var(--eds-size-2);
   /** 
    * Hide the input element visually.
@@ -34,7 +34,7 @@
    * especially on touch screen readers, still interact with the real checkbox element
    * where it would naturally be present. 
    */
-  opacity: 0; 
+  opacity: 0;
 }
 
 /**
@@ -44,13 +44,13 @@
   color: var(--eds-theme-color-icon-brand-primary);
 }
 .checkbox__input:focus-visible + .checkbox__icon {
-  @mixin focus; /* 1 */
+  @mixin focus;
   outline-offset: -2px;
 }
 
 @supports not selector(:focus-visible) {
   .checkbox__input:focus + .checkbox__icon {
-    @mixin focus; /* 1 */
+    @mixin focus;
     outline-offset: -2px;
   }
 }

--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -476,18 +476,20 @@
 
 /**
  * Link button styles
- * 1) Override default Clickable styles
- * 2) Smaller gap between text and icon in link button style
  */
 .clickable-style--link {
   @mixin textLink;
 
-  /* 1 */
+  /**
+   * Override default Clickable styles
+   */
   border: 0;
   border-radius: 0;
   background-color: transparent;
-
-  gap: 0.25em; /* 2 */
+  /**
+   * Smaller gap between text and icon in link button style
+   */
+  gap: 0.25em;
 }
 
 /**
@@ -515,12 +517,12 @@
   }
 
   &:focus-visible {
-    background-color: var(--eds-theme-color-border-link-neutral); /* 1 */
+    background-color: var(--eds-theme-color-border-link-neutral);
   }
 
   @supports not selector(:focus-visible) {
     &:focus {
-      background-color: var(--eds-theme-color-border-link-neutral); /* 1 */
+      background-color: var(--eds-theme-color-border-link-neutral);
     }
   }
 }

--- a/src/components/DataBar/DataBar.stories.tsx
+++ b/src/components/DataBar/DataBar.stories.tsx
@@ -123,13 +123,12 @@ const Interactive = () => {
   );
 };
 
-/**
- * 1) For interactive purposes only, low value in snapping or checking for visual regression since they should be covered in the other stories.
- */
 export const InteractiveExample: StoryObj<Args> = {
   render: () => <Interactive />,
   parameters: {
-    /* 1 */
+    /**
+     * For interactive purposes only, low value in snapping or checking for visual regression since they should be covered in the other stories.
+     */
     chromatic: {
       disableSnapshot: true,
     },

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -67,27 +67,27 @@ export const DragDrop = ({
 }: Props) => {
   /**
    * Set states and refs
-   * 1) Set isEnd state: set to true, right shadow gradient activates. Removed when false
-   * 2) Set isState state: set to true, left shadow gradient activates. Removed when false
-   * 3) Target drag drop and drag drop inner DOM elements
+   *
+   * Set isEnd state: set to true, right shadow gradient activates. Removed when false.
    */
-  const [isEnd, setIsEnd] = useState(true); /* 1 */
-  const [isStart, setIsStart] = useState(false); /* 2 */
-  const dragDropInnerRef = useRef() as MutableRefObject<HTMLDivElement>; /* 3 */
+  const [isEnd, setIsEnd] = useState(true);
+  /**
+   * Set isState state: set to true, left shadow gradient activates. Removed when false.
+   */
+  const [isStart, setIsStart] = useState(false);
+  /**
+   * Target drag drop and drag drop inner DOM elements
+   */
+  const dragDropInnerRef = useRef() as MutableRefObject<HTMLDivElement>;
   const dragDropRef = useRef() as MutableRefObject<HTMLElement>;
   /**
    * Set right and left gradients on tables
-   * 1) Target the actual drag drop inside drag drop
-   * 2) Get the width of the drag drop offscreen when drag drop overflows
-   * 3) If drag drop width is less than or equal to drag drop width, remove all shadows
-   * 4) If drag drop inner scroll isn't all the way to the left or to the right, turn all shadows on
-   * 5) If drag drop inner scroll is >= to width of drag drop offscreen, turn off right shadow and turn left shadow on
-   * 6) Else, set the right shadow to true and the left shadow to false
    */
   const setShadows = () => {
-    const overflowListItems = Array.from(
-      dragDropInnerRef.current.children,
-    ); /* 1 */
+    /**
+     * Target the actual drag drop inside drag drop.
+     */
+    const overflowListItems = Array.from(dragDropInnerRef.current.children);
     let childrenWidth = 0;
 
     overflowListItems.forEach(function (item) {
@@ -97,28 +97,39 @@ export const DragDrop = ({
       childrenWidth += item.clientWidth + itemMarginLeft;
     });
     if (overflowListItems) {
-      const dragDropWidth = dragDropRef.current.clientWidth; /* 2 */
-      const totalItemsWidth = childrenWidth; /* 2 */
+      /**
+       * Get the width of the drag drop offscreen when drag drop overflows.
+       */
+      const dragDropWidth = dragDropRef.current.clientWidth;
+      const totalItemsWidth = childrenWidth;
       const dragDropOffScreen =
-        totalItemsWidth - dragDropRef.current.clientWidth; /* 2 */
+        totalItemsWidth - dragDropRef.current.clientWidth;
 
       if (totalItemsWidth <= dragDropWidth) {
-        /* 3 */
+        /**
+         * If drag drop width is less than or equal to drag drop width, remove all shadows
+         */
         setIsEnd(false);
         setIsStart(false);
       } else if (
         dragDropInnerRef.current.scrollLeft > 0 &&
         dragDropInnerRef.current.scrollLeft < dragDropOffScreen
       ) {
-        /* 4 */
+        /**
+         * If drag drop inner scroll isn't all the way to the left or to the right, turn all shadows on
+         */
         setIsEnd(true);
         setIsStart(true);
       } else if (dragDropInnerRef.current.scrollLeft >= dragDropOffScreen) {
-        /* 5 */
+        /**
+         * If drag drop inner scroll is >= to width of drag drop offscreen, turn off right shadow and turn left shadow on
+         */
         setIsEnd(false);
         setIsStart(true);
       } else {
-        /* 6 */
+        /**
+         * Else, set the right shadow to true and the left shadow to false
+         */
         setIsEnd(true);
         setIsStart(false);
       }
@@ -127,32 +138,28 @@ export const DragDrop = ({
 
   /**
    * drag drop inner onscroll
-   * 1) Set shadows when user scrolls the drag drop right and left
+   *
+   * Set shadows when user scrolls the drag drop right and left.
    */
   const handleOnScroll = (e: UIEvent<HTMLElement>): void => {
-    setShadows(); /* 1 */
+    setShadows();
   };
 
   /**
-   * Use effect lifecycle
-   * 1) Set shadows when component is updated/loaded
-   * 2) Set window resize listener
-   * 3) Remove window resize listener
+   * Set shadows when component is updated/loaded.
    */
   useEffect(() => {
-    dragDropRef.current = dragDropInnerRef.current
-      .parentNode as HTMLElement; /* 3 */
-    setShadows(); /* 1 */
-    window.addEventListener('resize', setShadows); /* 2 */
+    dragDropRef.current = dragDropInnerRef.current.parentNode as HTMLElement;
+    setShadows();
+    window.addEventListener('resize', setShadows);
     return () => {
-      window.removeEventListener('resize', setShadows); /* 3 */
+      window.removeEventListener('resize', setShadows);
     };
   }, [items]);
 
   /**
    * Update sticky wrapper height on mount
    */
-
   const containerOrder: string[] = [];
   Object.entries(items).forEach(([key, item]) => {
     items[key] = { ...item, id: key };

--- a/src/components/Drawer/Drawer.module.css
+++ b/src/components/Drawer/Drawer.module.css
@@ -63,10 +63,12 @@
 
 /**
  * Drawer window inside active drawer container
- * Transform added for animation
  */
 .drawer__container--is-active .drawer {
-  transform: translateX(0); /* 1 */
+  /**
+   * Transform added for animation
+   */
+  transform: translateX(0);
 }
 
 /**

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -47,24 +47,25 @@ export default {
 
 type Args = React.ComponentProps<typeof Drawer>;
 
-/**
- * 1) Axe testing throws error due to Drawer component not being controlled, but this story is mostly for testing as the interactive story would only capture the toggle button.
- */
 export const Default: StoryObj<Args> = {
   parameters: {
     axe: {
-      disabledRules: ['aria-allowed-role'] /* 1 */,
+      /**
+       * Axe testing throws error due to Drawer component not being controlled,
+       * but this story is mostly for testing as the interactive story would only
+       * capture the toggle button.
+       */
+      disabledRules: ['aria-allowed-role'],
     },
   },
 };
 
-/**
- * 1) No point snapping the button as this story is an interaction example.
- */
 export const DefaultInteractive: StoryObj = {
   render: () => <DrawerExample />,
   parameters: {
-    /* 1 */
+    /**
+     * No point snapping the button as this story is an interaction example.
+     */
     snapshot: { skip: true },
     chromatic: { disableSnapshot: true },
   },

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -79,13 +79,10 @@ export const Drawer = ({
   const isMountedRef = useRef(true);
 
   /**
-   * Use effect
-   * 1) If isActive is defined ,set activeFocus state to true,
-   * else set activeFocus state to false.
+   * Update activeFocus to be consistent with isActive.
    */
   useEffect(() => {
     if (isActive) {
-      /* 1 */
       activateFocusTrap();
     } else {
       deactivateFocusTrap();
@@ -105,45 +102,39 @@ export const Drawer = ({
   }, []);
 
   /**
-   * Activate DOM
-   * 1) Open the Drawer
-   * 2) Set activeFocus state to true
-   * 3) This accommodates drawer animation so that it auto receives focus
+   * Open the Drawer and give it focus.
    */
   function activateFocusTrap() {
-    /* 3 */
+    /**
+     * This accommodates drawer animation so that it auto receives focus
+     */
     setTimeout(() => {
       if (isMountedRef.current) {
-        setActiveFocus(true); /* 2 */
+        setActiveFocus(true);
       }
     }, 300);
   }
 
   /**
-   * Deactivate DOM
-   * 1) Close the drawer
-   * 2) Set activeFocus state to false
+   * Close the drawer and remove focus.
    */
   function deactivateFocusTrap() {
-    setActiveFocus(false); /* 2 */
+    setActiveFocus(false);
   }
 
   /**
-   * Handle onClose
-   * 1) Close the drawer
-   * 2) Run the onClose prop (pass in function) if it exists
+   * Close the drawer and run the onClose prop (pass in function) if it exists.
    */
   function handleOnClose() {
-    deactivateFocusTrap(); /* 1 */
+    deactivateFocusTrap();
 
     if (onClose) {
-      onClose(); /* 2 */
+      onClose();
     }
   }
 
   /**
    * Handle "click outside"
-   * 1) onClick of the area around the drawer window, close the drawer
    */
   useEffect(() => {
     function handleOnClickOutside(e: MouseEvent) {
@@ -153,7 +144,10 @@ export const Drawer = ({
         windowRef.current &&
         !windowRef.current.contains(e.target as HTMLElement)
       ) {
-        handleOnClose(); /* 1 */
+        /**
+         * onClick of the area around the drawer window, close the drawer
+         */
+        handleOnClose();
       }
     }
     document.addEventListener('click', handleOnClickOutside);
@@ -163,12 +157,11 @@ export const Drawer = ({
   }, [isActive, windowRef]); // eslint-disable-line react-hooks/exhaustive-deps
 
   /**
-   * Handle onKeyDown
-   * 1) If escape button is struck, close the drawer
+   * If escape button is struck, close the drawer
    */
   function handleOnKeyDown(e: KeyboardEvent<HTMLElement>) {
     if (e.key === ESCAPE_KEYCODE) {
-      handleOnClose(); /* 1 */
+      handleOnClose();
     }
   }
 

--- a/src/components/Grid/Grid.module.css
+++ b/src/components/Grid/Grid.module.css
@@ -10,7 +10,7 @@
 .grid {
   display: flex;
   flex-wrap: wrap;
-  margin: 0 -1.5rem; /* TODO */
+  margin: 0 -1.5rem;
 
   > * {
     padding: var(--eds-size-1-and-half);
@@ -36,16 +36,17 @@
 
 /**
  * 1 to 3 grid pattern
- * 1) This pattern stacks grid items on top of each
- *    other until they can sit comfortably beside each other 
+ *
+ * This pattern stacks grid items on top of each
+ * other until they can sit comfortably beside each other.
  */
 .grid--1-3up {
-  margin: 0 -1.5rem; /* TODO */
+  margin: 0 -1.5rem;
 
   @media all and (min-width: $eds-bp-lg) {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 -1.5rem; /* TODO */
+    margin: 0 -1.5rem;
   }
 
   @supports (display: grid) {
@@ -53,25 +54,26 @@
     margin: 0;
 
     @media all and (min-width: $eds-bp-lg) {
-      grid-template-columns: 1fr 1fr 1fr; /* 2 */
+      grid-template-columns: 1fr 1fr 1fr;
     }
   }
 }
 
 .grid--side-by-side {
-  grid-template-columns: 1fr 1fr; /* 2 */
+  grid-template-columns: 1fr 1fr;
 }
 
 /**
  * 2up grid pattern
- * 1) This pattern stacks grid items on top of each
- *    other until they can sit comfortably beside each other 
+ *
+ * This pattern stacks grid items on top of each
+ * other until they can sit comfortably beside each other.
  */
 .grid--2up {
   @media all and (min-width: $eds-bp-md) {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 -1.5rem; /* TODO */
+    margin: 0 -1.5rem;
   }
 
   @supports (display: grid) {
@@ -79,15 +81,16 @@
     margin: 0;
 
     @media all and (min-width: $eds-bp-md) {
-      grid-template-columns: 1fr 1fr; /* 2 */
+      grid-template-columns: 1fr 1fr;
     }
   }
 }
 
 /**
  * 3up grid pattern
- * 1) This pattern stacks grid items on top of each
- *    other until they can sit comfortably beside each other 
+ *
+ * This pattern stacks grid items on top of each
+ * other until they can sit comfortably beside each other.
  */
 .grid--3up {
   @media all and (min-width: $eds-bp-md) {
@@ -113,14 +116,15 @@
 
 /**
  * 4up grid pattern
- * 1) This pattern stacks grid items on top of each
- *    other until they can sit comfortably beside each other 
+ *
+ * This pattern stacks grid items on top of each
+ * other until they can sit comfortably beside each other.
  */
 .grid--4up {
   @media all and (min-width: $eds-bp-md) {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 -1.5rem; /* TODO */
+    margin: 0 -1.5rem;
   }
 
   @supports (display: grid) {
@@ -143,6 +147,7 @@
 
 /**
  * 1-2-4up grid pattern
+ *
  * yields a Grid whose GridItems are stacked on small screens, transforms to a 2-across pattern, and
  * ultimately transforms to a 4-across pattern
  */
@@ -150,7 +155,7 @@
   @media all and (min-width: $eds-bp-md) {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 -1.5rem; /* TODO */
+    margin: 0 -1.5rem;
   }
 
   @supports (display: grid) {
@@ -169,6 +174,7 @@
 
 /**
  * 1-2-1up grid pattern
+ *
  * yields a Grid whose GridItems are stacked on small screens, transforms to a 2-across pattern, and
  * ultimately transforms back to a 1-across pattern
  */
@@ -176,7 +182,7 @@
   @media all and (min-width: $eds-bp-md) {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 -1.5rem; /* TODO */
+    margin: 0 -1.5rem;
   }
 
   @supports (display: grid) {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -60,22 +60,19 @@ export const Header = ({
 
   /**
    * Update the header wrapper height
-   * 1) Set the height of the header wrapper so that the spacing stays consistent when
-   * the header gets pinned to the top of the page.
    */
   const updateHeaderWrapperHeight = () => {
     if (behavior === 'sticky' && stickyRef.current) {
-      stickyRef.current.style.height =
-        ref?.current?.clientHeight + 'px'; /* 1 */
+      /**
+       * Set the height of the header wrapper so that the spacing stays consistent when
+       * the header gets pinned to the top of the page.
+       */
+      stickyRef.current.style.height = ref?.current?.clientHeight + 'px';
     }
   };
 
   /**
    * Handle window scroll
-   * 1) On scroll up below the bottom of the header position, pin the header to the top of the page
-   * 2) Else if on scroll down below the header position and above the pinnedStop prop, pin the header to the top of the page
-   * 3) Else if on scroll down below the header position, remove the pin
-   * 4) Otherwise, remove the pin and scrolled classes
    */
   const handleWindowScroll = () => {
     if (behavior === 'sticky') {
@@ -84,7 +81,9 @@ export const Header = ({
         stickyRef.current &&
         stickyRef.current.getBoundingClientRect().bottom < 0
       ) {
-        /* 1 */
+        /**
+         * On scroll up below the bottom of the header position, pin the header to the top of the page.
+         */
         setUnpinned(false);
         setPinned(true);
       } else if (
@@ -92,21 +91,27 @@ export const Header = ({
         stickyRef.current.getBoundingClientRect().top < 0 &&
         window.scrollY <= pinnedStop
       ) {
-        /* 2 */
+        /**
+         * Else if on scroll down below the header position and above the pinnedStop prop, pin the header to the top of the page.
+         */
         setUnpinned(false);
         setPinned(true);
       } else if (
         stickyRef.current &&
         stickyRef.current.getBoundingClientRect().bottom < 0
       ) {
-        /* 3 */
+        /**
+         * Else if on scroll down below the header position, remove the pin.
+         */
         setUnpinned(true);
         setPinned(false);
         setTimeout(() => {
           setScrolled(true);
         }, 300);
       } else {
-        /* 4 */
+        /**
+         * Otherwise, remove the pin and scrolled classes.
+         */
         setPinned(false);
         setUnpinned(false);
         setScrolled(false);

--- a/src/components/Heading/Heading.stories.module.css
+++ b/src/components/Heading/Heading.stories.module.css
@@ -4,10 +4,12 @@
 
 /**
  * For the "variant" story to display the different text variant options.
- * 1) Uses grid to neatly align the variant variations.
  */
 .variant__table {
-  display: grid; /* 1 */
+  /**
+   * Uses grid to neatly align the variant variations.
+   */
+  display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: var(--eds-size-half);
 }

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -74,9 +74,6 @@ export const TitleXs: StoryObj<Args> = {
   },
 };
 
-/**
- * 1) Mainly for visual use and other stories generate enough confidence for our needs.
- */
 export const Variants: StoryObj<Args> = {
   ...Heading1,
   render: (args) => {
@@ -98,7 +95,9 @@ export const Variants: StoryObj<Args> = {
     );
   },
   parameters: {
-    /* 1 */
+    /**
+     * Mainly for visual use and other stories generate enough confidence for our needs.
+     */
     axe: {
       skip: true,
     },

--- a/src/components/HorizontalStep/HorizontalStep.module.css
+++ b/src/components/HorizontalStep/HorizontalStep.module.css
@@ -4,13 +4,15 @@
 
 /**
  * Horizontal Step displays the step text and associated decorative icon.
- * 1) Required to prevent overflowing outside container.
  */
 .horizontal-step {
   display: flex;
   align-items: center;
   gap: var(--eds-size-1);
-  min-width: 0; /* 1 */
+  /**
+   * Required to prevent overflowing outside container.
+   */
+  min-width: 0;
 }
 
 /**
@@ -27,8 +29,9 @@
 }
 
 /**
- * Inherits the color from the parent
- * 1) Changes icon from black to gray by default.
+ * Inherits the color from the parent.
+ *
+ * Changes icon from black to gray by default.
  */
 .horizontal-step__number-icon {
   color: inherit;
@@ -58,12 +61,12 @@
  * Horizontal Step Text.
  */
 .horizontal-step__text {
-   /* Hides text for smaller screen sizes. */
+  /* Hides text for smaller screen sizes. */
   display: none;
   @media all and (min-width: $eds-bp-md) {
     display: inline;
     /* Hides overflow text with ellipsis. */
-    white-space: nowrap; 
+    white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -44,11 +44,13 @@ export const HorizontalStepper = ({
 }: Props) => {
   /**
    * Warns dev if the activeIndex is invalid
-   * 1) Negative conditional to account for 'NaN' values which pass the number type check since "typeof NaN === 'number'"
    */
   if (
     process.env.NODE_ENV !== 'production' &&
-    !(activeIndex >= 0 && activeIndex <= steps.length) /* 1 */
+    /**
+     * Negative conditional to account for 'NaN' values which pass the number type check since "typeof NaN === 'number'"
+     */
+    !(activeIndex >= 0 && activeIndex <= steps.length)
   ) {
     console.warn(
       'The active index is an invalid index relative to the number of steps.',
@@ -57,14 +59,12 @@ export const HorizontalStepper = ({
 
   /**
    * Creates a list of <HorizontalStep> components with lines in between.
-   * 1) If it is not the first step, add a line to stepComponents.
-   * 2) Hides the decorative line to prevent accessibility issue with it not being <li> in an <ol>.
-   * 3) Figure out what variant of step according to the activeIndex.
-   * 4) Add step to stepComponents.
    */
   const stepComponents: React.ReactNode[] = [];
   steps.forEach((step, index) => {
-    /* 1 */
+    /**
+     * If it is not the first step, add a line to stepComponents.
+     */
     if (index > 0) {
       const stepperLinesClassName = clsx(
         styles['horizontal-stepper__line'],
@@ -72,14 +72,19 @@ export const HorizontalStepper = ({
       );
       stepComponents.push(
         <hr
-          aria-hidden /* 2 */
+          aria-hidden
+          /**
+           * Hides the decorative line to prevent accessibility issue with it not being <li> in an <ol>.
+           */
           className={stepperLinesClassName}
           key={`horizontal-stepper__line-${index}`}
         />,
       );
     }
 
-    /* 3 */
+    /**
+     * Figure out what variant of step according to the activeIndex.
+     */
     const stepVariant =
       index < activeIndex
         ? 'complete'
@@ -87,7 +92,9 @@ export const HorizontalStepper = ({
         ? 'active'
         : 'incomplete';
 
-    /* 4 */
+    /**
+     * Add step to stepComponents.
+     */
     stepComponents.push(
       <HorizontalStep
         key={`horizontal-stepper__step-${index}`}

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -129,9 +129,6 @@ export const Mobile: StoryObj<Args> = {
   },
 };
 
-/**
- * 1) Chromatic sets viewport height to 900px, hence won't snap as necessary
- */
 export const MobileLandscape: StoryObj<Args> = {
   ...Default,
   parameters: {
@@ -147,7 +144,9 @@ export const MobileLandscape: StoryObj<Args> = {
           },
         },
       },
-      /* 1 */
+      /**
+       * Chromatic sets viewport height to 900px, hence won't snap as necessary
+       */
       chromatic: { disableSnapshot: true },
     },
   },
@@ -445,14 +444,13 @@ const InteractiveModalStepperComponent = () => {
   );
 };
 
-/**
- * 1) For interactive purposes only, low value in snapping or checking for visual regression since they should be covered in the other stories.
- */
 export const InteractiveModalStepper: StoryObj<ModalStepperArgs> = {
   ...ModalStepper,
   render: () => <InteractiveModalStepperComponent />,
   parameters: {
-    /* 1 */
+    /**
+     * For interactive purposes only, low value in snapping or checking for visual regression since they should be covered in the other stories.
+     */
     snapshot: {
       skip: true,
     },

--- a/src/components/ModalHeader/ModalHeader.module.css
+++ b/src/components/ModalHeader/ModalHeader.module.css
@@ -15,7 +15,6 @@
 
 /**
  * Brand variant for the header.
- * 1) Brand specific font for the title.
  */
 .modal-header--brand {
   display: flex;
@@ -35,7 +34,9 @@
   color: var(--eds-theme-color-text-neutral-default-inverse);
   background-color: var(--eds-color-brand-grape-500);
   h2 {
-    /* 1 */
+    /**
+     * Brand specific font for the title.
+     */
     flex: 1;
     font-family: 'Mint Grotesk V1.1', sans-serif;
     font-weight: var(--eds-font-weight-medium);

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -35,11 +35,10 @@ export const SuccessSmall: StoryObj<Args> = {
   },
 };
 
-/**
- * 1) Disables controls for args that have no affect on this story
- */
 export const DifferentNumbers: StoryObj<Args> = {
-  /* 1 */
+  /**
+   * Disables controls for args that have no affect on this story
+   */
   argTypes: {
     number: {
       table: {

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -65,22 +65,24 @@ export const NumberIcon = ({
     className,
   );
 
-  /**
-   * 1) Set as 'span' since icon use is more inline than block, but no effect since display is 'flex'.
-   * 2) When `incomplete` is defined and there is a numberIconTitle on the circle icon, then this will render
-   * the proper icon with the incomplete text provided to that icon.
-   * 3) If this is not incomplete, then the number prop provided will show within the border
-   */
   return (
     <Text
-      as="span" /* 1 */
+      /**
+       * Set as 'span' since icon use is more inline than block, but no effect since display is 'flex'.
+       */
+      as="span"
       className={componentClassName}
       role="img"
       size="sm"
       variant={variant === 'base' ? 'neutral-medium' : 'white'}
       {...other}
     >
-      {incomplete && numberIconTitle /* 2 */ ? (
+      {/**
+       *
+       * When `incomplete` is defined and there is a numberIconTitle on the circle icon, then this will render
+       * the proper icon with the incomplete text provided to that icon.
+       */}
+      {incomplete && numberIconTitle ? (
         <Icon
           className={styles['number-icon__icon']}
           color="inherit"
@@ -90,7 +92,10 @@ export const NumberIcon = ({
           title={numberIconTitle}
         />
       ) : (
-        number /* 3 */
+        /**
+         * If this is not incomplete, then the number prop provided will show within the border.
+         */
+        number
       )}
     </Text>
   );

--- a/src/components/OverflowList/OverflowList.tsx
+++ b/src/components/OverflowList/OverflowList.tsx
@@ -31,28 +31,27 @@ export interface Props {
 export const OverflowList = ({ className, children, ...other }: Props) => {
   /**
    * Set states and refs
-   * 1) Set isEnd state: set to true, right shadow gradient activates. Removed when false
-   * 2) Set isState state: set to true, left shadow gradient activates. Removed when false
-   * 3) Target overflow list and overflow list inner DOM elements
+   *
+   * Set isEnd state: set to true, right shadow gradient activates. Removed when false
    */
-  const [isEnd, setIsEnd] = useState(true); /* 1 */
-  const [isStart, setIsStart] = useState(false); /* 2 */
-  const overflowListRef = useRef() as MutableRefObject<HTMLDivElement>; /* 3 */
-  const overflowListInnerRef =
-    useRef() as MutableRefObject<HTMLUListElement>; /* 3 */
+  const [isEnd, setIsEnd] = useState(true);
   /**
-   * Set right and left gradients on tables
-   * 1) Target the actual overflow list inside overflow list
-   * 2) Get the width of the overflow list offscreen when overflow list overflows
-   * 3) If overflow list width is less than or equal to overflow list width, remove all shadows
-   * 4) If overflow list inner scroll isn't all the way to the left or to the right, turn all shadows on
-   * 5) If overflow list inner scroll is >= to width of overflow list offscreen, turn off right shadow and turn left shadow on
-   * 6) Else, set the right shadow to true and the left shadow to false
+   * Set isState state: set to true, left shadow gradient activates. Removed when false
+   */
+  const [isStart, setIsStart] = useState(false);
+  /**
+   * Target overflow list and overflow list inner DOM elements
+   */
+  const overflowListRef = useRef() as MutableRefObject<HTMLDivElement>;
+  const overflowListInnerRef = useRef() as MutableRefObject<HTMLUListElement>;
+  /**
+   * Set right and left gradients on tables.
    */
   const setShadows = () => {
-    const overflowListItems = Array.from(
-      overflowListInnerRef.current.children,
-    ); /* 1 */
+    /**
+     * Target the actual overflow list inside overflow list
+     */
+    const overflowListItems = Array.from(overflowListInnerRef.current.children);
     let childrenWidth = 0;
 
     overflowListItems.forEach(function (item) {
@@ -62,30 +61,41 @@ export const OverflowList = ({ className, children, ...other }: Props) => {
       childrenWidth += item.clientWidth + itemMarginLeft;
     });
     if (overflowListItems) {
-      const overflowListWidth = overflowListRef.current.clientWidth; /* 2 */
-      const totalItemsWidth = childrenWidth; /* 2 */
+      /**
+       * Get the width of the overflow list offscreen when overflow list overflows
+       */
+      const overflowListWidth = overflowListRef.current.clientWidth;
+      const totalItemsWidth = childrenWidth;
       const overflowListOffscreen =
-        totalItemsWidth - overflowListRef.current.clientWidth; /* 2 */
+        totalItemsWidth - overflowListRef.current.clientWidth;
 
       if (totalItemsWidth <= overflowListWidth) {
-        /* 3 */
+        /**
+         * If overflow list width is less than or equal to overflow list width, remove all shadows.
+         */
         setIsEnd(false);
         setIsStart(false);
       } else if (
         overflowListInnerRef.current.scrollLeft > 0 &&
         overflowListInnerRef.current.scrollLeft < overflowListOffscreen
       ) {
-        /* 4 */
+        /**
+         * If overflow list inner scroll isn't all the way to the left or to the right, turn all shadows on.
+         */
         setIsEnd(true);
         setIsStart(true);
       } else if (
         overflowListInnerRef.current.scrollLeft >= overflowListOffscreen
       ) {
-        /* 5 */
+        /**
+         * If overflow list inner scroll is >= to width of overflow list offscreen, turn off right shadow and turn left shadow on.
+         */
         setIsEnd(false);
         setIsStart(true);
       } else {
-        /* 6 */
+        /**
+         * Else, set the right shadow to true and the left shadow to false.
+         */
         setIsEnd(true);
         setIsStart(false);
       }
@@ -94,23 +104,22 @@ export const OverflowList = ({ className, children, ...other }: Props) => {
 
   /**
    * Overflow list inner onscroll
-   * 1) Set shadows when user scrolls the overflow list right and left
    */
   const handleOnScroll = (e: UIEvent<HTMLElement>): void => {
-    setShadows(); /* 1 */
+    /**
+     * Set shadows when user scrolls the overflow list right and left
+     */
+    setShadows();
   };
 
   /**
-   * Use effect lifecycle
-   * 1) Set shadows when component is updated/loaded
-   * 2) Set window resize listener
-   * 3) Remove window resize listener
+   * Set shadows when component is updated/loaded
    */
   useEffect(() => {
-    setShadows(); /* 1 */
-    window.addEventListener('resize', setShadows); /* 2 */
+    setShadows();
+    window.addEventListener('resize', setShadows);
     return () => {
-      window.removeEventListener('resize', setShadows); /* 3 */
+      window.removeEventListener('resize', setShadows);
     };
   });
 

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -66,7 +66,7 @@ export const Section = ({
   className,
   description,
   headingAs,
-  headingSize = 'h2' /* 2 */,
+  headingSize = 'h2',
   overline,
   right,
   title,

--- a/src/components/ShowHide/ShowHide.tsx
+++ b/src/components/ShowHide/ShowHide.tsx
@@ -80,25 +80,29 @@ export const ShowHide = ({
   }, []);
 
   /**
-   * Handle click outside the component
-   * 1) Close the show hide panel on click outside
+   * Handle click outside the component.
    */
   const handleOnClickOutside = (event: MouseEvent | TouchEvent) => {
     if (
       dropdownRef.current &&
       !dropdownRef.current.contains(event.target as HTMLElement)
     ) {
-      setIsActive(false); /* 1 */
+      /**
+       * Close the show hide panel on click outside
+       */
+      setIsActive(false);
     }
   };
 
   /**
    * Handle onKeyDown
-   * 1) If escape button is struck, close the show hide contents
    */
   function handleOnKeyDown(e: KeyboardEvent<HTMLElement>) {
     if (e.key === ESCAPE_KEYCODE) {
-      setIsActive(false); /* 1 */
+      /**
+       * If escape button is struck, close the show hide contents
+       */
+      setIsActive(false);
     }
   }
 

--- a/src/components/TableObjectBody/TableObjectBody.tsx
+++ b/src/components/TableObjectBody/TableObjectBody.tsx
@@ -35,37 +35,43 @@ export const TableObjectBody = ({
 }: Props) => {
   /**
    * Set states and refs
-   * 1) Set isEnd state: set to true, right shadow gradient activates. Removed when false
-   * 2) Set isState state: set to true, left shadow gradient activates. Removed when false
-   * 3) Target table body and table body inner DOM elements
+   *
+   * Set isEnd state: set to true, right shadow gradient activates. Removed when false.
    */
-  const [isEnd, setIsEnd] = useState(true); /* 1 */
-  const [isStart, setIsStart] = useState(false); /* 2 */
-  const tableObjectBodyRef = useRef<HTMLDivElement>(null); /* 3 */
-  const tableObjectBodyInnerRef = useRef<HTMLDivElement>(null); /* 3 */
+  const [isEnd, setIsEnd] = useState(true);
+  /**
+   * Set isState state: set to true, left shadow gradient activates. Removed when false.
+   */
+  const [isStart, setIsStart] = useState(false);
+  /**
+   * Target table body and table body inner DOM elements.
+   */
+  const tableObjectBodyRef = useRef<HTMLDivElement>(null);
+  const tableObjectBodyInnerRef = useRef<HTMLDivElement>(null);
 
   /**
    * Set right and left gradients on tables
-   * 1) Target the actual table inside table object body
-   * 2) Get the width of the table offscreen when table overflows
-   * 3) If table width is less than or equal to table object body width, remove all shadows
-   * 4) If table object body inner scroll isn't all the way to the left or to the right, turn all shadows on
-   * 5) If table body inner scroll is >= to width of table offscreen, turn off right shadow and turn left shadow on
-   * 6) Else, set the right shadow to true and the left shadow to false
    */
   const setShadows = () => {
+    /**
+     * Target the actual table inside table object body.
+     */
     const table =
       tableObjectBodyRef.current &&
-      tableObjectBodyRef.current.querySelector('table'); /* 1 */
+      tableObjectBodyRef.current.querySelector('table');
     if (table) {
-      const tableObjectBodyWidth =
-        tableObjectBodyRef.current.clientWidth; /* 2 */
-      const tableWidth = table.clientWidth; /* 2 */
+      /**
+       * Get the width of the table offscreen when table overflows.
+       */
+      const tableObjectBodyWidth = tableObjectBodyRef.current.clientWidth;
+      const tableWidth = table.clientWidth;
       const tableOffScreen =
-        table.clientWidth - tableObjectBodyRef?.current?.clientWidth; /* 2 */
+        table.clientWidth - tableObjectBodyRef?.current?.clientWidth;
 
       if (tableWidth <= tableObjectBodyWidth) {
-        /* 3 */
+        /**
+         * If table width is less than or equal to table object body width, remove all shadows.
+         */
         setIsEnd(false);
         setIsStart(false);
       } else if (
@@ -73,18 +79,24 @@ export const TableObjectBody = ({
         tableObjectBodyInnerRef.current.scrollLeft > 0 &&
         tableObjectBodyInnerRef.current.scrollLeft < tableOffScreen
       ) {
-        /* 4 */
+        /**
+         * If table object body inner scroll isn't all the way to the left or to the right, turn all shadows on.
+         */
         setIsEnd(true);
         setIsStart(true);
       } else if (
         tableObjectBodyInnerRef.current &&
         tableObjectBodyInnerRef.current.scrollLeft >= tableOffScreen
       ) {
-        /* 5 */
+        /**
+         * If table body inner scroll is >= to width of table offscreen, turn off right shadow and turn left shadow on.
+         */
         setIsEnd(false);
         setIsStart(true);
       } else {
-        /* 6 */
+        /**
+         * Else, set the right shadow to true and the left shadow to false.
+         */
         setIsEnd(true);
         setIsStart(false);
       }
@@ -93,26 +105,24 @@ export const TableObjectBody = ({
 
   /**
    * Table body inner onscroll
-   * 1) Set shadows when user scrolls the table right and left
+   *
+   * Set shadows when user scrolls the table right and left.
    */
   const handleOnScroll = (e: UIEvent<HTMLElement>): void => {
     if (behavior === 'overflow') {
-      setShadows(); /* 1 */
+      setShadows();
     }
   };
 
   /**
-   * Use effect lifecycle
-   * 1) Set shadows when component is updated/loaded
-   * 2) Set window resize listener
-   * 3) Remove window resize listener
+   * Set shadows when component is updated/loaded
    */
   useEffect(() => {
     if (behavior === 'overflow') {
-      setShadows(); /* 1 */
-      window.addEventListener('resize', setShadows); /* 2 */
+      setShadows();
+      window.addEventListener('resize', setShadows);
       return () => {
-        window.removeEventListener('resize', setShadows); /* 3 */
+        window.removeEventListener('resize', setShadows);
       };
     }
   });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -148,11 +148,13 @@ export const Tabs = ({
 
   /**
    * Use effect
-   * 1) Set prevActiveIndex to previous value prop
-   * 2) If prevActiveIndex is defined and previous value prop is not equal
-   * to current value prop, toggle state
+   *
+   * Set prevActiveIndex to previous value prop
+   *
+   * If prevActiveIndex is defined and previous value prop is not equal
+   * to current value prop, toggle state.
    */
-  const prevActiveIndex = usePrevious(activeIndex); /* 1 */
+  const prevActiveIndex = usePrevious(activeIndex);
   useEffect(() => {
     if (
       (prevActiveIndex !== undefined || null) &&
@@ -231,24 +233,23 @@ export const Tabs = ({
 
   /**
    * On open
-   * 1) On click of a tab, set activeIndexState to index of tab being clicked\
-   * 2) If function is passed into onChange prop, run that on click
    */
   function onOpen(index: number) {
-    setActiveIndexState(index); /* 1 */
+    /**
+     * On click of a tab, set activeIndexState to index of tab being clicked.
+     */
+    setActiveIndexState(index);
 
     if (onChange) {
-      /* 2 */
+      /**
+       * If function is passed into onChange prop, run that on click.
+       */
       onChange(index);
     }
   }
 
   /**
    * On KeyDown
-   * 1) Find active tab. If there isn't one, do nothing on Keydown
-   * 2) Set active tab, next tab, and previous tab.
-   * 3) If right or down arrow key keyed, focus on next tab.
-   * 4) If left or up arrow key keyed, focus on the previous tab.
    */
   function onKeyDown(e: KeyboardEvent<HTMLAnchorElement>) {
     let activeTab = null;
@@ -263,15 +264,22 @@ export const Tabs = ({
 
     if (!activeTab) return;
 
-    const index = tabRefs.indexOf(activeTab); /* 2 */
-    const next = index === tabRefs.length - 1 ? 0 : index + 1; /* 2 */
-    const prev = index === 0 ? tabRefs.length - 1 : index - 1; /* 2 */
+    /**
+     * Set active tab, next tab, and previous tab.
+     */
+    const index = tabRefs.indexOf(activeTab);
+    const next = index === tabRefs.length - 1 ? 0 : index + 1;
+    const prev = index === 0 ? tabRefs.length - 1 : index - 1;
 
     if ([R_ARROW_KEYCODE, D_ARROW_KEYCODE].includes(e.key)) {
-      /* 3 */
+      /**
+       * If right or down arrow key keyed, focus on next tab.
+       */
       tabRefs[next].current.focus();
     } else if ([L_ARROW_KEYCODE, U_ARROW_KEYCODE].includes(e.key)) {
-      /* 4 */
+      /**
+       * If left or up arrow key keyed, focus on the previous tab.
+       */
       tabRefs[prev].current.focus();
     }
   }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -98,7 +98,7 @@
 }
 
 /**
- * sA passage of text, including various components (i.e. article, blog post)
+ * A passage of text, including various components (i.e. article, blog post).
  */
 .text-passage {
   /**
@@ -110,20 +110,22 @@
 
   /**
    * First child of a text passage
-   * 1) Zero out top margin to avoid unintended
-   *    gaps when leading with a heading or other
-   *    element that has a top margin
    */
   > :first-child {
-    margin-top: 0; /* 1 */
+    /**
+     * Zero out top margin to avoid unintended gaps when leading with a heading or other
+     * element that has a top margin.
+     */
+    margin-top: 0;
   }
 
   /**
    * Last child of a text passage
-   * 1) Zero out bottom margin to allow the container
-   *    element to control the bottom margin
    */
   > :last-child {
+    /**
+     * Zero out bottom margin to allow the container element to control the bottom margin.
+     */
     margin-bottom: 0;
   }
 

--- a/src/components/Text/Text.stories.module.css
+++ b/src/components/Text/Text.stories.module.css
@@ -3,12 +3,11 @@
 \*------------------------------------ */
 
 /**
- * 1) For the "variant" story to display the different text variant options.
- * 2) Uses grid to neatly align the variant variations.
+ * For the "variant" story to display the different text variant options.
  */
 .variant__table {
-  /* 1 */
-  display: grid; /* 2 */
+  /*  Uses grid to neatly align the variant variations. */
+  display: grid;
   grid-template-columns: 1fr 1fr 1fr;
   gap: var(--eds-size-half);
 }
@@ -25,21 +24,23 @@
     var(--eds-theme-color-border-neutral-default);
 }
 
-/**
- * 1) Variants are segmented into left, middle, and right columns.
- * 2) Background variants were chosen to represent typical body backgrounds.
- */
 .variant__item-white {
-  grid-column: 1; /* 1 */
-  background-color: var(--eds-theme-color-background-neutral-default); /* 2 */
+  /* Variants are segmented into left, middle, and right columns. */
+  grid-column: 1;
+  /* Background variants were chosen to represent typical body backgrounds. */
+  background-color: var(--eds-theme-color-background-neutral-default);
 }
 
 .variant__item-light {
-  grid-column: 2; /* 1 */
-  background-color: var(--eds-theme-color-body-background); /* 2 */
+  /* Variants are segmented into left, middle, and right columns. */
+  grid-column: 2;
+  /* Background variants were chosen to represent typical body backgrounds. */
+  background-color: var(--eds-theme-color-body-background);
 }
 
 .variant__item-dark {
-  grid-column: 3; /* 1 */
-  background-color: var(--eds-theme-color-body-background-inverted); /* 2 */
+  /* Variants are segmented into left, middle, and right columns. */
+  grid-column: 3;
+  /* Background variants were chosen to represent typical body backgrounds. */
+  background-color: var(--eds-theme-color-body-background-inverted);
 }

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -117,8 +117,7 @@ export const Spacing: StoryObj<Args> = {
 };
 
 /**
- * 1) Used mainly for visual regression testing and to show the different color options available.
- * 2) Has problems with snapshots since it has too many components and other stories generate enough confidence for our needs.
+ * Used mainly for visual regression testing and to show the different color options available.
  */
 export const Variants: StoryObj<Args> = {
   render: () => {
@@ -162,7 +161,9 @@ export const Variants: StoryObj<Args> = {
     );
   },
   parameters: {
-    /* 2 */
+    /**
+     * Has problems with snapshots since it has too many components and other stories generate enough confidence for our needs.
+     */
     axe: {
       skip: true,
     },

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -107,8 +107,9 @@
 
 /**
 * Timeline nav back button
-* 1) On smaller viewports, a back button is placed at the top of the 
-* body to allow navigation back to the list of links
+* 
+* On smaller viewports, a back button is placed at the top of the 
+* body to allow navigation back to the list of links.
 */
 .timeline-nav__back {
   text-decoration: none;
@@ -136,12 +137,11 @@
 
 /**
  * Timeline nav item
- *
- * Flex shrink 0 keeps timeline-nav from expanding to fill up the space of the container.
  */
 .timeline-nav__item {
   position: relative;
-  flex-shrink: 0; /* 1 */
+  /* Flex shrink 0 keeps timeline-nav from expanding to fill up the space of the container. */
+  flex-shrink: 0;
   padding-bottom: var(--eds-size-5);
 
   @media all and (min-width: $eds-bp-lg) {
@@ -151,7 +151,8 @@
 
 /**
   * Timeline nav item after
-  * When list variant is 'ordered', add a line between items that shouldn't link out unlike the bullet
+  *
+  * When list variant is 'ordered', add a line between items that shouldn't link out unlike the bullet.
   */
 .timeline-nav__list--ordered .timeline-nav__item {
   &:after {
@@ -159,35 +160,35 @@
     position: absolute;
     top: 0;
     /**
-    * This sets the size of the gap above the vertical line by determining the top of the line relative to the top of the current 
-    * list item; a value of 0 would position the line at the top of the current list item; 100% would position it at the bottom of
-    * the current list item. We want a small visual gap between the bullet/icon and the top of the line 
-    */
+     * This sets the size of the gap above the vertical line by determining the top of the line relative to the top of the current 
+     * list item; a value of 0 would position the line at the top of the current list item; 100% would position it at the bottom of
+     * the current list item. We want a small visual gap between the bullet/icon and the top of the line 
+     */
     left: 0.75rem;
     /**
-    * This sets the height of the vertical line relative to the height of the current list item.
-    * We want a small visual gap between the bottom of the line and the next bullet/icon.
-    */
+     * This sets the height of the vertical line relative to the height of the current list item.
+     * We want a small visual gap between the bottom of the line and the next bullet/icon.
+     */
     height: 100%;
     width: 0.0625rem;
     /**
-    * Using a border color here because this is a vertical line, similar to a border
-    */
+     * Using a border color here because this is a vertical line, similar to a border
+     */
     background: var(--eds-theme-color-border-neutral-subtle);
     border-radius: var(--eds-border-radius-md);
   }
 
   /**
-    * Last Timeline nav item
-    */
+   * Last Timeline nav item
+   */
   &:last-child {
     padding-bottom: 0;
 
     /**
-      * List Timeline nav item after
-      *
-      * Don't add a line after the last list item.
-      */
+     * List Timeline nav item after
+     *
+     * Don't add a line after the last list item.
+     */
     &:after {
       content: none;
     }
@@ -207,7 +208,7 @@
   align-items: baseline;
   gap: var(--eds-size-1);
   text-decoration: none;
-  color: var(--eds-theme-color-text-neutral-subtle); /* 2 */
+  color: var(--eds-theme-color-text-neutral-subtle);
   cursor: pointer;
   transition: color var(--eds-anim-fade-quick) var(--eds-anim-ease),
     box-shadow var(--eds-anim-fade-quick) var(--eds-anim-ease),
@@ -273,13 +274,13 @@
 }
 /**
  * Timeline nav link-left 
- * 1) Provides white background to fake a visual gap in the vertical line between nav items
  */
 .timeline-nav__link-left {
   position: relative;
   height: fit-content;
   padding: var(--eds-size-half) 0;
-  background: var(--eds-theme-color-background-neutral-default); /* 1 */
+  /* Provides white background to fake a visual gap in the vertical line between nav items. */
+  background: var(--eds-theme-color-background-neutral-default);
   z-index: var(--eds-z-index-100);
 }
 
@@ -295,7 +296,7 @@
 .timeline-nav__link-title {
   display: block;
   overflow: hidden;
-  text-overflow: ellipsis; /* 2 */
+  text-overflow: ellipsis;
 }
 
 /**Timeline nav title after
@@ -318,7 +319,7 @@
 .timeline-nav__link-arrow {
   margin-left: auto;
   align-self: center;
-  flex-shrink: 0; /* 2 */
+  flex-shrink: 0;
 
   @media all and (min-width: $eds-bp-lg) {
     display: none;

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -147,11 +147,13 @@ export const TimelineNav = ({
 
   /**
    * Use effect
-   * 1) Set prevActiveIndex to previous value prop
-   * 2) If prevActiveIndex is defined and previous value prop is not equal
-   * to current value prop, toggle state
+   *
+   * Set prevActiveIndex to previous value prop.
+   *
+   * If prevActiveIndex is defined and previous value prop is not equal
+   * to current value prop, toggle state.
    */
-  const prevActiveIndex = usePrevious(activeIndex); /* 1 */
+  const prevActiveIndex = usePrevious(activeIndex);
   useEffect(() => {
     if (
       (prevActiveIndex !== undefined || null) &&
@@ -184,26 +186,24 @@ export const TimelineNav = ({
 
   /**
    * On open
-   * 1) On click of a tab, set activeIndexState to index of tab being clicked
-   * 2) If function is passed into onChange prop, run that on click
    */
   function onOpen(index: number) {
-    setActiveIndexState(index); /* 1 */
+    // On click of a tab, set activeIndexState to index of tab being clicked.
+    setActiveIndexState(index);
     setIsActive(true);
 
     if (onChange) {
-      /* 2 */
+      // If function is passed into onChange prop, run that on click.
       onChange(index);
     }
   }
 
   /**
    * On KeyDown
-   * 1) Find active tab. If there isn't one, do nothing on Keydown
-   * 2) Set active tab, next tab, and previous tab.
-   * 3) If right or down arrow key keyed, focus on next tab.
-   * 4) If left or up arrow key keyed, focus on the previous tab.
-   * 5) If enter or spacebar keyed, set focus to the 'Back' button. This is wrapped in a setTimeout() method to ensure that document.activeElement gets set properly. TODO: determine why backRef.current?.focus() needs to be in a callback
+   *
+   * Find active tab. If there isn't one, do nothing on Keydown.
+   *
+   * TODO: determine why backRef.current?.focus() needs to be in a callback
    *
    * TODO: improve `any` type
    */
@@ -219,21 +219,25 @@ export const TimelineNav = ({
 
     if (!activeTimelineNavPanel) return;
 
-    const index = timelineNavItemRefs.indexOf(activeTimelineNavPanel); /* 2 */
-    const next =
-      index === timelineNavItemRefs.length - 1 ? 0 : index + 1; /* 2 */
-    const prev =
-      index === 0 ? timelineNavItemRefs.length - 1 : index - 1; /* 2 */
+    // Set active tab, next tab, and previous tab.
+    const index = timelineNavItemRefs.indexOf(activeTimelineNavPanel);
+    const next = index === timelineNavItemRefs.length - 1 ? 0 : index + 1;
+    const prev = index === 0 ? timelineNavItemRefs.length - 1 : index - 1;
 
     if ([R_ARROW_KEYCODE, D_ARROW_KEYCODE].includes(e.key)) {
-      /* 3 */
+      // If right or down arrow key keyed, focus on next tab.
       timelineNavItemRefs[next].current.focus();
     } else if ([L_ARROW_KEYCODE, U_ARROW_KEYCODE].includes(e.key)) {
-      /* 4 */
+      // If left or up arrow key keyed, focus on the previous tab.
       timelineNavItemRefs[prev].current.focus();
     } else if (e.key === ENTER_KEYCODE || e.key === SPACEBAR_KEYCODE) {
       setTimeout(() => {
-        backRef.current?.focus(); /* 5 */
+        /**
+         * If enter or spacebar keyed, set focus to the 'Back' button. This
+         * is wrapped in a setTimeout() method to ensure that document.activeElement
+         * gets set properly.
+         */
+        backRef.current?.focus();
       }, 500);
     }
   }
@@ -332,14 +336,29 @@ export const TimelineNav = ({
 
   /**
    * onBack (used by 'Back' button on < lg viewports)
-   * 1) Return focus to the button that was clicked to open the current panel; activeIndexState holds the index of the last nav item selected in the timelinNavItemRefs array
-   * 2) Because the 'Back' button's onFocus listener removes the selected nav item from the tab order, we need to manually insert it back into the tab order by setting its tabIndex back to "0"
-   * 3) Body panel is visible/hidden depending on true/false value of isActive; hide it by setting isActive to false
+   *
+   * Return focus to the button that was clicked to open the current panel;
+   * activeIndexState holds the index of the last nav item selected in the
+   * timelinNavItemRefs array.
    */
   const onBack = () => {
-    timelineNavItemRefs[activeIndexState].current?.focus(); /* 1 */
-    timelineNavItemRefs[activeIndexState].current.tabIndex = '0'; /* 2 */
-    setIsActive(false); /* 3 */
+    /**
+     * Return focus to the button that was clicked to open the current panel;
+     * activeIndexState holds the index of the last nav item selected in the
+     * timelinNavItemRefs array.
+     */
+    timelineNavItemRefs[activeIndexState].current?.focus();
+    /**
+     * Because the 'Back' button's onFocus listener removes the selected nav
+     * item from the tab order, we need to manually insert it back into the tab
+     * order by setting its tabIndex back to "0".
+     */
+    timelineNavItemRefs[activeIndexState].current.tabIndex = '0';
+    /**
+     * Body panel is visible/hidden depending on true/false value of isActive;
+     * hide it by setting isActive to false.
+     */
+    setIsActive(false);
   };
 
   /**

--- a/src/components/Tooltip/Tooltip.stories.module.css
+++ b/src/components/Tooltip/Tooltip.stories.module.css
@@ -3,12 +3,12 @@
 \*------------------------------------*/
 
 /**
- * 1) Spacing is required for the Tooltip to be placed where alignment is indicated,
- * otherwise Tippy will place somewhere else due to lack of space
+ * Spacing is required for the Tooltip to be placed where alignment is indicated,
+ * otherwise Tippy will place somewhere else due to lack of space.
  */
 
 .trigger--spacing {
-  margin: 9rem; /* 1 */
+  margin: 9rem;
 }
 
 .trigger--spacing-top {

--- a/src/components/Utilities/Display.css
+++ b/src/components/Utilities/Display.css
@@ -39,13 +39,13 @@
 
 /**
  * Flex direction utility classes
- * 1) Forces display direction to column
- * 2) Forces display direction to row. Useful for overriding columnar display at specific breakpoints only
  */
 .u-flex-direction-column {
-  flex-direction: column !important /* 1 */;
+  /* Forces display direction to column. */
+  flex-direction: column !important;
 }
 
 .u-flex-direction-row {
-  flex-direction: row !important /* 2 */;
+  /* Forces display direction to row. Useful for overriding columnar display at specific breakpoints only. */
+  flex-direction: row !important;
 }

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -20,9 +20,6 @@
 
 /**
  * Link button styles
- * 6) Has smaller icons than other button styles
- * 7) Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
-      color, but it will also make borders 100% opacity black
  */
 @define-mixin textLink {
   font-size: inherit;
@@ -36,7 +33,8 @@
   text-underline-offset: 2px;
 
   svg {
-    --icon-size-default: 1.25em; /* 6 */
+    /* Has smaller icons than other button styles. */
+    --icon-size-default: 1.25em;
   }
 
   &:hover {
@@ -45,7 +43,11 @@
   }
 
   &:focus-visible {
-    outline: 1px solid transparent; /* 7 */
+    /**
+     * Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
+     * color, but it will also make borders 100% opacity black.
+     */
+    outline: 1px solid transparent;
     color: var(--eds-theme-color-text-neutral-default-inverse) !important;
     text-decoration-color: var(
       --eds-theme-color-text-neutral-default-inverse
@@ -55,7 +57,11 @@
 
   @supports not selector(:focus-visible) {
     &:focus {
-      outline: 1px solid transparent; /* 7 */
+      /**
+       * Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
+       * color, but it will also make borders 100% opacity black.
+       */
+      outline: 1px solid transparent;
       color: var(--eds-theme-color-text-neutral-default-inverse) !important;
       text-decoration-color: var(
         --eds-theme-color-text-neutral-default-inverse

--- a/src/upcoming-components/AccordionPanel/AccordionPanel.tsx
+++ b/src/upcoming-components/AccordionPanel/AccordionPanel.tsx
@@ -77,25 +77,25 @@ export const AccordionPanel = ({
 
   /**
    * Set panel height
-   * 1) If isActive is true, set the height to panel body inner height
-   * 2) If isActive is false, set the height to 0
    */
   const setPanelHeight = useCallback(() => {
     if (isActiveVar === true) {
+      // If isActive is true, set the height to panel body inner height.
       setHeight(
         panelRef?.current?.querySelector('[data-accordion-panel]')
           ?.scrollHeight + 'px',
-      ); /* 1 */
+      );
     } else if (isActiveVar === false) {
-      setHeight('0'); /* 2 */
+      // If isActive is false, set the height to 0.
+      setHeight('0');
     }
   }, [isActiveVar]);
 
   useEffect(() => {
     setPanelHeight();
-    window.addEventListener('resize', setPanelHeight); /* 2 */
+    window.addEventListener('resize', setPanelHeight);
     return () => {
-      window.removeEventListener('resize', setPanelHeight); /* 3 */
+      window.removeEventListener('resize', setPanelHeight);
     };
   }, [setPanelHeight]);
 

--- a/src/upcoming-components/CheckboxField/CheckboxField.module.css
+++ b/src/upcoming-components/CheckboxField/CheckboxField.module.css
@@ -33,30 +33,26 @@
 
   /**
    * Checkbox field list inside inline variant
-   * 1) place items beside each other
    */
   .checkbox-field--inline & {
-    display: flex; /* 1 */
+    display: flex;
     gap: var(--eds-size-4);
   }
 
   /**
    * Checkbox field list inside inline-wrap variant
-   * 1) place items beside each other
    */
   .checkbox-field--inline-wrap & {
-    display: flex; /* 1 */
+    display: flex;
     flex-wrap: wrap;
   }
 }
 
 /**
  * Checkbox field list item
- * 1) Place control and label beside each other
- * 2) Spacing between items
  */
 .checkbox-field__item {
-  display: flex; /* 1 */
+  display: flex;
   gap: var(--eds-size-1);
 }
 
@@ -73,12 +69,13 @@
 
 /**
  * Checkbox field item after
- * 1) Slot to place tooltip, icon, or other helpter text
- * 2) adds margin left to visually separate from label
+ * 
+ * Slot to place tooltip, icon, or other helpter text.
  */
 .checkbox-field__item-after {
   position: relative;
   top: 2px;
   display: inline;
-  margin-left: var(--eds-size-1); /* 2 */
+  /* adds margin left to visually separate from label. */
+  margin-left: var(--eds-size-1);
 }

--- a/src/upcoming-components/CheckboxFieldItem/CheckboxFieldItem.tsx
+++ b/src/upcoming-components/CheckboxFieldItem/CheckboxFieldItem.tsx
@@ -89,23 +89,20 @@ export const CheckboxFieldItem = ({
   }
 
   /**
-   * UseEffect lifecycle hook
-   * 1) When the component loads or updates, update the state if change from the outside
+   * When the component loads or updates, update the state if changed from the outside.
    */
   const prevChecked = usePrevious(checkboxChecked);
   useEffect(() => {
     if (prevChecked !== checkboxChecked) {
-      /* 1 */
       setCheckedState(checkboxChecked);
     }
   }, [prevChecked, checkboxChecked]);
 
   /**
-   * On change handler
-   * 1) Toggle the checked state of item on change
+   * Toggle the checked state of item on change.
    */
   function onChange() {
-    setCheckedState(!checkboxChecked); /* 1 */
+    setCheckedState(!checkboxChecked);
   }
 
   const componentClassName = clsx('checkbox-field__item', className);

--- a/src/upcoming-components/Counter/Counter.module.css
+++ b/src/upcoming-components/Counter/Counter.module.css
@@ -11,8 +11,10 @@
 
 /**
   * Counter body
-  * 1) Container of the buttons and input
-  * 2) Set a max width so content doesn't span the entire width 
+  * 
+  * Container of the buttons and input.
+  *
+  * Set a max width so content doesn't span the entire width .
   */
 .counter__body {
   display: flex;
@@ -30,14 +32,14 @@
 
 /**
  * Counter input
- * 1) Flex 1 added for IE to work with buttons
- * 2) Min width: 0 added to fix flexbox bug with inputs
  */
 .counter__input.counter__input {
   position: relative;
-  flex: 1; /* 1 */
+  /* Flex 1 added for IE to work with buttons. */
+  flex: 1;
   z-index: var(--eds-z-index-100);
-  min-width: 0; /* 2 */
+  /* Min width: 0 added to fix flexbox bug with inputs. */
+  min-width: 0;
   padding-left: 0;
   padding-right: 0;
   text-align: center;

--- a/src/upcoming-components/Feature/Feature.module.css
+++ b/src/upcoming-components/Feature/Feature.module.css
@@ -9,7 +9,7 @@
  * and information side by side.
  */
 .feature {
-  display: flex; /* 2 */
+  display: flex;
   flex-direction: column;
   align-items: stretch;
   background: var(--eds-theme-color-background-brand-primary-strong);

--- a/src/upcoming-components/FileUploadField/FileUploadField.tsx
+++ b/src/upcoming-components/FileUploadField/FileUploadField.tsx
@@ -237,18 +237,10 @@ export const FileUploadField = ({
     if (!fileObjects) return;
     const fileArray: Array<File> = Array.from(fileObjects);
 
-    /*
-     * 1. Copy existing files from state to a new variable
-     * 2. Append new files to this new array
-     * 3. If there is a maxFiles limit and if the more files have been selected than the max,
-     *    remove those over the limit from the array.
-     * 4. Set new state with existing and newly selected files
-     */
-
-    /* 1 */
+    // Copy existing files from state to a new variable.
     let files = [...filesState];
 
-    /* 2 */
+    // Append new files to this new array.
     fileArray.forEach((file: File) => {
       if (maxFileSize && file.size >= maxFileSize) {
         setFieldNoteState(maxFileSizeErrorText);
@@ -262,12 +254,13 @@ export const FileUploadField = ({
       }
     });
 
-    /* 3 */
+    // If there is a maxFiles limit and if the more files have been selected than the max,
+    // remove those over the limit from the array.
     if (maxFiles && files.length >= maxFiles) {
       files = files.splice(0, maxFiles);
     }
 
-    /* 4 */
+    // Set new state with existing and newly selected files
     setFilesState(files);
 
     if (onChange) {

--- a/src/upcoming-components/InlineForm/InlineForm.module.css
+++ b/src/upcoming-components/InlineForm/InlineForm.module.css
@@ -14,10 +14,13 @@
 
 /**
  * Inline form input
- * 1) Actual text input of the inline form
- * 2) Set to flex: 1 to allow the input to take up most of the space.
+ * 
+ * Actual text input of the inline form.
  */
 .inline-form__input {
-  flex: 1; /* 2 */
+  /**
+   * Set to flex: 1 to allow the input to take up most of the space.
+   */
+  flex: 1;
   padding: var(--eds-size-1);
 }

--- a/src/upcoming-components/MediaBlock/MediaBlock.module.css
+++ b/src/upcoming-components/MediaBlock/MediaBlock.module.css
@@ -5,11 +5,13 @@
 \*------------------------------------*/
 
 /**
- * 1) A media block features a block of media(i.e. image) and text
- * 2) Display flex is added to put contents within the media block side by side
+ * A media block features a block of media(i.e. image) and text.
  */
 .media-block {
-  display: flex; /* 2 */
+  /**
+   * Display flex is added to put contents within the media block side by side
+   */
+  display: flex;
   gap: var(--eds-size-4);
 }
 
@@ -39,8 +41,8 @@
  * Media Block body
  */
 .media-block__body {
-  display: flex; /* 2 */
-  flex-direction: column; /* 2 */
+  display: flex;
+  flex-direction: column;
   flex: 1;
 
   .media-block--reversed & {

--- a/src/upcoming-components/TextareaField/TextareaField.module.css
+++ b/src/upcoming-components/TextareaField/TextareaField.module.css
@@ -3,14 +3,12 @@
 \*------------------------------------*/
 
 /**
- * 1) Consists of a label, textarea input, and an optional note about the field.
- * 2) Default spacing away from text field
- * 3)
+ * Consists of a label, textarea input, and an optional note about the field.
  */
 .textarea-field {
-  margin-bottom: var(--eds-size-4); /* 2 */
+  margin-bottom: var(--eds-size-4);
   position: relative;
-  padding-top: var(--eds-size-1-and-half); /* 3 */
+  padding-top: var(--eds-size-1-and-half);
 }
 
 /**


### PR DESCRIPTION
### Summary:
This one is huge but I swear it's the last one. This PR removes the rest of the numbered lists in comments, mostly moving them inline but I also removed a couple that seemed redundant (and removed any empty TODO comments I saw as well).

### Test Plan:
Automated tests pass; no chromatic changes.