### PR TITLE
docs: misc cleanup for component comments

### DIFF
--- a/.storybook/recipes/CalendarCard/CalendarCard.tsx
+++ b/.storybook/recipes/CalendarCard/CalendarCard.tsx
@@ -52,7 +52,7 @@ interface TagType {
 }
 
 /**
- * Recipe for a Card component to represent an event within calendar UI
+ * Recipe for a Card component to represent an event within calendar UI.
  */
 export const CalendarCard = ({
   children,

--- a/.storybook/recipes/NotificationListPopover/NotificationListPopover.tsx
+++ b/.storybook/recipes/NotificationListPopover/NotificationListPopover.tsx
@@ -4,7 +4,7 @@ import { Button, Heading, Popover } from '../../../src';
 import NotificationList from '../../../src/components/NotificationList';
 
 /**
- * Demonstrates usage of the Popover with NotificationList
+ * Demonstrates usage of the Popover with NotificationList.
  */
 export const NotificationListPopover = () => (
   <Popover placement="top-start">

--- a/.storybook/recipes/StackedCardsToTable/StackedCardsToTable.tsx
+++ b/.storybook/recipes/StackedCardsToTable/StackedCardsToTable.tsx
@@ -5,7 +5,7 @@ import { Card, Table, Text } from '../../../src';
 import breakpoint from '../../../src/design-tokens/tier-1-definitions/breakpoints';
 
 /**
- * Demonstrates usage of stacked <Card> components for smaller breakpoints and <Table> component for larger breakpoints.
+ * Demonstrates usage of stacked `<Card>` components for smaller breakpoints and `<Table>` component for larger breakpoints.
  */
 export const StackedCardsToTable = () => {
   const [isTable, setIsTable] = useState(false);

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -398,7 +398,7 @@ Example:
  *
  * Example usage:
  *
- * ```ts
+ * ```tsx
  * <ButtonGroup
  *   className={componentClassName}
  *   spacing='1x'

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -64,7 +64,7 @@ export interface Props {
 /**
  * `import {ButtonDropdown} from "@chanzuckerberg/eds";`
  *
- * Contains the button and the dropdown
+ * Contains the button and the dropdown.
  */
 export const ButtonDropdown = ({
   fullWidth,

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -33,7 +33,7 @@ type Props = {
  *
  * Example usage:
  *
- * ```ts
+ * ```tsx
  * <ButtonGroup
  *   className={componentClassName}
  *   spacing='1x'

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -38,10 +38,6 @@ export interface Props {
  * Card component is the outer wrapper for the block that typically contains a title, image,
  *    text, and/or calls to action.
  */
-
-/**
- * Primary UI component for user interaction
- */
 export const Card = ({
   className,
   children,

--- a/src/components/CardBody/CardBody.tsx
+++ b/src/components/CardBody/CardBody.tsx
@@ -15,8 +15,6 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
- *
  * `import {CardBody} from "@chanzuckerberg/eds";`
  *
  * Body of the Card component.

--- a/src/components/CardFooter/CardFooter.tsx
+++ b/src/components/CardFooter/CardFooter.tsx
@@ -15,8 +15,6 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction
- *
  * `import {CardFooter} from "@chanzuckerberg/eds";`
  *
  * Footer of the Card component.

--- a/src/components/DefinitionList/DefinitionList.tsx
+++ b/src/components/DefinitionList/DefinitionList.tsx
@@ -28,7 +28,7 @@ export interface Props {
  * `import {DefinitionList} from "@chanzuckerberg/eds";`
  *
  * DefinitionList is the wrapper component that contains the definition term (`dt`)
- * and a definition description (`dd`)
+ * and a definition description (`dd`).
  */
 export const DefinitionList = ({
   orientation,

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -25,7 +25,7 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction for draggable components to be dropped within the container.
+ * Container for draggable components to be dropped within the container.
  */
 export const DragDropContainer = ({
   container,

--- a/src/components/DragDropItem/DragDropItem.tsx
+++ b/src/components/DragDropItem/DragDropItem.tsx
@@ -28,7 +28,7 @@ export interface Props {
 }
 
 /**
- * Primary UI component for user interaction to be dragged and dropped in containers.
+ * Item to be dragged and dropped in containers.
  */
 export const DragDropItem = ({ behavior, className, item, index }: Props) => {
   const componentClassName = clsx(

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -50,7 +50,7 @@ export const DropdownMenuContext = createContext<ContextRefs | null>(null);
 /**
  * `import {DropdownMenu} from "@chanzuckerberg/eds";`
  *
- * Dropdown menu with actions list
+ * Dropdown menu with actions list.
  */
 export const DropdownMenu: React.FC<Props> = ({
   children,

--- a/src/components/FiltersCheckboxField/FiltersCheckboxField.tsx
+++ b/src/components/FiltersCheckboxField/FiltersCheckboxField.tsx
@@ -22,8 +22,9 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * ```ts
+ * ```tsx
  * import {Filters} from "@chanzuckerberg/eds";
+ *
  * <Filters.CheckboxField>
  * ```
  *

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -171,7 +171,9 @@ export const ModalContent = (props: ModalContentProps) => {
  * NOTE: You must have at least one focusable element in the modal contents, for keyboard
  * accessibility reasons. (The close button counts as a focusable element.)
  *
- * @example
+ * Example usage:
+ *
+ * ```tsx
  * <Modal>
  *   <Modal.Header>
  *     <Modal.Title>{modalTitle}</Modal.Title>
@@ -182,6 +184,7 @@ export const ModalContent = (props: ModalContentProps) => {
  *     {modalFooterContent}
  *   </Modal.Footer>
  * </Modal>
+ * ```
  */
 export const Modal = (props: ModalProps) => {
   const {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -75,7 +75,7 @@ export const defaultPopoverModifiers = [
  *
  * `import {Popover} from "@chanzuckerberg/eds";`
  *
- * A styled popover built on 'headless UI' popover. Consider using the Dropdown component, instead.
+ * A styled popover built on 'headless UI' popover. Consider using the Dropdown component instead.
  */
 export const Popover = ({
   placement,

--- a/src/components/ProjectCard/ProjectCard.tsx
+++ b/src/components/ProjectCard/ProjectCard.tsx
@@ -74,8 +74,7 @@ export interface Props {
 }
 
 /**
- * ProjectCard is the primary UI component for user interaction contains card components, button components
- * and draggable components.
+ * A card containing project information to be used in the `DragDrop` component.
  */
 export const ProjectCard = ({
   behavior,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -26,7 +26,7 @@ export type Props = React.TableHTMLAttributes<HTMLTableElement> & {
  *
  * `import {Table} from "@chanzuckerberg/eds";`
  *
- * HTML table component
+ * HTML table component.
  */
 export const Table = ({ children, className, ...other }: Props) => {
   const componentClassName = clsx(styles['table'], className);

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -57,18 +57,21 @@ export type Props = {
  * `import {Text} from "@chanzuckerberg/eds";`
  *
  * There are two perceived use cases for the text component.
- * One is to decorate <p> and <span> with thematic variants.
- * Defaults to <p> and should pass as="span" to set as <span>
+ * One is to decorate `<p>` and `<span>` with thematic variants.
+ * Defaults to `<p>` and should pass `as="span"` to set as `<span>`.
  *
  * The second is to provide a wrapper for multiple text elements in usage as a text passage.
- * For such use, should pass as="div" and wrap various <p>, <h1>-<h6>, <a>, <ol>, <ul>, <blockquote>, <hr>.
- * Ex:
- * ```
+ * For such use, should pass as="div" and wrap various elements like `<p>`, `<h1>`-`<h6>`, `<a>`, `<ol>`, `<ul>`, `<blockquote>`, and `<hr>`.
+ *
+ * Example usage:
+ *
+ * ```tsx
  * <Text as="div">
  *   <h1>Heading for the text passage</h1>
  *   <p>First paragraph copy of the text passage</p>
  *   <p>Second paragraph copy of the text passage</p>
  * </Text>
+ * ```
  */
 export const Text = forwardRef(
   (

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -86,8 +86,6 @@ export interface TimelineNavItem {
 /**
  * `import {TimelineNav} from "@chanzuckerberg/eds";`
  *
- * Timeline nav Component
- *
  * Provides a list-view pane for item labels/titles, and a details pane for each item's content.
  * When an item in the list is selected, the details pane is updated.
  */

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -29,7 +29,7 @@ export interface Props {
 /**
  * `import {Toolbar} from "@chanzuckerberg/eds";`
  *
- * Toolbar component is a container that houses form controls for filtering a data table based on the conditional props passed through.
+ * A container that houses form controls for filtering a data table based on the conditional props passed through.
  */
 export const Toolbar = ({
   className,

--- a/src/components/ToolbarItem/ToolbarItem.tsx
+++ b/src/components/ToolbarItem/ToolbarItem.tsx
@@ -23,7 +23,7 @@ export interface Props {
 /**
  * `import {ToolbarItem} from "@chanzuckerberg/eds";`
  *
- * ToolbarItem component is used in the Toolbar component to filter the content based on alignment.
+ * Used in the Toolbar component to filter the content based on alignment.
  */
 export const ToolbarItem = ({
   align,


### PR DESCRIPTION
### Summary:
This PR contains a grab bag of various component comment cleanups, such as:
- removing any references to "Primary UI component for user interaction", which was the old default component comment and is still hanging around in a couple of places where the comment was updated to include actual useful information
- adding backticks around elements being used as text (mostly in `Text.tsx`)
- code blocks use `tsx` instead of `ts`
- various grammar touch-ups (like adding periods at the end of sentences)
- general wordsmithing to reduce redundancy

### Test Plan:
Viewed the updated components in storybook to verify their documentation has updated.