### PR TITLE
fix(Menu): sync width of trigger and popover

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -10,9 +10,10 @@
 }
 
 .menu__popover {
-  max-width: var(--eds-l-max-width);
   margin-top: var(--eds-size-1);
+  max-width: var(--eds-l-max-width);
   position: absolute;
+  width: 100%;
 }
 
 .menu__button {

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -11,17 +11,18 @@
 
 .menu__popover {
   margin-top: var(--eds-size-1);
+  min-width: max-content;
   max-width: var(--eds-l-max-width);
   position: absolute;
   width: 100%;
 }
 
-.menu__button {
+.menu__button.menu__button {
   background-color: var(--eds-theme-color-form-background);
 }
 
 /* Needed to create higher specificity than ClickableStyle. TODO: improve */
-.menu__button--icon.menu__button--icon.menu__button--icon {
+.menu__button--icon.menu__button--icon.menu__button--icon.menu__button--icon {
   color: var(--eds-theme-color-icon-neutral-default);
 }
 

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -48,3 +48,63 @@ export const Default: StoryObj<Args> = {
     </Menu>
   ),
 };
+
+export const WithLongButtonText: StoryObj<Args> = {
+  render: (args) => (
+    <Menu {...args}>
+      <Menu.Button>
+        Long Trigger Button Text to Demonstrate Popover Matching
+      </Menu.Button>
+      <Menu.Items data-testid="menu-content">
+        <Menu.Item
+          href="https://headlessui.com/react/menu#menu-button"
+          icon="link"
+        >
+          Headless UI Docs
+        </Menu.Item>
+        <Menu.Item
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
+          icon="link"
+        >
+          MDN: Menu
+        </Menu.Item>
+        {/* eslint-disable-next-line no-alert */}
+        <Menu.Item onClick={() => alert('Item clicked')}>
+          Trigger Action
+        </Menu.Item>
+        <Menu.Item disabled href="https://example.org/" icon="warning">
+          Not Possible (disabled)
+        </Menu.Item>
+      </Menu.Items>
+    </Menu>
+  ),
+};
+
+export const WithShortButtonText: StoryObj<Args> = {
+  render: (args) => (
+    <Menu {...args}>
+      <Menu.Button>Menu</Menu.Button>
+      <Menu.Items data-testid="menu-content">
+        <Menu.Item
+          href="https://headlessui.com/react/menu#menu-button"
+          icon="link"
+        >
+          Headless UI Docs
+        </Menu.Item>
+        <Menu.Item
+          href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
+          icon="link"
+        >
+          MDN: Menu
+        </Menu.Item>
+        {/* eslint-disable-next-line no-alert */}
+        <Menu.Item onClick={() => alert('Item clicked')}>
+          Trigger Action
+        </Menu.Item>
+        <Menu.Item disabled href="https://example.org/" icon="warning">
+          Not Possible (disabled)
+        </Menu.Item>
+      </Menu.Items>
+    </Menu>
+  ),
+};

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -39,7 +39,8 @@ export type MenuItemsProps = ExtractProps<typeof HeadlessMenu.Items>;
  * a profile menu with links to settings) or a set of actions
  */
 export const Menu = (props: MenuProps) => {
-  return <HeadlessMenu {...props} />;
+  const menuClassNames = clsx(props.className, styles['menu']);
+  return <HeadlessMenu as="div" className={menuClassNames} {...props} />;
 };
 
 /**

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -38,9 +38,9 @@ export type MenuItemsProps = ExtractProps<typeof HeadlessMenu.Items>;
  * be used when there is a discrete number of actions such as user navigations (e.g.,
  * a profile menu with links to settings) or a set of actions
  */
-export const Menu = (props: MenuProps) => {
-  const menuClassNames = clsx(props.className, styles['menu']);
-  return <HeadlessMenu as="div" className={menuClassNames} {...props} />;
+export const Menu = ({ className, ...other }: MenuProps) => {
+  const menuClassNames = clsx(className, styles['menu']);
+  return <HeadlessMenu as="div" className={menuClassNames} {...other} />;
 };
 
 /**

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -139,3 +139,283 @@ exports[`<Menu /> Default story renders snapshot 1`] = `
   </div>
 </div>
 `;
+
+exports[`<Menu /> WithLongButtonText story renders snapshot 1`] = `
+<div
+  class="menu"
+>
+  <button
+    aria-controls="headlessui-menu-items-8"
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral menu__button"
+    data-bootstrap-override="clickable-style-secondary"
+    id="headlessui-menu-button-7"
+    type="button"
+  >
+    Long Trigger Button Text to Demonstrate Popover Matching
+    <svg
+      aria-hidden="true"
+      class="icon menu__button--icon"
+      fill="currentColor"
+      height="1.5rem"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#expand-more"
+      />
+    </svg>
+  </button>
+  <div
+    aria-labelledby="headlessui-menu-button-7"
+    class="popover-container menu__popover"
+    data-testid="menu-content"
+    id="headlessui-menu-items-8"
+    role="menu"
+    tabindex="0"
+  >
+    <a
+      class="menu__item"
+      href="https://headlessui.com/react/menu#menu-button"
+      id="headlessui-menu-item-9"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="currentColor"
+            height="1.5rem"
+            style="--icon-size: 1.5rem;"
+            width="1.5rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#link"
+            />
+          </svg>
+        </div>
+        Headless UI Docs
+      </div>
+    </a>
+    <a
+      class="menu__item"
+      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
+      id="headlessui-menu-item-10"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="currentColor"
+            height="1.5rem"
+            style="--icon-size: 1.5rem;"
+            width="1.5rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#link"
+            />
+          </svg>
+        </div>
+        MDN: Menu
+      </div>
+    </a>
+    <a
+      class="menu__item"
+      id="headlessui-menu-item-11"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__no-icon"
+        />
+        Trigger Action
+      </div>
+    </a>
+    <div
+      aria-disabled="true"
+      class="popover-list-item popover-list-item--disabled"
+      id="headlessui-menu-item-12"
+      role="menuitem"
+    >
+      <div
+        class="popover-list-item__icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon"
+          fill="currentColor"
+          height="1.5rem"
+          style="--icon-size: 1.5rem;"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="test-file-stub#warning"
+          />
+        </svg>
+      </div>
+      Not Possible (disabled)
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<Menu /> WithShortButtonText story renders snapshot 1`] = `
+<div
+  class="menu"
+>
+  <button
+    aria-controls="headlessui-menu-items-14"
+    aria-expanded="true"
+    aria-haspopup="true"
+    class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral menu__button"
+    data-bootstrap-override="clickable-style-secondary"
+    id="headlessui-menu-button-13"
+    type="button"
+  >
+    Menu
+    <svg
+      aria-hidden="true"
+      class="icon menu__button--icon"
+      fill="currentColor"
+      height="1.5rem"
+      style="--icon-size: 1.5rem;"
+      width="1.5rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <use
+        xlink:href="test-file-stub#expand-more"
+      />
+    </svg>
+  </button>
+  <div
+    aria-labelledby="headlessui-menu-button-13"
+    class="popover-container menu__popover"
+    data-testid="menu-content"
+    id="headlessui-menu-items-14"
+    role="menu"
+    tabindex="0"
+  >
+    <a
+      class="menu__item"
+      href="https://headlessui.com/react/menu#menu-button"
+      id="headlessui-menu-item-15"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="currentColor"
+            height="1.5rem"
+            style="--icon-size: 1.5rem;"
+            width="1.5rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#link"
+            />
+          </svg>
+        </div>
+        Headless UI Docs
+      </div>
+    </a>
+    <a
+      class="menu__item"
+      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
+      id="headlessui-menu-item-16"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__icon"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon"
+            fill="currentColor"
+            height="1.5rem"
+            style="--icon-size: 1.5rem;"
+            width="1.5rem"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="test-file-stub#link"
+            />
+          </svg>
+        </div>
+        MDN: Menu
+      </div>
+    </a>
+    <a
+      class="menu__item"
+      id="headlessui-menu-item-17"
+      role="menuitem"
+      tabindex="-1"
+    >
+      <div
+        class="popover-list-item"
+      >
+        <div
+          class="popover-list-item__no-icon"
+        />
+        Trigger Action
+      </div>
+    </a>
+    <div
+      aria-disabled="true"
+      class="popover-list-item popover-list-item--disabled"
+      id="headlessui-menu-item-18"
+      role="menuitem"
+    >
+      <div
+        class="popover-list-item__icon"
+      >
+        <svg
+          aria-hidden="true"
+          class="icon"
+          fill="currentColor"
+          height="1.5rem"
+          style="--icon-size: 1.5rem;"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="test-file-stub#warning"
+          />
+        </svg>
+      </div>
+      Not Possible (disabled)
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<Menu /> Default story renders snapshot 1`] = `
-<div>
+<div
+  class="menu"
+>
   <button
     aria-controls="headlessui-menu-items-2"
     aria-expanded="true"


### PR DESCRIPTION
### Summary:

In [our designs](https://www.figma.com/file/Ff7hJoSvXX9hkAmIklnsT2/branch/4xGGJyfPCeoAvYX5Fjssdf/EDS-Paper-v1.1-%7C-UI-Components?node-id=7831%3A24711&t=tafQ4kj7AkliGAew-0), we have the popover content for menus match the width of the trigger, but the initial implementation didn't follow this pattern. use a non-fragment react node to allow width to be determined by DOM structure

### Test Plan:

- [x] update snapshots
- [x] view in storybook
