### PR TITLE
chore(tailwind): remove -@ in token bulding

### DIFF
--- a/src/tokens-dist/json/css-variables-nested.json
+++ b/src/tokens-dist/json/css-variables-nested.json
@@ -185,15 +185,12 @@
         "background": {
           "neutral": {
             "default": {
-              "@": "var(--eds-theme-color-background-neutral-default)",
               "hover": "var(--eds-theme-color-background-neutral-default-hover)"
             },
             "subtle": {
-              "@": "var(--eds-theme-color-background-neutral-subtle)",
               "hover": "var(--eds-theme-color-background-neutral-subtle-hover)"
             },
             "medium": {
-              "@": "var(--eds-theme-color-background-neutral-medium)",
               "hover": "var(--eds-theme-color-background-neutral-medium-hover)"
             }
           },
@@ -201,10 +198,10 @@
             "primary": {
               "default": "var(--eds-theme-color-background-brand-primary-default)",
               "strong": {
-                "@": "var(--eds-theme-color-background-brand-primary-strong)",
                 "hover": "var(--eds-theme-color-background-brand-primary-strong-hover)"
               }
-            }
+            },
+            "primary-strong": "var(--eds-theme-color-background-brand-primary-strong)"
           },
           "utility": {
             "success": "var(--eds-theme-color-background-utility-success)",
@@ -225,7 +222,10 @@
               "subtle": "var(--eds-theme-color-background-grade-stop-subtle)"
             }
           },
-          "disabled": "var(--eds-theme-color-background-disabled)"
+          "disabled": "var(--eds-theme-color-background-disabled)",
+          "neutral-default": "var(--eds-theme-color-background-neutral-default)",
+          "neutral-subtle": "var(--eds-theme-color-background-neutral-subtle)",
+          "neutral-medium": "var(--eds-theme-color-background-neutral-medium)"
         },
         "border": {
           "link": {
@@ -234,22 +234,18 @@
           },
           "neutral": {
             "subtle": {
-              "@": "var(--eds-theme-color-border-neutral-subtle)",
               "hover": "var(--eds-theme-color-border-neutral-subtle-hover)"
             },
             "default": {
-              "@": "var(--eds-theme-color-border-neutral-default)",
               "hover": "var(--eds-theme-color-border-neutral-default-hover)"
             },
             "strong": {
-              "@": "var(--eds-theme-color-border-neutral-strong)",
               "hover": "var(--eds-theme-color-border-neutral-strong-hover)"
             }
           },
           "brand": {
             "primary": {
               "subtle": "var(--eds-theme-color-border-brand-primary-subtle)",
-              "@": "var(--eds-theme-color-border-brand-primary)",
               "strong": "var(--eds-theme-color-border-brand-primary-strong)"
             }
           },
@@ -279,70 +275,73 @@
             },
             "stop": "var(--eds-theme-color-border-grade-stop)"
           },
-          "disabled": "var(--eds-theme-color-border-disabled)"
+          "disabled": "var(--eds-theme-color-border-disabled)",
+          "neutral-subtle": "var(--eds-theme-color-border-neutral-subtle)",
+          "neutral-default": "var(--eds-theme-color-border-neutral-default)",
+          "neutral-strong": "var(--eds-theme-color-border-neutral-strong)",
+          "brand-primary": "var(--eds-theme-color-border-brand-primary)"
         },
         "icon": {
           "neutral": {
             "default": {
-              "@": "var(--eds-theme-color-icon-neutral-default)",
               "inverse": "var(--eds-theme-color-icon-neutral-default-inverse)",
               "hover": "var(--eds-theme-color-icon-neutral-default-hover)"
             },
             "strong": {
-              "@": "var(--eds-theme-color-icon-neutral-strong)",
               "hover": "var(--eds-theme-color-icon-neutral-strong-hover)"
             },
             "subtle": {
-              "@": "var(--eds-theme-color-icon-neutral-subtle)",
               "hover": "var(--eds-theme-color-icon-neutral-subtle-hover)"
             }
           },
           "link": {
             "default": {
-              "@": "var(--eds-theme-color-icon-link-default)",
               "hover": "var(--eds-theme-color-icon-link-default-hover)"
             }
           },
           "brand": {
             "primary": {
-              "@": "var(--eds-theme-color-icon-brand-primary)",
               "hover": "var(--eds-theme-color-icon-brand-primary-hover)"
             }
           },
           "utility": {
             "success": {
-              "@": "var(--eds-theme-color-icon-utility-success)",
               "hover": "var(--eds-theme-color-icon-utility-success-hover)"
             },
             "warning": {
-              "@": "var(--eds-theme-color-icon-utility-warning)",
               "hover": "var(--eds-theme-color-icon-utility-warning-hover)"
             },
             "error": {
-              "@": "var(--eds-theme-color-icon-utility-error)",
               "hover": "var(--eds-theme-color-icon-utility-error-hover)"
             }
           },
           "grade": {
             "complete": {
-              "@": "var(--eds-theme-color-icon-grade-complete)",
               "hover": "var(--eds-theme-color-icon-grade-complete-hover)"
             },
             "revise": {
-              "@": "var(--eds-theme-color-icon-grade-revise)",
               "hover": "var(--eds-theme-color-icon-grade-revise-hover)"
             },
             "stop": {
-              "@": "var(--eds-theme-color-icon-grade-stop)",
               "hover": "var(--eds-theme-color-icon-grade-stop-hover)"
             }
           },
-          "disabled": "var(--eds-theme-color-icon-disabled)"
+          "disabled": "var(--eds-theme-color-icon-disabled)",
+          "neutral-default": "var(--eds-theme-color-icon-neutral-default)",
+          "neutral-strong": "var(--eds-theme-color-icon-neutral-strong)",
+          "neutral-subtle": "var(--eds-theme-color-icon-neutral-subtle)",
+          "link-default": "var(--eds-theme-color-icon-link-default)",
+          "brand-primary": "var(--eds-theme-color-icon-brand-primary)",
+          "utility-success": "var(--eds-theme-color-icon-utility-success)",
+          "utility-warning": "var(--eds-theme-color-icon-utility-warning)",
+          "utility-error": "var(--eds-theme-color-icon-utility-error)",
+          "grade-complete": "var(--eds-theme-color-icon-grade-complete)",
+          "grade-revise": "var(--eds-theme-color-icon-grade-revise)",
+          "grade-stop": "var(--eds-theme-color-icon-grade-stop)"
         },
         "text": {
           "neutral": {
             "default": {
-              "@": "var(--eds-theme-color-text-neutral-default)",
               "inverse": "var(--eds-theme-color-text-neutral-default-inverse)"
             },
             "strong": "var(--eds-theme-color-text-neutral-strong)",
@@ -365,7 +364,8 @@
           "disabled": "var(--eds-theme-color-text-disabled)",
           "brand": {
             "primary": "var(--eds-theme-color-text-brand-primary)"
-          }
+          },
+          "neutral-default": "var(--eds-theme-color-text-neutral-default)"
         },
         "transparent": {
           "black": {
@@ -378,7 +378,6 @@
         },
         "body": {
           "background": {
-            "@": "var(--eds-theme-color-body-background)",
             "inverted": "var(--eds-theme-color-body-background-inverted)"
           }
         },
@@ -386,265 +385,262 @@
           "primary": {
             "brand": {
               "background": {
-                "@": "var(--eds-theme-color-button-primary-brand-background)",
                 "hover": "var(--eds-theme-color-button-primary-brand-background-hover)",
                 "active": "var(--eds-theme-color-button-primary-brand-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-primary-brand-border)",
                 "hover": "var(--eds-theme-color-button-primary-brand-border-hover)",
                 "active": "var(--eds-theme-color-button-primary-brand-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-primary-brand-text)",
                 "hover": "var(--eds-theme-color-button-primary-brand-text-hover)",
                 "active": "var(--eds-theme-color-button-primary-brand-text-active)"
               }
             },
             "error": {
               "background": {
-                "@": "var(--eds-theme-color-button-primary-error-background)",
                 "hover": "var(--eds-theme-color-button-primary-error-background-hover)",
                 "active": "var(--eds-theme-color-button-primary-error-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-primary-error-border)",
                 "hover": "var(--eds-theme-color-button-primary-error-border-hover)",
                 "active": "var(--eds-theme-color-button-primary-error-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-primary-error-text)",
                 "hover": "var(--eds-theme-color-button-primary-error-text-hover)",
                 "active": "var(--eds-theme-color-button-primary-error-text-active)"
               }
-            }
+            },
+            "brand-background": "var(--eds-theme-color-button-primary-brand-background)",
+            "brand-border": "var(--eds-theme-color-button-primary-brand-border)",
+            "brand-text": "var(--eds-theme-color-button-primary-brand-text)",
+            "error-background": "var(--eds-theme-color-button-primary-error-background)",
+            "error-border": "var(--eds-theme-color-button-primary-error-border)",
+            "error-text": "var(--eds-theme-color-button-primary-error-text)"
           },
           "secondary": {
             "brand": {
               "background": {
-                "@": "var(--eds-theme-color-button-secondary-brand-background)",
                 "hover": "var(--eds-theme-color-button-secondary-brand-background-hover)",
                 "active": "var(--eds-theme-color-button-secondary-brand-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-secondary-brand-border)",
                 "hover": "var(--eds-theme-color-button-secondary-brand-border-hover)",
                 "active": "var(--eds-theme-color-button-secondary-brand-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-secondary-brand-text)",
                 "hover": "var(--eds-theme-color-button-secondary-brand-text-hover)",
                 "active": "var(--eds-theme-color-button-secondary-brand-text-active)"
               },
               "icon": {
-                "@": "var(--eds-theme-color-button-secondary-brand-icon)",
                 "hover": "var(--eds-theme-color-button-secondary-brand-icon-hover)",
                 "active": "var(--eds-theme-color-button-secondary-brand-icon-active)"
               }
             },
             "neutral": {
               "background": {
-                "@": "var(--eds-theme-color-button-secondary-neutral-background)",
                 "hover": "var(--eds-theme-color-button-secondary-neutral-background-hover)",
                 "active": "var(--eds-theme-color-button-secondary-neutral-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-secondary-neutral-border)",
                 "hover": "var(--eds-theme-color-button-secondary-neutral-border-hover)",
                 "active": "var(--eds-theme-color-button-secondary-neutral-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-secondary-neutral-text)",
                 "hover": "var(--eds-theme-color-button-secondary-neutral-text-hover)",
                 "active": "var(--eds-theme-color-button-secondary-neutral-text-active)"
               },
               "icon": {
-                "@": "var(--eds-theme-color-button-secondary-neutral-icon)",
                 "hover": "var(--eds-theme-color-button-secondary-neutral-icon-hover)",
                 "active": "var(--eds-theme-color-button-secondary-neutral-icon-active)"
               }
             },
             "success": {
               "background": {
-                "@": "var(--eds-theme-color-button-secondary-success-background)",
                 "hover": "var(--eds-theme-color-button-secondary-success-background-hover)",
                 "active": "var(--eds-theme-color-button-secondary-success-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-secondary-success-border)",
                 "hover": "var(--eds-theme-color-button-secondary-success-border-hover)",
                 "active": "var(--eds-theme-color-button-secondary-success-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-secondary-success-text)",
                 "hover": "var(--eds-theme-color-button-secondary-success-text-hover)",
                 "active": "var(--eds-theme-color-button-secondary-success-text-active)"
               },
               "icon": {
-                "@": "var(--eds-theme-color-button-secondary-success-icon)",
                 "hover": "var(--eds-theme-color-button-secondary-success-icon-hover)",
                 "active": "var(--eds-theme-color-button-secondary-success-icon-active)"
               }
             },
             "warning": {
               "background": {
-                "@": "var(--eds-theme-color-button-secondary-warning-background)",
                 "hover": "var(--eds-theme-color-button-secondary-warning-background-hover)",
                 "active": "var(--eds-theme-color-button-secondary-warning-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-secondary-warning-border)",
                 "hover": "var(--eds-theme-color-button-secondary-warning-border-hover)",
                 "active": "var(--eds-theme-color-button-secondary-warning-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-secondary-warning-text)",
                 "hover": "var(--eds-theme-color-button-secondary-warning-text-hover)",
                 "active": "var(--eds-theme-color-button-secondary-warning-text-active)"
               },
               "icon": {
-                "@": "var(--eds-theme-color-button-secondary-warning-icon)",
                 "hover": "var(--eds-theme-color-button-secondary-warning-icon-hover)",
                 "active": "var(--eds-theme-color-button-secondary-warning-icon-active)"
               }
             },
             "error": {
               "background": {
-                "@": "var(--eds-theme-color-button-secondary-error-background)",
                 "hover": "var(--eds-theme-color-button-secondary-error-background-hover)",
                 "active": "var(--eds-theme-color-button-secondary-error-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-secondary-error-border)",
                 "hover": "var(--eds-theme-color-button-secondary-error-border-hover)",
                 "active": "var(--eds-theme-color-button-secondary-error-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-secondary-error-text)",
                 "hover": "var(--eds-theme-color-button-secondary-error-text-hover)",
                 "active": "var(--eds-theme-color-button-secondary-error-text-active)"
               },
               "icon": {
-                "@": "var(--eds-theme-color-button-secondary-error-icon)",
                 "hover": "var(--eds-theme-color-button-secondary-error-icon-hover)",
                 "active": "var(--eds-theme-color-button-secondary-error-icon-active)"
               }
-            }
+            },
+            "brand-background": "var(--eds-theme-color-button-secondary-brand-background)",
+            "brand-border": "var(--eds-theme-color-button-secondary-brand-border)",
+            "brand-text": "var(--eds-theme-color-button-secondary-brand-text)",
+            "brand-icon": "var(--eds-theme-color-button-secondary-brand-icon)",
+            "neutral-background": "var(--eds-theme-color-button-secondary-neutral-background)",
+            "neutral-border": "var(--eds-theme-color-button-secondary-neutral-border)",
+            "neutral-text": "var(--eds-theme-color-button-secondary-neutral-text)",
+            "neutral-icon": "var(--eds-theme-color-button-secondary-neutral-icon)",
+            "success-background": "var(--eds-theme-color-button-secondary-success-background)",
+            "success-border": "var(--eds-theme-color-button-secondary-success-border)",
+            "success-text": "var(--eds-theme-color-button-secondary-success-text)",
+            "success-icon": "var(--eds-theme-color-button-secondary-success-icon)",
+            "warning-background": "var(--eds-theme-color-button-secondary-warning-background)",
+            "warning-border": "var(--eds-theme-color-button-secondary-warning-border)",
+            "warning-text": "var(--eds-theme-color-button-secondary-warning-text)",
+            "warning-icon": "var(--eds-theme-color-button-secondary-warning-icon)",
+            "error-background": "var(--eds-theme-color-button-secondary-error-background)",
+            "error-border": "var(--eds-theme-color-button-secondary-error-border)",
+            "error-text": "var(--eds-theme-color-button-secondary-error-text)",
+            "error-icon": "var(--eds-theme-color-button-secondary-error-icon)"
           },
           "icon": {
             "brand": {
-              "@": "var(--eds-theme-color-button-icon-brand)",
               "hover": "var(--eds-theme-color-button-icon-brand-hover)",
               "active": "var(--eds-theme-color-button-icon-brand-active)",
               "background": {
-                "@": "var(--eds-theme-color-button-icon-brand-background)",
                 "hover": "var(--eds-theme-color-button-icon-brand-background-hover)",
                 "active": "var(--eds-theme-color-button-icon-brand-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-icon-brand-border)",
                 "hover": "var(--eds-theme-color-button-icon-brand-border-hover)",
                 "active": "var(--eds-theme-color-button-icon-brand-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-icon-brand-text)",
                 "hover": "var(--eds-theme-color-button-icon-brand-text-hover)",
                 "active": "var(--eds-theme-color-button-icon-brand-text-active)"
               }
             },
             "neutral": {
-              "@": "var(--eds-theme-color-button-icon-neutral)",
               "hover": "var(--eds-theme-color-button-icon-neutral-hover)",
               "active": "var(--eds-theme-color-button-icon-neutral-active)",
               "background": {
-                "@": "var(--eds-theme-color-button-icon-neutral-background)",
                 "hover": "var(--eds-theme-color-button-icon-neutral-background-hover)",
                 "active": "var(--eds-theme-color-button-icon-neutral-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-icon-neutral-border)",
                 "hover": "var(--eds-theme-color-button-icon-neutral-border-hover)",
                 "active": "var(--eds-theme-color-button-icon-neutral-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-icon-neutral-text)",
                 "hover": "var(--eds-theme-color-button-icon-neutral-text-hover)",
                 "active": "var(--eds-theme-color-button-icon-neutral-text-active)"
               }
             },
             "success": {
-              "@": "var(--eds-theme-color-button-icon-success)",
               "hover": "var(--eds-theme-color-button-icon-success-hover)",
               "active": "var(--eds-theme-color-button-icon-success-active)",
               "background": {
-                "@": "var(--eds-theme-color-button-icon-success-background)",
                 "hover": "var(--eds-theme-color-button-icon-success-background-hover)",
                 "active": "var(--eds-theme-color-button-icon-success-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-icon-success-border)",
                 "hover": "var(--eds-theme-color-button-icon-success-border-hover)",
                 "active": "var(--eds-theme-color-button-icon-success-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-icon-success-text)",
                 "hover": "var(--eds-theme-color-button-icon-success-text-hover)",
                 "active": "var(--eds-theme-color-button-icon-success-text-active)"
               }
             },
             "warning": {
-              "@": "var(--eds-theme-color-button-icon-warning)",
               "hover": "var(--eds-theme-color-button-icon-warning-hover)",
               "active": "var(--eds-theme-color-button-icon-warning-active)",
               "background": {
-                "@": "var(--eds-theme-color-button-icon-warning-background)",
                 "hover": "var(--eds-theme-color-button-icon-warning-background-hover)",
                 "active": "var(--eds-theme-color-button-icon-warning-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-icon-warning-border)",
                 "hover": "var(--eds-theme-color-button-icon-warning-border-hover)",
                 "active": "var(--eds-theme-color-button-icon-warning-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-icon-warning-text)",
                 "hover": "var(--eds-theme-color-button-icon-warning-text-hover)",
                 "active": "var(--eds-theme-color-button-icon-warning-text-active)"
               }
             },
             "error": {
-              "@": "var(--eds-theme-color-button-icon-error)",
               "hover": "var(--eds-theme-color-button-icon-error-hover)",
               "active": "var(--eds-theme-color-button-icon-error-active)",
               "background": {
-                "@": "var(--eds-theme-color-button-icon-error-background)",
                 "hover": "var(--eds-theme-color-button-icon-error-background-hover)",
                 "active": "var(--eds-theme-color-button-icon-error-background-active)"
               },
               "border": {
-                "@": "var(--eds-theme-color-button-icon-error-border)",
                 "hover": "var(--eds-theme-color-button-icon-error-border-hover)",
                 "active": "var(--eds-theme-color-button-icon-error-border-active)"
               },
               "text": {
-                "@": "var(--eds-theme-color-button-icon-error-text)",
                 "hover": "var(--eds-theme-color-button-icon-error-text-hover)",
                 "active": "var(--eds-theme-color-button-icon-error-text-active)"
               }
-            }
-          }
+            },
+            "brand-background": "var(--eds-theme-color-button-icon-brand-background)",
+            "brand-border": "var(--eds-theme-color-button-icon-brand-border)",
+            "brand-text": "var(--eds-theme-color-button-icon-brand-text)",
+            "neutral-background": "var(--eds-theme-color-button-icon-neutral-background)",
+            "neutral-border": "var(--eds-theme-color-button-icon-neutral-border)",
+            "neutral-text": "var(--eds-theme-color-button-icon-neutral-text)",
+            "success-background": "var(--eds-theme-color-button-icon-success-background)",
+            "success-border": "var(--eds-theme-color-button-icon-success-border)",
+            "success-text": "var(--eds-theme-color-button-icon-success-text)",
+            "warning-background": "var(--eds-theme-color-button-icon-warning-background)",
+            "warning-border": "var(--eds-theme-color-button-icon-warning-border)",
+            "warning-text": "var(--eds-theme-color-button-icon-warning-text)",
+            "error-background": "var(--eds-theme-color-button-icon-error-background)",
+            "error-border": "var(--eds-theme-color-button-icon-error-border)",
+            "error-text": "var(--eds-theme-color-button-icon-error-text)"
+          },
+          "icon-brand": "var(--eds-theme-color-button-icon-brand)",
+          "icon-neutral": "var(--eds-theme-color-button-icon-neutral)",
+          "icon-success": "var(--eds-theme-color-button-icon-success)",
+          "icon-warning": "var(--eds-theme-color-button-icon-warning)",
+          "icon-error": "var(--eds-theme-color-button-icon-error)"
         },
         "focus-ring": {
-          "@": "var(--eds-theme-color-focus-ring)",
           "inverted": "var(--eds-theme-color-focus-ring-inverted)"
         },
         "form": {
           "border": {
-            "@": "var(--eds-theme-color-form-border)",
             "hover": "var(--eds-theme-color-form-border-hover)"
           },
           "background": {
-            "@": "var(--eds-theme-color-form-background)",
             "hover": "var(--eds-theme-color-form-background-hover)"
           },
           "label": "var(--eds-theme-color-form-label)"
@@ -652,14 +648,18 @@
         "text-highlight": {
           "foreground": "var(--eds-theme-color-text-highlight-foreground)",
           "background": "var(--eds-theme-color-text-highlight-background)"
-        }
+        },
+        "body-background": "var(--eds-theme-color-body-background)",
+        "form-border": "var(--eds-theme-color-form-border)",
+        "form-background": "var(--eds-theme-color-form-background)"
       },
       "form": {
         "border": {
           "width": "var(--eds-theme-form-border-width)",
           "radius": "var(--eds-theme-form-border-radius)"
         }
-      }
+      },
+      "color-focus-ring": "var(--eds-theme-color-focus-ring)"
     }
   },
   "legacy": {

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -90,9 +90,29 @@ function minifyCSSVarDictionary(obj) {
 }
 
 /**
- * Tokens with key '@' mean the value of the parent is the value of '@', e.g.:
- * {background: {neutral: {@: 'value' }}} is compiled to `background-neutral-default-@: 'value'`
+ * Tokens with key '@' are the base value of the parent, e.g.
+ * {background: {neutral: {@: 'value' }}} is compiled to `background-neutral-default-@: 'value'`,
  * but we want this to look like `background-neutral: 'value'`.
+ *
+ * This function moves the '@' token out to be a sibling of the parent with the '@' part of
+ * the name removed.
+ *
+ * Example:
+ * "neutral": {
+ *   "default": {
+ *     "@": "var(--eds-theme-color-border-neutral-default)",
+ *     "hover": "var(--eds-theme-color-border-neutral-default-hover)"
+ *   },
+ * },
+ *
+ * will be changed to
+ *
+ * "neutral": {
+ *   "default": {
+ *     "hover": "var(--eds-theme-color-border-neutral-default-hover)"
+ *   },
+ * },
+ * "neutral-default": "var(--eds-theme-color-border-neutral-default)",
  *
  * This helper function makes this happen by
  * 1) Scanning great grandchildren for the key '@'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -27,6 +27,7 @@ module.exports = {
     colors: {
       transparent: 'transparent',
       ...variableTokens.eds.color,
+      ...variableTokens.eds.theme.color,
     },
     fontSize: {
       // provide values for both font-size and line-height


### PR DESCRIPTION
### Summary:
[EDS-736]
[EDS-259]
Relates to #1375, except instead of replacing `-@` with `-default`, assigns the appropriate `child-grandchild` key to the respective value.

**<i>Please let me know if I could word the helper utility function comment any better to make it clearer.</i>**

- The `colors-background.json` and other similar files are where we define our tier 2 / 3 tokens, looks like: 
![image](https://user-images.githubusercontent.com/86632227/202558775-06a6705e-85bc-44c5-a5dd-fa9103c1ff09.png)
- In this screenshot, `{ eds: {theme: {color: {background: {neutral: {default: {@: {value: "{eds.color.neutral.white}"` compiles to `EdsThemeColorBackgroundNeutralDefault` in `src/tokens-dist/ts/colors.ts` and css custom property `--eds-theme-color-background-neutral-default`. 
- However the formatter used to generate `css-variables-nested.json` (primarily used for TW) compiles to `{ eds: {theme: {color: {background: {neutral: {default: {@: {value: "var(--eds-theme-color-background-neutral-default)"` which when used with `@apply` or TW utility classes, becomes `-color-background-neutral-default-@`, but I would like that to be `-color-background-neutral-default` to be similar with what's in the mocks, and the tokens that are generated.


### Test Plan:
newly built tokens work with @apply or tailwind utility classnames in storybook, e.g. `bg-background-neutral-brand-primary-strong` is `--eds-theme-color-background-brand-primary-strong`

[EDS-736]: https://czi-tech.atlassian.net/browse/EDS-736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDS-259]: https://czi-tech.atlassian.net/browse/EDS-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ