### PR TITLE
chore(wireframe-demo): comment out form border variable

### DIFF
--- a/.storybook/pages/WireframeDemo/GlobalStyles.module.css
+++ b/.storybook/pages/WireframeDemo/GlobalStyles.module.css
@@ -23,6 +23,13 @@
   --wireframe-gray-e: #161b1f;
 
   /* Override EDS tokens to apply wireframe theme */
+  /**
+   * The following tokens are commented out because they were causing issues for
+   * EDS chromatic testing. If you're using these variables in a different app,
+   * uncomment-out those lines and remove this comment.
+   */
+  /* --eds-theme-color-form-border: var(--wireframe-gray-c); */
+  /* --eds-theme-color-border-neutral-strong: var(--wireframe-gray-b); */
   --eds-anim-fade-long: var(--wireframe-anim-duration);
   --eds-anim-fade-quick: var(--wireframe-anim-duration);
   --eds-anim-move-long: var(--wireframe-anim-duration);
@@ -67,7 +74,6 @@
   --eds-theme-color-border-neutral-default-hover: var(--wireframe-gray-b);
   --eds-theme-color-border-neutral-default: var(--wireframe-gray-b);
   --eds-theme-color-border-neutral-strong-hover: var(--wireframe-gray-c);
-  --eds-theme-color-border-neutral-strong: var(--wireframe-gray-b);
   --eds-theme-color-border-neutral-subtle-hover: var(--wireframe-gray-b);
   --eds-theme-color-border-neutral-subtle: var(--wireframe-gray-a);
   --eds-theme-color-border-utility-error-default: var(--wireframe-gray-b);
@@ -298,7 +304,6 @@
   --eds-theme-color-form-background-hover: var(--wireframe-gray-a);
   --eds-theme-color-form-background: var(--wireframe-white);
   --eds-theme-color-form-border-hover: var(--wireframe-gray-e);
-  --eds-theme-color-form-border: var(--wireframe-gray-c);
   --eds-theme-color-form-label: var(--wireframe-gray-d);
   --eds-theme-color-icon-brand-primary-hover: var(--wireframe-gray-c);
   --eds-theme-color-icon-brand-primary: var(--wireframe-gray-c);


### PR DESCRIPTION
### Summary:
I've been seeing some instability in the wireframe demo watch page in chromatic. [Here's an example test result.](https://www.chromatic.com/test?appId=61313967cde49b003ae2a860&id=638fe69db3f2bd66f548e4d2) Specifically, for some reason, sometimes the form border variable isn't being updated correctly, and it's falling back to the value set in EDS. Why only this variable is an issue, I don't know. It's not showing up as a problem in the Along demo, which I don't understand either.

I'm not terribly motivated to dig too deep into the issue because this is just a demo page, and people won't notice if the gray we use on those borders is slightly different from the other grays on the page. So in this PR I'm commenting out that one variable.

We could instead turn off chromatic for this page. I figure that these demo pages are useful tests in chromatic because they're verifying that you can override the CSS variables for the components shown. But we also have the Along demo, so maybe it makes sense to turn off chromatic for the wireframe demo and leave the Along one in chromatic. Thoughts?

### Test Plan:
The wireframe demo now uses #878C90 for the form border color instead of #5d6369.