### PR TITLE
chore(Tooltip): replace tier 1 token usage in styles

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -37,17 +37,17 @@
  * Color Variants
  */
 .tooltip--light {
-  border-color: var(--eds-color-neutral-300);
-  color: var(--eds-color-neutral-700);
-  background-color: var(--eds-color-neutral-100);
-  --arrow-color: var(--eds-color-neutral-300);
+  border-color: var(--eds-theme-color-border-neutral-default);
+  color: var(--eds-theme-color-text-neutral-default);
+  background-color: var(--eds-theme-color-background-neutral-subtle);
+  --arrow-color: var(--eds-theme-color-border-neutral-default);
 }
 
 .tooltip--dark {
-  border-color: var(--eds-color-neutral-700);
-  color: var(--eds-color-neutral-white);
-  background-color: var(--eds-color-neutral-700);
-  --arrow-color: var(--eds-color-neutral-700);
+  border-color: var(--eds-theme-color-body-background-inverted);
+  color: var(--eds-theme-color-text-neutral-default-inverse);
+  background-color: var(--eds-theme-color-body-background-inverted);
+  --arrow-color: var(--eds-theme-color-body-background-inverted);
 }
 
 /**


### PR DESCRIPTION
### Summary:
In order for theming to work properly, components should only be using tier 2 or 3 tokens (except in cases of deprecated components or variants which we don't want people to theme anyway). There are a couple of instances where tier 1 tokens are being used, notably in the `Tooltip` component. I'll address the others in a separate PR.

### Test Plan:
Verify there are no color changes to the `Tooltip` component when open.