### PR TITLE
docs: import examples in component comments to one line with backticks

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -392,9 +392,7 @@ Example:
 
 ````
 /**
- * ```ts
- * import {ButtonGroup} from "@chanzuckerberg/eds";
- * ```
+ * `import {ButtonGroup} from "@chanzuckerberg/eds";`
  *
  * A container for buttons grouped together horizontally or vertically.
  *

--- a/plop-templates/Component/Component.tsx.hbs
+++ b/plop-templates/Component/Component.tsx.hbs
@@ -12,9 +12,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {{inBraces name}} from "@chanzuckerberg/eds";
- * ```
+ * `import {{inBraces name}} from "@chanzuckerberg/eds";`
  *
  * TODO: update this comment with a description of the component.
  */

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -94,9 +94,7 @@ const variantToIconAssetsMap: {
  * @deprecated The Banner component is deprecated and will be removed in an upcoming release.
  * Please visit Zeroheight to find the right notification component for your needs: https://eds.czi.design/
  *
- * ```ts
- * import {Banner} from "@chanzuckerberg/eds";
- * ```
+ * `import {Banner} from "@chanzuckerberg/eds";`
  *
  * A banner used to provide and highlight information to a user or ask for a decision or action.
  *

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -28,9 +28,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {Breadcrumbs} from "@chanzuckerberg/eds";
- * ```
+ * `import {Breadcrumbs} from "@chanzuckerberg/eds";`
  *
  * List of Breadcrumb components showing the user where they are in the system and allow them
  * to navigate to parent pages.

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -33,9 +33,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {BreadcrumbsItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {BreadcrumbsItem} from "@chanzuckerberg/eds";`
  *
  * A single breadcrumb subcomponent, to be used in the Breadcrumbs component.
  */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -37,9 +37,7 @@ export type ButtonProps = ButtonHTMLElementProps & {
 } & VariantStatus;
 
 /**
- * ```ts
- * import {Button} from "@chanzuckerberg/eds";
- * ```
+ * `import {Button} from "@chanzuckerberg/eds";`
  *
  * Component for making buttons that do not navigate the user to another page.
  *

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -62,6 +62,8 @@ export interface Props {
 }
 
 /**
+ * `import {ButtonDropdown} from "@chanzuckerberg/eds";`
+ *
  * Contains the button and the dropdown
  */
 export const ButtonDropdown = ({

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -27,9 +27,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {ButtonGroup} from "@chanzuckerberg/eds";
- * ```
+ * `import {ButtonGroup} from "@chanzuckerberg/eds";`
  *
  * A container for buttons grouped together horizontally or vertically.
  *

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -33,9 +33,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Card} from "@chanzuckerberg/eds";
- * ```
+ * `import {Card} from "@chanzuckerberg/eds";`
  *
  * Card component is the outer wrapper for the block that typically contains a title, image,
  *    text, and/or calls to action.

--- a/src/components/CardBody/CardBody.tsx
+++ b/src/components/CardBody/CardBody.tsx
@@ -17,9 +17,7 @@ export interface Props {
 /**
  * Primary UI component for user interaction
  *
- * ```ts
- * import {CardBody} from "@chanzuckerberg/eds";
- * ```
+ * `import {CardBody} from "@chanzuckerberg/eds";`
  *
  * Body of the Card component.
  */

--- a/src/components/CardFooter/CardFooter.tsx
+++ b/src/components/CardFooter/CardFooter.tsx
@@ -17,9 +17,7 @@ export interface Props {
 /**
  * Primary UI component for user interaction
  *
- * ```ts
- * import {CardFooter} from "@chanzuckerberg/eds";
- * ```
+ * `import {CardFooter} from "@chanzuckerberg/eds";`
  *
  * Footer of the Card component.
  */

--- a/src/components/CardHeader/CardHeader.tsx
+++ b/src/components/CardHeader/CardHeader.tsx
@@ -15,6 +15,8 @@ export interface Props {
 }
 
 /**
+ * `import {CardHeader} from "@chanzuckerberg/eds";`
+ *
  * Primary UI component for user interaction
  */
 export const CardHeader = ({ children, className, ...other }: Props) => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -26,12 +26,9 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
 };
 
 /**
- * ```ts
- * import {Checkbox} from "@chanzuckerberg/eds";
- * ```
- * ```ts
- * import {CheckboxInput, CheckboxLabel} from '@chanzuckerberg/eds';
- * ```
+ * `import {Checkbox} from "@chanzuckerberg/eds";`
+ *
+ * `import {CheckboxInput, CheckboxLabel} from '@chanzuckerberg/eds';`
  *
  * Checkbox control indicating if something is selected or unselected.
  *

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -82,9 +82,7 @@ export type ClickableStyleProps<IComponent extends React.ElementType> = {
 } & React.ComponentProps<IComponent>;
 
 /**
- * ```ts
- * import {ClickableStyle} from "@chanzuckerberg/eds";
- * ```
+ * `import {ClickableStyle} from "@chanzuckerberg/eds";`
  *
  * A helper component that contains all the styling for buttons and links.
  *

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -43,9 +43,7 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
- * ```ts
- * import {DataBar} from "@chanzuckerberg/eds";
- * ```
+ * `import {DataBar} from "@chanzuckerberg/eds";`
  *
  * A data bar component that represents the relative completion of a task represented by one or more segments.
  *

--- a/src/components/DataBarSegment/DataBarSegment.tsx
+++ b/src/components/DataBarSegment/DataBarSegment.tsx
@@ -30,9 +30,7 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
- * ```ts
- * import {DataBarSegment} from "@chanzuckerberg/eds";
- * ```
+ * `import {DataBarSegment} from "@chanzuckerberg/eds";`
  *
  * A segment sub component for the <DataBar>.
  *

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -25,9 +25,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {DefinitionList} from "@chanzuckerberg/eds";
- * ```
+ * `import {DefinitionList} from "@chanzuckerberg/eds";`
  *
  * DefinitionList is the wrapper component that contains the definition term (`dt`)
  * and a definition description (`dd`)

--- a/src/components/DefinitionListItem/DefinitionListItem.tsx
+++ b/src/components/DefinitionListItem/DefinitionListItem.tsx
@@ -19,9 +19,8 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {DefinitionListItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {DefinitionListItem} from "@chanzuckerberg/eds";`
+ *
  * DefinitionListItem is the component to show the definition term (`dt`)
  * and a definition description (`dd`)
  */

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -54,6 +54,8 @@ export interface NewState {
 }
 
 /**
+ * `import {DragDrop} from "@chanzuckerberg/eds"`
+ *
  * A flexible Drag and Drop component that allows items to be dragged and dropped in containers.
  */
 export const DragDrop = ({

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -54,9 +54,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {Drawer} from "@chanzuckerberg/eds";
- * ```
+ * `import {Drawer} from "@chanzuckerberg/eds";`
  *
  * A window component that slides from and out of the right side of the screen.
  */

--- a/src/components/Drawer/DrawerExample.tsx
+++ b/src/components/Drawer/DrawerExample.tsx
@@ -7,9 +7,7 @@ import Heading from '../Heading';
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {DrawerExample} from "@chanzuckerberg/eds";
- * ```
+ * `import {DrawerExample} from "@chanzuckerberg/eds";`
  *
  * An example of a controlled Drawer for use as a story.
  */

--- a/src/components/DrawerBody/DrawerBody.tsx
+++ b/src/components/DrawerBody/DrawerBody.tsx
@@ -17,9 +17,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {DrawerBody} from "@chanzuckerberg/eds";
- * ```
+ * `import {DrawerBody} from "@chanzuckerberg/eds";`
  *
  * The main center content of the Drawer component.
  */

--- a/src/components/DrawerFooter/DrawerFooter.tsx
+++ b/src/components/DrawerFooter/DrawerFooter.tsx
@@ -16,9 +16,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {DrawerFooter} from "@chanzuckerberg/eds";
- * ```
+ * `import {DrawerFooter} from "@chanzuckerberg/eds";`
  *
  * The footer content of the Drawer component. Usually houses interactible component controlling the Drawer functionality.
  */

--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -32,9 +32,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {DrawerHeader} from "@chanzuckerberg/eds";
- * ```
+ * `import {DrawerHeader} from "@chanzuckerberg/eds";`
  *
  * The header content of the Drawer component. Usually houses the heading and the close button.
  */

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -110,9 +110,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
 }
 
 /**
- * ```ts
- * import {Dropdown} from "@chanzuckerberg/eds";
- * ```
+ * `import {Dropdown} from "@chanzuckerberg/eds";`
  *
  * EDS Dropdown. Used to select one option from a list of options.
  *

--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -20,9 +20,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {DropdownButton} from "@chanzuckerberg/eds";
- * ```
+ * `import {DropdownButton} from "@chanzuckerberg/eds";`
  *
  * A styled button with an expand icon to be used in triggering Popovers, Dropdowns, etc.
  */

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -48,9 +48,7 @@ type ContextRefs = {
 export const DropdownMenuContext = createContext<ContextRefs | null>(null);
 
 /**
- * ```ts
- * import {DropdownMenu} from "@chanzuckerberg/eds";
- * ```
+ * `import {DropdownMenu} from "@chanzuckerberg/eds";`
  *
  * Dropdown menu with actions list
  */

--- a/src/components/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/src/components/DropdownMenuItem/DropdownMenuItem.tsx
@@ -51,9 +51,7 @@ export type DropdownMenuItemProps = {
 };
 
 /**
- * ```ts
- * import {DropdownMenuItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {DropdownMenuItem} from "@chanzuckerberg/eds";`
  *
  * Dropdown menu item within `DropdownMenu`
  */

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -30,9 +30,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {FieldNote} from "@chanzuckerberg/eds";
- * ```
+ * `import {FieldNote} from "@chanzuckerberg/eds";`
  *
  * Fieldnote component wraps text to describe other components.
  */

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -21,9 +21,7 @@ type FieldsetProps = {
 } & React.HTMLAttributes<HTMLFieldSetElement>;
 
 /**
- * ```ts
- * import {Fieldset} from "@chanzuckerberg/eds";
- * ```
+ * `import {Fieldset} from "@chanzuckerberg/eds";`
  *
  * A container for a fieldset that includes a legend and one or more form inputs.
  */

--- a/src/components/FieldsetItems/FieldsetItems.tsx
+++ b/src/components/FieldsetItems/FieldsetItems.tsx
@@ -20,9 +20,7 @@ export type FieldsetItemsProps = {
 };
 
 /**
- * ```ts
- * import {FieldsetItems} from "@chanzuckerberg/eds";
- * ```
+ * `import {FieldsetItems} from "@chanzuckerberg/eds";`
  *
  * Helper sub-component for styling the control elements in the component.
  */

--- a/src/components/FieldsetLegend/FieldsetLegend.tsx
+++ b/src/components/FieldsetLegend/FieldsetLegend.tsx
@@ -18,9 +18,7 @@ export interface FieldsetLegendProps {
 }
 
 /**
- * ```ts
- * import {FieldsetLegend} from "@chanzuckerberg/eds";
- * ```
+ * `import {FieldsetLegend} from "@chanzuckerberg/eds";`
  *
  * Helper sub-component for styling the legend in a fieldset.
  */

--- a/src/components/FiltersButton/FiltersButton.tsx
+++ b/src/components/FiltersButton/FiltersButton.tsx
@@ -23,9 +23,7 @@ export type FiltersButtonProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {FiltersButton} from "@chanzuckerberg/eds";
- * ```
+ * `import {FiltersButton} from "@chanzuckerberg/eds";`
  *
  * Default button for triggering Filters components.
  */

--- a/src/components/FiltersDrawer/FiltersDrawer.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.tsx
@@ -56,9 +56,7 @@ export type FiltersDrawerProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {FiltersDrawer} from "@chanzuckerberg/eds";
- * ```
+ * `import {FiltersDrawer} from "@chanzuckerberg/eds";`
  *
  * A drawer component with fields of checkboxes to select filters.
  */

--- a/src/components/FiltersPopover/FiltersPopover.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.tsx
@@ -162,9 +162,7 @@ const FiltersPopoverRender = ({
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {FiltersPopover} from "@chanzuckerberg/eds";
- * ```
+ * `import {FiltersPopover} from "@chanzuckerberg/eds";`
  *
  * A popover component with fields of form inputs to select filters.
  */

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -39,9 +39,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Grid} from "@chanzuckerberg/eds";
- * ```
+ * `import {Grid} from "@chanzuckerberg/eds";`
  *
  * Grid component used to layout GridItem components into a grid pattern. This is flexible component
  * allowing for a variety of responsive layout components.

--- a/src/components/GridItem/GridItem.tsx
+++ b/src/components/GridItem/GridItem.tsx
@@ -15,9 +15,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {GridItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {GridItem} from "@chanzuckerberg/eds";`
  *
  * Single grid item to be used in the Grid component.
  */

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -38,9 +38,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Header} from "@chanzuckerberg/eds";
- * ```
+ * `import {Header} from "@chanzuckerberg/eds";`
  *
  * Global container for the header component. This helps set the stage for header recipes across applications.
  */

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -58,9 +58,7 @@ const getComputedAs = (size: HeadingSize) => {
 };
 
 /**
- * ```ts
- * import {Heading} from "@chanzuckerberg/eds";
- * ```
+ * `import {Heading} from "@chanzuckerberg/eds";`
  */
 
 export const Heading = forwardRef(

--- a/src/components/HorizontalStep/HorizontalStep.tsx
+++ b/src/components/HorizontalStep/HorizontalStep.tsx
@@ -25,9 +25,7 @@ export type Props = {
 };
 
 /**
- * ```ts
- * import {HorizontalStep} from "@chanzuckerberg/eds";
- * ```
+ * `import {HorizontalStep} from "@chanzuckerberg/eds";`
  *
  * A step sub component for the <HorizontalStepper>.
  * Determines which icon to use and places the text next to it.

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -24,9 +24,7 @@ export type Props = {
 };
 
 /**
- * ```ts
- * import {HorizontalStepper} from "@chanzuckerberg/eds";
- * ```
+ * `import {HorizontalStepper} from "@chanzuckerberg/eds";`
  *
  * A stepper component used to display which steps have been completed, the current active step, and possible remaining steps.
  *

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -20,9 +20,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Hr} from "@chanzuckerberg/eds";
- * ```
+ * `import {Hr} from "@chanzuckerberg/eds";`
  *
  * Horizontal rule component to present a horizontal line separating content.
  */

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -90,9 +90,7 @@ interface SvgStyle extends CSSProperties {
 }
 
 /**
- * ```ts
- * import {Icon} from "@chanzuckerberg/eds";
- * ```
+ * `import {Icon} from "@chanzuckerberg/eds";`
  *
  * Render arbitrary SVG path data while enforcing good accessibility practices.
  *

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -64,9 +64,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {InlineNotification} from "@chanzuckerberg/eds";
- * ```
+ * `import {InlineNotification} from "@chanzuckerberg/eds";`
  *
  * This component provides an inline banner accompanied with an icon for messaging users.
  */

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -116,9 +116,7 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {InputField} from "@chanzuckerberg/eds";
- * ```
+ * `import {InputField} from "@chanzuckerberg/eds";`
  *
  * Text input component for one line of text. For multiple lines, consider the Textarea component.
  */

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -28,9 +28,7 @@ export type InputLabelProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {InputLabel} from "@chanzuckerberg/eds";
- * ```
+ * `import {InputLabel} from "@chanzuckerberg/eds";`
  *
  * Label associated with an input element such as a radio or checkbox.
  */

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -43,9 +43,8 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Label} from "@chanzuckerberg/eds";
- * ```
+ * `import {Label} from "@chanzuckerberg/eds";`
+ *
  * Component Label used as legends for field groups (i.e. radio field).
  */
 export const Label = ({

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -35,9 +35,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Layout} from "@chanzuckerberg/eds";
- * ```
+ * `import {Layout} from "@chanzuckerberg/eds";`
  *
  * Component that controls an overarching page layout. By default, the layout renders
  * a fixed-position left sidebar on larger screens.

--- a/src/components/LayoutContainer/LayoutContainer.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.tsx
@@ -24,9 +24,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {LayoutContainer} from "@chanzuckerberg/eds";
- * ```
+ * `import {LayoutContainer} from "@chanzuckerberg/eds";`
  *
  * Layout container. Caps the width of the content to the maximum width and centers the container.
  */

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.tsx
@@ -15,9 +15,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {LayoutLinelengthContainer} from "@chanzuckerberg/eds";
- * ```
+ * `import {LayoutLinelengthContainer} from "@chanzuckerberg/eds";`
  *
  * Component that caps the length of an excerpt of text to be easily readable.
  */

--- a/src/components/LayoutSection/LayoutSection.tsx
+++ b/src/components/LayoutSection/LayoutSection.tsx
@@ -19,9 +19,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {LayoutSection} from "@chanzuckerberg/eds";
- * ```
+ * `import {LayoutSection} from "@chanzuckerberg/eds";`
  *
  * Layout section.
  */

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -24,9 +24,7 @@ export type LinkProps = LinkHTMLElementProps & {
 } & VariantStatus;
 
 /**
- * ```ts
- * import {Link} from "@chanzuckerberg/eds";
- * ```
+ * `import {Link} from "@chanzuckerberg/eds";`
  *
  * Component for making styled anchor tags.
  *

--- a/src/components/LinkList/LinkList.tsx
+++ b/src/components/LinkList/LinkList.tsx
@@ -31,9 +31,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {LinkList} from "@chanzuckerberg/eds";
- * ```
+ * `import {LinkList} from "@chanzuckerberg/eds";`
  *
  * List of links.
  */

--- a/src/components/LinkListItem/LinkListItem.tsx
+++ b/src/components/LinkListItem/LinkListItem.tsx
@@ -49,9 +49,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {LinkListItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {LinkListItem} from "@chanzuckerberg/eds";`
  *
  * Link list item to be used inside the LinkList component.
  */

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -30,9 +30,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Logo} from "@chanzuckerberg/eds";
- * ```
+ * `import {Logo} from "@chanzuckerberg/eds";`
  *
  * Branding image or text of the site.
  */

--- a/src/components/Main/Main.tsx
+++ b/src/components/Main/Main.tsx
@@ -15,9 +15,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Main} from "@chanzuckerberg/eds";
- * ```
+ * `import {Main} from "@chanzuckerberg/eds";`
  *
  * Component defines the Main element inside layout.
  */

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -164,9 +164,7 @@ export const ModalContent = (props: ModalContentProps) => {
 };
 
 /**
- * ```ts
- * import {Modal} from "@chanzuckerberg/eds";
- * ```
+ * `import {Modal} from "@chanzuckerberg/eds";`
  *
  * Modal wrapping the Headless UI Diaglog component https://headlessui.dev/react/dialog
  *

--- a/src/components/ModalStepper/ModalStepper.tsx
+++ b/src/components/ModalStepper/ModalStepper.tsx
@@ -20,9 +20,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {ModalStepper} from "@chanzuckerberg/eds";
- * ```
+ * `import {ModalStepper} from "@chanzuckerberg/eds";`
  *
  * Stepper for the modal to indicate page status.
  */

--- a/src/components/NavContainer/NavContainer.tsx
+++ b/src/components/NavContainer/NavContainer.tsx
@@ -21,9 +21,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {NavContainer} from "@chanzuckerberg/eds";
- * ```
+ * `import {NavContainer} from "@chanzuckerberg/eds";`
  *
  * Container that houses navigation to be toggled on and off on small screens.
  */

--- a/src/components/NotificationList/NotificationList.tsx
+++ b/src/components/NotificationList/NotificationList.tsx
@@ -16,9 +16,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {NotificationList} from "@chanzuckerberg/eds";
- * ```
+ * `import {NotificationList} from "@chanzuckerberg/eds";`
  *
  * List of NotificationListItem components.
  */

--- a/src/components/NotificationListItem/NotificationListItem.tsx
+++ b/src/components/NotificationListItem/NotificationListItem.tsx
@@ -42,9 +42,7 @@ interface State {
 }
 
 /**
- * ```ts
- * import {NotificationListItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {NotificationListItem} from "@chanzuckerberg/eds";`
  *
  * Single notification item to be used in NotificationList.
  */

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -36,9 +36,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {NumberIcon} from "@chanzuckerberg/eds";
- * ```
+ * `import {NumberIcon} from "@chanzuckerberg/eds";`
  *
  * Encloses a number in a circle to be used as an icon.
  *

--- a/src/components/OverflowList/OverflowList.tsx
+++ b/src/components/OverflowList/OverflowList.tsx
@@ -21,9 +21,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {OverflowList} from "@chanzuckerberg/eds";
- * ```
+ * `import {OverflowList} from "@chanzuckerberg/eds";`
  *
  * Component that is used to maintain the object body with content overflowed.
  */

--- a/src/components/OverflowListItem/OverflowListItem.tsx
+++ b/src/components/OverflowListItem/OverflowListItem.tsx
@@ -15,9 +15,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {OverflowListItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {OverflowListItem} from "@chanzuckerberg/eds";`
  *
  * OverflowListItem to be used in the OverflowList component to maintain the body of the elements overflow.
  */

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -67,9 +67,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {PageHeader} from "@chanzuckerberg/eds";
- * ```
+ * `import {PageHeader} from "@chanzuckerberg/eds";`
  *
  * Header to be used at the top of a page.
  */

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -70,9 +70,7 @@ const variantToIconAssetsMap: {
 };
 
 /**
- * ```ts
- * import {PageLevelBanner} from "@chanzuckerberg/eds";
- * ```
+ * `import {PageLevelBanner} from "@chanzuckerberg/eds";`
  *
  * A banner placed at the top of the page with important information.
  *

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -30,9 +30,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Panel} from "@chanzuckerberg/eds";
- * ```
+ * `import {Panel} from "@chanzuckerberg/eds";`
  *
  * Component Panel is the container to show the contents with props passed through for conditional styling of the panel based on variants props.
  */

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -73,11 +73,9 @@ export const defaultPopoverModifiers = [
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * A styled popover built on 'headless UI' popover. Consider using the Dropdown component, instead.
+ * `import {Popover} from "@chanzuckerberg/eds";`
  *
- * ```ts
- * import {Popover} from "@chanzuckerberg/eds";
- * ```
+ * A styled popover built on 'headless UI' popover. Consider using the Dropdown component, instead.
  */
 export const Popover = ({
   placement,

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -25,9 +25,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {PrimaryNav} from "@chanzuckerberg/eds";
- * ```
+ * `import {PrimaryNav} from "@chanzuckerberg/eds";`
  *
  * Primary navigation existing in the header and maybe the footer.
  */

--- a/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -29,9 +29,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {PrimaryNavItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {PrimaryNavItem} from "@chanzuckerberg/eds";`
  *
  * Individual item within the PrimaryNav.
  */

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -26,9 +26,7 @@ export type RadioProps = RadioInputProps & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {Radio} from "@chanzuckerberg/eds";
- * ```
+ * `import {Radio} from "@chanzuckerberg/eds";`
  *
  * This component provides a radio component and a label for form selection.
  */

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -25,9 +25,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {Score} from "@chanzuckerberg/eds";
- * ```
+ * `import {Score} from "@chanzuckerberg/eds";`
  *
  * A (pill shaped badge) wrapper intended for use with scores.
  */

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -19,9 +19,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {SearchBar} from "@chanzuckerberg/eds";
- * ```
+ * `import {SearchBar} from "@chanzuckerberg/eds";`
  *
  * Input field and button used for searching through various data fields.
  */

--- a/src/components/SearchButton/SearchButton.tsx
+++ b/src/components/SearchButton/SearchButton.tsx
@@ -22,9 +22,7 @@ export type SearchButtonProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {SearchButton} from "@chanzuckerberg/eds";
- * ```
+ * `import {SearchButton} from "@chanzuckerberg/eds";`
  *
  * A button styled for use with the SearchBar.
  */

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -8,9 +8,7 @@ import InputField from '../InputField';
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {SearchField} from "@chanzuckerberg/eds";
- * ```
+ * `import {SearchField} from "@chanzuckerberg/eds";`
  *
  * A search InputField component styled for use with the SearchBar.
  */

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -53,9 +53,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Section} from "@chanzuckerberg/eds";
- * ```
+ * `import {Section} from "@chanzuckerberg/eds";`
  *
  * Section component contains a section header and body.
  *

--- a/src/components/ShowHide/ShowHide.tsx
+++ b/src/components/ShowHide/ShowHide.tsx
@@ -38,9 +38,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {ShowHide} from "@chanzuckerberg/eds";
- * ```
+ * `import {ShowHide} from "@chanzuckerberg/eds";`
  *
  * Component that shows and hides child content at the press of a button.
  */

--- a/src/components/StackedBlock/StackedBlock.tsx
+++ b/src/components/StackedBlock/StackedBlock.tsx
@@ -27,9 +27,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {StackedBlock} from "@chanzuckerberg/eds";
- * ```
+ * `import {StackedBlock} from "@chanzuckerberg/eds";`
  *
  * A stacked block is a block that contains stacked text content, with a
  * text link around the title and a description.

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -29,9 +29,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Tab} from "@chanzuckerberg/eds";
- * ```
+ * `import {Tab} from "@chanzuckerberg/eds";`
  *
  * Individual tab within the Tabs component.
  */

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -24,9 +24,7 @@ export type Props = React.TableHTMLAttributes<HTMLTableElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {Table} from "@chanzuckerberg/eds";
- * ```
+ * `import {Table} from "@chanzuckerberg/eds";`
  *
  * HTML table component
  */

--- a/src/components/TableBody/TableBody.tsx
+++ b/src/components/TableBody/TableBody.tsx
@@ -15,9 +15,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableBody} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableBody} from "@chanzuckerberg/eds";`
  *
  * HTML `tbody` of the `Table` component
  */

--- a/src/components/TableCaption/TableCaption.tsx
+++ b/src/components/TableCaption/TableCaption.tsx
@@ -10,9 +10,7 @@ export type Props = React.HTMLAttributes<HTMLTableCaptionElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableCaption} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableCaption} from "@chanzuckerberg/eds";`
  *
  * HTML caption cell for the `Table` component.
  * Must be first descendant of the `Table` component.

--- a/src/components/TableCell/TableCell.tsx
+++ b/src/components/TableCell/TableCell.tsx
@@ -37,9 +37,7 @@ export type Props = React.TdHTMLAttributes<HTMLTableCellElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableCell} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableCell} from "@chanzuckerberg/eds";`
  *
  * HTML table cell of the `Table` component
  */

--- a/src/components/TableFooter/TableFooter.tsx
+++ b/src/components/TableFooter/TableFooter.tsx
@@ -15,9 +15,7 @@ export interface Props {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableFooter} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableFooter} from "@chanzuckerberg/eds";`
  *
  * HTML `tfoot` of the `Table` component
  */

--- a/src/components/TableHeader/TableHeader.tsx
+++ b/src/components/TableHeader/TableHeader.tsx
@@ -15,9 +15,7 @@ export type Props = React.HTMLAttributes<HTMLTableSectionElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableHeader} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableHeader} from "@chanzuckerberg/eds";`
  *
  * HTML `thead` of the `Table` component
  */

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -56,9 +56,7 @@ export type SortDirectionsType = typeof SORT_DIRECTIONS[number];
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableHeaderCell} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableHeaderCell} from "@chanzuckerberg/eds";`
  *
  * HTML `th` cell of the `Table` component
  */

--- a/src/components/TableRow/TableRow.tsx
+++ b/src/components/TableRow/TableRow.tsx
@@ -21,9 +21,7 @@ export type Props = React.HTMLAttributes<HTMLTableRowElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TableRow} from "@chanzuckerberg/eds";
- * ```
+ * `import {TableRow} from "@chanzuckerberg/eds";`
  *
  * HTML `tr` of the `Table` component
  */

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -48,9 +48,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Tabs} from "@chanzuckerberg/eds";
- * ```
+ * `import {Tabs} from "@chanzuckerberg/eds";`
  *
  * List of of links where each link toggles open associated information in a tab panel.
  */

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -40,9 +40,7 @@ type Props = {
 };
 
 /**
- * ```ts
- * import {Tag} from "@chanzuckerberg/eds";
- * ```
+ * `import {Tag} from "@chanzuckerberg/eds";`
  *
  * This component provides a tag (pill shaped badge) wrapper.
  */

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -54,9 +54,7 @@ export type Props = {
 } & React.HTMLAttributes<HTMLElement>;
 
 /**
- * ```ts
- * import {Text} from "@chanzuckerberg/eds";
- * ```
+ * `import {Text} from "@chanzuckerberg/eds";`
  *
  * There are two perceived use cases for the text component.
  * One is to decorate <p> and <span> with thematic variants.

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -127,8 +127,7 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
- * import {TextField} from "@chanzuckerberg/eds";
+ * `import {TextField} from "@chanzuckerberg/eds";`
  */
 export const TextField = forwardRef<HTMLInputElement, Props>(
   (

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -84,9 +84,7 @@ export interface TimelineNavItem {
 }
 
 /**
- * ```ts
- * import {TimelineNav} from "@chanzuckerberg/eds";
- * ```
+ * `import {TimelineNav} from "@chanzuckerberg/eds";`
  *
  * Timeline nav Component
  *

--- a/src/components/TimelineNavPanel/TimelineNavPanel.tsx
+++ b/src/components/TimelineNavPanel/TimelineNavPanel.tsx
@@ -47,9 +47,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {TimelineNavPanel} from "@chanzuckerberg/eds";
- * ```
+ * `import {TimelineNavPanel} from "@chanzuckerberg/eds";`
  *
  * Panel to be used inside of the TimelineNav component.
  */

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -27,9 +27,7 @@ export type Props = {
 };
 
 /**
- * ```ts
- * import {Toast} from "@chanzuckerberg/eds";
- * ```
+ * `import {Toast} from "@chanzuckerberg/eds";`
  *
  * A toast used to provide information on the state of the page, usually in response to a
  * user action. Ex: The user updates their profile, and a toast pop-up informs them that the

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -27,9 +27,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {Toolbar} from "@chanzuckerberg/eds";
- * ```
+ * `import {Toolbar} from "@chanzuckerberg/eds";`
  *
  * Toolbar component is a container that houses form controls for filtering a data table based on the conditional props passed through.
  */

--- a/src/components/ToolbarItem/ToolbarItem.tsx
+++ b/src/components/ToolbarItem/ToolbarItem.tsx
@@ -21,9 +21,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {ToolbarItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {ToolbarItem} from "@chanzuckerberg/eds";`
  *
  * ToolbarItem component is used in the Toolbar component to filter the content based on alignment.
  */

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -90,9 +90,7 @@ type Plugins = NonNullable<React.ComponentProps<typeof Tippy>['plugins']>;
 type Plugin = Plugins[number];
 
 /**
- * ```ts
- * import {Tooltip} from "@chanzuckerberg/eds";
- * ```
+ * `import {Tooltip} from "@chanzuckerberg/eds";`
  *
  * A styled tooltip built on Tippy.js.
  *

--- a/src/components/UtilityNav/UtilityNav.tsx
+++ b/src/components/UtilityNav/UtilityNav.tsx
@@ -29,9 +29,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {UtilityNav} from "@chanzuckerberg/eds";
- * ```
+ * `import {UtilityNav} from "@chanzuckerberg/eds";`
  *
  * Utility navigation existing in the header and maybe the footer.
  */

--- a/src/components/UtilityNavItem/UtilityNavItem.tsx
+++ b/src/components/UtilityNavItem/UtilityNavItem.tsx
@@ -34,9 +34,7 @@ export interface Props {
 }
 
 /**
- * ```ts
- * import {UtilityNavItem} from "@chanzuckerberg/eds";
- * ```
+ * `import {UtilityNavItem} from "@chanzuckerberg/eds";`
  *
  * Individual item within the UtilityNav component.
  */


### PR DESCRIPTION
### Summary:
This is part of a series of updates I'm making to the "component comments" (docstrings on components that appear on the docs tab in storybook) to be more consistent and render properly.

There have been some issue with the `import` example that appears at the top of the component comments. For some reason, it sometimes appears as `[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]` with white text and a light gray outer glow. Right now there are 2 components in particular where this is happening:
- `Text`
  - to repro, navigate to https://chanzuckerberg.github.io/edu-design-system/?path=/docs/atoms-text-text--body and click one of the "Show code" buttons below
- `Dropdown`
  - to repro, navigate to https://chanzuckerberg.github.io/edu-design-system/?path=/docs/molecules-forms-dropdown--default and refresh the page

<img width="1445" alt="" src="https://user-images.githubusercontent.com/7761701/200391856-2f6bf7ae-a257-475a-b027-3d294e90bd0b.png">

As usual, I have no idea what's really going on, but it seems to be somehow related to the fact that these code examples use a code block (with a line of 3 backticks, the code on a new line, and another line with 3 backticks) but is only one line. If I duplicate the import line, it's fine and I can no longer repro the issue. This only seems to be a problem on pages that have other code blocks in the component comment.

Since it's just one line, my suggestion is that we change the import statements to just use 2 backticks on one line instead of a code block.

I'm suggesting we do this:
`import {Text} from "@chanzuckerberg/eds";`
instead of this:
```
import {Text} from "@chanzuckerberg/eds";
```
as long as it's only one line of code. In this PR, I'm making this change throughout the codebase to be consistent and avoiding running into this again when someone adds a code block with some example usage somewhere else.

### Test Plan:
- navigate to http://localhost:9000/?path=/docs/atoms-text-text--body
- refresh the page
- click one of the "Show code" buttons below
- verify the import statement at the top of the page is still readable text