### PR TITLE
Cleanup

### DIFF
--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { MutableRefObject, ReactNode, useEffect, useRef } from 'react';
+import React, { type ReactNode, useEffect, useRef } from 'react';
 import styles from './BaselineCard.module.css';
 
 import { Card, CardBody, CardFooter, CardHeader, Score } from '../../../src';
@@ -78,8 +78,8 @@ export const BaselineCard = ({
    * Initialize refs to use on the card container and the link
    *  (for clickable card)
    */
-  const cardRef = useRef() as MutableRefObject<HTMLDivElement>;
-  const linkRef = useRef() as MutableRefObject<HTMLAnchorElement>;
+  const cardRef = useRef<HTMLDivElement>(null);
+  const linkRef = useRef<HTMLAnchorElement>(null);
 
   /**
    * Hook up the link functionality on component mount if a link is present
@@ -103,7 +103,7 @@ export const BaselineCard = ({
     function handleClick() {
       const isTextSelected = window.getSelection()?.toString();
       if (!isTextSelected) {
-        linkRef.current.click();
+        linkRef.current?.click();
       }
     }
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import debounce from 'lodash.debounce';
-import React, { ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 import { useUID } from 'react-uid';
 import styles from './Breadcrumbs.module.css';
 import { flattenReactChildren } from '../../util/flattenReactChildren';
@@ -47,36 +47,32 @@ export const Breadcrumbs = ({
   const ref = React.useRef<HTMLUListElement>(null);
 
   /**
-   * Checks if breadcrumbs would overflow
-   */
-  const updateShouldTruncate = () => {
-    setShouldTruncate(false);
-    if (
-      ref &&
-      ref.current &&
-      ref.current.clientWidth < ref.current.scrollWidth
-    ) {
-      setShouldTruncate(true);
-    }
-  };
-  const debouncedUpdateShouldTruncate = debounce(updateShouldTruncate, 200);
-
-  /**
    * Needs useLayoutEffect over useEffect since it needs to be run before paint.
    * TODO: with React 18, might be able to use useEffect https://github.com/reactjs/reactjs.org/blob/d14cbdca2445cd676526c4c52e1e106342ff7bb3/content/docs/hooks-reference.md?plain=1#L155
    */
   React.useLayoutEffect(() => {
+    const updateShouldTruncate = () => {
+      const willOverflow = ref.current
+        ? ref.current.clientWidth < ref.current.scrollWidth
+        : false;
+
+      setShouldTruncate(willOverflow);
+    };
+
+    const debouncedUpdateShouldTruncate = debounce(updateShouldTruncate, 200);
+
     updateShouldTruncate();
     window.addEventListener('resize', debouncedUpdateShouldTruncate);
     return () => {
       window.removeEventListener('resize', debouncedUpdateShouldTruncate);
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   /**
    * Flattens breadcrumb items that may be wrapped in React.Fragment into an array so they can be manipulated easily.
    */
   const breadcrumbsItems = flattenBreadcrumbsItems(children);
+
   /**
    * Finds the second to last breadcrumb item for mobile Breadcrumbs back icon.
    */
@@ -91,6 +87,7 @@ export const Breadcrumbs = ({
           },
         )
       : null;
+
   /**
    * Finds all the breadcrumb items between the first and last breadcrumb items so they can be placed in the dropdown.
    */

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -1,11 +1,10 @@
 import clsx from 'clsx';
 import React, {
-  ReactNode,
+  type ReactNode,
   useState,
   useEffect,
   useRef,
-  MutableRefObject,
-  UIEvent,
+  type UIEvent,
 } from 'react';
 import {
   DragDropContext,
@@ -78,12 +77,16 @@ export const DragDrop = ({
   /**
    * Target drag drop and drag drop inner DOM elements
    */
-  const dragDropInnerRef = useRef() as MutableRefObject<HTMLDivElement>;
-  const dragDropRef = useRef() as MutableRefObject<HTMLElement>;
+  const dragDropInnerRef = useRef<HTMLDivElement>(null);
+  const dragDropRef = useRef<HTMLElement | null>(null);
   /**
    * Set right and left gradients on tables
    */
   const setShadows = () => {
+    if (!dragDropInnerRef.current) {
+      return;
+    }
+
     /**
      * Target the actual drag drop inside drag drop.
      */
@@ -96,7 +99,8 @@ export const DragDrop = ({
       );
       childrenWidth += item.clientWidth + itemMarginLeft;
     });
-    if (overflowListItems) {
+
+    if (dragDropRef.current) {
       /**
        * Get the width of the drag drop offscreen when drag drop overflows.
        */
@@ -149,7 +153,7 @@ export const DragDrop = ({
    * Set shadows when component is updated/loaded.
    */
   useEffect(() => {
-    dragDropRef.current = dragDropInnerRef.current.parentNode as HTMLElement;
+    dragDropRef.current = dragDropInnerRef.current?.parentNode as HTMLElement;
     setShadows();
     window.addEventListener('resize', setShadows);
     return () => {

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,10 +1,11 @@
 import clsx from 'clsx';
 import React, {
+  useCallback,
   useState,
   useEffect,
   useRef,
-  ReactNode,
-  KeyboardEvent,
+  type ReactNode,
+  type KeyboardEvent,
 } from 'react';
 import { oneByType } from 'react-children-by-type';
 import FocusLock from 'react-focus-lock';
@@ -75,8 +76,8 @@ export const Drawer = ({
    */
   const [activeFocus, setActiveFocus] = useState(isActive);
   const windowRef = useRef<HTMLElement | null>(null);
-  const ref = useRef<HTMLDivElement | null>(null);
   const isMountedRef = useRef(true);
+  const onCloseRef = useRef(onClose);
 
   /**
    * Update activeFocus to be consistent with isActive.
@@ -100,6 +101,10 @@ export const Drawer = ({
       isMountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   /**
    * Open the Drawer and give it focus.
@@ -125,13 +130,13 @@ export const Drawer = ({
   /**
    * Close the drawer and run the onClose prop (pass in function) if it exists.
    */
-  function handleOnClose() {
+  const handleOnClose = useCallback(() => {
     deactivateFocusTrap();
 
-    if (onClose) {
-      onClose();
+    if (onCloseRef.current) {
+      onCloseRef.current();
     }
-  }
+  }, []);
 
   /**
    * Handle "click outside"
@@ -154,7 +159,7 @@ export const Drawer = ({
     return () => {
       document.removeEventListener('click', handleOnClickOutside);
     };
-  }, [isActive, windowRef]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isActive, dismissible, handleOnClose, windowRef]);
 
   /**
    * If escape button is struck, close the drawer
@@ -198,7 +203,6 @@ export const Drawer = ({
           aria-hidden={!isActive}
           className={containerClassName}
           onKeyDown={handleOnKeyDown}
-          ref={ref}
           {...other}
         >
           <article

--- a/src/components/FiltersPopover/FiltersPopover.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ReactNode, useEffect, useRef } from 'react';
+import React, { type ReactNode, useEffect, useRef } from 'react';
 import styles from './FiltersPopover.module.css';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
@@ -91,6 +91,12 @@ const FiltersPopoverRender = ({
     );
   }
 
+  // Get a stable reference to the onClose callback.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
   /**
    * Hooks to emulate an onClose callback for the Popover.
    * Tracking first render is required to prevent useEffect callback from running on first render since Popover may render as closed.
@@ -99,11 +105,10 @@ const FiltersPopoverRender = ({
   useEffect(() => {
     if (firstRender.current) {
       firstRender.current = false;
-    } else if (!open && onClose) {
-      onClose();
+    } else if (!open && onCloseRef.current) {
+      onCloseRef.current();
     }
-    // onClose is not included as a dependency since it usually affects external state and can cause a callback loop
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const trigger = triggerElement || (
     <FiltersButton

--- a/src/components/OverflowList/OverflowList.tsx
+++ b/src/components/OverflowList/OverflowList.tsx
@@ -1,11 +1,10 @@
 import clsx from 'clsx';
 import React, {
-  ReactNode,
+  type ReactNode,
   useState,
   useRef,
   useEffect,
-  UIEvent,
-  MutableRefObject,
+  type UIEvent,
 } from 'react';
 import styles from './OverflowList.module.css';
 
@@ -42,16 +41,21 @@ export const OverflowList = ({ className, children, ...other }: Props) => {
   /**
    * Target overflow list and overflow list inner DOM elements
    */
-  const overflowListRef = useRef() as MutableRefObject<HTMLDivElement>;
-  const overflowListInnerRef = useRef() as MutableRefObject<HTMLUListElement>;
+  const overflowListRef = useRef<HTMLDivElement>(null);
+  const overflowListInnerRef = useRef<HTMLUListElement>(null);
   /**
    * Set right and left gradients on tables.
    */
   const setShadows = () => {
+    if (!overflowListInnerRef.current) {
+      return;
+    }
+
     /**
      * Target the actual overflow list inside overflow list
      */
     const overflowListItems = Array.from(overflowListInnerRef.current.children);
+
     let childrenWidth = 0;
 
     overflowListItems.forEach(function (item) {
@@ -60,7 +64,8 @@ export const OverflowList = ({ className, children, ...other }: Props) => {
       );
       childrenWidth += item.clientWidth + itemMarginLeft;
     });
-    if (overflowListItems) {
+
+    if (overflowListRef.current) {
       /**
        * Get the width of the overflow list offscreen when overflow list overflows
        */

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import debounce from 'lodash.debounce';
 import React, {
-  ReactNode,
+  type ReactNode,
   useRef,
   useState,
   useEffect,
   useCallback,
-  KeyboardEvent,
+  type KeyboardEvent,
 } from 'react';
 import { allByType } from 'react-children-by-type';
 import { useUIDSeed } from 'react-uid';
@@ -120,6 +120,7 @@ export const Tabs = ({
   const [activeIndexState, setActiveIndexState] = useState(activeIndex);
   const [scrollableLeft, setScrollableLeft] = useState<boolean>(false);
   const [scrollableRight, setScrollableRight] = useState<boolean>(false);
+
   /**
    * Set the only children components allowed within <Tabs> to be Tab
    */
@@ -186,37 +187,39 @@ export const Tabs = ({
   /**
    * Handles if scroll fade indicators should be displayed.
    */
-  const handleTabsScroll = debounce(
-    (headerEl: HTMLDivElement) => {
-      const scrollLeft = headerEl.scrollLeft;
-      const width = headerEl.clientWidth;
-      const scrollWidth = headerEl.scrollWidth;
+  const handleTabsScroll = useCallback((headerEl: HTMLDivElement) => {
+    const scrollLeft = headerEl.scrollLeft;
+    const width = headerEl.clientWidth;
+    const scrollWidth = headerEl.scrollWidth;
 
-      if (scrollLeft > 0) {
-        setScrollableLeft(true);
-      } else {
-        setScrollableLeft(false);
-      }
+    if (scrollLeft > 0) {
+      setScrollableLeft(true);
+    } else {
+      setScrollableLeft(false);
+    }
 
-      if (scrollWidth > width && scrollLeft + width < scrollWidth) {
-        setScrollableRight(true);
-      } else {
-        setScrollableRight(false);
-      }
-    },
-    100,
-    { leading: true },
-  );
+    if (scrollWidth > width && scrollLeft + width < scrollWidth) {
+      setScrollableRight(true);
+    } else {
+      setScrollableRight(false);
+    }
+  }, []);
 
   /**
    * Listens for window resize to display scroll fade indicators.
    */
   useEffect(() => {
     if (headerRef && headerRef.current) {
-      const resizeHandleTabs = () => {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        handleTabsScroll(headerRef.current!);
-      };
+      const resizeHandleTabs = debounce(
+        () => {
+          if (headerRef.current) {
+            handleTabsScroll(headerRef.current);
+          }
+        },
+        100,
+        { leading: true },
+      );
+
       /**
        * The event listener actually calls the callback once when initiated, but the event listener
        * is not triggered with prop changes so this line is required.
@@ -229,7 +232,7 @@ export const Tabs = ({
         window.removeEventListener('resize', resizeHandleTabs);
       };
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [handleTabsScroll]);
 
   /**
    * On open

--- a/src/hooks/useMergedRefs.test.tsx
+++ b/src/hooks/useMergedRefs.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import React, { useRef, type RefObject } from 'react';
+import { useMergedRefs } from './useMergedRefs';
+
+it('assigns a value to all provided refs', () => {
+  let refA: RefObject<HTMLElement> = { current: null };
+  let refB: RefObject<HTMLElement> = { current: null };
+
+  function Component() {
+    refA = useRef(null);
+    refB = useRef(null);
+    const combinedRef = useMergedRefs(refA, refB);
+    return <span ref={combinedRef}>hi</span>;
+  }
+
+  render(<Component />);
+
+  expect(refA.current?.textContent).toEqual('hi');
+  expect(refB.current?.textContent).toEqual('hi');
+});


### PR DESCRIPTION
### Summary:

Follow up to #1311 and #1314.

Cleaning up some stuff:
- Removed unnecessary type casting when using `useRef`
- Removed all suppressions of the react-hooks/exhaustive-deps rule
- Simplified `useMergedRefs` (too achieve the above bullet)
- Added some tests

![mr clean](https://user-images.githubusercontent.com/2503289/192298231-c5bcf0d3-12db-4cb3-8f7b-f2a94f649eb0.jpg)

### Test Plan:

- Tests
- Storybook