### PR TITLE
More tabs cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "svg-spritemap-webpack-plugin": "^3.9.1",
     "tailwindcss": "^3.1.8",
     "ts-jest": "^29.0.1",
-    "typescript": "^4.6.2"
+    "typescript": "^4.8.3"
   },
   "husky": {
     "hooks": {

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -17,7 +17,7 @@ import {
   R_ARROW_KEYCODE,
   D_ARROW_KEYCODE,
 } from '../../util/keycodes';
-import { default as Tab, TabProps } from '../Tab';
+import Tab from '../Tab';
 
 export interface Props {
   /**
@@ -77,9 +77,7 @@ export const Tabs = ({
   /**
    * Set the only children components allowed within <Tabs> to be Tab
    */
-  const tabs = useCallback<() => React.ReactElement<TabProps>[]>(() => {
-    // TODO: apply types from module, specify type definitions in custom.d.ts,
-    // or replace with inline equivalent
+  const tabs = useCallback(() => {
     return allByType(children, Tab);
   }, [children]);
 

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -12,15 +12,15 @@ declare module '*.md';
 
 // Reference https://github.com/tshelburne/react-children-by-type
 declare module 'react-children-by-type' {
-  import type { ReactNode, JSXElementConstructor } from 'react';
+  import * as React from 'react';
 
   export function allByType<P>(
-    children: ReactNode,
-    type: JSXElementConstructor<P>,
-  ): ReactElement<P>[];
+    children: React.ReactNode,
+    type: React.JSXElementConstructor<P>,
+  ): React.ReactElement<P>[];
 
   export function oneByType<P>(
-    children: ReactNode,
-    type: JSXElementConstructor<P>,
-  ): ReactElement<P>;
+    children: React.ReactNode,
+    type: React.JSXElementConstructor<P>,
+  ): React.ReactElement<P>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2070,7 +2070,7 @@ __metadata:
     svg4everybody: ^2.1.9
     tailwindcss: ^3.1.8
     ts-jest: ^29.0.1
-    typescript: ^4.6.2
+    typescript: ^4.8.3
   peerDependencies:
     react: ">= 16.8.0"
   languageName: unknown
@@ -21169,13 +21169,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.6.2":
-  version: 4.8.2
-  resolution: "typescript@npm:4.8.2"
+"typescript@npm:^4.8.3":
+  version: 4.8.3
+  resolution: "typescript@npm:4.8.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 7f5b81d0d558c9067f952c7af52ab7f19c2e70a916817929e4a5b256c93990bf3178eccb1ac8a850bc75df35f6781b6f4cb3370ce20d8b1ded92ed462348f628
+  checksum: 8286a5edcaf3d68e65c451aa1e7150ad1cf53ee0813c07ec35b7abdfdb10f355ecaa13c6a226a694ae7a67785fd7eeebf89f845da0b4f7e4a35561ddc459aba0
   languageName: node
   linkType: hard
 
@@ -21199,13 +21199,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.6.2#~builtin<compat/typescript>":
-  version: 4.8.2
-  resolution: "typescript@patch:typescript@npm%3A4.8.2#~builtin<compat/typescript>::version=4.8.2&hash=493e53"
+"typescript@patch:typescript@^4.8.3#~builtin<compat/typescript>":
+  version: 4.8.3
+  resolution: "typescript@patch:typescript@npm%3A4.8.3#~builtin<compat/typescript>::version=4.8.3&hash=493e53"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 6f49363af8af2fe480da1d5fa68712644438785208b06690a3cbe5e7365fd652c3a0f1e587bc8684d78fb69de3dde4de185c0bad7bb4f3664ddfc813ce8caad6
+  checksum: 0404a09c625df01934ef774b45ce1ca57ccae41cd625fcdbb82056715320d9329e70d9d75c2c732ec6ef947444ca978c189a332b71fa21f5c1437d5a83e24906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[sc-196807]

### Summary:

Follow up to #1314. This PR does a couple (somewhat related) things:
- Updates TypeScript to 4.8
- Fixes the types for react-children-by-type
- Cleans up some comments and names in Tabs a bit

### Test Plan:

- Tests
