### PR TITLE
chore(tabs): add size for tabs right mask

### DIFF
--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -34,7 +34,11 @@
 }
 
 .tabs--scrollable-right {
-  -webkit-mask-image: -webkit-linear-gradient(right, transparent);
+  -webkit-mask-image: -webkit-linear-gradient(
+    right,
+    transparent,
+    white var(--eds-size-8)
+  );
 }
 
 .tabs--scrollable-left.tabs--scrollable-right {

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryObj, Meta } from '@storybook/react';
+import { within } from '@storybook/testing-library';
 import React from 'react';
 
 import { Tabs } from './Tabs';
@@ -130,4 +131,55 @@ export const Default: StoryObj<Args> = {
   parameters: {
     chromatic: { viewports: [414, 1366] },
   },
+};
+
+// For visual regression testing of both masks
+export const ScrollMiddle: StoryObj<Args> = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+    chromatic: { viewports: [414] },
+    snapshot: { skip: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tablist = await canvas.findByRole('tablist');
+    // eslint-disable-next-line testing-library/no-node-access
+    tablist?.parentElement?.scroll(50, 0);
+  },
+  decorators: [
+    (Story) => (
+      <div>
+        For Chromatic visual regression testing of the masks on both sides of
+        the Tabs. Currently does not work properly on local.
+        <Story />
+      </div>
+    ),
+  ],
+};
+// For visual regression testing of the left mask
+export const ScrollEnd: StoryObj<Args> = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile2',
+    },
+    chromatic: { viewports: [414] },
+    snapshot: { skip: true },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tablist = await canvas.findByRole('tablist');
+    // eslint-disable-next-line testing-library/no-node-access
+    tablist?.parentElement?.scroll(1000, 0);
+  },
+  decorators: [
+    (Story) => (
+      <div>
+        For Chromatic visual regression testing of the masks on the left side of
+        the Tabs. Currently does not work properly on local.
+        <Story />
+      </div>
+    ),
+  ],
 };

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -126,4 +126,8 @@ export default {
 
 type Args = React.ComponentProps<typeof Tabs>;
 
-export const Default: StoryObj<Args> = {};
+export const Default: StoryObj<Args> = {
+  parameters: {
+    chromatic: { viewports: [414, 1366] },
+  },
+};


### PR DESCRIPTION
### Summary:
- noticed right mask for tabs was not being styled correctly, adds size to show mask
![image](https://user-images.githubusercontent.com/86632227/195406367-6a61da72-3715-450f-85ee-7d49eec79422.png)

### Test Plan:
- right mask exists in deployed storybook