### PR TITLE
fix(icons): remove play-arrow hard-coded fill color

### DIFF
--- a/src/icons/play-arrow.svg
+++ b/src/icons/play-arrow.svg
@@ -1,3 +1,3 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M8 19V5L19 12L8 19Z" fill="#5D6369"/>
+<path d="M8 19V5L19 12L8 19Z" />
 </svg>

--- a/src/icons/spritemap/spritemap.svg
+++ b/src/icons/spritemap/spritemap.svg
@@ -344,7 +344,7 @@
 
 </symbol>
 <symbol id="play-arrow" viewBox="0 0 24 24">
-<path d="M8 19V5L19 12L8 19Z" fill="#5D6369"/>
+<path d="M8 19V5L19 12L8 19Z"/>
 
 </symbol>
 <symbol id="print" viewBox="0 0 24 24">


### PR DESCRIPTION
### Summary:
In https://github.com/FB-PLP/traject/pull/12532 we updated the `play-arrow` icon to no longer have a mask. This involved reexporting the icon from figma, which brought along a hard-coded fill color. That hard-coded fill color blocked the icon color from being changed. This PR removes the `fill` attribute to be consistent with the other icons.

### Test Plan:
Navigate to the [icon story in storybook](http://localhost:9000/?path=/docs/atoms-icons-icon--default),
switch to the "docs" tab (if it's not there already),
in the props list, change the icon to "play-arrow" and the color to something random (like grape 800),
and verify the icon color changes to the selected color.

<img width="1483" alt="" src="https://user-images.githubusercontent.com/7761701/196821667-9eb06983-a4ba-4281-8e17-9e9fd49e8fc7.png">

