### PR TITLE
chore(dropdownmenu): close with tab, revert to :focus, close on click

### DIFF
--- a/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
@@ -16,19 +16,35 @@ export default {
   args: {
     children: (
       <>
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            console.log('yeehaw');
+          }}
+        >
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 1
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            console.log('yeehaw');
+          }}
+        >
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 2
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            console.log('yeehaw');
+          }}
+        >
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 3
         </DropdownMenuItem>
-        <DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={() => {
+            console.log('yeehaw');
+          }}
+        >
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 4
         </DropdownMenuItem>

--- a/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
@@ -16,35 +16,19 @@ export default {
   args: {
     children: (
       <>
-        <DropdownMenuItem
-          onClick={() => {
-            console.log('yeehaw');
-          }}
-        >
+        <DropdownMenuItem>
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 1
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => {
-            console.log('yeehaw');
-          }}
-        >
+        <DropdownMenuItem>
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 2
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => {
-            console.log('yeehaw');
-          }}
-        >
+        <DropdownMenuItem>
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 3
         </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={() => {
-            console.log('yeehaw');
-          }}
-        >
+        <DropdownMenuItem>
           <Icon name="schedule" purpose="decorative" size="1.25rem" />
           Item 4
         </DropdownMenuItem>

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import React, { ReactNode, SyntheticEvent } from 'react';
 import styles from './ButtonDropdown.module.css';
 import { DropdownMenu } from '../..';
-import { ESCAPE_KEYCODE } from '../../util/keycodes';
+import { ESCAPE_KEYCODE, TAB_KEYCODE } from '../../util/keycodes';
 import type { ClickableStyleProps } from '../ClickableStyle';
 
 interface FocusEvent<T = Element> extends SyntheticEvent<T> {
@@ -141,7 +141,7 @@ export const ButtonDropdown = ({
    * If the escape key is struck, close the panel.
    */
   function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === ESCAPE_KEYCODE) {
+    if (e.key === ESCAPE_KEYCODE || e.key === TAB_KEYCODE) {
       closePanel();
     }
   }
@@ -172,14 +172,6 @@ export const ButtonDropdown = ({
     },
   );
 
-  const handleBlur = (event: FocusEvent<HTMLDivElement>) => {
-    if (!event.currentTarget.contains(event.relatedTarget as HTMLElement)) {
-      if (isActiveVar) {
-        closePanel();
-      }
-    }
-  };
-
   const componentClassName = clsx(
     styles['button-dropdown'],
     isActiveVar && styles['eds-is-active'],
@@ -189,18 +181,12 @@ export const ButtonDropdown = ({
     className,
   );
   return (
-    <div
-      className={componentClassName}
-      /* TODO: Figure out role that allows blur to entire menu
-      /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */
-      onBlur={handleBlur}
-      ref={ref}
-      {...other}
-    >
+    <div className={componentClassName} ref={ref} {...other}>
       {dropdownMenuTriggerWithProps}
       <DropdownMenu
         className={styles['button-dropdown__dropdown-menu']}
-        handleOnEscDown={(e: React.KeyboardEvent) => handleKeyDown(e)}
+        handleOnEscDown={(e) => handleKeyDown(e)}
+        handleOnTabDown={(e) => handleKeyDown(e)}
         isActive={isActiveVar}
       >
         {children}

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -1,14 +1,9 @@
 import clsx from 'clsx';
-import React, { ReactNode, SyntheticEvent } from 'react';
+import React, { ReactNode } from 'react';
 import styles from './ButtonDropdown.module.css';
 import { DropdownMenu } from '../..';
 import { ESCAPE_KEYCODE, TAB_KEYCODE } from '../../util/keycodes';
 import type { ClickableStyleProps } from '../ClickableStyle';
-
-interface FocusEvent<T = Element> extends SyntheticEvent<T> {
-  relatedTarget: EventTarget | null;
-  target: EventTarget & T;
-}
 
 export interface Props {
   buttonAriaLabel?: string;
@@ -185,6 +180,7 @@ export const ButtonDropdown = ({
       {dropdownMenuTriggerWithProps}
       <DropdownMenu
         className={styles['button-dropdown__dropdown-menu']}
+        handleOnClick={closePanel}
         handleOnEscDown={(e) => handleKeyDown(e)}
         handleOnTabDown={(e) => handleKeyDown(e)}
         isActive={isActiveVar}

--- a/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
+++ b/src/components/ButtonDropdown/__snapshots__/ButtonDropdown.test.tsx.snap
@@ -27,6 +27,7 @@ exports[`<ButtonDropdown /> ComponentWrapped story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -50,6 +51,7 @@ exports[`<ButtonDropdown /> ComponentWrapped story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <div
             style="background-color: blanchedalmond;"
@@ -77,6 +79,7 @@ exports[`<ButtonDropdown /> ComponentWrapped story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -100,6 +103,7 @@ exports[`<ButtonDropdown /> ComponentWrapped story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <div
             style="background-color: blanchedalmond;"
@@ -153,6 +157,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -176,6 +181,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -199,6 +205,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -222,6 +229,7 @@ exports[`<ButtonDropdown /> Default story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -271,6 +279,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -294,6 +303,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -317,6 +327,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -340,6 +351,7 @@ exports[`<ButtonDropdown /> PositionBottomRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -389,6 +401,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -412,6 +425,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -435,6 +449,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -458,6 +473,7 @@ exports[`<ButtonDropdown /> PositionTopLeft story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -507,6 +523,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -530,6 +547,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -553,6 +571,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"
@@ -576,6 +595,7 @@ exports[`<ButtonDropdown /> PositionTopRight story renders snapshot 1`] = `
       >
         <button
           class="dropdown-menu__link"
+          tabindex="-1"
         >
           <svg
             aria-hidden="true"

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -13,7 +13,7 @@
  */
 .dropdown-menu {
   /* Set a minimum width for the dropdown menu. */
-  width: 16rem; 
+  width: 16rem;
   background: var(--eds-theme-color-background-neutral-default);
   border: 1px solid var(--eds-theme-color-border-neutral-subtle);
   border-radius: var(--eds-border-radius-md);
@@ -71,24 +71,12 @@
   color: var(--eds-theme-color-text-neutral-default);
   transition: background var(--eds-anim-fade-quick) var(--eds-anim-ease);
 
-  &:hover,
-  &:focus-visible {
+  &:hover {
     background: var(--eds-theme-color-background-neutral-subtle);
   }
 
-  &:focus-visible {
+  &:focus {
     @mixin focus;
-  }
-
-  @supports not selector(:focus-visible) {
-    &:hover,
-    &:focus {
-      background: var(--eds-theme-color-background-neutral-subtle);
-    }
-
-    &:focus {
-      @mixin focus;
-    }
   }
 
   @media screen and (prefers-reduced-motion) {
@@ -100,7 +88,7 @@
    */
   .dropdown-menu__item--lined & {
     /* Add bottom border to the item. */
-    border-bottom: 1px solid var(--eds-theme-color-border-neutral-subtle); 
+    border-bottom: 1px solid var(--eds-theme-color-border-neutral-subtle);
   }
 
   .dropdown-menu__item--error & {

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
   KeyboardEvent,
   HTMLAttributes,
+  MouseEventHandler,
 } from 'react';
 import styles from './DropdownMenu.module.css';
 import {
@@ -40,6 +41,10 @@ export type Props = {
    * Invoked when the tab key is pressed.
    */
   handleOnTabDown?: (e: React.KeyboardEvent) => void;
+  /**
+   * Invoked when the dropdown menu is clicked. Used to close the dropdown menu.
+   */
+  handleOnClick?: MouseEventHandler;
 } & HTMLAttributes<HTMLElement>;
 
 type Refs = {
@@ -63,6 +68,7 @@ export const DropdownMenu: React.FC<Props> = ({
   children,
   className,
   isActive,
+  handleOnClick,
   handleOnEscDown,
   handleOnTabDown,
   ...other
@@ -143,6 +149,7 @@ export const DropdownMenu: React.FC<Props> = ({
       <div className={componentClassName} {...other}>
         <ul
           className={styles['dropdown-menu__list']}
+          onClick={handleOnClick}
           onKeyDown={onKeyDown}
           role="menu"
         >

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -16,6 +16,7 @@ import {
   ESCAPE_KEYCODE,
   HOME_KEYCODE,
   END_KEYCODE,
+  TAB_KEYCODE,
 } from '../../util/keycodes';
 
 export type Props = {
@@ -35,6 +36,10 @@ export type Props = {
    * Invoked when the escape key is pressed.
    */
   handleOnEscDown?: (e: React.KeyboardEvent) => void;
+  /**
+   * Invoked when the tab key is pressed.
+   */
+  handleOnTabDown?: (e: React.KeyboardEvent) => void;
 } & HTMLAttributes<HTMLElement>;
 
 type Refs = {
@@ -59,6 +64,7 @@ export const DropdownMenu: React.FC<Props> = ({
   className,
   isActive,
   handleOnEscDown,
+  handleOnTabDown,
   ...other
 }) => {
   const refs = useRef<Refs>({
@@ -80,9 +86,12 @@ export const DropdownMenu: React.FC<Props> = ({
   }, [isActive]);
 
   const onKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
-    // Calls callback on escape key trigger, typically to close the menu.
+    // Calls callback on escape and tab key triggers, typically to close the menu.
     if (e.key === ESCAPE_KEYCODE && handleOnEscDown) {
       handleOnEscDown(e);
+    }
+    if (e.key === TAB_KEYCODE && handleOnTabDown) {
+      handleOnTabDown(e);
     }
 
     // Focus next element with right or down arrow key.

--- a/src/components/DropdownMenu/__snapshots__/DropdownMenu.test.tsx.snap
+++ b/src/components/DropdownMenu/__snapshots__/DropdownMenu.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         Item 1
       </button>
@@ -24,6 +25,7 @@ exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         Item 2
       </button>
@@ -34,6 +36,7 @@ exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         Item 3
       </button>
@@ -45,6 +48,7 @@ exports[`<DropdownMenu /> Default story renders snapshot 1`] = `
       <a
         class="dropdown-menu__link"
         href="#"
+        tabindex="-1"
       >
         Item 4
       </a>
@@ -67,6 +71,7 @@ exports[`<DropdownMenu /> WithDeleteButton story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -90,6 +95,7 @@ exports[`<DropdownMenu /> WithDeleteButton story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -113,6 +119,7 @@ exports[`<DropdownMenu /> WithDeleteButton story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -136,6 +143,7 @@ exports[`<DropdownMenu /> WithDeleteButton story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -171,6 +179,7 @@ exports[`<DropdownMenu /> WithIcons story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -194,6 +203,7 @@ exports[`<DropdownMenu /> WithIcons story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -217,6 +227,7 @@ exports[`<DropdownMenu /> WithIcons story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"
@@ -240,6 +251,7 @@ exports[`<DropdownMenu /> WithIcons story renders snapshot 1`] = `
     >
       <button
         class="dropdown-menu__link"
+        tabindex="-1"
       >
         <svg
           aria-hidden="true"

--- a/src/components/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem/DropdownMenuItem.tsx
@@ -99,6 +99,7 @@ export const DropdownMenuItem = ({
         className={styles['dropdown-menu__link']}
         href={href}
         onClick={onClick}
+        tabIndex={-1}
         target={target}
       >
         {children}

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -80,6 +80,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -103,6 +104,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -126,6 +128,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -149,6 +152,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -245,6 +249,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -268,6 +273,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -291,6 +297,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -314,6 +321,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -445,6 +453,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -468,6 +477,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -491,6 +501,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"
@@ -514,6 +525,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
           >
             <button
               class="dropdown-menu__link"
+              tabindex="-1"
             >
               <svg
                 aria-hidden="true"


### PR DESCRIPTION
### Summary:
[sc-216210]
- [slack context](https://czi-edu.slack.com/archives/CTFV79JH4/p1665004863841489)
Motivation: 
- After opening button dropdown via click, the focus lands on the first item, but previously due to `:focus-visible` this is not indicated
- This means that there needs to be separate hover and focus indicators for the dropdown menu items
- In safari, apparently clicking a `<button>` [doesn't focus it](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#clicking_and_focus) for some odd reason and hence keyboard functionality is lost after clicking button

Execution:
- go back to `:focus` from `:focus-visible` and separate from `:hover`
- close dropdown menu on click and on tab to make safari not focusing not a problem (sorry double negative)
  - Items are no longer focusable via tab
  - This follows same behavior as default HeadlessUI menu and Bootstrap menu
  - Items are still cyclable via arrow keys and home / end keys
  - Since items are anchor or button elements anyways, closing is fine 
### Test Plan:
- manual safari testing:

https://user-images.githubusercontent.com/86632227/194253918-ed6bcd61-20e9-4a90-b6db-edeb2ba5927f.mov

- same expected behavior on chrome, and unit tests exist for keyboard navigation
- no visual regression
