### PR TITLE
Auto accept chromatic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
             --storybook-build-dir storybook-static \
             --exit-zero-on-changes \
             --exit-once-uploaded \
+            --auto-accept-changes '{main,next}' \
             --skip 'dependabot/**'
       - name: Run Accessibility Tests 💛
         run: yarn run storybook:axeOnly


### PR DESCRIPTION
### Summary:

Auto accept chromatic changes on the `next` and `main` branches.

I noticed there were changes on `next`. Definitely indicates some flakiness, but I think it's best to assume that what's on `main`/`next` is correct (or at least that's what we do in LP and Along... but what do YOU think?).

### Test Plan:

🤞 