### PR TITLE
chore(buttondropdown): apply class name to dropdown menu

### DIFF
--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -27,7 +27,7 @@ export interface Props {
    */
   children?: ReactNode;
   /**
-   * CSS class names that can be appended to the component.
+   * CSS class names that can be appended to the component to further style the dropdown menu.
    */
   className?: string;
   /**
@@ -168,11 +168,17 @@ export const ButtonDropdown = ({
     position === 'bottom-right' && styles['button-dropdown--bottom-right'],
     className,
   );
+
+  const dropdownMenuClassName = clsx(
+    styles['button-dropdown__dropdown-menu'],
+    className,
+  );
+
   return (
     <div className={componentClassName} ref={ref} {...other}>
       {dropdownMenuTriggerWithProps}
       <DropdownMenu
-        className={styles['button-dropdown__dropdown-menu']}
+        className={dropdownMenuClassName}
         closeDropdownMenu={closePanel}
         isActive={isActiveVar}
       >

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -166,7 +166,6 @@ export const ButtonDropdown = ({
     position === 'top-left' && styles['button-dropdown--top-left'],
     position === 'top-right' && styles['button-dropdown--top-right'],
     position === 'bottom-right' && styles['button-dropdown--bottom-right'],
-    className,
   );
 
   const dropdownMenuClassName = clsx(

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -136,7 +136,6 @@ export const ProjectCard = ({
       {buttonDropdownItems && (
         <CardFooter className={styles['project-card__footer']}>
           <ButtonDropdown
-            className={styles['project-card__button-dropdown']}
             dropdownMenuTrigger={
               <Button
                 aria-label="Open project dropdown"

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
     class="card__footer project-card__footer"
   >
     <div
-      class="button-dropdown project-card__button-dropdown"
+      class="button-dropdown"
     >
       <button
         aria-expanded="false"
@@ -215,7 +215,7 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
     class="card__footer project-card__footer"
   >
     <div
-      class="button-dropdown project-card__button-dropdown"
+      class="button-dropdown"
     >
       <button
         aria-expanded="false"
@@ -419,7 +419,7 @@ exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
     class="card__footer project-card__footer"
   >
     <div
-      class="button-dropdown project-card__button-dropdown"
+      class="button-dropdown"
     >
       <button
         aria-expanded="false"


### PR DESCRIPTION
### Summary:
- applies the className prop in `ButtonDropdown` to `DropdownMenu` and not the wrapper
- the trigger button and the items can already be styled individually, just not the menu through `ButtonDropdown`
### Test Plan:
- no visual regression
- unit tests pass