### PR TITLE
Add types for react-children-by-type

### DIFF
--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -45,6 +45,7 @@ export const DragDropContainer = ({
     container.header,
     DragDropContainerHeader,
   );
+
   const header = React.Children.map(dragDropContainerHeader, (child) => {
     return React.cloneElement(child);
   });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -83,7 +83,6 @@ export const Tabs = ({
     return allByType(children, Tab);
   }, [children]);
 
-  // When rendered, we use the anchor tag below to attach these refs
   const tabRefs = tabs().map(() => React.createRef<HTMLAnchorElement>());
 
   // we can't use the hook in an iterator like this, so generate the base and increment if needed
@@ -246,7 +245,7 @@ export const Tabs = ({
     scrollableRight && styles['tabs--scrollable-right'],
   );
 
-  const childrenWithProps = React.Children.map(tabs(), (child, i: number) => {
+  const childrenWithProps = React.Children.map(tabs(), (child, i) => {
     // Checking isValidElement is the safe way and avoids a typescript
     // error too.
     if (React.isValidElement(child)) {
@@ -266,7 +265,7 @@ export const Tabs = ({
         ref={headerRef}
       >
         <ul className={styles['tabs__list']} role="tablist">
-          {tabs().map((tab, i: number) => {
+          {tabs().map((tab, i) => {
             const isActive = activeIndexState === i;
             return (
               <li

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -126,7 +126,9 @@ export const TimelineNav = ({
     return allByType(children, TimelineNavPanel);
   }, [children]);
 
-  const timelineNavItemRefs = timelineNavItems().map(() => React.createRef());
+  const timelineNavItemRefs = timelineNavItems().map(() =>
+    React.createRef<HTMLAnchorElement>(),
+  );
 
   // we can't use the hook in an iterator like this, so generate the base and increment if needed
   const [idVar, setId] = useState<string[]>([]);
@@ -160,7 +162,7 @@ export const TimelineNav = ({
       prevActiveIndex !== activeIndex
     ) {
       setActiveIndexState(activeIndex);
-      timelineNavItemRefs[activeIndex].current.focus();
+      timelineNavItemRefs[activeIndex].current?.focus();
     }
   }, [prevActiveIndex, activeIndex, timelineNavItemRefs]);
 
@@ -169,14 +171,12 @@ export const TimelineNav = ({
    */
   useEffect(() => {
     setId(
-      // TODO: improve `any` type
-      timelineNavItems().map((item: any) =>
+      timelineNavItems().map((item) =>
         item.props.id ? item.props.id : getUID(item),
       ),
     );
     setAriaLabelledBy(
-      // TODO: improve `any` type
-      timelineNavItems().map((item: any) =>
+      timelineNavItems().map((item) =>
         item.props['aria-labelledby']
           ? item.props['aria-labelledby']
           : getUID(item),
@@ -209,8 +209,7 @@ export const TimelineNav = ({
    */
   function onKeyDown(e: any) {
     let activeTimelineNavPanel = null;
-    // TODO: improve `any` type
-    timelineNavItemRefs.map((item: any) => {
+    timelineNavItemRefs.map((item) => {
       if (item.current === document.activeElement) {
         activeTimelineNavPanel = item;
       }
@@ -226,10 +225,10 @@ export const TimelineNav = ({
 
     if ([R_ARROW_KEYCODE, D_ARROW_KEYCODE].includes(e.key)) {
       // If right or down arrow key keyed, focus on next tab.
-      timelineNavItemRefs[next].current.focus();
+      timelineNavItemRefs[next].current?.focus();
     } else if ([L_ARROW_KEYCODE, U_ARROW_KEYCODE].includes(e.key)) {
       // If left or up arrow key keyed, focus on the previous tab.
-      timelineNavItemRefs[prev].current.focus();
+      timelineNavItemRefs[prev].current?.focus();
     } else if (e.key === ENTER_KEYCODE || e.key === SPACEBAR_KEYCODE) {
       setTimeout(() => {
         /**
@@ -244,8 +243,7 @@ export const TimelineNav = ({
 
   const childrenWithProps = React.Children.map(
     timelineNavItems(),
-    // TODO: improve `any` type
-    (child: any, i: number) => {
+    (child, i) => {
       // Checking isValidElement is the safe way and avoids a typescript
       // error too.
       if (React.isValidElement(child)) {
@@ -342,18 +340,23 @@ export const TimelineNav = ({
    * timelinNavItemRefs array.
    */
   const onBack = () => {
-    /**
-     * Return focus to the button that was clicked to open the current panel;
-     * activeIndexState holds the index of the last nav item selected in the
-     * timelinNavItemRefs array.
-     */
-    timelineNavItemRefs[activeIndexState].current?.focus();
-    /**
-     * Because the 'Back' button's onFocus listener removes the selected nav
-     * item from the tab order, we need to manually insert it back into the tab
-     * order by setting its tabIndex back to "0".
-     */
-    timelineNavItemRefs[activeIndexState].current.tabIndex = '0';
+    const element = timelineNavItemRefs[activeIndexState].current;
+
+    if (element) {
+      /**
+       * Return focus to the button that was clicked to open the current panel;
+       * activeIndexState holds the index of the last nav item selected in the
+       * timelinNavItemRefs array.
+       */
+      element.focus();
+      /**
+       * Because the 'Back' button's onFocus listener removes the selected nav
+       * item from the tab order, we need to manually insert it back into the tab
+       * order by setting its tabIndex back to "0".
+       */
+      element.tabIndex = 0;
+    }
+
     /**
      * Body panel is visible/hidden depending on true/false value of isActive;
      * hide it by setting isActive to false.
@@ -375,7 +378,11 @@ export const TimelineNav = ({
    * See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#sect1
    */
   const resetTabIndex = () => {
-    timelineNavItemRefs[activeIndexState].current.tabIndex = '-1';
+    const element = timelineNavItemRefs[activeIndexState].current;
+
+    if (element) {
+      element.tabIndex = -1;
+    }
   };
 
   return (
@@ -391,8 +398,7 @@ export const TimelineNav = ({
           )}
           role="tablist"
         >
-          {/* TODO: improve `any` type */}
-          {timelineNavItems().map((tab: TimelineNavItem, i: number) => {
+          {timelineNavItems().map((tab, i) => {
             const isActive = activeIndexState === i;
             const itemVariant = variant && tab.props.variant;
             return (

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -10,6 +10,17 @@ declare module '*.module.css' {
 
 declare module '*.md';
 
-// TODO: improve typing for exported functions.
 // Reference https://github.com/tshelburne/react-children-by-type
-declare module 'react-children-by-type';
+declare module 'react-children-by-type' {
+  import type { ReactNode, JSXElementConstructor } from 'react';
+
+  export function allByType<P>(
+    children: ReactNode,
+    type: JSXElementConstructor<P>,
+  ): ReactElement<P>[];
+
+  export function oneByType<P>(
+    children: ReactNode,
+    type: JSXElementConstructor<P>,
+  ): ReactElement<P>;
+}


### PR DESCRIPTION
[sc-196807]

### Summary:

Add types for `react-children-by-types`, to improve the types, of some of our types.

Inspired by the cleanups in #1311.

### Test Plan:

- Type checking
- Unit tests