### PR TITLE
Update databar styles

### DIFF
--- a/src/components/DataBar/DataBar.module.css
+++ b/src/components/DataBar/DataBar.module.css
@@ -18,6 +18,7 @@
   /* Rounds the sides rather than making the bar elliptical. */
   border-radius: var(--eds-border-radius-full);
 
+  /* Prevents segments from overflowing outside borders */
   overflow: hidden;
 }
 

--- a/src/components/DataBar/DataBar.module.css
+++ b/src/components/DataBar/DataBar.module.css
@@ -28,6 +28,8 @@
 .data-bar__label {
   @mixin eds-theme-typography-title-sm;
   color: var(--eds-theme-color-text-neutral-strong);
+
+  margin-bottom: 0;
 }
 
 /**

--- a/src/components/DataBar/DataBar.module.css
+++ b/src/components/DataBar/DataBar.module.css
@@ -8,15 +8,17 @@
  * The data bar represents the relative completion of a task.
  */
 .data-bar {
-  --data-bar-height: var(--eds-size-2);
+  --data-bar-height: 0.875rem;
   height: var(--data-bar-height);
 
   background-color: var(--eds-theme-color-background-neutral-subtle);
 
   border: var(--eds-theme-color-border-neutral-default) solid
     var(--eds-theme-border-width);
-  /* Rounds the sides rather than making the bar elliptical. */  
-  border-radius: var(--eds-border-radius-full); 
+  /* Rounds the sides rather than making the bar elliptical. */
+  border-radius: var(--eds-border-radius-full);
+
+  overflow: hidden;
 }
 
 /**
@@ -35,22 +37,19 @@
   align-items: flex-end;
   justify-content: space-between;
 
-  margin-bottom: var(--eds-size-2);
+  margin-bottom: var(--eds-size-1);
 }
 
 /**
  * The amount of space the segments can consume. Is overlayed on top of the containing bar.
  */
 .data-bar__segment-space {
-  position: relative;
-  /* Shifts a border width amount to completely overlay instead of being offset from the containing borders. */
-  bottom: var(--eds-theme-border-width); 
-  right: var(--eds-theme-border-width);
+  height: 100%;
 
   display: flex;
   gap: var(--eds-size-half);
   /* Makes the last segment overlap the containing bar right border. */
-  width: calc(100% + 2 * var(--eds-theme-border-width)); 
+  width: calc(100% + 2 * var(--eds-theme-border-width));
 }
 /**
  * Shortens the amount of space the segments consume by an amount equal to the radius of the semicircle end of the containing bar (half the height of the bar).

--- a/src/components/DataBar/DataBar.module.css
+++ b/src/components/DataBar/DataBar.module.css
@@ -8,7 +8,10 @@
  * The data bar represents the relative completion of a task.
  */
 .data-bar {
-  --data-bar-height: 0.875rem;
+  /* 0.875rem, a summation of the data bar height of 0.75rem and the border width 1px */
+  --data-bar-height: calc(
+    var(--eds-size-1-and-half) + 2 * var(--eds-theme-border-width)
+  );
   height: var(--data-bar-height);
 
   background-color: var(--eds-theme-color-background-neutral-subtle);
@@ -26,7 +29,7 @@
  * The label title above the data bar that provides an accessible name.
  */
 .data-bar__label {
-  @mixin eds-theme-typography-title-sm;
+  @mixin eds-theme-typography-label-md;
   color: var(--eds-theme-color-text-neutral-strong);
 
   margin-bottom: 0;

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -118,12 +118,9 @@ export const DataBar = ({
     accumulator += segment.value;
     /* Ensures a minimumum width of 5% for the segment. */
     const percentage = Math.max(5, (segment.value / max) * 100);
-    /* Rounds the right side of the segment if it completes the data bar. */
-    const isRoundRight = accumulator >= max;
     segmentComponents.push(
       <DataBarSegment
         aria-label={segment.text}
-        isRoundRight={isRoundRight}
         key={`segment-${index}`}
         onKeyDown={(e) => handleOnKeyDown(e, index)}
         ref={(el) => (segmentsRef.current[index] = el)}

--- a/src/components/DataBar/__snapshots__/DataBar.test.tsx.snap
+++ b/src/components/DataBar/__snapshots__/DataBar.test.tsx.snap
@@ -234,7 +234,7 @@ exports[`<DataBar /> TotalsMax story renders snapshot 1`] = `
         />
         <div
           aria-label="Segment 3"
-          class="data-bar-segment data-bar-segment--brand data-bar-segment--hoverable data-bar-segment--round-right"
+          class="data-bar-segment data-bar-segment--brand data-bar-segment--hoverable"
           role="gridcell"
           style="width: 30%;"
           tabindex="-1"
@@ -278,7 +278,7 @@ exports[`<DataBar /> TotalsMoreThanMax story renders snapshot 1`] = `
       >
         <div
           aria-label="Segment 1"
-          class="data-bar-segment data-bar-segment--brand data-bar-segment--hoverable data-bar-segment--round-right"
+          class="data-bar-segment data-bar-segment--brand data-bar-segment--hoverable"
           role="gridcell"
           style="width: 100%;"
           tabindex="0"

--- a/src/components/DataBarSegment/DataBarSegment.module.css
+++ b/src/components/DataBarSegment/DataBarSegment.module.css
@@ -6,23 +6,7 @@
  * A block that represents its progress in a data bar.
  */
 .data-bar-segment {
-  height: var(--eds-size-2);
-}
-
-/**
- * Rounds the left side of the first databar segment.
- */
-.data-bar-segment:first-child {
-  border-top-left-radius: var(--eds-border-radius-full);
-  border-bottom-left-radius: var(--eds-border-radius-full);
-}
-
-/**
- * Rounds the right side of the last databar segment if progress is complete.
- */
-.data-bar-segment--round-right {
-  border-top-right-radius: var(--eds-border-radius-full);
-  border-bottom-right-radius: var(--eds-border-radius-full);
+  height: 100%;
 }
 
 /**

--- a/src/components/DataBarSegment/DataBarSegment.tsx
+++ b/src/components/DataBarSegment/DataBarSegment.tsx
@@ -11,11 +11,6 @@ export type Props = {
    */
   className?: string;
   /**
-   * Indicates if this segment should be rounded on the right side.
-   * Used for data bars that are 100% complete.
-   */
-  isRoundRight?: boolean;
-  /**
    * Tooltip text to be displayed when the segment is hovered.
    */
   text?: string;
@@ -42,21 +37,13 @@ export type Props = {
  */
 export const DataBarSegment = React.forwardRef(
   (
-    {
-      className,
-      isRoundRight,
-      text,
-      width,
-      variant = 'brand',
-      ...other
-    }: Props,
+    { className, text, width, variant = 'brand', ...other }: Props,
     ref: React.ForwardedRef<HTMLDivElement>,
   ) => {
     const componentClassName = clsx(
       styles['data-bar-segment'],
       styles[`data-bar-segment--${variant}`],
       text && styles['data-bar-segment--hoverable'],
-      isRoundRight && styles['data-bar-segment--round-right'],
       className,
     );
     const segmentComponent = (


### PR DESCRIPTION
### Summary:
- whilst working on the progress bar noticed that the databar styles were not in sync with the mocks
- syncs styles with the mocks and cleans up some now obsolete code
  - stylistically, shrinks spacing between the label wrapper and the databar from 1rem to 0.5rem and the height of the databar from 1rem to 0.875rem
- impact is indicated by visual diffs of the recipes/pages, and in LP the only page impacted is the [`CoursePlanEdit` page](https://www.chromatic.com/test?appId=614b969675171d003ac6f98a&id=638974d54f0d45e3f3992aa2). This uses the [`estimatedInstructionalBlocks` lp component](https://www.chromatic.com/test?appId=614b969675171d003ac6f98a&id=638974d54f0d45e3f3992aa3) where visual diffs are again represented.
  - Change is safe since only one page is impacted, and only in about 10px of vertical spacing
### Test Plan:
- alpha publish v7.1.0-alpha.1 reflects these changes and are shown https://www.chromatic.com/build?appId=614b969675171d003ac6f98a&number=15188