### PR TITLE
chore(build): remove source map

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "outDir": "lib",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true,
     "strict": true,
     "suppressImplicitAnyIndexErrors": true,
     "target": "es6"


### PR DESCRIPTION
### Summary:
[sc-225828]
- Thought about trying to change the source to the `lib` folder but doesn't make too much sense since the source file itself is not part of the publish
- Including the source files in the publish is unnecessary and makes it heavier
- Source maps don't seem too useful as devs hopefully don't need to debug EDS components from consuming apps and and its currently not working state can either block or spam warnings
- As a result remove source maps
### Test Plan:
- Build is unaffected besides source maps