### PR TITLE
chore(tabs): unflake scroll end story

### DIFF
--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -158,28 +158,3 @@ export const ScrollMiddle: StoryObj<Args> = {
     ),
   ],
 };
-// For visual regression testing of the left mask
-export const ScrollEnd: StoryObj<Args> = {
-  parameters: {
-    viewport: {
-      defaultViewport: 'mobile2',
-    },
-    chromatic: { delay: 300, viewports: [414] },
-    snapshot: { skip: true },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const tablist = await canvas.findByRole('tablist');
-    // eslint-disable-next-line testing-library/no-node-access
-    tablist?.parentElement?.scroll(2000, 0);
-  },
-  decorators: [
-    (Story) => (
-      <div>
-        For Chromatic visual regression testing of the masks on the left side of
-        the Tabs. Currently does not work properly on local.
-        <Story />
-      </div>
-    ),
-  ],
-};

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -164,7 +164,7 @@ export const ScrollEnd: StoryObj<Args> = {
     viewport: {
       defaultViewport: 'mobile2',
     },
-    chromatic: { viewports: [414] },
+    chromatic: { delay: 300, viewports: [414] },
     snapshot: { skip: true },
   },
   play: async ({ canvasElement }) => {

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -171,7 +171,7 @@ export const ScrollEnd: StoryObj<Args> = {
     const canvas = within(canvasElement);
     const tablist = await canvas.findByRole('tablist');
     // eslint-disable-next-line testing-library/no-node-access
-    tablist?.parentElement?.scroll(1000, 0);
+    tablist?.parentElement?.scroll(2000, 0);
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
### Summary:
- scrolls even farther to ensure scrolled fully
- adds delay to account for viewport size change
- this story should just be removed if chromatic continues to flake
### Test Plan:
- ran chromatic locally 3 times and got the same visual result
  - https://www.chromatic.com/build?appId=61313967cde49b003ae2a860&number=2863
  - https://www.chromatic.com/build?appId=61313967cde49b003ae2a860&number=2862
  - https://www.chromatic.com/build?appId=61313967cde49b003ae2a860&number=2861
- no visual regression
- unit tests pass