### PR TITLE
chore(tooltip): expose appendTo prop and add docstring

### DIFF
--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -13,6 +13,12 @@ type TooltipProps = {
    */
   align?: 'top' | 'right' | 'bottom' | 'left';
   /**
+   * The element or ref to append the tooltip to.
+   * Defaults to the body element.
+   * 'parent' is suggested if used in a modal.
+   */
+  appendTo?: 'parent' | Element | ((ref: Element) => Element);
+  /**
    * Behavior of the tooltip transition, defaults to an opacity "fade".
    * Animation guidelines are provided in https://atomiks.github.io/tippyjs/v5/animations/.
    * To disable animations, pass `duration={0}`.


### PR DESCRIPTION
### Summary:
Exposes the `appendTo` prop from Tippy with docstring
### Test Plan:
- No visual regressions
- Unit tests pass