### PR TITLE
feat(LoadingIndicator): add loader indicator component

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-children-by-type": "^1.1.0",
     "react-focus-lock": "^2.9.2",
+    "react-loader-spinner": "^5.3.4",
     "react-popper": "^2.3.0",
     "react-portal": "^4.2.2",
     "react-uid": "^2.3.2",

--- a/src/components/LoadingIndicator/LoadingIndicator.module.css
+++ b/src/components/LoadingIndicator/LoadingIndicator.module.css
@@ -1,0 +1,21 @@
+/*------------------------------------*\
+    # LOADINGINDICATOR
+\*------------------------------------*/
+
+/**
+ * LoadingIndicator
+ */
+.loading-indicator {
+  background-color: transparent;
+}
+
+/* override for `color` */
+.loading-indicator > svg path {
+  stroke: var(--eds-theme-color-background-brand-primary-strong);
+}
+
+/* override for `secondaryColor` */
+.loading-indicator > svg circle {
+  stroke: var(--eds-theme-color-background-neutral-medium);
+  stroke-opacity: 1;
+}

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.ts
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.ts
@@ -1,0 +1,48 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import type { StoryObj, Meta } from '@storybook/react';
+import type React from 'react';
+
+import { LoadingIndicator } from './LoadingIndicator';
+
+export default {
+  title: 'Atoms/LoadingIndicator',
+  component: LoadingIndicator,
+  parameters: {
+    layout: 'centered',
+    badges: [BADGE.BETA],
+  },
+} as Meta<Args>;
+
+type Args = React.ComponentProps<typeof LoadingIndicator>;
+
+export const Default: StoryObj<Args> = {};
+
+export const Small: StoryObj<Args> = {
+  args: {
+    size: 'sm',
+  },
+};
+
+export const Medium: StoryObj<Args> = {
+  args: {
+    size: 'md',
+  },
+};
+
+export const Large: StoryObj<Args> = {
+  args: {
+    size: 'lg',
+  },
+};
+
+export const Invisible: StoryObj<Args> = {
+  args: {
+    visible: false,
+  },
+};
+
+export const WithAriaLabel: StoryObj<Args> = {
+  args: {
+    ariaLabel: 'Loading, Please Wait',
+  },
+};

--- a/src/components/LoadingIndicator/LoadingIndicator.test.ts
+++ b/src/components/LoadingIndicator/LoadingIndicator.test.ts
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as stories from './LoadingIndicator.stories';
+
+describe('<LoadingIndicator />', () => {
+  generateSnapshots(stories);
+});

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -1,0 +1,83 @@
+import clsx from 'clsx';
+import React from 'react';
+
+import { Oval } from 'react-loader-spinner';
+import styles from './LoadingIndicator.module.css';
+
+export type Props = {
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+
+  /**
+   * Layout size of the loader. This affects the overall size and associated
+   * stroke width.
+   */
+  size?: 'sm' | 'md' | 'lg';
+
+  /**
+   * Aria label of the oval. Default is "loading". Will be overridden if ariaLabel is passed in props
+   * (Shadowed from OvalProps)
+   *
+   * See: https://mhnpd.github.io/react-loader-spinner/docs/components/oval
+   */
+  ariaLabel?: string;
+
+  /**
+   * Whether the oval is visible. Default is true.
+   * (Shadowed from OvalProps)
+   *
+   * See: https://mhnpd.github.io/react-loader-spinner/docs/components/oval
+   */
+  visible?: boolean;
+};
+
+// Pixel sizes corresponding to EDS size units
+const loaderSize = {
+  sm: 24, // --eds-size-2-and-half
+  md: 40, // --eds-size-5
+  lg: 56, // --eds-size-7
+};
+
+// Given a loader size, the stroke widths can change
+const loaderStrokeSize = {
+  sm: 2,
+  md: 3,
+  lg: 4,
+};
+
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * `import {LoadingIndicator} from "@chanzuckerberg/eds";`
+ *
+ * Show a loading state within a component container, or a specific page or area, where
+ * arbitrary content will appear once some request has completed.
+ */
+export const LoadingIndicator = ({
+  ariaLabel = 'loading',
+  className,
+  size = 'md',
+  visible = true,
+  ...other
+}: Props) => {
+  const componentClassName = clsx(styles['loading-indicator'], className);
+
+  // setting the colors to be transparent since we override in CSS
+  // (and have a lint rule prevent token variable use in components)
+  return (
+    <Oval
+      ariaLabel={ariaLabel}
+      color="transparent"
+      height={loaderSize[size]}
+      secondaryColor="transparent"
+      strokeWidth={loaderStrokeSize[size]}
+      strokeWidthSecondary={loaderStrokeSize[size]}
+      visible={visible}
+      width={loaderSize[size]}
+      wrapperClass={componentClassName}
+      {...other}
+    />
+  );
+};

--- a/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.test.ts.snap
+++ b/src/components/LoadingIndicator/__snapshots__/LoadingIndicator.test.ts.snap
@@ -1,0 +1,313 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LoadingIndicator /> Default story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="loading"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: flex; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="40"
+    stroke="transparent"
+    viewBox="-20.5 -20.5 43 43"
+    width="40"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="3"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="3"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`<LoadingIndicator /> Invisible story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="loading"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: none; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="40"
+    stroke="transparent"
+    viewBox="-20.5 -20.5 43 43"
+    width="40"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="3"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="3"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`<LoadingIndicator /> Large story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="loading"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: flex; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="56"
+    stroke="transparent"
+    viewBox="-21 -21 44 44"
+    width="56"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="4"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="4"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`<LoadingIndicator /> Medium story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="loading"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: flex; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="40"
+    stroke="transparent"
+    viewBox="-20.5 -20.5 43 43"
+    width="40"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="3"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="3"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`<LoadingIndicator /> Small story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="loading"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: flex; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="24"
+    stroke="transparent"
+    viewBox="-20 -20 42 42"
+    width="24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="2"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="2"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;
+
+exports[`<LoadingIndicator /> WithAriaLabel story renders snapshot 1`] = `
+<div
+  aria-busy="true"
+  aria-label="Loading, Please Wait"
+  class="loading-indicator"
+  data-testid="oval-loading"
+  role="status"
+  style="display: flex; padding: 3px;"
+>
+  <svg
+    data-testid="oval-svg"
+    height="40"
+    stroke="transparent"
+    viewBox="-20.5 -20.5 43 43"
+    width="40"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g
+      fill="none"
+      fill-rule="evenodd"
+    >
+      <g
+        data-testid="oval-secondary-group"
+        stroke-width="3"
+        transform="translate(1 1)"
+      >
+        <circle
+          cx="0"
+          cy="0"
+          r="20"
+          stroke="transparent"
+          stroke-opacity=".5"
+          stroke-width="3"
+        />
+        <path
+          d="M20 0c0-9.94-8.06-20-20-20"
+        >
+          <animatetransform
+            attributeName="transform"
+            dur="1s"
+            from="0 0 0"
+            repeatCount="indefinite"
+            to="360 0 0"
+            type="rotate"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
+</div>
+`;

--- a/src/components/LoadingIndicator/index.ts
+++ b/src/components/LoadingIndicator/index.ts
@@ -1,0 +1,1 @@
+export { LoadingIndicator as default } from './LoadingIndicator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export { default as LayoutLinelengthContainer } from './components/LayoutLinelen
 export { default as LayoutSection } from './components/LayoutSection';
 export { default as Link } from './components/Link';
 export { default as LinkList } from './components/LinkList';
+export { default as LoadingIndicator } from './components/LoadingIndicator';
 export { default as Logo } from './components/Logo';
 export { default as Menu } from './components/Menu';
 export { default as Modal } from './components/Modal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2053,6 +2053,7 @@ __metadata:
     react-children-by-type: ^1.1.0
     react-dom: ^16.14.0
     react-focus-lock: ^2.9.2
+    react-loader-spinner: ^5.3.4
     react-popper: ^2.3.0
     react-portal: ^4.2.2
     react-uid: ^2.3.2
@@ -18569,10 +18570,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
+  languageName: node
+  linkType: hard
+
+"react-loader-spinner@npm:^5.3.4":
+  version: 5.3.4
+  resolution: "react-loader-spinner@npm:5.3.4"
+  dependencies:
+    react-is: ^18.2.0
+    styled-components: ^5.3.5
+    styled-tools: ^1.7.2
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: 429ee74233b2a225164bd77cce94459c20443411248e00604a21752fabf31a36749cc4d52c2a2cf194b98b37c543e0cbb9b76a0e49188acd1f17087035544ca6
   languageName: node
   linkType: hard
 
@@ -20716,6 +20731,35 @@ __metadata:
     react-dom: ">= 16.8.0"
     react-is: ">= 16.8.0"
   checksum: 05a664dfe423c2906959a0f3f47f9b1ad630e493eb2e06deea0dc0906af33ba5ca17277b98948a6c9642e73894d6533391aebf45576489f5afe920c974e9f8eb
+  languageName: node
+  linkType: hard
+
+"styled-components@npm:^5.3.5":
+  version: 5.3.6
+  resolution: "styled-components@npm:5.3.6"
+  dependencies:
+    "@babel/helper-module-imports": ^7.0.0
+    "@babel/traverse": ^7.4.5
+    "@emotion/is-prop-valid": ^1.1.0
+    "@emotion/stylis": ^0.8.4
+    "@emotion/unitless": ^0.7.4
+    babel-plugin-styled-components: ">= 1.12.0"
+    css-to-react-native: ^3.0.0
+    hoist-non-react-statics: ^3.0.0
+    shallowequal: ^1.1.0
+    supports-color: ^5.5.0
+  peerDependencies:
+    react: ">= 16.8.0"
+    react-dom: ">= 16.8.0"
+    react-is: ">= 16.8.0"
+  checksum: 68eac1e451be81d66739cf86de8ec9e72f46e7584aa359271761a2437468210bd7cf0a864281fc97dab08c32b35e6bf7513dc8b4104ed6b196cf8d65674dd289
+  languageName: node
+  linkType: hard
+
+"styled-tools@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "styled-tools@npm:1.7.2"
+  checksum: 00cc1796085589b8d95d5a4183806d45b1d332fbc1dcf19922b01b81bd871c5a499fce64e82bb63bbead5bb8fe317f60a6e91c2fe01bf1ed79f5953977a05065
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary:

Add in a loader component, which can be used when there's a non-finite amount of time until loading is completed. Allow for some preliminary props to control size, and apply color overrides by CSS (blocking the component interface).

use the [react loader spinner](https://mhnpd.github.io/react-loader-spinner/docs/components/oval)'s `Oval` implementation. 

Future use case, apply an `as` prop to allow any other loader types using the same component (for example).

### Test Plan:

- [x] storybook
- [x] unit tests (for coverage)