### PR TITLE
refactor: remove default exports from components

### DIFF
--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -393,7 +393,7 @@ The comment should begin with an import example, include a general description o
 
 Example:
 
-````
+````tsx
 /**
  * `import {ButtonGroup} from "@chanzuckerberg/eds";`
  *
@@ -419,7 +419,7 @@ Do not use [jsdoc tags](https://devhints.io/jsdoc) (e.g. `@example`) if possible
 
 Example:
 
-````
+````tsx
 /**
  * The Banner component is deprecated and will be removed in an upcoming release.
  *
@@ -458,6 +458,22 @@ export const ComponentName = ({
 ```
 
 This defines the component name and passes in all the `Props`.
+
+The `src/components/{componentFolder}/index.ts` file should should import and re-export the component `as default`. The `src/index.ts` file should re-export the component for an easy way to consume it downstream.
+
+i.e. in `src/components/{componentFolder}/index.ts`
+
+```ts
+export { ComponentName as default } from './ComponentName';
+```
+
+and in `src/index.ts`
+
+```ts
+...
+export { default as ComponentName } from './components/ComponentName';
+...
+```
 
 ### Children
 

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -2,7 +2,7 @@ import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
-import Heading, { VARIANTS } from './Heading';
+import { Heading, VARIANTS } from './Heading';
 import styles from './Heading.stories.module.css';
 
 export default {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -110,5 +110,3 @@ export const Heading = forwardRef(
 );
 
 Heading.displayName = 'Heading'; // Satisfy eslint.
-
-export default Heading;

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
 import { useState } from 'react';
-import Modal, { ModalContent } from './Modal';
+import { Modal, ModalContent } from './Modal';
 import styles from './Modal.stories.module.css';
 import { Button, ButtonGroup, Heading, Text, Tooltip } from '../../';
 import { VARIANTS } from '../Heading/Heading';

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -2,7 +2,7 @@ import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import Modal from './Modal';
+import { Modal } from './Modal';
 import * as stories from './Modal.stories';
 import '../../../jest/helpers/removeModalTransitionStylesJestSerializer';
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -258,5 +258,3 @@ Modal.Title = ModalTitle;
 Modal.Body = FocusableModalBody;
 Modal.Footer = StickyModalFooter;
 Modal.Stepper = ModalStepper;
-
-export default Modal;

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,6 +1,6 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
-import Tag, { VARIANTS } from './Tag';
+import { Tag, VARIANTS } from './Tag';
 import styles from './Tag.stories.module.css';
 import Icon from '../Icon';
 

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -72,5 +72,3 @@ export const Tag = ({
     </Text>
   );
 };
-
-export default Tag;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -118,5 +118,3 @@ export const Text = forwardRef(
   },
 );
 Text.displayName = 'Text'; // Satisfy eslint
-
-export default Text;

--- a/src/components/Toast/Toast.stories.ts
+++ b/src/components/Toast/Toast.stories.ts
@@ -1,6 +1,6 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import type { ComponentProps } from 'react';
-import Toast from './Toast';
+import { Toast } from './Toast';
 
 export default {
   title: 'Components/Toast',

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -71,5 +71,3 @@ export const Toast = ({
     </div>
   );
 };
-
-export default Toast;


### PR DESCRIPTION
### Summary:
- removes default exports from 5 components
- correctly points affected files to named import
- all other components don't have default exports
- resolves eslint errors that were happening locally 
### Test Plan:
- doesn't break LP
  - tested via [7.3.0-alpha.0](https://www.npmjs.com/package/@chanzuckerberg/eds/v/7.3.0-alpha.0) release and [tests pass](https://app.circleci.com/pipelines/github/FB-PLP/traject?branch=jlee%2FtestNoDefaultComponentExportEDS) in LP test branch
  - manually looked for imports to `@czi/eds/lib/components/{component}/{component}` and didn't find default import instances
