### PR TITLE
Set renovate version and prevent onboarding pr

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,9 @@
   rangeStrategy: 'bump', // Always bump minor/patch to latest
   reviewers: ['team:edu-design-system'],
 
+  onboarding: false,
+  requireConfig: false,
+
   major: {
     rangeStrategy: 'replace',
     fetchReleaseNotes: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,6 +12,7 @@
   rangeStrategy: 'bump', // Always bump minor/patch to latest
   reviewers: ['team:edu-design-system'],
 
+  // Required to prevent onboarding pr and generation of new config file https://github.com/renovatebot/github-action#configurationfile
   onboarding: false,
   requireConfig: false,
 

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,10 +1,9 @@
 name: Update NPM Dependencies
 
 on:
-  schedule:
-    # The "*" (#42, asterisk) character has special semantics in YAML, so this
-    # string has to be quoted.
-    - cron: '0 13 * * MON' # Monday, 6am (PST)
+  push:
+    branches:
+      - jlee/testRenovate
 
 jobs:
   renovate:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,9 +1,10 @@
 name: Update NPM Dependencies
 
 on:
-  push:
-    branches:
-      - jlee/testRenovate
+  schedule:
+    # The "*" (#42, asterisk) character has special semantics in YAML, so this
+    # string has to be quoted.
+    - cron: '0 13 * * MON' # Monday, 6am (PST)
 
 jobs:
   renovate:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Renovate
         # The version of renovatebot should be kept up-to-date with major releases
         # https://github.com/renovatebot/github-action/blob/release/CHANGELOG.md
-        uses: renovatebot/github-action@v34
+        uses: renovatebot/github-action@v34.50.1
         with:
           configurationFile: .github/renovate.json5
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
### Summary:
- Saw that putting only [major version of renovate](https://github.com/chanzuckerberg/edu-design-system/actions/runs/3634187356/jobs/6132023885#step:1:35) is not recognized
- Sets renovate version to prevent
- Also prevents onboarding renovate pr according to https://github.com/renovatebot/github-action#configurationfile
### Test Plan:
- https://github.com/chanzuckerberg/edu-design-system/actions/workflows/update-dependencies.yml update deps jobs ran with push on this branch (which was reverted cuz we want it on cron)
- Saw that renovate action works since it generated the onboarding prs (which I closed since we don't want this behavior)
![image](https://user-images.githubusercontent.com/86632227/206285539-a0c796eb-f561-47ff-b324-3da402579c45.png)
- Will have to see if job runs correctly on Monday as scheduled