### PR TITLE
chore: configure tailwind to allow nested css in eds

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -8,8 +8,6 @@ module.exports = {
     'tailwindcss/nesting': {},
     'postcss-mixins': {},
     'postcss-simple-vars': { variables: breakpoints },
-    // TODO: replace with tailwindcss/nesting (https://tailwindcss.com/docs/using-with-preprocessors#nesting)
-    // to silence warnings; for some reason this is not working currently.
     'postcss-nested': {},
     tailwindcss: {},
   },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,6 +5,7 @@ module.exports = {
     'postcss-import': {
       addModulesDirectories: ['node_modules'],
     },
+    'tailwindcss/nesting': {},
     'postcss-mixins': {},
     'postcss-simple-vars': { variables: breakpoints },
     // TODO: replace with tailwindcss/nesting (https://tailwindcss.com/docs/using-with-preprocessors#nesting)


### PR DESCRIPTION
### Summary:
This PR is to configure the tailwind to allow nested css in eds ,to handle the bunch of warnings in the dev console in EDS storybook complaining about tailwind not being configured to handle nested CSS.
### Test Plan:
