### PR TITLE
fix(style-dictionary): delete empty object in css-variables-nested

### DIFF
--- a/src/tokens-dist/json/css-variables-nested.json
+++ b/src/tokens-dist/json/css-variables-nested.json
@@ -647,9 +647,6 @@
         },
         "modal": {
           "brand": {
-            "header": {
-              "background": {}
-            },
             "header-background": "var(--eds-theme-color-modal-brand-header-background)"
           }
         },

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -127,6 +127,12 @@ function formatEdsTokens(obj) {
         if (obj[name][nestedName]['@']) {
           obj[name + '-' + nestedName] = obj[name][nestedName]['@'];
           delete obj[name][nestedName]['@'];
+          if (Object.keys(obj[name][nestedName]).length === 0) {
+            delete obj[name][nestedName];
+          }
+          if (Object.keys(obj[name]).length === 0) {
+            delete obj[name];
+          }
         } else if (typeof obj[name][nestedName] === 'object') {
           formatEdsTokens(obj[name]);
         }

--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -117,7 +117,8 @@ function minifyCSSVarDictionary(obj) {
  * This helper function makes this happen by
  * 1) Scanning great grandchildren for the key '@'
  * 2) If such key exists, child and grandchild names are combined to make the new child key and value of the great grandchild '@' key is assigned to the new child key
- * 2.5) The great grandchild '@' key/value pair is deleted for housekeeping.
+ * 2.1) The great grandchild '@' key/value pair is deleted for housekeeping.
+ * 2.2) If objects are now empty, deletes them to prevent potential token name clashing which could cause Tailwind bugs.
  * 3) If such key does not exist, but grand child is an object, recurses with the child to repeat this process.
  */
 function formatEdsTokens(obj) {


### PR DESCRIPTION
### Summary:
[EDS-743]
- deletes empty objects in `css-variables-nested.json` to prevent potential TW utility class bugs and housekeeping
### Test Plan:
- run `yarn build:tokens`
  - `css-variables-nested.json` eds theme objects should not have empty objects as properties

[EDS-743]: https://czi-tech.atlassian.net/browse/EDS-743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ