### PR TITLE
chore: tidy up theming demos

### DIFF
--- a/.storybook/pages/AlongDemo/AlongDemo.module.css
+++ b/.storybook/pages/AlongDemo/AlongDemo.module.css
@@ -232,7 +232,6 @@
   right: 0;
   bottom: 0;
   border-left: var(--eds-theme-form-border-width) solid transparent;
-  /* TODO: capture box shadows in tokens */
   box-shadow: rgb(0 0 0 / 15%) 0px 0.125rem 0.75rem;
   background-color: var(--eds-theme-color-background-neutral-default);
   flex-direction: column;
@@ -265,7 +264,6 @@
   background-color: white;
   border-radius: 1rem;
   max-width: 188px !important;
-  /* TODO: capture box shadows in tokens */
   box-shadow: 0px 1px 0px rgba(33, 40, 102, 0.4);
 }
 

--- a/.storybook/pages/AlongDemo/AlongDemo.module.css
+++ b/.storybook/pages/AlongDemo/AlongDemo.module.css
@@ -10,9 +10,30 @@
 .wireframe-demo__footer {
   padding: 7.5rem 0 2rem;
   display: flex;
-  gap: 3rem;
+  align-items: flex-start;
   flex-wrap: wrap;
   justify-content: center;
+  margin-bottom: 0.5rem;
+  list-style-type: none;
+
+  @media screen and (min-width: $eds-bp-md) {
+    flex-wrap: no-wrap;
+    margin-bottom: 0;
+  }
+}
+
+.wireframe-demo__footer-link {
+  border-left: 1px solid var(--along-color-space-100);
+  &:first-child {
+    border-left: none;
+  }
+
+  padding: 0 1.5rem 0.5rem 1.5rem;
+  margin-bottom: 1rem;
+
+  @media screen and (min-width: $eds-bp-md) {
+    padding: 0 1rem;
+  }
 }
 
 /**
@@ -120,7 +141,7 @@
 
 .watch-page__main-section {
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
   padding-top: 2rem;
@@ -163,6 +184,8 @@
  */
 .watch-page__dropdown button {
   border-color: var(--along-color-space-500);
+  background-color: transparent;
+  justify-content: center;
   transition-property: color, border-color;
   transition-duration: var(--eds-anim-fade-quick);
   transition-timing-function: var(--eds-anim-ease);
@@ -200,7 +223,6 @@
   margin-left: 1.5rem;
   display: flex;
   flex-direction: column;
-  width: 24.125rem;
 }
 
 .watch-page__sidebar {

--- a/.storybook/pages/AlongDemo/AlongDemo.tsx
+++ b/.storybook/pages/AlongDemo/AlongDemo.tsx
@@ -268,7 +268,6 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
             <Dropdown
               aria-label="student groups"
               buttonText={selectedOption.label}
-              // TODO: why isn't the selected styling showing up when selecting a new option?
               onChange={setSelectedOption}
               options={studentGroupOptions}
               value={selectedOption}

--- a/.storybook/pages/AlongDemo/AlongDemo.tsx
+++ b/.storybook/pages/AlongDemo/AlongDemo.tsx
@@ -28,45 +28,55 @@ import MicrosoftLogo from '../../static/microsoft-logo.svg';
 import Sprout from '../../static/sprout.svg';
 
 const GlobalFooter = ({ className }: { className?: string }) => (
-  <div className={clsx(styles['wireframe-demo__footer'], className)}>
-    <Link>
-      Privacy Policy{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        size="0.8em"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>Cookie Settings</Link>
-    <Link>
-      User Agreement{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        size="0.8em"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>
-      Code of Conduct{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        size="0.8em"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>
-      Help Center{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        size="0.8em"
-        title="opens in a new tab"
-      />
-    </Link>
-  </div>
+  <ul className={clsx(styles['wireframe-demo__footer'], className)}>
+    <li className={styles['wireframe-demo__footer-link']}>
+      <Link>
+        Privacy Policy{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          size="0.8em"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li className={styles['wireframe-demo__footer-link']}>
+      <Link>Cookie Settings</Link>
+    </li>
+    <li className={styles['wireframe-demo__footer-link']}>
+      <Link>
+        User Agreement{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          size="0.8em"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li className={styles['wireframe-demo__footer-link']}>
+      <Link>
+        Code of Conduct{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          size="0.8em"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li className={styles['wireframe-demo__footer-link']}>
+      <Link>
+        Help Center{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          size="0.8em"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+  </ul>
 );
 
 const LoggedOutPage = ({ onLogin }: { onLogin: () => void }) => (
@@ -74,7 +84,7 @@ const LoggedOutPage = ({ onLogin }: { onLogin: () => void }) => (
     <div className="flex flex-col items-center mb-16 p-8 grow">
       <header className="flex gap-4">
         <img
-          alt="placeholder for decorative illustration"
+          alt="A studious youth with specs smiling and looking at his laptop"
           className={styles['logged-out-page__header-img']}
           height="160"
           src={AlongUserIllustration1}
@@ -88,7 +98,7 @@ const LoggedOutPage = ({ onLogin }: { onLogin: () => void }) => (
           <Text>Remember to use your school email to sign in:</Text>
         </div>
         <img
-          alt="placeholder for decorative illustration"
+          alt="Girl with red headphones smiling and looking at mobile phone"
           className={styles['logged-out-page__header-img']}
           height="160"
           src={AlongUserIllustration2}
@@ -234,7 +244,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
   };
 
   return (
-    <div className="h-screen">
+    <div>
       <div className={styles['watch-page__main-section']}>
         <div className="ml-10 mr-8 flex gap-4">
           <Button
@@ -245,8 +255,8 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
             <Icon name="arrow-back" purpose="informative" title="go back" />
           </Button>
           <div>
-            <Text className="mb-2">Playing reflections in response to:</Text>
-            <Heading as="h1" size="h3">
+            <Text className="!mb-2">Playing reflections in response to:</Text>
+            <Heading as="h1" className="!font-normal" size="h3">
               What's something in your life, big or small, that you're proud of?
               Why are you proud of it?
             </Heading>
@@ -298,7 +308,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
         </div>
 
         <div className={styles['watch-page__reflection']}>
-          <div className="w-full">
+          <div className="w-full mt-2 lg:w-[31.25rem]">
             <div className="flex cursor-pointer">
               <div
                 className={clsx(
@@ -319,7 +329,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
             </div>
             <video
               aria-label="student makes the sign for the word 'along' in american sign language"
-              className="w-full mt-2 lg:w-[31.25rem]"
+              className="w-full"
               controls
               muted
               src="https://ia801706.us.archive.org/18/items/stringalongtagalong-accompanyASL/string%20along%2Ctag%20along-accompany.ia.mp4"
@@ -330,9 +340,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
                 video on archive.org.
               </a>
             </video>
-          </div>
 
-          <div className="w-[26.8125rem]">
             <div className="flex gap-4 mt-4 ml-2">
               {ReplyIcon}
               <Text>
@@ -460,12 +468,9 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
 };
 
 /**
- * A page demoing what a wireframe demo could look like in a pilot prototype. Best viewed on the "canvas" tab in storybook.
+ * A page demoing what it looks like when you apply a mature brand theme to the EDS components. We're using the Along product as an example. Best viewed on the "canvas" tab in storybook.
  *
  * See the [theming documentation](./?path=/docs/documentation-theming--theming) for more information on the purpose of this demo.
- *
- * Just for the purpose of demonstration, we're using the logged out homepage and
- * the teacher watch page in the Along app.
  */
 export const AlongDemo = () => {
   const [currentPage, setCurrentPage] = useState<'loggedOut' | 'watch'>(

--- a/.storybook/pages/WireframeDemo/WireframeDemo.module.css
+++ b/.storybook/pages/WireframeDemo/WireframeDemo.module.css
@@ -13,6 +13,7 @@
   gap: 3rem;
   flex-wrap: wrap;
   justify-content: center;
+  list-style-type: none;
   /* Pushes footer to bottom of the page if there's more vertical space than content */
   flex-grow: 1;
   align-items: flex-end;
@@ -120,7 +121,6 @@
   margin-left: 1.5rem;
   display: flex;
   flex-direction: column;
-  width: 24.125rem;
 }
 
 .watch-page__sidebar {

--- a/.storybook/pages/WireframeDemo/WireframeDemo.tsx
+++ b/.storybook/pages/WireframeDemo/WireframeDemo.tsx
@@ -23,41 +23,51 @@ import PlaceholderImage from '../../static/placeholder-image.svg';
 import PlaceholderVideo from '../../static/placeholder-video.svg';
 
 const GlobalFooter = () => (
-  <div className={styles['wireframe-demo__footer']}>
-    <Link>
-      Privacy Policy{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>Cookie Settings</Link>
-    <Link>
-      User Agreement{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>
-      Code of Conduct{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        title="opens in a new tab"
-      />
-    </Link>
-    <Link>
-      Help Center{' '}
-      <Icon
-        name="open-in-new"
-        purpose="informative"
-        title="opens in a new tab"
-      />
-    </Link>
-  </div>
+  <ul className={styles['wireframe-demo__footer']}>
+    <li>
+      <Link>
+        Privacy Policy{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li>
+      <Link>Cookie Settings</Link>
+    </li>
+    <li>
+      <Link>
+        User Agreement{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li>
+      <Link>
+        Code of Conduct{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+    <li>
+      <Link>
+        Help Center{' '}
+        <Icon
+          name="open-in-new"
+          purpose="informative"
+          title="opens in a new tab"
+        />
+      </Link>
+    </li>
+  </ul>
 );
 
 const LoggedOutPage = ({ onLogin }: { onLogin: () => void }) => (
@@ -178,7 +188,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
   };
 
   return (
-    <div className="">
+    <div className={styles['watch-page']}>
       <div className={styles['watch-page__main-section']}>
         <div className="ml-10 mr-8 flex gap-4">
           <Button onClick={onLogout} variant="secondary">
@@ -230,7 +240,7 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
         </div>
 
         <div className={styles['watch-page__reflection']}>
-          <div className="w-full">
+          <div className="w-full mt-2 lg:w-[31.25rem]">
             <div className="flex cursor-pointer">
               <div
                 className={clsx(styles['watch-page__avatar'], 'mr-2 w-9 h-9')}
@@ -245,12 +255,10 @@ const WatchPage = ({ onLogout }: { onLogout: () => void }) => {
             </div>
             <img
               alt="placeholder for video player"
-              className="w-full mt-2 lg:w-[31.25rem]"
+              className="w-full"
               src={PlaceholderVideo}
             />
-          </div>
 
-          <div className="w-[26.8125rem]">
             <div className="flex gap-4 mt-4 ml-8">
               <Icon
                 className="min-w-[1rem]"


### PR DESCRIPTION
### Summary:
Ticket: https://czi-tech.atlassian.net/browse/EDS-741

Just some polish on the theming demos:
- in both demos, global footer is an unordered list
- in both demos, the reflection text and response text area is the same width as the video
- wireframe demo watch page background is white
- along demo watch page white background extends to the bottom
- along demo logged out page user illustrations have relevant alt text
- along demo global footer has vertical dividers between the links
- along watch page heading text is not bold and has a margin above it
- along demo watch page dropdown button has transparent background and horizontally centered content

### Test Plan:
Verify the listed changes are present in the theming demos in storybook.

### Some screenshots
#### Along watch page video and text are full-width on narrow windows
![Screenshot 2022-11-22 at 9 22 36 AM](https://user-images.githubusercontent.com/7761701/203380751-c70c2e4c-fb0c-4e4a-a982-9ad02e081628.png)

#### Wireframe watch page has a white background
![Screenshot 2022-11-22 at 9 23 01 AM](https://user-images.githubusercontent.com/7761701/203380830-bb2ff7f5-dc2b-473d-acd4-5ec325fafae2.png)

#### Along global footer has vertical dividers
![Screenshot 2022-11-22 at 9 21 18 AM](https://user-images.githubusercontent.com/7761701/203380506-5d5dc2b7-d163-468b-9d2a-e1ad253cbbdc.png)

#### Along dropdown button is transparent and content is horizontally centered
![Screenshot 2022-11-22 at 9 22 12 AM](https://user-images.githubusercontent.com/7761701/203380909-9583c655-77a9-44c4-83a1-b6ebe3c3ed4e.png)