### PR TITLE
chore(tab): export props as type

### DIFF
--- a/src/components/Tab/index.ts
+++ b/src/components/Tab/index.ts
@@ -1,2 +1,2 @@
 export { Tab as default } from './Tab';
-export { Props as TabProps } from './Tab';
+export type { Props as TabProps } from './Tab';


### PR DESCRIPTION
### Summary:
I noticed a console warning in storybook about `Tab` not having an export called `Props`:
```
./src/components/Tab/index.ts 2:0-42"export 'Props' (reexported as 'TabProps') was not found in './Tab'
```

<img width="1625" alt="console warning in storybook" src="https://user-images.githubusercontent.com/7761701/196291784-334a7d09-26f0-4842-93ae-ee57af900fb8.png">

This PR removes the warning by exporting `Props` as a `type`.

### Test Plan:
Boot up storybook,
open the browser console,
and verify the warning's gone.