### PR TITLE
docs: sync doc.s for new components with zeroheight

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -42,7 +42,7 @@ export const AccordionContext = createContext<{
  *
  * `import {Accordion} from "@chanzuckerberg/eds;`
  *
- * One or multiple interactive headings that reveal or hide associated content.
+ * Displays a list of headers stacked on top of one another that can reveal or hide associated content.
  *
  * ```tsx
  * <Accordion>

--- a/src/components/AccordionButton/AccordionButton.tsx
+++ b/src/components/AccordionButton/AccordionButton.tsx
@@ -32,7 +32,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * The button subcomponent that houses the heading text and open indicator icon for the EDS Accordion component.
+ * Contains the subject of hidden content and a down/up or chevron icon to signify that the row can expand or collapse.
  */
 export const AccordionButton = ({
   children,

--- a/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.tsx
@@ -18,7 +18,7 @@ export type Props = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * The heading text subcomponent for the Accordion.Button subcomponent for the EDS Accordion component.
+ * An expandable/collapsible content area.
  */
 export const AccordionPanel = ({ className, children, ...other }: Props) => {
   const { hasOutline, size } = useContext(AccordionContext);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -73,10 +73,9 @@ const BadgeDot = () => <BadgeText />;
  *
  * `import {Badge} from "@chanzuckerberg/eds";`
  *
- * Wraps an element to apply a small pill shaped container (Badge) on the upper righthand corner of the element.
- * A badge indicates something has changed in regards to the attached element.
+ * A badge is used to communicate an update or change to an object since the last interaction.
  *
- * The attached element MUST have accessible name and other relevant aria properties in relevance to the badge.
+ * A badged object MUST have screen reader text describing the attached badge (i.e. dot: has notification, number: has number updates)
  *
  * Example usage:
  *

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -52,8 +52,10 @@ const loaderStrokeSize = {
  *
  * `import {LoadingIndicator} from "@chanzuckerberg/eds";`
  *
- * Show a loading state within a component container, or a specific page or area, where
- * arbitrary content will appear once some request has completed.
+ * Loading indicators inform users about the wait time, reason, and status of ongoing processes when the layout is unknown
+ *
+ * For screen readers, add an `aria-label` to describe what is loading.
+ *
  */
 export const LoadingIndicator = ({
   ariaLabel = 'loading',

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -21,9 +21,21 @@ export type MenuProps = ExtractProps<typeof HeadlessMenu> & {
 };
 
 export type MenuItemProps = ExtractProps<typeof HeadlessMenu.Item> & {
+  /**
+   * Allow custom classes to be applied to the menu container.
+   */
   className?: string;
+  /**
+   * Target URL for the menu item action
+   */
   href?: string;
+  /**
+   * Icons are able to appear next to each Option in the Options list if it is relevant; before using any icons, please refer to the appropriate icon usage guidelines
+   */
   icon?: IconName;
+  /**
+   * Configurable action for the menu item action. If both `href` and `onClick` are used, `onClick` takes precedent.
+   */
   onClick?: MouseEventHandler<HTMLAnchorElement>;
 };
 
@@ -35,9 +47,7 @@ export type MenuItemsProps = ExtractProps<typeof HeadlessMenu.Items>;
  *
  * `import {Menu} from "@chanzuckerberg/eds";`
  *
- * Creates a list of actions which appear next to a trigger component. This should
- * be used when there is a discrete number of actions such as user navigations (e.g.,
- * a profile menu with links to settings) or a set of actions
+ * A dropdown that reveals or hides a list of actions
  */
 export const Menu = ({ className, ...other }: MenuProps) => {
   const menuClassNames = clsx(className, styles['menu']);
@@ -45,7 +55,7 @@ export const Menu = ({ className, ...other }: MenuProps) => {
 };
 
 /**
- * Trigger for the popover menu (dropdown)
+ * A button that when clicked, shows or hides the Options
  */
 const MenuButton = ({ children, className, ...other }: MenuButtonProps) => {
   const buttonClassNames = clsx(styles['menu__button'], className);
@@ -68,7 +78,7 @@ const MenuButton = ({ children, className, ...other }: MenuButtonProps) => {
 };
 
 /**
- * A set of menu items in the Menu
+ * A list of actions that are revealed in the menu
  *
  * @param props Props used on the set of menu items
  * @see https://headlessui.com/react/menu#menu-items
@@ -82,7 +92,7 @@ const MenuItems = (props: MenuItemsProps) => (
 );
 
 /**
- * Individual menu items, styled with the popover list item component
+ * An individual option that represent an action in the menu
  */
 const MenuItem = ({
   children,

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -63,7 +63,7 @@ export const PopoverContext = createContext<PopoverContextType>({});
  *
  * `import {Popover} from "@chanzuckerberg/eds";`
  *
- * A styled popover built on 'headless UI' popover. Consider using the Dropdown component instead.
+ * General-purpose floating menus that appear proximal to a trigger point
  */
 export const Popover = ({
   placement,
@@ -159,6 +159,9 @@ export type PopoverContentProps = {
   ) => void;
 }>;
 
+/**
+ * A floating container that can be resized to fit content inside
+ */
 const PopoverContent = ({
   arrowClassName,
   bodyClassName,
@@ -203,17 +206,14 @@ const PopoverContent = ({
 };
 
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
- * Popover trigger button.
- *
- * By default will render a button, so you shouldn't pass a button component as its children.
- * Instead, pass the contents of the button.
+ * A button that when clicked, can show or hide the Popover Menu
+ * (Product teams can decide how a Popover will close, if it is on click, release, hover, etc.)
  *
  * If you need to use some sort of special button, pass it as the `as` prop. Make sure the
  * component accepts `aria-expanded` and `aria-controls` props for accessibility.
  *
- * @example
+ * Examples:
+ *
  * ```ts
  * import {Popover} from "@chanzuckerberg/eds";
  *
@@ -224,7 +224,6 @@ const PopoverContent = ({
  * </Popover.Button>
  * ```
  *
- * @example
  * ```ts
  * import {Popover} from "@chanzuckerberg/eds";
  *
@@ -243,16 +242,14 @@ const PopoverContent = ({
  */
 Popover.Button = PopoverButton;
 /**
- * BETA: This component is still a work in progress and is subject to change.
- *
- * The floating panel container for the Popover.
+ * A floating container that can be resized to fit content inside
  *
  * @example
  * ```ts
  * import {Popover} from "@chanzuckerberg/eds";
  *
  * <Popover.Content>
- *  {Possible Popover Elements}
+ *  {children}
  * </Popover.Content>
  * ```
  */

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -36,7 +36,7 @@ export type Props = {
  *
  * `import {ProgressBar} from "@chanzuckerberg/eds";`
  *
- * A progress bar component that indicates how much progress has been made on a task.
+ * Show the progression of a system operation: downloading, uploading, processing, etc., in a visual way
  */
 export const ProgressBar = ({
   caption,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -78,14 +78,7 @@ function childrenHaveLabelComponent(children?: ReactNode): boolean {
  *
  * `import {Select} from "@chanzuckerberg/eds";`
  *
- * EDS Select. Used to select one option from a list of options.
- *
- * Built on top of the Headless UI Listbox: https://headlessui.dev/react/listbox#basic-example
- *
- * You can pass in the <Select.Label>, <Select.Button>, and options
- * (using <Select.Options> and <Select.Option>) through `children` to
- * have more control and customization over each aspect of the Select's
- * appearance.
+ * A dropdown that reveals or hides a list of options to select
  *
  * Examples:
  *
@@ -271,6 +264,9 @@ const SelectTrigger = function (
   );
 };
 
+/**
+ * The content container showing the available options when the trigger is activated
+ */
 const SelectOptions = function (props: PropsWithRenderProp<{ open: boolean }>) {
   const { className, ...other } = props;
   const { compact, optionsAlign, optionsClassName } = useContext(SelectContext);
@@ -301,6 +297,9 @@ type SelectOptionProps = {
     | RenderProp<{ active: boolean; disabled: boolean; selected: boolean }>;
 };
 
+/**
+ * Represents one of the available options for selection
+ */
 const SelectOption = function (props: SelectOptionProps) {
   const { children, className, ...other } = props;
 
@@ -354,7 +353,7 @@ type SelecButtonProps = {
 };
 
 /**
- * A styled button with an expand icon to be used for triggering
+ * The component functioning as a trigger, which also shows the current selection
  */
 export const SelectButton = React.forwardRef<
   HTMLButtonElement,

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -24,13 +24,7 @@ type SkeletonProps = BaseProps & {
  *
  * `import {Skeleton} from "@chanzuckerberg/eds";`
  *
- * Skeleton states allow for hinting at the layout of pending content before the
- * content is available. The different shapes allow for representation of different
- * types of content. Mix and match to create a layout that mimicks the pending data.
- *
- * Skeletons come in a variety of shapes. The default is a round rect, and there are
- * others for circular objects, or text layouts. Use any meaningful CSS length values
- * (e.g., rem, ch, px, etc.)
+ * Skeleton states inform users about the wait time, reason, and status of ongoing processes, showing the expected layout
  *
  * Examples:
  *
@@ -38,7 +32,7 @@ type SkeletonProps = BaseProps & {
  *
  * For circular objects, use `Skeleton.Circle' and specify the width (which is the same as the height).
  *
- * For all other shapes, use `Skeleton.Rect` (or just Skeleton) and specify the width and height.
+ * For all other objects, use `Skeleton.Rect` (or just `Skeleton`) and specify the width and height.
  */
 export const Skeleton = ({
   className,


### PR DESCRIPTION
### Summary:

- Pull in the documentation from zeroheight to synchronize with what's in zeroheight (see ticket for link(s)). 

### Test Plan:

- [x] existing test suite passes as expected
