### PR TITLE
fix(renovate): reviewers option not working, using codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Overview: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# Any line with invalid syntax will invalidate the entire file.
+
+# Frontend infra
+package.json chanzuckerberg/edu-frontend-infra

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,6 @@
   prConcurrentLimit: 1,
   repositories: ['chanzuckerberg/edu-design-system'],
   rangeStrategy: 'bump', // Always bump minor/patch to latest
-  reviewers: ['team:edu-design-system'],
 
   // Required to prevent onboarding pr and generation of new config file https://github.com/renovatebot/github-action#configurationfile
   onboarding: false,


### PR DESCRIPTION
### Summary:
noticed in https://github.com/chanzuckerberg/edu-design-system/pull/1433 that the team was not being automatically asked to review, using codeowners instead since that seems to work for LP
### Test Plan:
next renovate pr has frontend infra team tagged