### PR TITLE
docs: advise against using jsdoc tags

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -384,9 +384,9 @@ All component props must be defined with appropriate [TypeScript type](https://w
 
 ### Component comments
 
-All components should be documented with a comment directly before the component declaration. (It's important that there are no spaces between the comment and the component so that the comment will appear in storybook.)
+All components should be documented with a comment directly before the component declaration.
 
-The comment should begin with an import example, include a general description of the component, possibly note behavior that may not be obvious to developers (so they don't have to dig through the code to understand what it does), and end with example usage.
+The comment should begin with an import example, include a general description of the component, possibly note behavior that may not be obvious to developers (so they don't have to dig through the code to understand what it does), and end with example usage for complex components (such as compound components).
 
 Example:
 
@@ -410,6 +410,35 @@ Example:
  * ```
  */
  export const ButtonGroup = ({
+````
+
+Do not use [jsdoc tags](https://devhints.io/jsdoc) (e.g. `@example`) if possible because these will break the documentation in storybook and cause all following text to not be shown on the page. For important jsdoc tags that we really want to include, place them at the end of the comment to avoid hiding comment content. For example, we use the `@deprecated` tag so Visual Studio Code will indicate a component is deprecated for developers, but we place that at the end of a component's docstring to avoid disrupting any of the other text.
+
+Example:
+
+````
+/**
+ * The Banner component is deprecated and will be removed in an upcoming release.
+ *
+ * Please visit Zeroheight to find the right notification component for your needs: https://eds.czi.design/
+ *
+ * `import {Banner} from "@chanzuckerberg/eds";`
+ *
+ * A banner used to provide and highlight information to a user or ask for a decision or action.
+ *
+ * Example usage:
+ *
+ * ```tsx
+ * <Banner
+ *   onDismiss={handleDismiss}
+ *   title="Some Title"
+ *   description={<>Some description, possibly with a <Link href="https://go.czi.team/eds">link to some other resource</Link>.</>}
+ *   action={<Button onClick={handleAction}>Action</Button>}
+ * />
+ * ```
+ *
+ * @deprecated
+ */
 ````
 
 ### Export module


### PR DESCRIPTION
### Summary:
Follow-up to https://github.com/chanzuckerberg/edu-design-system/pull/1377 in which I moved and removed jsdoc tags because they mess up how documentation appears in storybook. This PR updates the documentation to advise against using jsdoc tags to avoid hitting these issues again in the future.

### Test Plan:
Previewed the documentation in visual studio code and verified it looked good.