### PR TITLE
Side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",
   "license": "MIT",
   "main": "lib/index.js",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Summary:

This PR specifies that EDS does not have [sideEffects](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free)
- Let's esbuild and webpack tree shake EDS.
- Meaning apps using EDS only ship code for the components they use, as opposed to all components.
- I actually made this change 1.5 years ago in #554, but it seems to have gotten wiped out in the BM repo changes 🤨 

### Test Plan:

- Before this change: in the Remix test app code for all EDS components is present, despite only using Heading.
- After this change: only the Heading code is present.