### PR TITLE
chore(filtersdrawer): use useRef not createRef

### DIFF
--- a/src/components/FiltersDrawer/FiltersDrawer.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import React, {
-  createRef,
+  useRef,
   ReactElement,
   ReactNode,
   useEffect,
@@ -116,7 +116,7 @@ export const FiltersDrawer = ({
    * Manages overflow state.
    */
   const [isOverflowing, setIsOverflowing] = useState(false);
-  const filtersBody = createRef<HTMLDivElement>();
+  const filtersBody = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
### Summary:
- guilty of using `createRef` and was reminded by https://github.com/chanzuckerberg/edu-design-system/pull/1314#discussion_r979126279
- uses `useRef` not `createRef` for `filtersDrawer`
### Test Plan:
- all tests pass