### PR TITLE
chore(wireframe-demo): disable chromatic snapshot tests

### DIFF
--- a/.storybook/pages/WireframeDemo/WireframeDemo.stories.ts
+++ b/.storybook/pages/WireframeDemo/WireframeDemo.stories.ts
@@ -7,6 +7,9 @@ import { WireframeDemo } from './WireframeDemo';
 export default {
   title: 'Pages/Theming/WireframeDemo',
   component: WireframeDemo,
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof WireframeDemo>;


### PR DESCRIPTION
### Summary:
I've been seeing some instability in the wireframe demo watch page in chromatic. [Here's an example test result.](https://www.chromatic.com/test?appId=61313967cde49b003ae2a860&id=638fe69db3f2bd66f548e4d2) Specifically, for some reason, sometimes the form border and border neutral strong variables aren't being updated correctly, and they're falling back to the value set in EDS. Why only these 2 variables are an issue, I don't know. This isn't not showing up as a problem in the Along demo, which I don't understand either.

I'm not terribly motivated to dig too deep into the issue because this is just a demo page, and people won't notice if the gray we use on those borders is slightly different from the other grays on the page. I'm more interested in quieting the test so it doesn't get in the way of development.

I figure that these demo pages are useful tests in chromatic because they're verifying that you can override the CSS variables for the components shown. But we also have the Along demo, so having both demos tested in chromatic is a little redundant. Therefore, in this PR, I'm disabling the wireframe demo in chromatic but leaving the along one alone.

### Test Plan:
The wireframe demo does not trigger a chromatic change.