### PR TITLE
chore: use css variables instead of js variables for color in icons

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -276,7 +276,17 @@ Use:
 }
 ```
 
-- Avoid using classes on one component to alter the styling of a different component. For example, instead of:
+- Use CSS variables instead of JavaScript variables for styling in components. This enables theming the components because our theming system relies on overrides CSS variables.
+
+Instead of:
+
+```tsx
+import { EdsThemeColorUtilitySuccessForeground } from 'src/tokens-dist/ts/colors';
+
+<Icon color={EdsThemeColorUtilitySuccessForeground} />;
+```
+
+Use:
 
 ```css
 .banner__icon {
@@ -284,13 +294,7 @@ Use:
 }
 ```
 
-Use:
-
-```tsx
-import { EdsThemeColorUtilitySuccessForeground } from 'src/tokens-dist/ts/colors';
-
-<Icon color={EdsThemeColorUtilitySuccessForeground} />;
-```
+You can continue to use the `Icon` components' `color` prop with JavaScript variables in storybook (including recipes and pages) because those will not be imported and themed in other prodcuts.
 
 ## Utility classes <a name="utility-classes"></a>
 

--- a/src/components/Drawer/__snapshots__/Drawer.test.ts.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.test.ts.snap
@@ -29,7 +29,7 @@ exports[`<Drawer /> Default story renders snapshot 1`] = `
       >
         <svg
           class="icon"
-          fill="#878C90"
+          fill="currentColor"
           height="1.5rem"
           role="img"
           style="--icon-size: 1.5rem;"

--- a/src/components/DrawerHeader/DrawerHeader.tsx
+++ b/src/components/DrawerHeader/DrawerHeader.tsx
@@ -3,7 +3,6 @@ import type { MouseEventHandler, ReactNode } from 'react';
 import React from 'react';
 import Button from '../../components/Button';
 import Icon from '../../components/Icon';
-import { EdsThemeColorIconNeutralSubtle } from '../../tokens-dist/ts/colors';
 import styles from '../Drawer/Drawer.module.css';
 
 export type Props = {
@@ -51,7 +50,6 @@ export const DrawerHeader = ({
       {dismissible && (
         <Button onClick={onClick} status="neutral" variant="icon">
           <Icon
-            color={EdsThemeColorIconNeutralSubtle}
             name="close"
             purpose="informative"
             size="1.5rem"

--- a/src/components/FiltersDrawer/__snapshots__/FiltersDrawer.test.tsx.snap
+++ b/src/components/FiltersDrawer/__snapshots__/FiltersDrawer.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
       >
         <svg
           class="icon"
-          fill="#878C90"
+          fill="currentColor"
           height="1.5rem"
           role="img"
           style="--icon-size: 1.5rem;"
@@ -198,7 +198,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
       >
         <svg
           class="icon"
-          fill="#878C90"
+          fill="currentColor"
           height="1.5rem"
           role="img"
           style="--icon-size: 1.5rem;"
@@ -840,7 +840,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
       >
         <svg
           class="icon"
-          fill="#878C90"
+          fill="currentColor"
           height="1.5rem"
           role="img"
           style="--icon-size: 1.5rem;"
@@ -1025,7 +1025,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
       >
         <svg
           class="icon"
-          fill="#878C90"
+          fill="currentColor"
           height="1.5rem"
           role="img"
           style="--icon-size: 1.5rem;"

--- a/src/components/NavContainer/__snapshots__/NavContainer.test.ts.snap
+++ b/src/components/NavContainer/__snapshots__/NavContainer.test.ts.snap
@@ -26,7 +26,7 @@ exports[`<NavContainer /> Default story renders snapshot 1`] = `
             <svg
               aria-hidden="true"
               class="icon primary-nav__icon"
-              fill="#FFFFFF"
+              fill="currentColor"
               height="1.25rem"
               style="--icon-size: 1.25rem;"
               width="1.25rem"
@@ -51,7 +51,7 @@ exports[`<NavContainer /> Default story renders snapshot 1`] = `
             <svg
               aria-hidden="true"
               class="icon primary-nav__icon"
-              fill="#FFFFFF"
+              fill="currentColor"
               height="1.25rem"
               style="--icon-size: 1.25rem;"
               width="1.25rem"
@@ -76,7 +76,7 @@ exports[`<NavContainer /> Default story renders snapshot 1`] = `
             <svg
               aria-hidden="true"
               class="icon primary-nav__icon"
-              fill="#FFFFFF"
+              fill="currentColor"
               height="1.25rem"
               style="--icon-size: 1.25rem;"
               width="1.25rem"

--- a/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.ts.snap
+++ b/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.ts.snap
@@ -23,7 +23,7 @@ exports[`<PrimaryNav /> Default story renders snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="icon primary-nav__icon"
-            fill="#FFFFFF"
+            fill="currentColor"
             height="1.25rem"
             style="--icon-size: 1.25rem;"
             width="1.25rem"
@@ -48,7 +48,7 @@ exports[`<PrimaryNav /> Default story renders snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="icon primary-nav__icon"
-            fill="#FFFFFF"
+            fill="currentColor"
             height="1.25rem"
             style="--icon-size: 1.25rem;"
             width="1.25rem"
@@ -73,7 +73,7 @@ exports[`<PrimaryNav /> Default story renders snapshot 1`] = `
           <svg
             aria-hidden="true"
             class="icon primary-nav__icon"
-            fill="#FFFFFF"
+            fill="currentColor"
             height="1.25rem"
             style="--icon-size: 1.25rem;"
             width="1.25rem"

--- a/src/components/PrimaryNavItem/PrimaryNavItem.module.css
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.module.css
@@ -59,4 +59,5 @@
  */
 .primary-nav__icon {
   margin-right: var(--eds-size-2-and-half);
+  color: var(--eds-theme-color-text-neutral-default-inverse);
 }

--- a/src/components/PrimaryNavItem/PrimaryNavItem.tsx
+++ b/src/components/PrimaryNavItem/PrimaryNavItem.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import React from 'react';
 import styles from './PrimaryNavItem.module.css';
-import { EdsThemeColorIconNeutralDefaultInverse } from '../../tokens-dist/ts/colors';
 import type { IconName } from '../Icon';
 import Icon from '../Icon';
 
@@ -58,7 +57,6 @@ export const PrimaryNavItem = React.forwardRef<HTMLLIElement, Props>(
         <TagName className={styles['primary-nav__link']} href={href}>
           <Icon
             className={styles['primary-nav__icon']}
-            color={EdsThemeColorIconNeutralDefaultInverse}
             name={iconName}
             purpose="decorative"
             size="1.25rem"

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -349,3 +349,19 @@
     border-color: 1px solid var(--eds-theme-color-text-neutral-strong);
   }
 }
+
+.timeline-nav__icon--success {
+  color: var(--eds-theme-color-background-grade-complete-default);
+}
+
+.timeline-nav__icon--warning {
+  color: var(--eds-theme-color-background-grade-revise-default);
+}
+
+.timeline-nav__icon--error {
+  color: var(--eds-theme-color-background-grade-stop-default);
+}
+
+.timeline-nav__icon--incomplete {
+  color: var(--eds-theme-color-border-neutral-subtle);
+}

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -5,12 +5,6 @@ import { allByType } from 'react-children-by-type';
 import { useUIDSeed } from 'react-uid';
 import styles from './TimelineNav.module.css';
 import {
-  EdsThemeColorBackgroundGradeCompleteDefault,
-  EdsThemeColorBackgroundGradeReviseDefault,
-  EdsThemeColorBackgroundGradeStopDefault,
-  EdsThemeColorBorderNeutralSubtle,
-} from '../../tokens-dist/ts/colors';
-import {
   L_ARROW_KEYCODE,
   U_ARROW_KEYCODE,
   R_ARROW_KEYCODE,
@@ -262,8 +256,10 @@ export const TimelineNav = ({
       case 'success':
         return (
           <Icon
-            className={styles['timeline-nav__icon']}
-            color={EdsThemeColorBackgroundGradeCompleteDefault}
+            className={clsx(
+              styles['timeline-nav__icon'],
+              styles['timeline-nav__icon--success'],
+            )}
             name="check-circle"
             purpose="decorative"
           />
@@ -271,8 +267,10 @@ export const TimelineNav = ({
       case 'warning':
         return (
           <Icon
-            className={styles['timeline-nav__icon']}
-            color={EdsThemeColorBackgroundGradeReviseDefault}
+            className={clsx(
+              styles['timeline-nav__icon'],
+              styles['timeline-nav__icon--warning'],
+            )}
             name="error"
             purpose="decorative"
           />
@@ -280,8 +278,10 @@ export const TimelineNav = ({
       case 'error':
         return (
           <Icon
-            className={styles['timeline-nav__icon']}
-            color={EdsThemeColorBackgroundGradeStopDefault}
+            className={clsx(
+              styles['timeline-nav__icon'],
+              styles['timeline-nav__icon--error'],
+            )}
             name="cancel"
             purpose="decorative"
           />
@@ -298,8 +298,10 @@ export const TimelineNav = ({
       case 'incomplete':
         return (
           <Icon
-            className={styles['timeline-nav__icon']}
-            color={EdsThemeColorBorderNeutralSubtle}
+            className={clsx(
+              styles['timeline-nav__icon'],
+              styles['timeline-nav__icon--incomplete'],
+            )}
             name="star-outline"
             purpose="decorative"
           />
@@ -307,8 +309,10 @@ export const TimelineNav = ({
       case 'complete':
         return (
           <Icon
-            className={styles['timeline-nav__icon']}
-            color={EdsThemeColorBackgroundGradeCompleteDefault}
+            className={clsx(
+              styles['timeline-nav__icon'],
+              styles['timeline-nav__icon--success'],
+            )}
             name="star"
             purpose="decorative"
           />

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -166,8 +166,8 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon timeline-nav__icon"
-              fill="#D41E52"
+              class="icon timeline-nav__icon timeline-nav__icon--error"
+              fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
             >
               <use
@@ -218,8 +218,8 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon timeline-nav__icon"
-              fill="#F7BE2D"
+              class="icon timeline-nav__icon timeline-nav__icon--warning"
+              fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
             >
               <use
@@ -294,8 +294,8 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon timeline-nav__icon"
-              fill="#008656"
+              class="icon timeline-nav__icon timeline-nav__icon--success"
+              fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
             >
               <use
@@ -461,8 +461,8 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="icon timeline-nav__icon"
-              fill="#008656"
+              class="icon timeline-nav__icon timeline-nav__icon--success"
+              fill="currentColor"
               xmlns="http://www.w3.org/2000/svg"
             >
               <use


### PR DESCRIPTION
### Summary:
Ticket: https://czi-tech.atlassian.net/browse/EDS-705

In order to support theming, we only want to use CSS variables, not JavaScript variables, for styling components. This will allow other downstream products to override the variables we use for styling. The `Icon` component is typically colored by passing in a JS variable via the `color` prop. This is fine in other products, and it's fine in storybook files, but we don't want to use this convention in components themselves.

This PR updates components with colored `Icon`s to use css variables for the color, and I updated the documentation that says to do the opposite.

<img width="811" alt="" src="https://user-images.githubusercontent.com/7761701/202761338-46c2ad8c-44e2-4272-ba93-775fdcf6450d.png">

There is also one icon color change—the `DrawerHeader` was overriding the close button icon color to be lighter. I checked the [figma design for the Filter component](https://www.figma.com/file/Ff7hJoSvXX9hkAmIklnsT2/EDS-Paper-v1.1-%7C-UI-Components?node-id=7452%3A24882&t=509XHeTp0Hscikjj-1), and it's actually using the default icon button color. I would prefer we not override default button styling unless we have a really good reason, so I'm removing the color to match figma.

<img width="467" alt="" src="https://user-images.githubusercontent.com/7761701/202761468-8942a858-f07f-494b-8423-b02dcd21eacb.png">

### Test Plan:
- no visual changes to the `PrimaryNav` and `TimelineNav` components
- the `DrawerHeader` close button icon is a little darker and now matches the figma mock
- the code guidelines have been updated