### PR TITLE
chore(dropdownmenu, textfield, inputfield): clean up types and onclick, forward ref 

### DIFF
--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -180,7 +180,6 @@ export const ButtonDropdown = ({
       {dropdownMenuTriggerWithProps}
       <DropdownMenu
         className={styles['button-dropdown__dropdown-menu']}
-        handleOnClick={closePanel}
         handleOnEscDown={(e) => handleKeyDown(e)}
         handleOnTabDown={(e) => handleKeyDown(e)}
         isActive={isActiveVar}

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -2,15 +2,13 @@ import clsx from 'clsx';
 import React, { ReactNode } from 'react';
 import styles from './ButtonDropdown.module.css';
 import { DropdownMenu } from '../..';
-import { ESCAPE_KEYCODE, TAB_KEYCODE } from '../../util/keycodes';
 import type { ClickableStyleProps } from '../ClickableStyle';
 
 export interface Props {
-  buttonAriaLabel?: string;
   /**
-   * Makes button full width
+   * Aria label to be attacehd to the dropdown trigger button.
    */
-  fullWidth?: boolean;
+  buttonAriaLabel?: string;
   /**
    * Adds status to the button (e.g. error, success)
    */
@@ -24,9 +22,27 @@ export interface Props {
    */
   buttonVariant?: ClickableStyleProps<'button'>['variant'];
   /**
+   * Prop used to pass in `DropdownMenuItem` child components
+   */
+  children?: ReactNode;
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
    * Disables the field and prevents editing the contents
    */
   disabled?: boolean;
+  /**
+   * Prop used to pass in the dropdown menu trigger (dropdownTrigger={<Button />}). This
+   * allows for maximum flexbility with extending the button and passing in props from the
+   * outside
+   */
+  dropdownMenuTrigger?: ReactNode;
+  /**
+   * Makes button full width
+   */
+  fullWidth?: boolean;
   /**
    * Determines type of clickable
    * - default renders a dropdown menu to the bottom left of the button
@@ -42,20 +58,6 @@ export interface Props {
    * - **reset** The clickable is a reset clickable (resets the form-data to its initial values)
    */
   type?: 'button' | 'reset' | 'submit';
-  /**
-   * Prop used to pass in the dropdown menu trigger (dropdownTrigger={<Button />}). This
-   * allows for maximum flexbility with extending the button and passing in props from the
-   * outside
-   */
-  dropdownMenuTrigger?: ReactNode;
-  /**
-   * Prop used to pass in `DropdownMenuItem` child components
-   */
-  children?: ReactNode;
-  /**
-   * CSS class names that can be appended to the component.
-   */
-  className?: string;
 }
 
 /**
@@ -131,17 +133,6 @@ export const ButtonDropdown = ({
   }
 
   /**
-   * Handle keydown function
-   *
-   * If the escape key is struck, close the panel.
-   */
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === ESCAPE_KEYCODE || e.key === TAB_KEYCODE) {
-      closePanel();
-    }
-  }
-
-  /**
    * Toggle accordion panel
    */
   function togglePanel() {
@@ -151,7 +142,7 @@ export const ButtonDropdown = ({
   const dropdownMenuTriggerWithProps = React.Children.map(
     dropdownMenuTrigger,
     // TODO: improve `any` type
-    (child: any, i: number) => {
+    (child: any) => {
       // Checking isValidElement is the safe way and avoids a typescript
       // error too.
       if (React.isValidElement(child)) {
@@ -180,8 +171,7 @@ export const ButtonDropdown = ({
       {dropdownMenuTriggerWithProps}
       <DropdownMenu
         className={styles['button-dropdown__dropdown-menu']}
-        handleOnEscDown={(e) => handleKeyDown(e)}
-        handleOnTabDown={(e) => handleKeyDown(e)}
+        closeDropdownMenu={closePanel}
         isActive={isActiveVar}
       >
         {children}

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   KeyboardEvent,
   HTMLAttributes,
-  MouseEventHandler,
+  MouseEvent,
 } from 'react';
 import styles from './DropdownMenu.module.css';
 import {
@@ -41,10 +41,6 @@ export type Props = {
    * Invoked when the tab key is pressed.
    */
   handleOnTabDown?: (e: React.KeyboardEvent) => void;
-  /**
-   * Invoked when the dropdown menu is clicked. Used to close the dropdown menu.
-   */
-  handleOnClick?: MouseEventHandler;
 } & HTMLAttributes<HTMLElement>;
 
 type Refs = {
@@ -68,7 +64,6 @@ export const DropdownMenu: React.FC<Props> = ({
   children,
   className,
   isActive,
-  handleOnClick,
   handleOnEscDown,
   handleOnTabDown,
   ...other
@@ -141,6 +136,13 @@ export const DropdownMenu: React.FC<Props> = ({
       // prevents page from scrolling
       e.preventDefault();
     }
+  };
+
+  const handleOnClick = (e: MouseEvent) => {
+    focusIndex = refs.current.list.findIndex((ref) =>
+      ref.contains(e.target as HTMLElement),
+    );
+    focusItem(focusIndex);
   };
 
   const componentClassName = clsx(styles['dropdown-menu'], className);

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,7 +6,7 @@ import React, {
   useEffect,
   KeyboardEvent,
   HTMLAttributes,
-  MouseEvent,
+  MouseEventHandler,
 } from 'react';
 import styles from './DropdownMenu.module.css';
 import {
@@ -34,13 +34,9 @@ export type Props = {
    */
   isActive?: boolean;
   /**
-   * Invoked when the escape key is pressed.
+   * Callback used to close the dropdown menu. Typically sets active state to false in parent.
    */
-  handleOnEscDown?: (e: React.KeyboardEvent) => void;
-  /**
-   * Invoked when the tab key is pressed.
-   */
-  handleOnTabDown?: (e: React.KeyboardEvent) => void;
+  closeDropdownMenu?: () => void;
 } & HTMLAttributes<HTMLElement>;
 
 type Refs = {
@@ -63,9 +59,8 @@ export const DropdownMenuContext = createContext<ContextRefs | null>(null);
 export const DropdownMenu: React.FC<Props> = ({
   children,
   className,
+  closeDropdownMenu,
   isActive,
-  handleOnEscDown,
-  handleOnTabDown,
   ...other
 }) => {
   const refs = useRef<Refs>({
@@ -87,12 +82,12 @@ export const DropdownMenu: React.FC<Props> = ({
   }, [isActive]);
 
   const onKeyDown = (e: KeyboardEvent<HTMLUListElement>) => {
-    // Calls callback on escape and tab key triggers, typically to close the menu.
-    if (e.key === ESCAPE_KEYCODE && handleOnEscDown) {
-      handleOnEscDown(e);
-    }
-    if (e.key === TAB_KEYCODE && handleOnTabDown) {
-      handleOnTabDown(e);
+    // Calls callback on escape or tab key, typically to close the menu.
+    if (
+      (e.key === ESCAPE_KEYCODE || e.key === TAB_KEYCODE) &&
+      closeDropdownMenu
+    ) {
+      closeDropdownMenu();
     }
 
     // Focus next element with right or down arrow key.
@@ -138,7 +133,7 @@ export const DropdownMenu: React.FC<Props> = ({
     }
   };
 
-  const handleOnClick = (e: MouseEvent) => {
+  const handleOnClick: MouseEventHandler = (e) => {
     focusIndex = refs.current.list.findIndex((ref) =>
       ref.contains(e.target as HTMLElement),
     );

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -88,6 +88,8 @@ export const DropdownMenu: React.FC<Props> = ({
       closeDropdownMenu
     ) {
       closeDropdownMenu();
+      // Prevents focus from moving onto next element in tab order and keeps it on trigger button.
+      e.preventDefault();
     }
 
     // Focus next element with right or down arrow key.

--- a/src/components/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem/DropdownMenuItem.tsx
@@ -24,7 +24,7 @@ export type DropdownMenuItemProps = {
   /**
    * On click handler for component
    */
-  onClick?: () => void;
+  onClick?: MouseEventHandler;
   /**
    * On hover handler for component
    */

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ChangeEventHandler } from 'react';
+import React, { ChangeEventHandler, forwardRef } from 'react';
 import styles from './InputField.module.css';
 
 export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
@@ -121,25 +121,23 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
  *
  * Text input component for one line of text. For multiple lines, consider the Textarea component.
  */
-export const InputField = ({
-  className,
-  disabled,
-  id,
-  isError,
-  ...other
-}: InputFieldProps) => {
-  const componentClassName = clsx(
-    styles['input-field'],
-    isError && styles['error'],
-    className,
-  );
+export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
+  ({ className, disabled, id, isError, ...other }, ref) => {
+    const componentClassName = clsx(
+      styles['input-field'],
+      isError && styles['error'],
+      className,
+    );
 
-  return (
-    <input
-      className={componentClassName}
-      disabled={disabled}
-      id={id}
-      {...other}
-    />
-  );
-};
+    return (
+      <input
+        className={componentClassName}
+        disabled={disabled}
+        id={id}
+        ref={ref}
+        {...other}
+      />
+    );
+  },
+);
+InputField.displayName = 'InputField';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { ChangeEventHandler, ReactNode } from 'react';
+import React, { ChangeEventHandler, forwardRef, ReactNode } from 'react';
 import { useUID } from 'react-uid';
 import styles from './TextField.module.css';
 import FieldNote from '../FieldNote';
@@ -125,78 +125,89 @@ export interface Props {
  * ```ts
  * import {TextField} from "@chanzuckerberg/eds";
  */
-export const TextField = ({
-  'aria-describedby': ariaDescribedBy,
-  className,
-  disabled,
-  fieldNote,
-  id,
-  inputWithin,
-  isError,
-  label,
-  required,
-  type = 'text',
-  ...other
-}: Props) => {
-  if (process.env.NODE_ENV !== 'production' && !label && !other['aria-label']) {
-    throw new Error('You must provide a visible label or aria-label');
-  }
+export const TextField = forwardRef<HTMLInputElement, Props>(
+  (
+    {
+      'aria-describedby': ariaDescribedBy,
+      className,
+      disabled,
+      fieldNote,
+      id,
+      inputWithin,
+      isError,
+      label,
+      required,
+      type = 'text',
+      ...other
+    },
+    ref,
+  ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      !label &&
+      !other['aria-label']
+    ) {
+      throw new Error('You must provide a visible label or aria-label');
+    }
 
-  const shouldRenderOverline = !!(label || required);
-  const overlineClassName = clsx(
-    styles['text-field__overline'],
-    !label && styles['text-field__overline--no-label'],
-    disabled && styles['text-field__overline--disabled'],
-  );
+    const shouldRenderOverline = !!(label || required);
+    const overlineClassName = clsx(
+      styles['text-field__overline'],
+      !label && styles['text-field__overline--no-label'],
+      disabled && styles['text-field__overline--disabled'],
+    );
 
-  const generatedId = useUID();
-  const idVar = id || generatedId;
+    const generatedId = useUID();
+    const idVar = id || generatedId;
 
-  const generatedAriaDescribedById = useUID();
-  const ariaDescribedByVar = fieldNote
-    ? ariaDescribedBy || generatedAriaDescribedById
-    : undefined;
+    const generatedAriaDescribedById = useUID();
+    const ariaDescribedByVar = fieldNote
+      ? ariaDescribedBy || generatedAriaDescribedById
+      : undefined;
 
-  return (
-    <div className={className}>
-      {shouldRenderOverline && (
-        <div className={overlineClassName}>
-          {label && <Label htmlFor={idVar} text={label} />}
-          {required && (
-            <Text as="p" size="sm">
-              Required
-            </Text>
-          )}
-        </div>
-      )}
-
-      <div className={styles['text-field__body']}>
-        <InputField
-          aria-describedby={ariaDescribedByVar}
-          aria-invalid={!!isError}
-          data-bootstrap-override="inputfield"
-          disabled={disabled}
-          id={idVar}
-          isError={isError}
-          required={required}
-          type={type}
-          {...other}
-        />
-        {inputWithin && (
-          <div className={styles['text-field__input-within']}>
-            {inputWithin}
+    return (
+      <div className={className}>
+        {shouldRenderOverline && (
+          <div className={overlineClassName}>
+            {label && <Label htmlFor={idVar} text={label} />}
+            {required && (
+              <Text as="p" size="sm">
+                Required
+              </Text>
+            )}
           </div>
         )}
+
+        <div className={styles['text-field__body']}>
+          <InputField
+            aria-describedby={ariaDescribedByVar}
+            aria-invalid={!!isError}
+            data-bootstrap-override="inputfield"
+            disabled={disabled}
+            id={idVar}
+            isError={isError}
+            ref={ref}
+            required={required}
+            type={type}
+            {...other}
+          />
+          {inputWithin && (
+            <div className={styles['text-field__input-within']}>
+              {inputWithin}
+            </div>
+          )}
+        </div>
+        {fieldNote && (
+          <FieldNote
+            disabled={disabled}
+            id={ariaDescribedByVar}
+            isError={isError}
+          >
+            {fieldNote}
+          </FieldNote>
+        )}
       </div>
-      {fieldNote && (
-        <FieldNote
-          disabled={disabled}
-          id={ariaDescribedByVar}
-          isError={isError}
-        >
-          {fieldNote}
-        </FieldNote>
-      )}
-    </div>
-  );
-};
+    );
+  },
+);
+TextField.displayName = 'TextField';

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -7,7 +7,7 @@ import InputField from '../InputField';
 import Label from '../Label';
 import Text from '../Text';
 
-export interface Props {
+export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
   /**
    * Aria-describedby id string
    */
@@ -56,6 +56,10 @@ export interface Props {
    * HTML label text
    */
   label?: string;
+  /**
+   * Maximum value allowed for the input, if type is 'number'. When the input value matches this maximum, the plus button becomes disabled.
+   */
+  max?: number;
   /**
    * Max number of characters for the text input
    */
@@ -117,7 +121,7 @@ export interface Props {
    * Default value passed down from higher levels for initial state
    */
   defaultValue?: string | number;
-}
+};
 
 /**
  * BETA: This component is still a work in progress and is subject to change.


### PR DESCRIPTION
### Summary:
Due to `projectCard` using `buttonDropdown`/`dropdownMenu` and not `popover` some issues arise as it tries to use secondary functionality when dropdown menus should purely be primary functionality (aka anchor and button elements only)
![image](https://user-images.githubusercontent.com/86632227/194485019-bd6f5942-c725-41c1-addc-c54fdf2684f2.png)
This panel with the `TextField` and `ButtonGroup` is rendered when a menu item is clicked, so it initially made sense to use a dropdown menu.

[While projectCard is being worked on to use popover instead](https://app.shortcut.com/czi-edu/story/224122/use-popover-and-not-dropdown-in-project-card), we need to support this secondary functionality in a dropdown menu.

Hence changes in this pr: 
- no longer closes dropdownmenu on close
- forwards ref to the input element in `TextField` and `InputField`
- clean up work with types

### Test Plan:
- alpha build created with the changes from this pr, and is being used in https://github.com/FB-PLP/traject/pull/12436
- no visual regressions in both eds or in LP using alpha build
- in both eds and LP using alpha build:
  - project card dropdown should cycle via arrow, home, and end keys when in menu mode
  - project card dropdown should close with escape or tab when in menu mode
- in LP using alpha build [course plan edit story](https://614b969675171d003ac6f98a-tlejigwjjt.chromatic.com/?path=/story/teachers-courses-courseplan-courseplanwizard--course-plan-edit), arrive at the previous screenshot dropdown by clicking the three dots on a card and click "Adjust instructional blocks":
![image](https://user-images.githubusercontent.com/86632227/194486464-5d4fc837-cc58-4857-a6fe-c9ee4ed609d2.png)
  - in secondary func dropdown:
    - tab should cycle through tabbable elements
    - if tab leaves tabbable elements (shift+tab on inputfield or tab on last button), dropdown should close
    - escape closes dropdown
