### PR TITLE
fix(icons): remove mask from play icon

### DIFF
--- a/src/icons/play-arrow.svg
+++ b/src/icons/play-arrow.svg
@@ -1,8 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<mask id="mask0_2618_11853" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
-<rect width="24" height="24" fill="#D9D9D9"/>
-</mask>
-<g mask="url(#mask0_2618_11853)">
-<path d="M8 19V5L19 12L8 19Z" />
-</g>
+<path d="M8 19V5L19 12L8 19Z" fill="#5D6369"/>
 </svg>

--- a/src/icons/spritemap/spritemap.svg
+++ b/src/icons/spritemap/spritemap.svg
@@ -344,12 +344,7 @@
 
 </symbol>
 <symbol id="play-arrow" viewBox="0 0 24 24">
-<mask id="mask0_2618_11853" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="24" height="24">
-<rect width="24" height="24" fill="#D9D9D9"/>
-</mask>
-<g mask="url(#mask0_2618_11853)">
-<path d="M8 19V5L19 12L8 19Z"/>
-</g>
+<path d="M8 19V5L19 12L8 19Z" fill="#5D6369"/>
 
 </symbol>
 <symbol id="print" viewBox="0 0 24 24">


### PR DESCRIPTION
### Summary:

[sc-201336] This icon included a bounding rectangle in figma, which was causing a strange appearance in Firefox, and was inconsistent with the other icons. Import a new icon that does not have this mask, but preserves the same dimensions. Tested in Firefox and other Webkit-based browsers.

### Test Plan:

- test icon layout in chrome / firefox : http://localhost:9000/?path=/story/atoms-icons-icongrid--default
- ensure icon is not clipped