### PR TITLE
docs(publishing): add warning about terminal message suggesting you publish the version

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -27,6 +27,8 @@ We follow a [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)
 
 #### Cutting a release branch
 
+_Warning: In step 4 you will see a message in your terminal with instructions on publising the package. Ignore the message in your terminal and follow the instructions in this guide instead. We send the release branch through the pull request review process before publishing._
+
 1. Confirm that all checks are green on CI.
 2. Run `git checkout next && git pull origin next` to ensure you have the most up-to-date changes.
 3. Run `git checkout -b release-v<version>`
@@ -52,7 +54,7 @@ git push --follow-tags origin <branch>
 #### Merging a release branch
 
 6. Open a pull request for the release branch, merging into **`main`**. Merge the PR through a **merge commit**:
-   ![Screen Shot 2022-05-26 at 10 56 20 AM](https://user-images.githubusercontent.com/15840841/170514789-4f936ba2-c63d-486c-827a-b9e9e86b612e.png)
+   ![github user interface showing a dropdown with the different merge options. the option "create a merge commit" is highlighted](https://user-images.githubusercontent.com/15840841/170514789-4f936ba2-c63d-486c-827a-b9e9e86b612e.png)
 
 This is important to ensure `next` and `main` stay in sync!
 


### PR DESCRIPTION
### Summary:
I was just going through the release publish flow, following our publishing documentation, with @booc0mtaco and accidentally published the version before sending it through the pull request review process because of that message printed in the terminal after running `yarn release`. I normally don't publish the version until after the release PR has been reviewed (which is what our documentation says to do), but I was led astray by the siren song of the confusing terminal message. The message (which reads "Run \`git push --follow-tags origin release-v[some version] && npm publish\` to publish") comes from the [standard-release package](https://github.com/conventional-changelog/standard-version/blob/f5bff12515aadf5f532c2e7a992c929c5f633469/lib/lifecycles/tag.js#L38), so I don't think we can change it, only warn others to ignore it.

In this PR, I'm adding a line to the documentation to note that the terminal message is coming up for you to ignore. Another solution could be adding a script that logs our own message after `standard-version` is run telling you to ignore the instruction just printed and go back to the documentation instead. I'm open to thoughts on other ways to handle this.

I also updated the alt text for the merge commit screenshot in the publishing documentation because I just happened to notice that it was using the original file name.

### Test Plan:
I previewed the readme in visual studio code to verify the new warning is now present.
<img width="629" alt="preview of publishing documentation in visual studio code" src="https://user-images.githubusercontent.com/7761701/196261850-19f8db13-1b05-41a4-b6a1-bef5cf0ac00d.png">
