### PR TITLE
chore(projectcard)!: add metaIconName to allow custom meta icons and remove if not present

### DIFF
--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -384,6 +384,7 @@ export const CoursePlannerEdit = () => {
           behavior="draggable"
           buttonDropdownItems={projectCardMenuItemsWithDelete()}
           meta="12 days"
+          metaIconName="event-note"
           number={1}
           numberAriaLabel="Project 1"
           title="Longer project card title that wraps"
@@ -397,6 +398,7 @@ export const CoursePlannerEdit = () => {
           behavior="draggable"
           buttonDropdownItems={projectCardMenuItems()}
           meta="12 days"
+          metaIconName="event-note"
           number={indexState}
           numberAriaLabel="Project 2"
           title="Project card title"
@@ -410,6 +412,7 @@ export const CoursePlannerEdit = () => {
           behavior="draggable"
           buttonDropdownItems={projectCardMenuItems()}
           meta="12 days"
+          metaIconName="event-note"
           number={3}
           numberAriaLabel="Project 3"
           title="Project card title"
@@ -423,6 +426,7 @@ export const CoursePlannerEdit = () => {
           behavior="draggable"
           buttonDropdownItems={projectCardMenuItems()}
           meta="12 days"
+          metaIconName="event-note"
           number={4}
           numberAriaLabel="Project 4"
           title="Project card title"
@@ -437,6 +441,7 @@ export const CoursePlannerEdit = () => {
           buttonDropdownItems={projectCardMenuItems()}
           buttonDropdownPosition="top-left"
           meta="12 days"
+          metaIconName="event-note"
           number={5}
           numberAriaLabel="Project 5"
           title="Project card title"
@@ -451,6 +456,7 @@ export const CoursePlannerEdit = () => {
           buttonDropdownItems={projectCardMenuItems()}
           buttonDropdownPosition="top-left"
           meta="12 days"
+          metaIconName="event-note"
           number={6}
           numberAriaLabel="Project 6"
           title="Project card title"

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -604,6 +604,7 @@ const InteractiveDragDrop = () => {
         <ProjectCard
           behavior="draggable"
           meta="12 days"
+          metaIconName="event-note"
           number={1}
           numberAriaLabel="Project 1"
           title="Longer project card title that wraps lorem ipsum dolor"
@@ -616,6 +617,7 @@ const InteractiveDragDrop = () => {
         <ProjectCard
           behavior="draggable"
           meta="12 days"
+          metaIconName="event-note"
           number={indexState}
           numberAriaLabel="Project 2"
           title="Project card title"
@@ -628,6 +630,7 @@ const InteractiveDragDrop = () => {
         <ProjectCard
           behavior="draggable"
           meta="12 days"
+          metaIconName="event-note"
           number={3}
           numberAriaLabel="Project 3"
           title="Project card title"
@@ -639,7 +642,8 @@ const InteractiveDragDrop = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          meta="12 days"
+          meta="face icon"
+          metaIconName="face"
           number={4}
           numberAriaLabel="Project 4"
           title="Project card title"
@@ -651,22 +655,10 @@ const InteractiveDragDrop = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          meta="12 days"
+          meta="no icon"
           number={5}
           numberAriaLabel="Project 5"
-          title="Project card title"
-        />
-      ),
-    },
-    'item-6': {
-      title: 'Project #6',
-      children: (
-        <ProjectCard
-          behavior="draggable"
-          meta="12 days"
-          number={6}
-          numberAriaLabel="Project 6"
-          title="Project card title"
+          title="Hi"
         />
       ),
     },

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.ts.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.ts.snap
@@ -1184,10 +1184,10 @@ exports[`<DragDrop /> Interactive story renders snapshot 1`] = `
                     xmlns="http://www.w3.org/2000/svg"
                   >
                     <use
-                      xlink:href="test-file-stub#event-note"
+                      xlink:href="test-file-stub#face"
                     />
                   </svg>
-                  12 days
+                  face icon
                 </div>
               </div>
             </article>
@@ -1241,25 +1241,12 @@ exports[`<DragDrop /> Interactive story renders snapshot 1`] = `
                 <h3
                   class="heading heading--size-body-sm heading--neutral-strong project-card__title"
                 >
-                  Project card title
+                  Hi
                 </h3>
                 <div
                   class="project-card__meta"
                 >
-                  <svg
-                    aria-hidden="true"
-                    class="icon project-card__meta-icon"
-                    fill="currentColor"
-                    height="0.875rem"
-                    style="--icon-size: 0.875rem;"
-                    width="0.875rem"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <use
-                      xlink:href="test-file-stub#event-note"
-                    />
-                  </svg>
-                  12 days
+                  no icon
                 </div>
               </div>
             </article>

--- a/src/components/ProjectCard/ProjectCard.stories.tsx
+++ b/src/components/ProjectCard/ProjectCard.stories.tsx
@@ -16,7 +16,6 @@ type Args = React.ComponentProps<typeof ProjectCard>;
 export const Default: StoryObj<Args> = {
   args: {
     title: 'Project card title',
-    meta: '12 days',
     number: 1,
     numberAriaLabel: 'Project 1',
     buttonDropdownItems: (
@@ -46,6 +45,34 @@ export const Draggable: StoryObj<Args> = {
   args: {
     behavior: 'draggable',
     title: 'DragDropItem provides handle to the left',
+    numberAriaLabel: 'Project 1',
+    buttonDropdownItems: (
+      <>
+        <DropdownMenuItem>
+          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+          Move to other section
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+          Move up
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+          Move down
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+          Move view details
+        </DropdownMenuItem>
+      </>
+    ),
+  },
+};
+
+export const WithMeta: StoryObj<Args> = {
+  args: {
+    number: 1,
+    title: 'Project card title',
     meta: '12 days',
     numberAriaLabel: 'Project 1',
     buttonDropdownItems: (
@@ -71,31 +98,10 @@ export const Draggable: StoryObj<Args> = {
   },
 };
 
-export const WithoutMeta: StoryObj<Args> = {
+export const WithMetaIcon: StoryObj<Args> = {
   args: {
-    number: 1,
-    title: 'Project card title',
-    numberAriaLabel: 'Project 1',
-    buttonDropdownItems: (
-      <>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
-          Move to other section
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
-          Move up
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
-          Move down
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
-          Move view details
-        </DropdownMenuItem>
-      </>
-    ),
+    ...WithMeta.args,
+    metaIconName: 'event-note',
   },
 };
 
@@ -103,7 +109,6 @@ export const WithoutDropdown: StoryObj<Args> = {
   args: {
     number: 1,
     title: 'DragDropItem provides handle to the left',
-    meta: '12 days',
     numberAriaLabel: 'Project 1',
   },
 };

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -16,6 +16,8 @@ import {
 } from '../..';
 import type { HeadingElement } from '../Heading';
 
+import type { IconName } from '../Icon';
+
 export interface Props {
   /**
    * Determines type of clickable
@@ -54,6 +56,10 @@ export interface Props {
    */
   meta?: string;
   /**
+   * Project card meta icon name. Should be appropriate EDS icon name.
+   */
+  metaIconName?: IconName;
+  /**
    * Project card number
    */
   number?: number;
@@ -76,6 +82,7 @@ export const ProjectCard = ({
   className,
   title,
   meta,
+  metaIconName,
   number,
   headingAs = 'h3',
   buttonDropdownItems,
@@ -123,12 +130,14 @@ export const ProjectCard = ({
         </Heading>
         {meta && (
           <div className={styles['project-card__meta']}>
-            <Icon
-              className={styles['project-card__meta-icon']}
-              name="event-note"
-              purpose="decorative"
-              size="0.875rem"
-            />
+            {metaIconName && (
+              <Icon
+                className={styles['project-card__meta-icon']}
+                name={metaIconName}
+                purpose="decorative"
+                size="0.875rem"
+              />
+            )}
             {meta}
           </div>
         )}

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -23,11 +23,6 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
     >
       Project card title
     </h3>
-    <div
-      class="project-card__meta"
-    >
-      12 days
-    </div>
   </div>
   <footer
     class="card__footer project-card__footer"
@@ -179,9 +174,345 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
     >
       DragDropItem provides handle to the left
     </h3>
+  </div>
+  <footer
+    class="card__footer project-card__footer"
+  >
+    <div
+      class="button-dropdown"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="menu"
+        aria-label="Open project dropdown"
+        class="clickable-style clickable-style--sm clickable-style--icon clickable-style--neutral button button--icon project-card__menu-button"
+        data-bootstrap-override="clickable-style-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="test-file-stub#dots-vertical"
+          />
+        </svg>
+      </button>
+      <div
+        class="dropdown-menu button-dropdown__dropdown-menu"
+      >
+        <ul
+          class="dropdown-menu__list"
+          role="menu"
+        >
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move to other section
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move up
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move down
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move view details
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+</article>
+`;
+
+exports[`<ProjectCard /> WithMeta story renders snapshot 1`] = `
+<article
+  class="card card--horizontal card--raised project-card"
+>
+  <header
+    class="card__header project-card__header"
+  >
+    <span
+      aria-label="Project 1"
+      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+      role="img"
+    >
+      1
+    </span>
+  </header>
+  <div
+    class="card__body project-card__body"
+  >
+    <h3
+      class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+    >
+      Project card title
+    </h3>
     <div
       class="project-card__meta"
     >
+      12 days
+    </div>
+  </div>
+  <footer
+    class="card__footer project-card__footer"
+  >
+    <div
+      class="button-dropdown"
+    >
+      <button
+        aria-expanded="false"
+        aria-haspopup="menu"
+        aria-label="Open project dropdown"
+        class="clickable-style clickable-style--sm clickable-style--icon clickable-style--neutral button button--icon project-card__menu-button"
+        data-bootstrap-override="clickable-style-icon"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon"
+          fill="currentColor"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="test-file-stub#dots-vertical"
+          />
+        </svg>
+      </button>
+      <div
+        class="dropdown-menu button-dropdown__dropdown-menu"
+      >
+        <ul
+          class="dropdown-menu__list"
+          role="menu"
+        >
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move to other section
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move up
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move down
+            </button>
+          </li>
+          <li
+            class="dropdown-menu__item"
+            role="menuitem"
+          >
+            <button
+              class="dropdown-menu__link"
+              tabindex="-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="icon"
+                fill="currentColor"
+                height="1.25rem"
+                style="--icon-size: 1.25rem;"
+                width="1.25rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="test-file-stub#schedule"
+                />
+              </svg>
+              Move view details
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </footer>
+</article>
+`;
+
+exports[`<ProjectCard /> WithMetaIcon story renders snapshot 1`] = `
+<article
+  class="card card--horizontal card--raised project-card"
+>
+  <header
+    class="card__header project-card__header"
+  >
+    <span
+      aria-label="Project 1"
+      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
+      role="img"
+    >
+      1
+    </span>
+  </header>
+  <div
+    class="card__body project-card__body"
+  >
+    <h3
+      class="heading heading--size-body-sm heading--neutral-strong project-card__title"
+    >
+      Project card title
+    </h3>
+    <div
+      class="project-card__meta"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon project-card__meta-icon"
+        fill="currentColor"
+        height="0.875rem"
+        style="--icon-size: 0.875rem;"
+        width="0.875rem"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="test-file-stub#event-note"
+        />
+      </svg>
       12 days
     </div>
   </div>
@@ -343,170 +674,6 @@ exports[`<ProjectCard /> WithoutDropdown story renders snapshot 1`] = `
     >
       DragDropItem provides handle to the left
     </h3>
-    <div
-      class="project-card__meta"
-    >
-      12 days
-    </div>
   </div>
-</article>
-`;
-
-exports[`<ProjectCard /> WithoutMeta story renders snapshot 1`] = `
-<article
-  class="card card--horizontal card--raised project-card"
->
-  <header
-    class="card__header project-card__header"
-  >
-    <span
-      aria-label="Project 1"
-      class="text text--sm text--neutral-medium number-icon number-icon--base number-icon--sm project-card__number"
-      role="img"
-    >
-      1
-    </span>
-  </header>
-  <div
-    class="card__body project-card__body"
-  >
-    <h3
-      class="heading heading--size-body-sm heading--neutral-strong project-card__title"
-    >
-      Project card title
-    </h3>
-  </div>
-  <footer
-    class="card__footer project-card__footer"
-  >
-    <div
-      class="button-dropdown"
-    >
-      <button
-        aria-expanded="false"
-        aria-haspopup="menu"
-        aria-label="Open project dropdown"
-        class="clickable-style clickable-style--sm clickable-style--icon clickable-style--neutral button button--icon project-card__menu-button"
-        data-bootstrap-override="clickable-style-icon"
-        type="button"
-      >
-        <svg
-          aria-hidden="true"
-          class="icon"
-          fill="currentColor"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <use
-            xlink:href="test-file-stub#dots-vertical"
-          />
-        </svg>
-      </button>
-      <div
-        class="dropdown-menu button-dropdown__dropdown-menu"
-      >
-        <ul
-          class="dropdown-menu__list"
-          role="menu"
-        >
-          <li
-            class="dropdown-menu__item"
-            role="menuitem"
-          >
-            <button
-              class="dropdown-menu__link"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                fill="currentColor"
-                height="1.25rem"
-                style="--icon-size: 1.25rem;"
-                width="1.25rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="test-file-stub#schedule"
-                />
-              </svg>
-              Move to other section
-            </button>
-          </li>
-          <li
-            class="dropdown-menu__item"
-            role="menuitem"
-          >
-            <button
-              class="dropdown-menu__link"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                fill="currentColor"
-                height="1.25rem"
-                style="--icon-size: 1.25rem;"
-                width="1.25rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="test-file-stub#schedule"
-                />
-              </svg>
-              Move up
-            </button>
-          </li>
-          <li
-            class="dropdown-menu__item"
-            role="menuitem"
-          >
-            <button
-              class="dropdown-menu__link"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                fill="currentColor"
-                height="1.25rem"
-                style="--icon-size: 1.25rem;"
-                width="1.25rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="test-file-stub#schedule"
-                />
-              </svg>
-              Move down
-            </button>
-          </li>
-          <li
-            class="dropdown-menu__item"
-            role="menuitem"
-          >
-            <button
-              class="dropdown-menu__link"
-              tabindex="-1"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon"
-                fill="currentColor"
-                height="1.25rem"
-                style="--icon-size: 1.25rem;"
-                width="1.25rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="test-file-stub#schedule"
-                />
-              </svg>
-              Move view details
-            </button>
-          </li>
-        </ul>
-      </div>
-    </div>
-  </footer>
 </article>
 `;

--- a/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
+++ b/src/components/ProjectCard/__snapshots__/ProjectCard.test.tsx.snap
@@ -26,19 +26,6 @@ exports[`<ProjectCard /> Default story renders snapshot 1`] = `
     <div
       class="project-card__meta"
     >
-      <svg
-        aria-hidden="true"
-        class="icon project-card__meta-icon"
-        fill="currentColor"
-        height="0.875rem"
-        style="--icon-size: 0.875rem;"
-        width="0.875rem"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="test-file-stub#event-note"
-        />
-      </svg>
       12 days
     </div>
   </div>
@@ -195,19 +182,6 @@ exports[`<ProjectCard /> Draggable story renders snapshot 1`] = `
     <div
       class="project-card__meta"
     >
-      <svg
-        aria-hidden="true"
-        class="icon project-card__meta-icon"
-        fill="currentColor"
-        height="0.875rem"
-        style="--icon-size: 0.875rem;"
-        width="0.875rem"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="test-file-stub#event-note"
-        />
-      </svg>
       12 days
     </div>
   </div>
@@ -372,19 +346,6 @@ exports[`<ProjectCard /> WithoutDropdown story renders snapshot 1`] = `
     <div
       class="project-card__meta"
     >
-      <svg
-        aria-hidden="true"
-        class="icon project-card__meta-icon"
-        fill="currentColor"
-        height="0.875rem"
-        style="--icon-size: 0.875rem;"
-        width="0.875rem"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="test-file-stub#event-note"
-        />
-      </svg>
       12 days
     </div>
   </div>


### PR DESCRIPTION
### Summary:
[slack context](https://czi-edu.slack.com/archives/CTFV79JH4/p1666915992251169)
There's a request to allow custom icons on the ProjectCard component.
Due to high specificity of the ProjectCard, it should probably live in LP ([ticket](https://app.shortcut.com/czi-edu/story/226852)
But due to immediate need, this pr is raised

![image](https://user-images.githubusercontent.com/86632227/198706665-a50fa16f-77ff-4942-94fa-080d34cfc44b.png)

### Test Plan:
No visual regression outside ProjectCard stories
Unit tests pass