### PR TITLE
chore: lint for JS color variables imported into components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -84,6 +84,23 @@
           }
         ]
       }
+    },
+    {
+      "files": ["src/**/*.{ts,tsx}"],
+      "excludedFiles": ["src/**/*.stories.{ts,tsx}"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "patterns": [
+              {
+                "group": ["**/tokens-dist/ts/colors"],
+                "message": "Do not import JavaScript color variables into component files. Use CSS variables in styles instead."
+              }
+            ]
+          }
+        ]
+      }
     }
   ],
   "ignorePatterns": ["!.storybook", ".storybook/components/Docs/prism.js"]


### PR DESCRIPTION
### Summary:
Ticket: https://czi-tech.atlassian.net/browse/EDS-706

There are a couple of coding patterns we've been using that interfere with theming. After having cleaned up those patterns, I'm looking at adding lint rules to avoid them creeping back in in the future.

This PR adds an eslint rule for importing JS color variables into component files. (Importing JS color variables into the `.storybook` directory and `*.stories.ts/x` files is still okay.)

### Test Plan:
I added `import { EdsThemeColorIconNeutralSubtle } from '../../tokens-dist/ts/colors';` to the `DrawerHeader.tsx` file (it could be any color variable and any component file, but I used a code example from [when I cleaned up this pattern earlier](https://github.com/chanzuckerberg/edu-design-system/pull/1391)) and verified the JS color variable import lint rule was triggered.

I also added `import AlongLogoBulb from '../../../.storybook/static/along-logo-bulb.svg';` into `Dropdown.stories.tsx` (could have been anything from `.storybook` into any stories file; I chose these at random) to verify the "Do not import files from `.storybook/` into `src`" lint rule still works.