### PR TITLE
fix: apply consistency updates to popovers

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -1,3 +1,5 @@
+@import '../../design-tokens/mixins.css';
+
 /*------------------------------------*\
     # MENU
 \*------------------------------------*/
@@ -18,7 +20,12 @@
 }
 
 .menu__button.menu__button {
+  @mixin eds-theme-typography-body-text-md;
+
+  color: var(--eds-theme-text-neutral-subtle);
   background-color: var(--eds-theme-color-form-background);
+  border-color: var(--eds-theme-color-form-border);
+  font-weight: var(--eds-font-weight-light);
 }
 
 /* Needed to create higher specificity than ClickableStyle. TODO: improve */

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -21,6 +21,7 @@ export type MenuProps = ExtractProps<typeof HeadlessMenu> & {
 };
 
 export type MenuItemProps = ExtractProps<typeof HeadlessMenu.Item> & {
+  className?: string;
   href?: string;
   icon?: IconName;
   onClick?: MouseEventHandler<HTMLAnchorElement>;
@@ -60,7 +61,7 @@ const MenuButton = ({ children, className, ...other }: MenuButtonProps) => {
         className={styles['menu__button--icon']}
         name="expand-more"
         purpose="decorative"
-        size="1.5rem"
+        size="1.25rem"
       />
     </HeadlessMenu.Button>
   );
@@ -85,6 +86,7 @@ const MenuItems = (props: MenuItemsProps) => (
  */
 const MenuItem = ({
   children,
+  className,
   href,
   icon,
   onClick,
@@ -96,7 +98,12 @@ const MenuItem = ({
     <HeadlessMenu.Item {...other}>
       {({ active, disabled }) => {
         const listItemView = (
-          <PopoverListItem active={active} disabled={disabled} icon={icon}>
+          <PopoverListItem
+            active={active}
+            className={className}
+            disabled={disabled}
+            icon={icon}
+          >
             {children}
           </PopoverListItem>
         );

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -20,9 +20,9 @@ exports[`<Menu /> Default story renders snapshot 1`] = `
       aria-hidden="true"
       class="icon menu__button--icon"
       fill="currentColor"
-      height="1.5rem"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <use
@@ -167,9 +167,9 @@ exports[`<Menu /> WithLongButtonText story renders snapshot 1`] = `
       aria-hidden="true"
       class="icon menu__button--icon"
       fill="currentColor"
-      height="1.5rem"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <use
@@ -314,9 +314,9 @@ exports[`<Menu /> WithShortButtonText story renders snapshot 1`] = `
       aria-hidden="true"
       class="icon menu__button--icon"
       fill="currentColor"
-      height="1.5rem"
-      style="--icon-size: 1.5rem;"
-      width="1.5rem"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
       <use

--- a/src/components/PopoverContainer/PopoverContainer.module.css
+++ b/src/components/PopoverContainer/PopoverContainer.module.css
@@ -1,3 +1,5 @@
+@import '../../design-tokens/mixins.css';
+
 /*------------------------------------*\
  # POPOVER CONTAINER
 \*------------------------------------*/
@@ -10,4 +12,8 @@
   overflow: auto;
   box-shadow: var(--eds-box-shadow-md);
   background-color: var(--eds-theme-color-background-neutral-default);
+
+  &:focus-visible {
+    @mixin focus;
+  }
 }

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -39,10 +39,6 @@
   max-width: var(--eds-l-max-width);
   position: absolute;
   z-index: var(--eds-z-index-100);
-
-  &:focus-visible {
-    @mixin focus;
-  }
 }
 
 .select__options--compact {
@@ -64,33 +60,43 @@
   right: 0;
 }
 
+.select__option-text {
+  color: var(--eds-theme-color-text-neutral-default);
+}
+
+.select__option-item {
+  color: var(--eds-theme-color-icon-brand-primary);
+}
+
 /*------------------------------------*\
-    # DROPDOWN BUTTON
+    # SELECT BUTTON
 \*------------------------------------*/
 
 /**
- * The button to trigger the display of the dropdown.
+ * The button to trigger the display of the select field.
  */
 .select-button {
   @mixin eds-theme-typography-body-text-md;
   /* Allow select component font to shrink in contexts where body font size is smaller. */
   font-size: inherit;
+  color: var(--eds-theme-text-neutral-subtle);
 
+  height: var(--eds-size-5);
   width: 100%;
-  padding: var(--eds-size-1);
+  padding: 0 var(--eds-size-2);
 
-  border: var(--eds-theme-border-width) solid
-    var(--eds-theme-color-border-neutral-strong);
+  border: var(--eds-theme-border-width) solid var(--eds-theme-color-form-border);
   border-radius: var(--eds-border-radius-md);
 
   display: flex;
   /* Place button text on the left and the expand more icon on the right. */
   justify-content: space-between;
   align-items: center;
+  gap: 0.75rem;
 
   cursor: pointer;
 
-  background-color: var(--eds-theme-color-background-neutral-default);
+  background-color: var(--eds-theme-color-form-background);
 
   &:focus-visible {
     @mixin focus;
@@ -100,6 +106,7 @@
 
 .select-button:disabled {
   cursor: not-allowed;
+  color: var(--eds-theme-color-text-disabled);
 }
 
 /**

--- a/src/components/Select/Select.stories.module.css
+++ b/src/components/Select/Select.stories.module.css
@@ -2,10 +2,6 @@
     # SELECT STORIES
 \*------------------------------------*/
 
-.interactive-example {
-  height: 12rem;
-}
-
 .interactive-example--align-right {
   padding-left: var(--eds-size-4);
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -324,10 +324,13 @@ const SelectOption = function (props: SelectOptionProps) {
             return (
               <PopoverListItem
                 active={active}
+                className={styles['select__option-item']}
                 disabled={disabled}
                 icon={selected ? 'check' : undefined}
               >
-                {children}
+                <span className={styles['select__option-text']}>
+                  {children}
+                </span>
               </PopoverListItem>
             );
           }}

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-14"
       role="option"
@@ -52,11 +52,15 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-15"
       role="option"
@@ -65,11 +69,15 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-16"
       role="option"
@@ -78,7 +86,11 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -127,7 +139,7 @@ exports[`<Select /> CompactUsingChildrenPropAndNoVisibleLabel story renders snap
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-40"
       role="option"
@@ -136,11 +148,15 @@ exports[`<Select /> CompactUsingChildrenPropAndNoVisibleLabel story renders snap
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-41"
       role="option"
@@ -149,11 +165,15 @@ exports[`<Select /> CompactUsingChildrenPropAndNoVisibleLabel story renders snap
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-42"
       role="option"
@@ -162,7 +182,11 @@ exports[`<Select /> CompactUsingChildrenPropAndNoVisibleLabel story renders snap
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -211,7 +235,7 @@ exports[`<Select /> CompactWithOptionsRightAligned story renders snapshot 1`] = 
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-19"
       role="option"
@@ -220,11 +244,15 @@ exports[`<Select /> CompactWithOptionsRightAligned story renders snapshot 1`] = 
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-20"
       role="option"
@@ -233,11 +261,15 @@ exports[`<Select /> CompactWithOptionsRightAligned story renders snapshot 1`] = 
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-21"
       role="option"
@@ -246,7 +278,11 @@ exports[`<Select /> CompactWithOptionsRightAligned story renders snapshot 1`] = 
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -295,7 +331,7 @@ exports[`<Select /> Default story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-3"
       role="option"
@@ -304,11 +340,15 @@ exports[`<Select /> Default story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-4"
       role="option"
@@ -317,11 +357,15 @@ exports[`<Select /> Default story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-5"
       role="option"
@@ -330,7 +374,11 @@ exports[`<Select /> Default story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -387,7 +435,7 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-9"
       role="option"
@@ -396,11 +444,15 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-10"
       role="option"
@@ -409,11 +461,15 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-11"
       role="option"
@@ -422,7 +478,11 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -471,7 +531,7 @@ exports[`<Select /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-24"
       role="option"
@@ -480,11 +540,15 @@ exports[`<Select /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-25"
       role="option"
@@ -493,11 +557,15 @@ exports[`<Select /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-26"
       role="option"
@@ -506,7 +574,11 @@ exports[`<Select /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -563,7 +635,7 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-30"
       role="option"
@@ -572,11 +644,15 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-31"
       role="option"
@@ -585,11 +661,15 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-32"
       role="option"
@@ -598,7 +678,11 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -647,7 +731,7 @@ exports[`<Select /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-35"
       role="option"
@@ -656,11 +740,15 @@ exports[`<Select /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-36"
       role="option"
@@ -669,11 +757,15 @@ exports[`<Select /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-37"
       role="option"
@@ -682,7 +774,11 @@ exports[`<Select /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -727,7 +823,7 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-45"
       role="option"
@@ -736,11 +832,15 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-46"
       role="option"
@@ -749,11 +849,15 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-47"
       role="option"
@@ -762,7 +866,11 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>
@@ -812,7 +920,7 @@ exports[`<Select /> renders the OpenByDefault story 1`] = `
   >
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-55"
       role="option"
@@ -821,11 +929,15 @@ exports[`<Select /> renders the OpenByDefault story 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Dogs
+      <span
+        class="select__option-text"
+      >
+        Dogs
+      </span>
     </div>
     <div
       aria-selected="true"
-      class="popover-list-item popover-list-item--active"
+      class="popover-list-item popover-list-item--active select__option-item"
       data-headlessui-state="active selected"
       id="headlessui-listbox-option-56"
       role="option"
@@ -848,11 +960,15 @@ exports[`<Select /> renders the OpenByDefault story 1`] = `
           />
         </svg>
       </div>
-      Cats
+      <span
+        class="select__option-text"
+      >
+        Cats
+      </span>
     </div>
     <div
       aria-selected="false"
-      class="popover-list-item"
+      class="popover-list-item select__option-item"
       data-headlessui-state=""
       id="headlessui-listbox-option-57"
       role="option"
@@ -861,7 +977,11 @@ exports[`<Select /> renders the OpenByDefault story 1`] = `
       <div
         class="popover-list-item__no-icon"
       />
-      Birds
+      <span
+        class="select__option-text"
+      >
+        Birds
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Summary:

align styles, layout, and focus changes to `Menu`, `Select` and their shared sub-components. make sure the spacing works the same between the components, their text and icons, and that they match the mocks where noted. This is applying design feedback to the current implementations, but changes no behavioral details.

### Test Plan:

- [x] update snapshots
- [x] review chromatic differences
- [x] compare to figma branch

Select Component (before/after):
![Screen Shot 2022-12-12 at 17 47 07 ](https://user-images.githubusercontent.com/3056447/207183983-7789efa0-af88-41ac-a80c-7c97adf0e350.png)

![Screen Shot 2022-12-12 at 17 44 33 ](https://user-images.githubusercontent.com/3056447/207183679-0ac96ed4-fa25-46a3-9bb3-da96c9227e8e.png)

Menu Component (before/after): 
![Screen Shot 2022-12-12 at 17 46 42 ](https://user-images.githubusercontent.com/3056447/207184004-f7c3593f-7aca-469e-89f0-49dac99c99f6.png)

![Screen Shot 2022-12-12 at 17 44 44 ](https://user-images.githubusercontent.com/3056447/207183705-073a8622-3472-4e61-affa-1162986b057d.png)

(essentially the "after" pictures show how this updates the two components to remove unwanted inconsistencies)