### PR TITLE
docs(select): remove mentions of undefined prop

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -25,10 +25,9 @@ type SelectProps = ExtractProps<typeof Listbox> & {
   /**
    * Screen-reader text for the select's label.
    *
-   * When possible, use a visible label through the `labelText` prop or
-   * by passing a <Select.Label> into `chidren`. In rare cases where there's no
-   * visible label, you must provide an `aria-label` for screen readers.
-   * If you pass in an `aria-label`, you don't need `labelText` or <Select.Label>.
+   * When possible, use a visible label by passing a <Select.Label> into `chidren`.
+   * In rare cases where there's no visible label, you must provide an `aria-label` for screen readers.
+   * If you pass in an `aria-label`, <Select.Label>.
    */
   'aria-label'?: string;
   /**


### PR DESCRIPTION
### Summary:
I don't think `labelText` prop is being used in `Select`, removing references to it in the prop desc
### Test Plan:
n/a