### PR TITLE
chore: run storybook on port 9000 instead of 9009

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "release:patch": "yarn release --release-as patch",
     "release:alpha": "yarn release --prerelease alpha",
     "start": "yarn build:tokens && yarn storybook",
-    "storybook": "start-storybook -p 9009 -s src/design-tokens/tier-1-definitions/fonts",
+    "storybook": "start-storybook -p 9000 -s src/design-tokens/tier-1-definitions/fonts",
     "storybook:axe": "yarn run build:storybook && yarn run storybook:axeOnly",
     "storybook:axeOnly": "axe-storybook --build-dir storybook-static",
     "plop": "plop component",


### PR DESCRIPTION
### Summary:
We use Sauce Labs for testing on various browsers and devices. [Sauce Labs only supports certain ports for testing localhost](https://docs.saucelabs.com/secure-connections/sauce-connect/advanced/specifications/#supported-browsers-and-ports), and the current port (9009) isn't on the list. This PR updates the storybook port to 9000 to make Sauce Labs testing easier.

![the "it's over 9000" dragonball z meme but the "over" word is covered and replaced with the word "port" so the text reads "it's port 9000"](https://user-images.githubusercontent.com/7761701/192381805-016e0495-4c47-4850-a2a5-aaa9156cf4e2.jpg)

### Test Plan:
- run `yarn storybook`
- verify it runs on `localhost:9000` instead of `localhost:9009`