### PR TITLE
chore(tooltip): allow HTMLElement attributes as props

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -177,6 +177,7 @@ export const TextChild: StoryObj<Args> = {
 
 export const Interactive: StoryObj<Args> = {
   args: {
+    id: 'id-for-testing',
     // reset prop values defined in defaultArgs
     duration: undefined,
     visible: undefined,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -75,7 +75,8 @@ type TooltipProps = {
    * controls if/when the bubble appears (on hover, click, focus, etc).
    */
   visible?: boolean;
-} & TippyProps;
+} & TippyProps &
+  React.HTMLAttributes<HTMLElement>;
 
 // @tippyjs/react does not expose tippy.js types, have to extract via props and grab element type from array type
 type Plugins = NonNullable<React.ComponentProps<typeof Tippy>['plugins']>;


### PR DESCRIPTION
### Summary:
Someone ran into an issue when using the `Tooltip` where Typescript complains when you pass it an `id` prop. To avoid running into this again in the future when someone needs to pass in a `data-testid` or something, I'm extending the prop type to include `React.HTMLAttributes<HTMLElement>`.

### Test Plan:
- I added an `id` prop to one of the stories,
- verified that Typescript threw an error before making the change to the prop types,
- and verified the error stopped after I made the change to the prop types.