### PR TITLE
Use renovate to auto bump deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -30,9 +30,6 @@
       matchDatasources: ['npm'],
       stabilityDays: 3,
     },
-    {
-      enabled: false,
-    },
     // Our peerDependencies for React are as low as 16.8.0, so we should support React v16
     {
       matchPackageNames: ['react', 'react-dom'],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,7 @@
   prConcurrentLimit: 1,
   repositories: ['FB-PLP/traject'],
   rangeStrategy: 'bump', // Always bump minor/patch to latest
+  reviewers: ['team:edu-design-system'],
 
   major: {
     rangeStrategy: 'replace',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   internalChecksFilter: 'strict', // PRs will be skipped unless a non-pending version is available (applies to "stabilityDays" check only)
   labels: ['npm-dependencies'],
   prConcurrentLimit: 1,
-  repositories: ['FB-PLP/traject'],
+  repositories: ['chanzuckerberg/edu-design-system'],
   rangeStrategy: 'bump', // Always bump minor/patch to latest
   reviewers: ['team:edu-design-system'],
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,84 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+
+  baseBranches: ['next'],
+  enabledManagers: ['npm'],
+  extends: ['config:base', 'group:allNonMajor'],
+  fetchReleaseNotes: false, // Only fetch release notes for breaking changes
+  internalChecksFilter: 'strict', // PRs will be skipped unless a non-pending version is available (applies to "stabilityDays" check only)
+  labels: ['npm-dependencies'],
+  prConcurrentLimit: 1,
+  repositories: ['FB-PLP/traject'],
+  rangeStrategy: 'bump', // Always bump minor/patch to latest
+
+  major: {
+    rangeStrategy: 'replace',
+    fetchReleaseNotes: true,
+  },
+
+  ignoreDeps: [
+    // svg-spritemap-webpack-plugin v4 requires webpack 5 but EDS currently uses webpack 4 for storybook
+    'svg-spritemap-webpack-plugin',
+  ],
+
+  packageRules: [
+    {
+      // Hold back from creating branches until 3 or more days have elapsed since the version
+      // was released. Note: this only works for packages that provide a release timestamp header
+      // and does not ensure all updates are "stable".
+      matchDatasources: ['npm'],
+      stabilityDays: 3,
+    },
+    {
+      enabled: false,
+    },
+    // Our peerDependencies for React are as low as 16.8.0, so we should support React v16
+    {
+      matchPackageNames: ['react', 'react-dom'],
+      groupName: 'react',
+      allowedVersions: '<17.0.0',
+    },
+    // Handle patch updates under 0.1.0 as potentially breaking and group them separately.
+    // Workaround for https://github.com/renovatebot/renovate/issues/3588
+    {
+      matchManagers: ['npm'],
+      matchCurrentVersion: '<0.1.0',
+      rangeStrategy: 'replace',
+      groupName: 'maybe breaking patch updates',
+      groupSlug: 'maybe-breaking-patch',
+      fetchReleaseNotes: true,
+    },
+    // Handle minor updates under 1.0.0 as potentially breaking and group them separately.
+    // Workaround for https://github.com/renovatebot/renovate/issues/3588
+    {
+      matchManagers: ['npm'],
+      matchCurrentVersion: '<1.0.0 >=0.1.0',
+      rangeStrategy: 'replace',
+      minor: {
+        groupName: 'maybe breaking minor updates',
+        groupSlug: 'maybe-breaking-minor',
+        fetchReleaseNotes: true,
+      },
+    },
+    // Updating packages with 'prettier' separately because updates to these packages often
+    // require modifying code to satistfy the new formatting rules.
+    {
+      matchPackagePatterns: ['prettier'],
+      groupName: 'prettier',
+    },
+    // Update typescript separately because typescript updates can create new
+    // typescript errors that need to be manually resolved.
+    {
+      matchPackageNames: ['typescript'],
+      groupName: 'typescript',
+    },
+    {
+      matchDepTypes: ['devDependencies'],
+      groupName: 'devDependencies',
+    },
+  ],
+
+  // Customize how PRs are displayed
+  prBodyTemplate: '{{{table}}}{{{notes}}}{{{changelogs}}}{{{controls}}}{{{footer}}}',
+  prBodyColumns: ['Package', 'Type', 'Change'],
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,10 +70,6 @@
       matchPackageNames: ['typescript'],
       groupName: 'typescript',
     },
-    {
-      matchDepTypes: ['devDependencies'],
-      groupName: 'devDependencies',
-    },
   ],
 
   // Customize how PRs are displayed

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -17,9 +17,9 @@ jobs:
           ref: 'next'
 
       - name: Renovate
-        # The version of renovatebot should be kept up-to-date
+        # The version of renovatebot should be kept up-to-date with major releases
         # https://github.com/renovatebot/github-action/blob/release/CHANGELOG.md
-        uses: renovatebot/github-action@v34.40.2
+        uses: renovatebot/github-action@v34
         with:
           configurationFile: .github/renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.
-    - cron: '0 13,19 * * MON' # Monday, 6am and 12pm (PST)
+    - cron: '0 13 * * MON' # Monday, 6am (PST)
 
 jobs:
   renovate:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,27 @@
+name: Update NPM Dependencies
+
+on:
+  schedule:
+    # The "*" (#42, asterisk) character has special semantics in YAML, so this
+    # string has to be quoted.
+    - cron: '0 13,19 * * MON' # Monday, 6am and 12pm (PST)
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # We want this running on the development 'next' branch
+          ref: 'next'
+
+      - name: Renovate
+        # The version of renovatebot should be kept up-to-date
+        # https://github.com/renovatebot/github-action/blob/release/CHANGELOG.md
+        uses: renovatebot/github-action@v34.40.2
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: 'debug'


### PR DESCRIPTION
### Summary:
[EDS-758]
- Uses Renovate to auto bump EDS dependencies
- Runs Every Monday 0600 PST
- Supposed to:
 - based off `next` branch
 - assign `edu-design-system` [team](https://docs.renovatebot.com/configuration-options/#reviewers) as reviewers
 - have one concurrent pr 
 - bump non major versions, except for < 0.1.0 and > 0.1.0 and < 1.0.0
 - and some other similar behavior as the [LP renovate](https://github.com/FB-PLP/traject/blob/master/.github/renovate.json5)
### Test Plan:
- tested somewhat working in `jlee/renovate-run` where renovate did create pr's #1403 and #1404 
  - need someone to confirm this is correct behavior since it was 2 concurrent prs and attempted to bump major versions
  - didn't assign `edu-design-system` team 
  - these might be some funky behavior due to not having a ["special token"](https://github.com/renovatebot/github-action#token) so I want to land this to see if it is working correctly with the cron job
  - is correctly based off `next`
- CI runs with renovate prs

[EDS-758]: https://czi-tech.atlassian.net/browse/EDS-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ