### PR TITLE
fix(LoadingIndicator): add reduced motion behavior

### DIFF
--- a/src/components/LoadingIndicator/LoadingIndicator.module.css
+++ b/src/components/LoadingIndicator/LoadingIndicator.module.css
@@ -19,3 +19,10 @@
   stroke: var(--eds-theme-color-background-neutral-medium);
   stroke-opacity: 1;
 }
+
+@media screen and (prefers-reduced-motion: reduce) {
+  /* if reducing motion, don't show the moving portion */
+  .loading-indicator > svg path {
+    stroke: none;
+  }
+}


### PR DESCRIPTION
### Summary:

Define a fallback behavior when reduce motion is enabled. This accessibility behavior is esp. useful in context of many loading indicators on screen at once, which could produce some undesirable optical effects.

### Test Plan:

- [x] add fallback and test by toggling "reduce motion" at OS level
- [x] existing test suite should pass