### PR TITLE
chore(dragdrop): allow further styling

### DIFF
--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -60,7 +60,7 @@
 /**
  * Outer container for DragDrop component; provides <DragDropContext />, which wraps droppable components (i.e. containers) and provides them with context.
  */
-.drag-drop__inner {
+:where(.drag-drop__inner) {
   /* Uses a flex row to align containers. */
   display: flex;
   overflow: auto;

--- a/src/components/DragDrop/DragDrop.module.css
+++ b/src/components/DragDrop/DragDrop.module.css
@@ -59,6 +59,7 @@
 
 /**
  * Outer container for DragDrop component; provides <DragDropContext />, which wraps droppable components (i.e. containers) and provides them with context.
+ * The `:where` pseudo class function allows easy overriding via className.
  */
 :where(.drag-drop__inner) {
   /* Uses a flex row to align containers. */

--- a/src/components/DragDrop/DragDrop.stories.module.css
+++ b/src/components/DragDrop/DragDrop.stories.module.css
@@ -1,3 +1,22 @@
 .example-card {
   padding-left: var(--eds-size-6);
 }
+
+.bg-yellow {
+  background-color: yellow;
+}
+
+.bg-white {
+  background-color: white;
+}
+
+.grid-square {
+  width: fit-content;
+  display: grid;
+  grid-template-areas: 'a a' 'a a';
+  gap: var(--eds-size-6);
+}
+
+.margin-0 {
+  margin: 0;
+}

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -1,12 +1,15 @@
 import { StoryObj, Meta } from '@storybook/react';
-import React, { ComponentProps } from 'react';
-import { DragDrop } from './DragDrop';
+import React, { ComponentProps, useState } from 'react';
+import { DragDrop, NewState } from './DragDrop';
 import styles from './DragDrop.stories.module.css';
 
+import Button from '../Button';
 import Card from '../Card';
 import CardBody from '../CardBody';
 import DragDropContainerHeader from '../DragDropContainerHeader';
 import Heading from '../Heading';
+import Icon from '../Icon';
+import ProjectCard from '../ProjectCard';
 import Text from '../Text';
 import Toolbar from '../Toolbar';
 
@@ -489,4 +492,207 @@ export const HoveredHandle: StoryObj<Args> = {
     },
     unstyledItems: true,
   },
+};
+
+const InteractiveDragDrop = () => {
+  const emptyContent = () => (
+    <Text as="p" className="u-margin-bottom-xl">
+      Empty Content
+    </Text>
+  );
+
+  const [indexState, setIndexState] = useState<number | undefined>(2);
+  const [containers, setContainers] = useState({
+    'container-1': {
+      columnClassName: styles['bg-yellow'],
+      emptyContent: emptyContent(),
+      itemIds: ['item-1', 'item-2', 'item-3', 'item-4', 'item-5'],
+      header: (
+        <DragDropContainerHeader>
+          <Toolbar className="u-margin-bottom-md" variant="bare">
+            <Toolbar.Item>
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
+                Available projects
+              </Heading>
+            </Toolbar.Item>
+            <Toolbar.Item align="right">
+              <Button variant="icon">
+                <Icon name="add" purpose="decorative" />
+                Add project
+              </Button>
+            </Toolbar.Item>
+          </Toolbar>
+        </DragDropContainerHeader>
+      ),
+    },
+    'container-2': {
+      className: styles['margin-0'],
+      columnClassName: styles['bg-white'],
+      emptyContent: emptyContent(),
+      itemIds: [],
+      header: (
+        <DragDropContainerHeader>
+          <Toolbar className="u-margin-bottom-md" variant="bare">
+            <Toolbar.Item>
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
+                Planned projects
+              </Heading>
+            </Toolbar.Item>
+            <Toolbar.Item align="right">
+              <Button variant="icon">
+                <Icon name="add" purpose="decorative" />
+                Add project
+              </Button>
+            </Toolbar.Item>
+          </Toolbar>
+        </DragDropContainerHeader>
+      ),
+    },
+    'container-3': {
+      className: styles['margin-0'],
+      columnClassName: styles['bg-white'],
+      emptyContent: emptyContent(),
+      itemIds: [],
+      header: (
+        <DragDropContainerHeader>
+          <Toolbar className="u-margin-bottom-md" variant="bare">
+            <Toolbar.Item>
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
+                Planned projects
+              </Heading>
+            </Toolbar.Item>
+            <Toolbar.Item align="right">
+              <Button variant="icon">
+                <Icon name="add" purpose="decorative" />
+                Add project
+              </Button>
+            </Toolbar.Item>
+          </Toolbar>
+        </DragDropContainerHeader>
+      ),
+    },
+    'container-4': {
+      className: styles['margin-0'],
+      columnClassName: styles['bg-white'],
+      emptyContent: emptyContent(),
+      itemIds: [],
+      header: (
+        <DragDropContainerHeader>
+          <Toolbar className="u-margin-bottom-md" variant="bare">
+            <Toolbar.Item>
+              <Heading as="h2" size="title-sm" variant="neutral-strong">
+                Planned projects
+              </Heading>
+            </Toolbar.Item>
+            <Toolbar.Item align="right">
+              <Button variant="icon">
+                <Icon name="add" purpose="decorative" />
+                Add project
+              </Button>
+            </Toolbar.Item>
+          </Toolbar>
+        </DragDropContainerHeader>
+      ),
+    },
+  });
+  const [items, setItems] = useState({
+    'item-1': {
+      title: 'Project #1',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={1}
+          numberAriaLabel="Project 1"
+          title="Longer project card title that wraps lorem ipsum dolor"
+        />
+      ),
+    },
+    'item-2': {
+      title: 'Project #2',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={indexState}
+          numberAriaLabel="Project 2"
+          title="Project card title"
+        />
+      ),
+    },
+    'item-3': {
+      title: 'Project #3',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={3}
+          numberAriaLabel="Project 3"
+          title="Project card title"
+        />
+      ),
+    },
+    'item-4': {
+      title: 'Project #4',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={4}
+          numberAriaLabel="Project 4"
+          title="Project card title"
+        />
+      ),
+    },
+    'item-5': {
+      title: 'Project #5',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={5}
+          numberAriaLabel="Project 5"
+          title="Project card title"
+        />
+      ),
+    },
+    'item-6': {
+      title: 'Project #6',
+      children: (
+        <ProjectCard
+          behavior="draggable"
+          meta="12 days"
+          number={6}
+          numberAriaLabel="Project 6"
+          title="Project card title"
+        />
+      ),
+    },
+  });
+  const returnUpdatedItems = (updatedItems: any) => {
+    setContainers(updatedItems.containers);
+    setItems(updatedItems.items);
+    updatedItems.containers['container-2'].itemIds.map(
+      (item: string, index: number) => {
+        if (item === 'item-2') {
+          updatedItems.items['item-2'].behavior = 'hover';
+          setIndexState(index + 1);
+        }
+      },
+    );
+  };
+  return (
+    <DragDrop
+      containers={containers}
+      containersClassName={styles['grid-square']}
+      getNewState={(updatedItems: NewState) => returnUpdatedItems(updatedItems)}
+      items={items}
+      multipleContainers={false}
+      unstyledItems={true}
+    />
+  );
+};
+
+export const Interactive: StoryObj<Args> = {
+  render: () => <InteractiveDragDrop />,
 };

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -31,6 +31,10 @@ export interface Props {
    */
   containers: Containers;
   /**
+   * CSS class names that can be appended to div wrapping the containers.
+   */
+  containersClassName?: string;
+  /**
    * By default, the last container in a context gets unique styling. If more than two containers will be used, setting this prop to true will remove this unique styling and give all containers a simple border.
    */
   multipleContainers: boolean;
@@ -61,6 +65,7 @@ export const DragDrop = ({
   className,
   items,
   containers,
+  containersClassName,
   getNewState,
   multipleContainers = false,
   unstyledItems = false,
@@ -283,6 +288,8 @@ export const DragDrop = ({
     className,
   );
 
+  const innerClassName = clsx(styles['drag-drop__inner'], containersClassName);
+
   return (
     <DragDropContext onDragEnd={onDragEnd}>
       <Droppable
@@ -298,7 +305,7 @@ export const DragDrop = ({
               ref={provided.innerRef}
             >
               <div
-                className={styles['drag-drop__inner']}
+                className={innerClassName}
                 onScroll={handleOnScroll}
                 ref={dragDropInnerRef}
               >
@@ -313,7 +320,6 @@ export const DragDrop = ({
 
                     return (
                       <DragDropContainer
-                        columnClassName={container.columnClassName}
                         container={container}
                         emptyContent={container.emptyContent}
                         items={items}

--- a/src/components/DragDrop/DragDropTypes.ts
+++ b/src/components/DragDrop/DragDropTypes.ts
@@ -17,9 +17,10 @@ export interface Containers {
 }
 
 export interface ContainerType {
+  className?: string;
+  columnClassName?: string;
+  emptyContent?: React.ReactNode;
+  header?: React.ReactNode;
   id?: string;
   itemIds: string[];
-  header?: React.ReactNode;
-  emptyContent?: React.ReactNode;
-  columnClassName?: string[];
 }

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.tsx.snap
@@ -847,3 +847,579 @@ exports[`<DragDrop /> HoveredHandle story renders snapshot 1`] = `
   </section>
 </div>
 `;
+
+exports[`<DragDrop /> Interactive story renders snapshot 1`] = `
+<div
+  style="margin: 1rem;"
+>
+  <section
+    class="drag-drop drag-drop--unstyled eds-is-overflow-right"
+    data-rbd-droppable-context-id="2"
+    data-rbd-droppable-id="all-containers"
+  >
+    <div
+      class="drag-drop__inner grid-square"
+    >
+      <div
+        class="drag-drop__container"
+      >
+        <header>
+          <div
+            class="toolbar toolbar--bare u-margin-bottom-md"
+          >
+            <div
+              class="toolbar__item"
+            >
+              <h2
+                class="heading heading--size-title-sm heading--neutral-strong"
+              >
+                Available projects
+              </h2>
+            </div>
+            <div
+              class="toolbar__item toolbar__item--align-right"
+            >
+              <button
+                class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
+                data-bootstrap-override="clickable-style-icon"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="icon"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="test-file-stub#add"
+                  />
+                </svg>
+                Add project
+              </button>
+            </div>
+          </div>
+        </header>
+        <ol
+          class="drag-drop__container-inner bg-yellow"
+          data-rbd-droppable-context-id="2"
+          data-rbd-droppable-id="container-1"
+        >
+          <li
+            class="drag-drop__item"
+            data-rbd-draggable-context-id="2"
+            data-rbd-draggable-id="item-1"
+          >
+            <div
+              aria-describedby="rbd-hidden-text-2-hidden-text-18"
+              aria-label="Handle for draggable item: Project #1"
+              class="drag-drop__item-handle"
+              data-rbd-drag-handle-context-id="2"
+              data-rbd-drag-handle-draggable-id="item-1"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#drag-indicator"
+                />
+              </svg>
+            </div>
+            <article
+              class="card card--horizontal card--raised project-card project-card--draggable"
+            >
+              <header
+                class="card__header project-card__header"
+              >
+                <span
+                  aria-label="Project 1"
+                  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+                  role="img"
+                >
+                  1
+                </span>
+              </header>
+              <div
+                class="card__body project-card__body"
+              >
+                <h3
+                  class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+                >
+                  Longer project card title that wraps lorem ipsum dolor
+                </h3>
+                <div
+                  class="project-card__meta"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="icon project-card__meta-icon"
+                    fill="currentColor"
+                    height="0.875rem"
+                    style="--icon-size: 0.875rem;"
+                    width="0.875rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="test-file-stub#event-note"
+                    />
+                  </svg>
+                  12 days
+                </div>
+              </div>
+            </article>
+          </li>
+          <li
+            class="drag-drop__item"
+            data-rbd-draggable-context-id="2"
+            data-rbd-draggable-id="item-2"
+          >
+            <div
+              aria-describedby="rbd-hidden-text-2-hidden-text-18"
+              aria-label="Handle for draggable item: Project #2"
+              class="drag-drop__item-handle"
+              data-rbd-drag-handle-context-id="2"
+              data-rbd-drag-handle-draggable-id="item-2"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#drag-indicator"
+                />
+              </svg>
+            </div>
+            <article
+              class="card card--horizontal card--raised project-card project-card--draggable"
+            >
+              <header
+                class="card__header project-card__header"
+              >
+                <span
+                  aria-label="Project 2"
+                  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+                  role="img"
+                >
+                  2
+                </span>
+              </header>
+              <div
+                class="card__body project-card__body"
+              >
+                <h3
+                  class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+                >
+                  Project card title
+                </h3>
+                <div
+                  class="project-card__meta"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="icon project-card__meta-icon"
+                    fill="currentColor"
+                    height="0.875rem"
+                    style="--icon-size: 0.875rem;"
+                    width="0.875rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="test-file-stub#event-note"
+                    />
+                  </svg>
+                  12 days
+                </div>
+              </div>
+            </article>
+          </li>
+          <li
+            class="drag-drop__item"
+            data-rbd-draggable-context-id="2"
+            data-rbd-draggable-id="item-3"
+          >
+            <div
+              aria-describedby="rbd-hidden-text-2-hidden-text-18"
+              aria-label="Handle for draggable item: Project #3"
+              class="drag-drop__item-handle"
+              data-rbd-drag-handle-context-id="2"
+              data-rbd-drag-handle-draggable-id="item-3"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#drag-indicator"
+                />
+              </svg>
+            </div>
+            <article
+              class="card card--horizontal card--raised project-card project-card--draggable"
+            >
+              <header
+                class="card__header project-card__header"
+              >
+                <span
+                  aria-label="Project 3"
+                  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+                  role="img"
+                >
+                  3
+                </span>
+              </header>
+              <div
+                class="card__body project-card__body"
+              >
+                <h3
+                  class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+                >
+                  Project card title
+                </h3>
+                <div
+                  class="project-card__meta"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="icon project-card__meta-icon"
+                    fill="currentColor"
+                    height="0.875rem"
+                    style="--icon-size: 0.875rem;"
+                    width="0.875rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="test-file-stub#event-note"
+                    />
+                  </svg>
+                  12 days
+                </div>
+              </div>
+            </article>
+          </li>
+          <li
+            class="drag-drop__item"
+            data-rbd-draggable-context-id="2"
+            data-rbd-draggable-id="item-4"
+          >
+            <div
+              aria-describedby="rbd-hidden-text-2-hidden-text-18"
+              aria-label="Handle for draggable item: Project #4"
+              class="drag-drop__item-handle"
+              data-rbd-drag-handle-context-id="2"
+              data-rbd-drag-handle-draggable-id="item-4"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#drag-indicator"
+                />
+              </svg>
+            </div>
+            <article
+              class="card card--horizontal card--raised project-card project-card--draggable"
+            >
+              <header
+                class="card__header project-card__header"
+              >
+                <span
+                  aria-label="Project 4"
+                  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+                  role="img"
+                >
+                  4
+                </span>
+              </header>
+              <div
+                class="card__body project-card__body"
+              >
+                <h3
+                  class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+                >
+                  Project card title
+                </h3>
+                <div
+                  class="project-card__meta"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="icon project-card__meta-icon"
+                    fill="currentColor"
+                    height="0.875rem"
+                    style="--icon-size: 0.875rem;"
+                    width="0.875rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="test-file-stub#event-note"
+                    />
+                  </svg>
+                  12 days
+                </div>
+              </div>
+            </article>
+          </li>
+          <li
+            class="drag-drop__item"
+            data-rbd-draggable-context-id="2"
+            data-rbd-draggable-id="item-5"
+          >
+            <div
+              aria-describedby="rbd-hidden-text-2-hidden-text-18"
+              aria-label="Handle for draggable item: Project #5"
+              class="drag-drop__item-handle"
+              data-rbd-drag-handle-context-id="2"
+              data-rbd-drag-handle-draggable-id="item-5"
+              draggable="false"
+              role="button"
+              tabindex="0"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#drag-indicator"
+                />
+              </svg>
+            </div>
+            <article
+              class="card card--horizontal card--raised project-card project-card--draggable"
+            >
+              <header
+                class="card__header project-card__header"
+              >
+                <span
+                  aria-label="Project 5"
+                  class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+                  role="img"
+                >
+                  5
+                </span>
+              </header>
+              <div
+                class="card__body project-card__body"
+              >
+                <h3
+                  class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+                >
+                  Project card title
+                </h3>
+                <div
+                  class="project-card__meta"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="icon project-card__meta-icon"
+                    fill="currentColor"
+                    height="0.875rem"
+                    style="--icon-size: 0.875rem;"
+                    width="0.875rem"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <use
+                      xlink:href="test-file-stub#event-note"
+                    />
+                  </svg>
+                  12 days
+                </div>
+              </div>
+            </article>
+          </li>
+        </ol>
+      </div>
+      <div
+        class="drag-drop__container drag-drop__container--empty margin-0"
+      >
+        <header>
+          <div
+            class="toolbar toolbar--bare u-margin-bottom-md"
+          >
+            <div
+              class="toolbar__item"
+            >
+              <h2
+                class="heading heading--size-title-sm heading--neutral-strong"
+              >
+                Planned projects
+              </h2>
+            </div>
+            <div
+              class="toolbar__item toolbar__item--align-right"
+            >
+              <button
+                class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
+                data-bootstrap-override="clickable-style-icon"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="icon"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="test-file-stub#add"
+                  />
+                </svg>
+                Add project
+              </button>
+            </div>
+          </div>
+        </header>
+        <div
+          class="drag-drop__container-inner bg-white"
+          data-rbd-droppable-context-id="2"
+          data-rbd-droppable-id="container-2"
+        >
+          <p
+            class="text text--body u-margin-bottom-xl"
+          >
+            Empty Content
+          </p>
+        </div>
+      </div>
+      <div
+        class="drag-drop__container drag-drop__container--empty margin-0"
+      >
+        <header>
+          <div
+            class="toolbar toolbar--bare u-margin-bottom-md"
+          >
+            <div
+              class="toolbar__item"
+            >
+              <h2
+                class="heading heading--size-title-sm heading--neutral-strong"
+              >
+                Planned projects
+              </h2>
+            </div>
+            <div
+              class="toolbar__item toolbar__item--align-right"
+            >
+              <button
+                class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
+                data-bootstrap-override="clickable-style-icon"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="icon"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="test-file-stub#add"
+                  />
+                </svg>
+                Add project
+              </button>
+            </div>
+          </div>
+        </header>
+        <div
+          class="drag-drop__container-inner bg-white"
+          data-rbd-droppable-context-id="2"
+          data-rbd-droppable-id="container-3"
+        >
+          <p
+            class="text text--body u-margin-bottom-xl"
+          >
+            Empty Content
+          </p>
+        </div>
+      </div>
+      <div
+        class="drag-drop__container drag-drop__container--empty margin-0"
+      >
+        <header>
+          <div
+            class="toolbar toolbar--bare u-margin-bottom-md"
+          >
+            <div
+              class="toolbar__item"
+            >
+              <h2
+                class="heading heading--size-title-sm heading--neutral-strong"
+              >
+                Planned projects
+              </h2>
+            </div>
+            <div
+              class="toolbar__item toolbar__item--align-right"
+            >
+              <button
+                class="clickable-style clickable-style--lg clickable-style--icon clickable-style--brand button button--icon"
+                data-bootstrap-override="clickable-style-icon"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="icon"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="test-file-stub#add"
+                  />
+                </svg>
+                Add project
+              </button>
+            </div>
+          </div>
+        </header>
+        <div
+          class="drag-drop__container-inner bg-white"
+          data-rbd-droppable-context-id="2"
+          data-rbd-droppable-id="container-4"
+        >
+          <p
+            class="text text--body u-margin-bottom-xl"
+          >
+            Empty Content
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -9,16 +9,6 @@ import DragDropItem from '../DragDropItem';
 
 export interface Props {
   /**
-   * CSS class names that can be appended to the component.
-   */
-  className?: string;
-  /**
-   * Column class names that can be appended to the component.
-   *
-   * Used to add additional styles to the column.
-   */
-  columnClassName?: string[];
-  /**
    * Prop that will contain an id for each container and an array of itemIds that will be used on initial render
    */
   container: ContainerType;
@@ -36,7 +26,6 @@ export interface Props {
  * Primary UI component for user interaction for draggable components to be dropped within the container.
  */
 export const DragDropContainer = ({
-  className,
   container,
   items,
   emptyContent,
@@ -44,7 +33,7 @@ export const DragDropContainer = ({
   const componentClassName = clsx(
     styles['drag-drop__container'],
     items.length < 1 && styles['drag-drop__container--empty'],
-    className,
+    container.className,
   );
 
   const containerInnerClassName = clsx(


### PR DESCRIPTION
### Summary:
- [slack discussion](https://czi-edu.slack.com/archives/CTFV79JH4/p1663958436719399?thread_ts=1663181721.585879&cid=CTFV79JH4)
- This allows classnames to be passed in to style the dragdrop containers, containers wrapper, dragdrop containers columns, and does a little cleanup regarding


https://user-images.githubusercontent.com/86632227/192334637-18577425-98ff-4c12-8eb1-af3447d7348d.mov


- DragDrop itself is not the easiest to read and could definitely [use some clean up or even a refactor](https://app.shortcut.com/czi-edu/story/216547)
### Test Plan:
- Adds interactive story in DragDrop showing the customizable wrapper, container, and column
- No other visual regression
- Unit tests pass