### PR TITLE
docs(icons): specify that colored icons should use tier 2 or 3 variables

### DIFF
--- a/docs/ICONS.md
+++ b/docs/ICONS.md
@@ -21,7 +21,7 @@ View the "Icon Grid" story in Storybook for a visualization of all available ico
 **TODO: formalize this process with design in the Icon design workflow**
 
 1. Export SVG icon asset(s) from Figma
-2. If necessary, remove the `fill` attribute on the `<path>` in the exported SVG file(s).
+2. If necessary, remove the `fill` attribute on the `<path>` in the exported SVG file(s). In the very rare case that an icon needs colors defined in the icon (like the `status-` icons), only use tier 2 or tier 3 CSS variables for the color.
 3. In a new feature branch, locate `src/icons` and add new icon to the directory.
 4. Run `yarn build:icons` in the terminal to build the new icon sprite.
 5. In Storybook, view the "Icon Grid" component to see the new component added to the available list of icons, which is now ready to use in EDS components.


### PR DESCRIPTION
### Summary:
In https://github.com/chanzuckerberg/edu-design-system/pull/1396 I updated all the icons that were using colors in their `fill` properties that were not tier 2 or tier 3 css color variables.

To avoid this happening in the future, I considered adding a linter, but decided it was too much work considering we don't add icons very often. ([There is a ticket, set to "won't do", for this in case it turns out to be a problem in the future.](https://czi-tech.atlassian.net/browse/EFI-819))

Instead, I'm updating the documentation for adding icons to include a snippet about this.

### Test Plan:
I previewed the file in VS Code and verified the new text looked like I was expecting.

![](https://user-images.githubusercontent.com/7761701/206276374-7b18f8d1-4b33-4141-ac46-d9b3fe0db622.png)
