### PR TITLE
chore(modal-header): use tier 3 token for brand header background color

### DIFF
--- a/.storybook/data/tokens.json
+++ b/.storybook/data/tokens.json
@@ -360,6 +360,7 @@
   "eds-theme-color-form-background": "#FFFFFF",
   "eds-theme-color-form-background-hover": "#F4F6F8",
   "eds-theme-color-form-label": "#383C43",
+  "eds-theme-color-modal-brand-header-background": "#8984E8",
   "eds-theme-color-text-highlight-foreground": "#21272D",
   "eds-theme-color-text-highlight-background": "#F5FF8F",
   "eds-theme-form-border-width": "1px",

--- a/src/components/ModalHeader/ModalHeader.module.css
+++ b/src/components/ModalHeader/ModalHeader.module.css
@@ -32,7 +32,7 @@
   flex-shrink: 0;
 
   color: var(--eds-theme-color-text-neutral-default-inverse);
-  background-color: var(--eds-color-brand-grape-500);
+  background-color: var(--eds-theme-color-modal-brand-header-background);
   h2 {
     /**
      * Brand specific font for the title.

--- a/src/design-tokens/tier-3-component/modals.json
+++ b/src/design-tokens/tier-3-component/modals.json
@@ -1,0 +1,19 @@
+{
+  "eds": {
+    "theme": {
+      "color": {
+        "modal": {
+          "brand": {
+            "header": {
+              "background": {
+                "@": {
+                  "value": "{eds.color.brand.grape.500}"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -360,6 +360,7 @@
   --eds-theme-color-form-background: #FFFFFF;
   --eds-theme-color-form-background-hover: #F4F6F8;
   --eds-theme-color-form-label: #383C43;
+  --eds-theme-color-modal-brand-header-background: #8984E8;
   --eds-theme-color-text-highlight-foreground: #21272D;
   --eds-theme-color-text-highlight-background: #F5FF8F;
   --eds-theme-form-border-width: 1px;

--- a/src/tokens-dist/json/css-variables-nested.json
+++ b/src/tokens-dist/json/css-variables-nested.json
@@ -645,6 +645,14 @@
           },
           "label": "var(--eds-theme-color-form-label)"
         },
+        "modal": {
+          "brand": {
+            "header": {
+              "background": {}
+            },
+            "header-background": "var(--eds-theme-color-modal-brand-header-background)"
+          }
+        },
         "text-highlight": {
           "foreground": "var(--eds-theme-color-text-highlight-foreground)",
           "background": "var(--eds-theme-color-text-highlight-background)"

--- a/src/tokens-dist/json/variables-nested.json
+++ b/src/tokens-dist/json/variables-nested.json
@@ -649,6 +649,15 @@
           },
           "label": "#383C43"
         },
+        "modal": {
+          "brand": {
+            "header": {
+              "background": {
+                "@": "#8984E8"
+              }
+            }
+          }
+        },
         "text-highlight": {
           "foreground": "#21272D",
           "background": "#F5FF8F"

--- a/src/tokens-dist/scss/_variables.scss
+++ b/src/tokens-dist/scss/_variables.scss
@@ -360,6 +360,7 @@ $eds-theme-color-form-border-hover: #21272D !default;
 $eds-theme-color-form-background: #FFFFFF !default;
 $eds-theme-color-form-background-hover: #F4F6F8 !default;
 $eds-theme-color-form-label: #383C43 !default;
+$eds-theme-color-modal-brand-header-background: #8984E8 !default;
 $eds-theme-color-text-highlight-foreground: #21272D !default;
 $eds-theme-color-text-highlight-background: #F5FF8F !default;
 $eds-theme-form-border-width: 1px !default;
@@ -1043,6 +1044,15 @@ $tokens: (
             'hover': $eds-theme-color-form-background-hover
           ),
           'label': $eds-theme-color-form-label
+        ),
+        'modal': (
+          'brand': (
+            'header': (
+              'background': (
+                '@': $eds-theme-color-modal-brand-header-background
+              )
+            )
+          )
         ),
         'text-highlight': (
           'foreground': $eds-theme-color-text-highlight-foreground,

--- a/src/tokens-dist/ts/colors.ts
+++ b/src/tokens-dist/ts/colors.ts
@@ -296,6 +296,7 @@ export const EdsThemeColorFormBorderHover = '#21272D';
 export const EdsThemeColorFormBackground = '#FFFFFF';
 export const EdsThemeColorFormBackgroundHover = '#F4F6F8';
 export const EdsThemeColorFormLabel = '#383C43';
+export const EdsThemeColorModalBrandHeaderBackground = '#8984E8';
 export const EdsThemeColorTextHighlightForeground = '#21272D';
 export const EdsThemeColorTextHighlightBackground = '#F5FF8F';
 export const LegacyColorGray50 = '#F8F9FC';


### PR DESCRIPTION
### Summary:
Ticket: https://czi-tech.atlassian.net/browse/EDS-704

We only want tier 2 and tier 3 tokens to be used in components so that downstream products using the components can easily override the token values using css variables. We have just 1 left I believe, which is in the `ModalHeader` brand background color. We synced with design today and decided a new tier 3 token would be added, and it would be called "color modal brand header background". This PR adds the new token and uses it in the `ModalHeader` `brand` variant.

### Test Plan:
No visual changes in the brand modal.