### PR TITLE
Pin headlessui/react to 1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "react": ">= 16.8.0"
   },
   "dependencies": {
-    "@headlessui/react": "^1.7.7",
+    "@headlessui/react": "1.7.5",
     "@popperjs/core": "^2.11.6",
     "@tippyjs/react": "^4.2.6",
     "clsx": "^1.2.1",

--- a/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`<Dropdown /> Compact story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-15"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-13 headlessui-listbox-button-14"
     class="dropdown-button dropdown-button--compact"
     data-headlessui-state="open"
@@ -112,7 +112,7 @@ exports[`<Dropdown /> CompactUsingChildrenPropAndNoVisibleLabel story renders sn
   <button
     aria-controls="headlessui-listbox-options-45"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-43 headlessui-listbox-button-44"
     class="dropdown-button dropdown-button--compact"
     data-headlessui-state="open"
@@ -208,7 +208,7 @@ exports[`<Dropdown /> CompactWithOptionsRightAligned story renders snapshot 1`] 
   <button
     aria-controls="headlessui-listbox-options-21"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-19 headlessui-listbox-button-20"
     class="dropdown-button dropdown-button--compact"
     data-headlessui-state="open"
@@ -304,7 +304,7 @@ exports[`<Dropdown /> Default story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-3"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-1 headlessui-listbox-button-2"
     class="dropdown-button"
     data-headlessui-state="open"
@@ -400,7 +400,7 @@ exports[`<Dropdown /> DefaultWithoutVisibleLabel story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-9"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-7 headlessui-listbox-button-8"
     class="dropdown-button"
     data-headlessui-state="open"
@@ -496,7 +496,7 @@ exports[`<Dropdown /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-27"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-25 headlessui-listbox-button-26"
     class="dropdown-button"
     data-headlessui-state="open"
@@ -592,7 +592,7 @@ exports[`<Dropdown /> UsingChildrenProp story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-33"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-31 headlessui-listbox-button-32"
     class="dropdown-button"
     data-headlessui-state="open"
@@ -688,7 +688,7 @@ exports[`<Dropdown /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 
   <button
     aria-controls="headlessui-listbox-options-39"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-37 headlessui-listbox-button-38"
     class="dropdown-button"
     data-headlessui-state="open"
@@ -778,7 +778,7 @@ exports[`<Dropdown /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-50"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="function-children__button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-49"
@@ -868,7 +868,7 @@ exports[`<Dropdown /> renders the OpenByDefault story 1`] = `
   <button
     aria-controls="headlessui-listbox-options-56"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-54 headlessui-listbox-button-55"
     class="dropdown-button"
     data-headlessui-state="open"

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`<Menu /> Default story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-menu-items-2"
     aria-expanded="true"
-    aria-haspopup="menu"
+    aria-haspopup="true"
     class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral menu__button"
     data-bootstrap-override="clickable-style-secondary"
     data-headlessui-state="open"
@@ -159,7 +159,7 @@ exports[`<Menu /> WithLongButtonText story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-menu-items-8"
     aria-expanded="true"
-    aria-haspopup="menu"
+    aria-haspopup="true"
     class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral menu__button"
     data-bootstrap-override="clickable-style-secondary"
     data-headlessui-state="open"
@@ -310,7 +310,7 @@ exports[`<Menu /> WithShortButtonText story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-menu-items-14"
     aria-expanded="true"
-    aria-haspopup="menu"
+    aria-haspopup="true"
     class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--neutral menu__button"
     data-bootstrap-override="clickable-style-secondary"
     data-headlessui-state="open"

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-13"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button select-button--compact"
     data-headlessui-state="open"
     id="headlessui-listbox-button-12"
@@ -106,7 +106,7 @@ exports[`<Select /> CompactUsingChildrenPropAndNoVisibleLabel story renders snap
   <button
     aria-controls="headlessui-listbox-options-39"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button select-button--compact"
     data-headlessui-state="open"
     id="headlessui-listbox-button-38"
@@ -203,7 +203,7 @@ exports[`<Select /> CompactWithOptionsRightAligned story renders snapshot 1`] = 
   <button
     aria-controls="headlessui-listbox-options-18"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button select-button--compact"
     data-headlessui-state="open"
     id="headlessui-listbox-button-17"
@@ -300,7 +300,7 @@ exports[`<Select /> Default story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-2"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-1"
@@ -404,7 +404,7 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-8"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-6 headlessui-listbox-button-7"
     class="select-button"
     data-headlessui-state="open"
@@ -502,7 +502,7 @@ exports[`<Select /> SeparateButtonAndMenuWidth story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-23"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-22"
@@ -606,7 +606,7 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-29"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     aria-labelledby="headlessui-listbox-label-27 headlessui-listbox-button-28"
     class="select-button"
     data-headlessui-state="open"
@@ -704,7 +704,7 @@ exports[`<Select /> UsingChildrenPropAndNoVisibleLabel story renders snapshot 1`
   <button
     aria-controls="headlessui-listbox-options-34"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-33"
@@ -802,7 +802,7 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   <button
     aria-controls="headlessui-listbox-options-44"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="function-children__button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-43"
@@ -894,7 +894,7 @@ exports[`<Select /> renders the OpenByDefault story 1`] = `
   <button
     aria-controls="headlessui-listbox-options-51"
     aria-expanded="true"
-    aria-haspopup="listbox"
+    aria-haspopup="true"
     class="select-button"
     data-headlessui-state="open"
     id="headlessui-listbox-button-50"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2002,7 +2002,7 @@ __metadata:
     "@commitlint/config-conventional": ^16.2.4
     "@commitlint/prompt-cli": ^16.3.0
     "@geometricpanda/storybook-addon-badges": ^0.2.2
-    "@headlessui/react": ^1.7.7
+    "@headlessui/react": 1.7.5
     "@popperjs/core": ^2.11.6
     "@size-limit/preset-small-lib": ^4.12.0
     "@storybook/addon-a11y": ^6.5.14
@@ -2534,15 +2534,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@headlessui/react@npm:^1.7.7":
-  version: 1.7.7
-  resolution: "@headlessui/react@npm:1.7.7"
+"@headlessui/react@npm:1.7.5":
+  version: 1.7.5
+  resolution: "@headlessui/react@npm:1.7.5"
   dependencies:
     client-only: ^0.0.1
   peerDependencies:
     react: ^16 || ^17 || ^18
     react-dom: ^16 || ^17 || ^18
-  checksum: 049d7ee46056fe96067f7b2f4f962672dfc824e68044ae38561a457278c8e38c0fd17592ab648ba5648e7e82bef9890eddbf329c9a00d11acf85700c7072a0bf
+  checksum: 0658251a38a23cb6e41bc4edb15184fa8a5470f57f8c9d948a1aa5ce4da5b1d6ec24ac488ce5d5dbf0ed49c0ad1f147a03db4d6661262eb60a1eed299527a0f0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Pin headlessui/react to 1.7.5, to resolve E2E test failures in https://github.com/FB-PLP/traject/pull/13040.

Seeing

```
Error: RangeError: Maximum call stack size exceeded.
      at HTMLDocument.enforceFocus (http://localhost:3003/javascripts/js/vendor.js:134963:21)
      at S (http://localhost:3003/javascripts/js/vendor.js:162697:1335)
      at onBlur (http://localhost:3003/javascripts/js/vendor.js:161872:2651)
      at onBlur (http://localhost:3003/javascripts/js/vendor.js:162820:954)
      at HTMLUnknownElement.callCallback (http://localhost:3003/javascripts/js/vendor.js:110567:14)
      at Object.invokeGuardedCallbackDev (http://localhost:3003/javascripts/js/vendor.js:110616:16)
      at invokeGuardedCallback (http://localhost:3003/javascripts/js/vendor.js:110678:31)
      at invokeGuardedCallbackAndCatchFirstError (http://localhost:3003/javascripts/js/vendor.js:110692:25)
      at executeDispatch (http://localhost:3003/javascripts/js/vendor.js:114865:3)
      at processDispatchQueueItemsInOrder (http://localhost:3003/javascripts/js/vendor.js:114897:7)
```

The `HTMLDocument.enforceFocus` makes me think this could be 2 different focus traps fighting for focus.

---

This issue first shows up in [headlessui/react 1.7.6](https://github.com/tailwindlabs/headlessui/blob/main/packages/@headlessui-react/CHANGELOG.md#176---2022-12-15).

The most suspicious changelog item is "Fix FocusTrap escape due to strange tabindex values" from https://github.com/tailwindlabs/headlessui/pull/2093.

In any case, we should merge this PR to unblock updating EDS in Traject. A future effort can look at resolving unpinning.