### PR TITLE
Tabs cleanup #3

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -9,6 +9,7 @@ const { Default } = composeStories(stories);
 
 describe('<Tabs />', () => {
   generateSnapshots(stories);
+
   it('should focus and select with keyboard controls', () => {
     render(<Default />);
     const firstTab = screen.getByRole('tab', { name: 'Tab Title 1' });
@@ -31,5 +32,13 @@ describe('<Tabs />', () => {
       'aria-selected',
       'true',
     );
+  });
+
+  it('changes the active tab when activeIndex changes', () => {
+    const { rerender } = render(<Default activeIndex={0} />);
+    expect(screen.getByRole('heading', { name: 'Tab 1' })).toBeInTheDocument();
+
+    rerender(<Default activeIndex={1} />);
+    expect(screen.getByRole('heading', { name: 'Tab 2' })).toBeInTheDocument();
   });
 });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -44,11 +44,6 @@ export interface Props {
    * Passed down to initially set the activeIndex state
    */
   activeIndex?: number;
-  /**
-   * The array of items to be passed into the component. The array must take on the specified shape
-   * TODO: improve `any` type
-   */
-  items?: Array<any>;
 }
 
 /**

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -10,7 +10,7 @@ import React, {
   type KeyboardEvent,
 } from 'react';
 import { allByType } from 'react-children-by-type';
-import { useUID } from 'react-uid';
+import { useUID, useUIDSeed } from 'react-uid';
 import styles from './Tabs.module.css';
 import {
   L_ARROW_KEYCODE,
@@ -61,7 +61,7 @@ export const Tabs = ({
   onChange,
   ...other
 }: Props) => {
-  const activeTabId = useUID();
+  const getUID = useUIDSeed();
   const activeTabPanelId = useUID();
   const headerRef = useRef<HTMLDivElement>(null);
   const [activeIndexState, setActiveIndexState] = useState(activeIndex);
@@ -76,6 +76,11 @@ export const Tabs = ({
   const tabRefs = useMemo(
     () => tabs.map(() => React.createRef<HTMLAnchorElement>()),
     [tabs],
+  );
+
+  const tabIds = useMemo(
+    () => tabs.map((tab) => tab.props['aria-labelledby'] || getUID(tab)),
+    [tabs, getUID],
   );
 
   // Set the active tab if the `activeIndex` prop changes.
@@ -181,7 +186,7 @@ export const Tabs = ({
 
   const activeTabPanel = React.cloneElement(tabs[activeIndexState], {
     id: activeTabPanelId,
-    'aria-labelledby': activeTabId,
+    'aria-labelledby': tabIds[activeIndexState],
   });
 
   return (
@@ -200,7 +205,7 @@ export const Tabs = ({
                   styles['tabs__item'],
                   isActive && styles['eds-is-active'],
                 )}
-                key={'tabs-item-' + i}
+                key={tabIds[i]}
                 role="presentation"
               >
                 <a
@@ -208,8 +213,7 @@ export const Tabs = ({
                   aria-selected={isActive}
                   className={styles['tabs__link']}
                   href={`#${activeTabPanelId}`}
-                  id={isActive ? activeTabId : undefined}
-                  key={'tab-' + i}
+                  id={tabIds[i]}
                   onClick={(e) => {
                     e.preventDefault();
                     handleClick(i);

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -209,16 +209,9 @@ export const Tabs = ({
     scrollableRight && styles['tabs--scrollable-right'],
   );
 
-  const childrenWithProps = React.Children.map(tabs, (child, i) => {
-    // Checking isValidElement is the safe way and avoids a typescript
-    // error too.
-    if (React.isValidElement(child)) {
-      return React.cloneElement<Props>(child, {
-        id: tabPanelIds[i],
-        'aria-labelledby': tabIds[i],
-      });
-    }
-    return child;
+  const activeTabPanel = React.cloneElement(tabs[activeIndexState], {
+    id: tabPanelIds[activeIndexState],
+    'aria-labelledby': tabIds[activeIndexState],
   });
 
   return (
@@ -263,7 +256,7 @@ export const Tabs = ({
           })}
         </ul>
       </div>
-      <div>{childrenWithProps[activeIndexState]}</div>
+      <div>{activeTabPanel}</div>
     </div>
   );
 };

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -78,18 +78,10 @@ export const Tabs = ({
     [tabs],
   );
 
-  /**
-   * Set prevActiveIndex to previous value prop
-   *
-   * If prevActiveIndex is defined and previous value prop is not equal
-   * to current value prop, toggle state.
-   */
+  // Set the active tab if the `activeIndex` prop changes.
   const prevActiveIndex = usePrevious(activeIndex);
   useEffect(() => {
-    if (
-      (prevActiveIndex !== undefined || null) &&
-      prevActiveIndex !== activeIndex
-    ) {
+    if (prevActiveIndex != null && prevActiveIndex !== activeIndex) {
       setActiveIndexState(activeIndex);
       tabRefs[activeIndex].current?.focus();
     }

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -10,7 +10,7 @@ import React, {
   type KeyboardEvent,
 } from 'react';
 import { allByType } from 'react-children-by-type';
-import { useUIDSeed } from 'react-uid';
+import { useUID } from 'react-uid';
 import styles from './Tabs.module.css';
 import {
   L_ARROW_KEYCODE,
@@ -61,7 +61,8 @@ export const Tabs = ({
   onChange,
   ...other
 }: Props) => {
-  const getUID = useUIDSeed();
+  const activeTabId = useUID();
+  const activeTabPanelId = useUID();
   const ref = useRef<number | undefined>();
   const headerRef = useRef<HTMLDivElement>(null);
   const [activeIndexState, setActiveIndexState] = useState(activeIndex);
@@ -76,16 +77,6 @@ export const Tabs = ({
   const tabRefs = useMemo(
     () => tabs.map(() => React.createRef<HTMLAnchorElement>()),
     [tabs],
-  );
-
-  const tabPanelIds = useMemo(
-    () => tabs.map((tab, i) => tab.props.id || getUID('panel' + i)),
-    [tabs, getUID],
-  );
-
-  const tabIds = useMemo(
-    () => tabs.map((tab) => tab.props['aria-labelledby'] || getUID(tab)),
-    [tabs, getUID],
   );
 
   /**
@@ -210,8 +201,8 @@ export const Tabs = ({
   );
 
   const activeTabPanel = React.cloneElement(tabs[activeIndexState], {
-    id: tabPanelIds[activeIndexState],
-    'aria-labelledby': tabIds[activeIndexState],
+    id: activeTabPanelId,
+    'aria-labelledby': activeTabId,
   });
 
   return (
@@ -234,11 +225,11 @@ export const Tabs = ({
                 role="presentation"
               >
                 <a
-                  aria-controls={tabPanelIds[i]}
+                  aria-controls={activeTabPanelId}
                   aria-selected={isActive}
                   className={styles['tabs__link']}
-                  href={`#${tabPanelIds[i]}`}
-                  id={tabIds[i]}
+                  href={`#${activeTabPanelId}`}
+                  id={isActive ? activeTabId : undefined}
                   key={'tab-' + i}
                   onClick={(e) => {
                     e.preventDefault();

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -63,7 +63,6 @@ export const Tabs = ({
 }: Props) => {
   const activeTabId = useUID();
   const activeTabPanelId = useUID();
-  const ref = useRef<number | undefined>();
   const headerRef = useRef<HTMLDivElement>(null);
   const [activeIndexState, setActiveIndexState] = useState(activeIndex);
   const [scrollableLeft, setScrollableLeft] = useState<boolean>(false);
@@ -78,18 +77,6 @@ export const Tabs = ({
     () => tabs.map(() => React.createRef<HTMLAnchorElement>()),
     [tabs],
   );
-
-  /**
-   * Get previous prop
-   *
-   * This is used to compare the previous prop to the current prop.
-   */
-  function usePrevious(activeIndex: number) {
-    useEffect(() => {
-      ref.current = activeIndex;
-    });
-    return ref.current;
-  }
 
   /**
    * Set prevActiveIndex to previous value prop
@@ -251,3 +238,14 @@ export const Tabs = ({
     </div>
   );
 };
+
+/**
+ * Get the previous value of a prop. Useful for comparing the previous to the current value.
+ */
+function usePrevious<T>(prop: T) {
+  const ref = useRef<T | undefined>();
+  useEffect(() => {
+    ref.current = prop;
+  });
+  return ref.current;
+}

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -16,11 +16,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid1"
+          aria-controls="1val-panel0"
           aria-selected="true"
           class="tabs__link"
-          href="#1uid1"
-          id="1uid10"
+          href="#1val-panel0"
+          id="1uid1"
           role="tab"
           tabindex="0"
         >
@@ -32,11 +32,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid2"
+          aria-controls="1val-panel1"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid2"
-          id="1uid11"
+          href="#1val-panel1"
+          id="1uid2"
           role="tab"
           tabindex="-1"
         >
@@ -48,11 +48,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid3"
+          aria-controls="1val-panel2"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid3"
-          id="1uid12"
+          href="#1val-panel2"
+          id="1uid3"
           role="tab"
           tabindex="-1"
         >
@@ -64,11 +64,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid4"
+          aria-controls="1val-panel3"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid4"
-          id="1uid13"
+          href="#1val-panel3"
+          id="1uid4"
           role="tab"
           tabindex="-1"
         >
@@ -80,11 +80,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid5"
+          aria-controls="1val-panel4"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid5"
-          id="1uid14"
+          href="#1val-panel4"
+          id="1uid5"
           role="tab"
           tabindex="-1"
         >
@@ -96,11 +96,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid6"
+          aria-controls="1val-panel5"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid6"
-          id="1uid15"
+          href="#1val-panel5"
+          id="1uid6"
           role="tab"
           tabindex="-1"
         >
@@ -112,11 +112,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid7"
+          aria-controls="1val-panel6"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid7"
-          id="1uid16"
+          href="#1val-panel6"
+          id="1uid7"
           role="tab"
           tabindex="-1"
         >
@@ -128,11 +128,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid8"
+          aria-controls="1val-panel7"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid8"
-          id="1uid17"
+          href="#1val-panel7"
+          id="1uid8"
           role="tab"
           tabindex="-1"
         >
@@ -144,11 +144,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1uid9"
+          aria-controls="1val-panel8"
           aria-selected="false"
           class="tabs__link"
-          href="#1uid9"
-          id="1uid18"
+          href="#1val-panel8"
+          id="1uid9"
           role="tab"
           tabindex="-1"
         >
@@ -160,8 +160,8 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
   <div>
     <div
       aria-hidden="false"
-      aria-labelledby="1uid10"
-      id="1uid1"
+      aria-labelledby="1uid1"
+      id="1val-panel0"
       role="tabpanel"
     >
       <div

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -16,11 +16,11 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel0"
+          aria-controls="2"
           aria-selected="true"
           class="tabs__link"
-          href="#1val-panel0"
-          id="1uid1"
+          href="#2"
+          id="1"
           role="tab"
           tabindex="0"
         >
@@ -32,11 +32,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel1"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel1"
-          id="1uid2"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -48,11 +47,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel2"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel2"
-          id="1uid3"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -64,11 +62,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel3"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel3"
-          id="1uid4"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -80,11 +77,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel4"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel4"
-          id="1uid5"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -96,11 +92,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel5"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel5"
-          id="1uid6"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -112,11 +107,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel6"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel6"
-          id="1uid7"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -128,11 +122,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel7"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel7"
-          id="1uid8"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -144,11 +137,10 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
         role="presentation"
       >
         <a
-          aria-controls="1val-panel8"
+          aria-controls="2"
           aria-selected="false"
           class="tabs__link"
-          href="#1val-panel8"
-          id="1uid9"
+          href="#2"
           role="tab"
           tabindex="-1"
         >
@@ -160,8 +152,8 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
   <div>
     <div
       aria-hidden="false"
-      aria-labelledby="1uid1"
-      id="1val-panel0"
+      aria-labelledby="1"
+      id="2"
       role="tabpanel"
     >
       <div

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="true"
           class="tabs__link"
           href="#2"
-          id="1"
+          id="1uid1"
           role="tab"
           tabindex="0"
         >
@@ -36,6 +36,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid2"
           role="tab"
           tabindex="-1"
         >
@@ -51,6 +52,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid3"
           role="tab"
           tabindex="-1"
         >
@@ -66,6 +68,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid4"
           role="tab"
           tabindex="-1"
         >
@@ -81,6 +84,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid5"
           role="tab"
           tabindex="-1"
         >
@@ -96,6 +100,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid6"
           role="tab"
           tabindex="-1"
         >
@@ -111,6 +116,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid7"
           role="tab"
           tabindex="-1"
         >
@@ -126,6 +132,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid8"
           role="tab"
           tabindex="-1"
         >
@@ -141,6 +148,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#2"
+          id="1uid9"
           role="tab"
           tabindex="-1"
         >
@@ -152,7 +160,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
   <div>
     <div
       aria-hidden="false"
-      aria-labelledby="1"
+      aria-labelledby="1uid1"
       id="2"
       role="tabpanel"
     >


### PR DESCRIPTION
### Summary:

More tabs cleanup:
- Remove unused prop
- Simplify getting tab children, refs, and ids
- Don't clone elements that won't be shown
- Fix some logic
- Use good keys

### Test Plan:

- Storybook
- Tests