### PR TITLE
chore(release): 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [7.1.1](https://github.com/chanzuckerberg/edu-design-system/compare/v7.1.0...v7.1.1) (2022-12-09)
+
+
+### Bug Fixes
+
+* **deploy:** apply workaround for node 18 ([ccb3517](https://github.com/chanzuckerberg/edu-design-system/commit/ccb3517fbad0d4e93507d2512e4eb4f3d6764473))
+
 ## [7.1.0](https://github.com/chanzuckerberg/edu-design-system/compare/v7.0.0...v7.1.0) (2022-12-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "7.1.0",
+  "version": "7.1.1",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",


### PR DESCRIPTION
### Summary:
Keeping `next` up-to-date with `main`.