### PR TITLE
ci(chromatic): turn on turbo snap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
         run: yarn build:tokens
       - name: Build Storybook 📚
         run: yarn build:storybook
+        with:
+          node-version: 16.15.0
       # Note: Since the storybook builds to root now, no longer need to fiddle with "--storybook-base-dir", "--webpack-stats-json",
       # and other related storybook/chromatic flags, explore turning TurboSnap back on with "--only-changed".
       # https://app.shortcut.com/czi-edu/story/203071

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,6 @@ jobs:
         run: yarn build:tokens
       - name: Build Storybook 📚
         run: yarn build:storybook --webpack-stats-json
-      # Note: Since the storybook builds to root now, no longer need to fiddle with "--storybook-base-dir", "--webpack-stats-json",
-      # and other related storybook/chromatic flags, explore turning TurboSnap back on with "--only-changed".
-      # https://app.shortcut.com/czi-edu/story/203071
       - name: Publish to Chromatic 🦄
         run: |
           yarn run chromatic \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # 👈 Required to retrieve git history
       - name: Install dependencies
@@ -54,8 +54,6 @@ jobs:
         run: yarn build:tokens
       - name: Build Storybook 📚
         run: yarn build:storybook
-        with:
-          node-version: 16.15.0
       # Note: Since the storybook builds to root now, no longer need to fiddle with "--storybook-base-dir", "--webpack-stats-json",
       # and other related storybook/chromatic flags, explore turning TurboSnap back on with "--only-changed".
       # https://app.shortcut.com/czi-edu/story/203071

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
             --exit-zero-on-changes \
             --exit-once-uploaded \
             --auto-accept-changes '{main,next}' \
+            --only-changed \
             --skip 'dependabot/**'
       - name: Run Accessibility Tests 💛
         run: yarn run storybook:axeOnly

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build design tokens
         run: yarn build:tokens
       - name: Build Storybook 📚
-        run: yarn build:storybook
+        run: yarn build:storybook --webpack-stats-json
       # Note: Since the storybook builds to root now, no longer need to fiddle with "--storybook-base-dir", "--webpack-stats-json",
       # and other related storybook/chromatic flags, explore turning TurboSnap back on with "--only-changed".
       # https://app.shortcut.com/czi-edu/story/203071

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:clean": "rm -rf lib/",
     "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn prettier-tokens-dist && yarn copy-tokens-to-lib",
     "build:js": "tsc --project tsconfig.build.json",
-    "build:storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts --webpack-stats-json",
+    "build:storybook": "build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",
     "build:styles": "postcss \"src/components/**/*.css\" --dir lib/ --base src/ --verbose",
     "chromatic": "chromatic",
     "commit": "./node_modules/.bin/cz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:clean": "rm -rf lib/",
     "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn prettier-tokens-dist && yarn copy-tokens-to-lib",
     "build:js": "tsc --project tsconfig.build.json",
-    "build:storybook": "build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",
+    "build:storybook": "NODE_OPTIONS=--openssl-legacy-provider build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts --webpack-stats-json",
     "build:styles": "postcss \"src/components/**/*.css\" --dir lib/ --base src/ --verbose",
     "chromatic": "chromatic",
     "commit": "./node_modules/.bin/cz",


### PR DESCRIPTION
### Summary

Turns on Chromatic's [turbosnap](https://www.chromatic.com/docs/turbosnap) feature (again).
Needs building storybook with `--webpack-stats-json` flag

### Testing

[GH action](https://github.com/chanzuckerberg/edu-design-system/actions/runs/3963705567/jobs/6791843654#step:6:52) shows turbosnap on and this pr skipped all snapshots