### PR TITLE
[EFI-875] chore: remove uneccessary usage of react-uid

### DIFF
--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -34,9 +34,7 @@ exports[`<Accordion /> Default story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="1"
-          >
+          <title>
             show content
           </title>
           <path
@@ -84,9 +82,7 @@ exports[`<Accordion /> DefaultOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="38"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -141,9 +137,7 @@ exports[`<Accordion /> Small story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="4"
-          >
+          <title>
             show content
           </title>
           <path
@@ -191,9 +185,7 @@ exports[`<Accordion /> SmallOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="40"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -247,9 +239,7 @@ exports[`<Accordion /> Stacked story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="6"
-          >
+          <title>
             show content
           </title>
           <path
@@ -284,9 +274,7 @@ exports[`<Accordion /> Stacked story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="7"
-          >
+          <title>
             show content
           </title>
           <path
@@ -321,9 +309,7 @@ exports[`<Accordion /> Stacked story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="8"
-          >
+          <title>
             show content
           </title>
           <path
@@ -358,9 +344,7 @@ exports[`<Accordion /> Stacked story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="9"
-          >
+          <title>
             show content
           </title>
           <path
@@ -407,9 +391,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="42"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -452,9 +434,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="43"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -497,9 +477,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="44"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -542,9 +520,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="45"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -597,9 +573,7 @@ exports[`<Accordion /> StackedOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="22"
-          >
+          <title>
             show content
           </title>
           <path
@@ -634,9 +608,7 @@ exports[`<Accordion /> StackedOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="23"
-          >
+          <title>
             show content
           </title>
           <path
@@ -671,9 +643,7 @@ exports[`<Accordion /> StackedOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="24"
-          >
+          <title>
             show content
           </title>
           <path
@@ -708,9 +678,7 @@ exports[`<Accordion /> StackedOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="25"
-          >
+          <title>
             show content
           </title>
           <path
@@ -757,9 +725,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="58"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -802,9 +768,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="59"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -847,9 +811,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="60"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -892,9 +854,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="61"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -947,9 +907,7 @@ exports[`<Accordion /> StackedSmall story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="14"
-          >
+          <title>
             show content
           </title>
           <path
@@ -984,9 +942,7 @@ exports[`<Accordion /> StackedSmall story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="15"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1021,9 +977,7 @@ exports[`<Accordion /> StackedSmall story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="16"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1058,9 +1012,7 @@ exports[`<Accordion /> StackedSmall story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="17"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1107,9 +1059,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="50"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1152,9 +1102,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="51"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1197,9 +1145,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="52"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1242,9 +1188,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="53"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1297,9 +1241,7 @@ exports[`<Accordion /> StackedSmallOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="30"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1334,9 +1276,7 @@ exports[`<Accordion /> StackedSmallOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="31"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1371,9 +1311,7 @@ exports[`<Accordion /> StackedSmallOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="32"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1408,9 +1346,7 @@ exports[`<Accordion /> StackedSmallOutline story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="33"
-          >
+          <title>
             show content
           </title>
           <path
@@ -1457,9 +1393,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="66"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1502,9 +1436,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="67"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1547,9 +1479,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="68"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1592,9 +1522,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="69"
-          >
+          <title>
             hide content
           </title>
           <path
@@ -1649,9 +1577,7 @@ exports[`<Accordion /> UsingRenderProp story renders snapshot 1`] = `
           width="1.625rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="74"
-          >
+          <title>
             show content
           </title>
           <path

--- a/src/components/Banner/__snapshots__/Banner.test.ts.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.ts.snap
@@ -11,9 +11,7 @@ exports[`<Banner /> Brand story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="1"
-    >
+    <title>
       attention
     </title>
     <path
@@ -58,9 +56,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="13"
-    >
+    <title>
       attention
     </title>
     <path
@@ -103,9 +99,7 @@ exports[`<Banner /> BrandDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="14"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -127,9 +121,7 @@ exports[`<Banner /> BrandWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="8"
-    >
+    <title>
       attention
     </title>
     <path
@@ -193,9 +185,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="23"
-    >
+    <title>
       attention
     </title>
     <path
@@ -249,9 +239,7 @@ exports[`<Banner /> DismissableWithAction story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="24"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -273,9 +261,7 @@ exports[`<Banner /> Error story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="5"
-    >
+    <title>
       error
     </title>
     <path
@@ -320,9 +306,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="21"
-    >
+    <title>
       error
     </title>
     <path
@@ -365,9 +349,7 @@ exports[`<Banner /> ErrorDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="22"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -389,9 +371,7 @@ exports[`<Banner /> ErrorWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="12"
-    >
+    <title>
       error
     </title>
     <path
@@ -447,9 +427,7 @@ exports[`<Banner /> Flat story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="33"
-    >
+    <title>
       attention
     </title>
     <path
@@ -494,9 +472,7 @@ exports[`<Banner /> Neutral story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="2"
-    >
+    <title>
       notice
     </title>
     <path
@@ -541,9 +517,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="15"
-    >
+    <title>
       notice
     </title>
     <path
@@ -586,9 +560,7 @@ exports[`<Banner /> NeutralDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="16"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -610,9 +582,7 @@ exports[`<Banner /> NeutralWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="9"
-    >
+    <title>
       notice
     </title>
     <path
@@ -668,9 +638,7 @@ exports[`<Banner /> NoDescription story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="6"
-    >
+    <title>
       attention
     </title>
     <path
@@ -702,9 +670,7 @@ exports[`<Banner /> NoTitle story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="7"
-    >
+    <title>
       attention
     </title>
     <path
@@ -744,9 +710,7 @@ exports[`<Banner /> Success story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="3"
-    >
+    <title>
       success
     </title>
     <path
@@ -791,9 +755,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="17"
-    >
+    <title>
       success
     </title>
     <path
@@ -836,9 +798,7 @@ exports[`<Banner /> SuccessDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="18"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -860,9 +820,7 @@ exports[`<Banner /> SuccessWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="10"
-    >
+    <title>
       success
     </title>
     <path
@@ -918,9 +876,7 @@ exports[`<Banner /> Vertical story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="27"
-    >
+    <title>
       attention
     </title>
     <path
@@ -965,9 +921,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="28"
-    >
+    <title>
       attention
     </title>
     <path
@@ -1010,9 +964,7 @@ exports[`<Banner /> VerticalDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="29"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -1034,9 +986,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="31"
-    >
+    <title>
       attention
     </title>
     <path
@@ -1090,9 +1040,7 @@ exports[`<Banner /> VerticalDismissableWithAction story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="32"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -1114,9 +1062,7 @@ exports[`<Banner /> VerticalWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="30"
-    >
+    <title>
       attention
     </title>
     <path
@@ -1172,9 +1118,7 @@ exports[`<Banner /> Warning story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="4"
-    >
+    <title>
       warning
     </title>
     <path
@@ -1219,9 +1163,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="19"
-    >
+    <title>
       warning
     </title>
     <path
@@ -1264,9 +1206,7 @@ exports[`<Banner /> WarningDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="20"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -1288,9 +1228,7 @@ exports[`<Banner /> WarningWithAction story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="11"
-    >
+    <title>
       warning
     </title>
     <path

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import debounce from 'lodash.debounce';
 import React, { type ReactNode } from 'react';
-import { useUID } from 'react-uid';
 import styles from './Breadcrumbs.module.css';
 import { flattenReactChildren } from '../../util/flattenReactChildren';
 import BreadcrumbsItem from '../BreadcrumbsItem';
@@ -105,15 +104,12 @@ export const Breadcrumbs = ({
       );
     });
 
-  const generatedId = useUID();
-  const breadcrumbsId = id || generatedId;
-
   const componentClassName = clsx(styles['breadcrumbs'], className);
   return (
     <nav
       aria-label={ariaLabel}
       className={componentClassName}
-      id={breadcrumbsId}
+      id={id}
       {...other}
     >
       <ul className={styles['breadcrumbs__list']} ref={ref}>

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`<Breadcrumbs /> Default story renders snapshot 1`] = `
   <nav
     aria-label="breadcrumbs links"
     class="breadcrumbs"
-    id="1"
   >
     <ul
       class="breadcrumbs__list"
@@ -26,9 +25,7 @@ exports[`<Breadcrumbs /> Default story renders snapshot 1`] = `
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="2"
-            >
+            <title>
               Child
             </title>
             <path
@@ -103,7 +100,6 @@ exports[`<Breadcrumbs /> LongList story renders snapshot 1`] = `
   <nav
     aria-label="breadcrumbs links"
     class="breadcrumbs"
-    id="6"
   >
     <ul
       class="breadcrumbs__list"
@@ -122,9 +118,7 @@ exports[`<Breadcrumbs /> LongList story renders snapshot 1`] = `
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="7"
-            >
+            <title>
               Breadcrumb 9
             </title>
             <path
@@ -327,7 +321,6 @@ exports[`<Breadcrumbs /> LongText story renders snapshot 1`] = `
   <nav
     aria-label="breadcrumbs links"
     class="breadcrumbs"
-    id="8"
   >
     <ul
       class="breadcrumbs__list"
@@ -346,9 +339,7 @@ exports[`<Breadcrumbs /> LongText story renders snapshot 1`] = `
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="9"
-            >
+            <title>
               Breadcrumb 2 Lorem ipsum dolor sit amet, no overflow is two lines at 320px
             </title>
             <path
@@ -439,7 +430,6 @@ exports[`<Breadcrumbs /> OneCrumb story renders snapshot 1`] = `
   <nav
     aria-label="breadcrumbs links"
     class="breadcrumbs"
-    id="3"
   >
     <ul
       class="breadcrumbs__list"
@@ -472,7 +462,6 @@ exports[`<Breadcrumbs /> TwoCrumbs story renders snapshot 1`] = `
   <nav
     aria-label="breadcrumbs links"
     class="breadcrumbs"
-    id="4"
   >
     <ul
       class="breadcrumbs__list"
@@ -491,9 +480,7 @@ exports[`<Breadcrumbs /> TwoCrumbs story renders snapshot 1`] = `
             viewBox="0 0 24 24"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="5"
-            >
+            <title>
               Breadcrumb 1
             </title>
             <path

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -87,9 +87,7 @@ exports[`<Button /> IconButtonIconOnly story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="10"
-    >
+    <title>
       go back
     </title>
     <path
@@ -112,9 +110,7 @@ exports[`<Button /> IconButtonIconOnlySmall story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="13"
-    >
+    <title>
       go back
     </title>
     <path
@@ -338,9 +334,7 @@ exports[`<Button /> LinkRightIcon story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="14"
-    >
+    <title>
       opens in a new tab
     </title>
     <path
@@ -368,9 +362,7 @@ exports[`<Button /> Loading story renders snapshot 1`] = `
     width="1.5em"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="16"
-    >
+    <title>
       loading
     </title>
     <path

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Checkbox /> Checked story renders snapshot 1`] = `
         checked=""
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="3"
+        id="2"
         type="checkbox"
       />
       <svg
@@ -35,7 +35,7 @@ exports[`<Checkbox /> Checked story renders snapshot 1`] = `
     <label
       class="label label--lg"
       data-bootstrap-override="label"
-      for="3"
+      for="2"
     >
       Checkbox
     </label>
@@ -105,7 +105,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 1`] = `
                 class="checkbox__input"
                 data-bootstrap-override="checkbox"
                 disabled=""
-                id="11"
+                id="6"
                 type="checkbox"
               />
               <svg
@@ -125,208 +125,208 @@ exports[`<Checkbox /> Disabled story renders snapshot 1`] = `
             </span>
             <label
               class="label label--lg label--disabled"
+              data-bootstrap-override="label"
+              for="6"
+            >
+              Disabled
+            </label>
+          </div>
+        </td>
+        <td>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="7"
+                readonly=""
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="7"
+            >
+              Default
+            </label>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper input__wrapper--disabled"
+            >
+              <input
+                checked=""
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                disabled=""
+                id="8"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon checkbox__icon--disabled"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10.6 16.2L17.65 9.15L16.25 7.75L10.6 13.4L7.75 10.55L6.35 11.95L10.6 16.2ZM3 21V3H21V21H3Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg label--disabled"
+              data-bootstrap-override="label"
+              for="8"
+            >
+              Disabled
+            </label>
+          </div>
+        </td>
+        <td>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                checked=""
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="9"
+                readonly=""
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10.6 16.2L17.65 9.15L16.25 7.75L10.6 13.4L7.75 10.55L6.35 11.95L10.6 16.2ZM3 21V3H21V21H3Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="9"
+            >
+              Default
+            </label>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper input__wrapper--disabled"
+            >
+              <input
+                aria-checked="mixed"
+                checked=""
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                disabled=""
+                id="10"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon checkbox__icon--disabled"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 13H17V11H7V13ZM3 21V3H21V21H3Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg label--disabled"
+              data-bootstrap-override="label"
+              for="10"
+            >
+              Disabled
+            </label>
+          </div>
+        </td>
+        <td>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                aria-checked="mixed"
+                checked=""
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="11"
+                readonly=""
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M7 13H17V11H7V13ZM3 21V3H21V21H3Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
               data-bootstrap-override="label"
               for="11"
-            >
-              Disabled
-            </label>
-          </div>
-        </td>
-        <td>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="13"
-                readonly=""
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="13"
-            >
-              Default
-            </label>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper input__wrapper--disabled"
-            >
-              <input
-                checked=""
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                disabled=""
-                id="15"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon checkbox__icon--disabled"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10.6 16.2L17.65 9.15L16.25 7.75L10.6 13.4L7.75 10.55L6.35 11.95L10.6 16.2ZM3 21V3H21V21H3Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg label--disabled"
-              data-bootstrap-override="label"
-              for="15"
-            >
-              Disabled
-            </label>
-          </div>
-        </td>
-        <td>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                checked=""
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="17"
-                readonly=""
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10.6 16.2L17.65 9.15L16.25 7.75L10.6 13.4L7.75 10.55L6.35 11.95L10.6 16.2ZM3 21V3H21V21H3Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="17"
-            >
-              Default
-            </label>
-          </div>
-        </td>
-      </tr>
-      <tr>
-        <td>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper input__wrapper--disabled"
-            >
-              <input
-                aria-checked="mixed"
-                checked=""
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                disabled=""
-                id="19"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon checkbox__icon--disabled"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7 13H17V11H7V13ZM3 21V3H21V21H3Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg label--disabled"
-              data-bootstrap-override="label"
-              for="19"
-            >
-              Disabled
-            </label>
-          </div>
-        </td>
-        <td>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                aria-checked="mixed"
-                checked=""
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="21"
-                readonly=""
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M7 13H17V11H7V13ZM3 21V3H21V21H3Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="21"
             >
               Default
             </label>
@@ -349,7 +349,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 2`] = `
       class="checkbox__input"
       data-bootstrap-override="checkbox"
       disabled=""
-      id="44"
+      id="22"
       type="checkbox"
     />
     <svg
@@ -370,7 +370,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 2`] = `
   <label
     class="label label--lg label--disabled"
     data-bootstrap-override="label"
-    for="44"
+    for="22"
   >
     Disabled
   </label>
@@ -392,7 +392,7 @@ exports[`<Checkbox /> Indeterminate story renders snapshot 1`] = `
         checked=""
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="9"
+        id="5"
         readonly=""
         type="checkbox"
       />
@@ -414,7 +414,7 @@ exports[`<Checkbox /> Indeterminate story renders snapshot 1`] = `
     <label
       class="label label--lg"
       data-bootstrap-override="label"
-      for="9"
+      for="5"
     >
       Checkbox
     </label>
@@ -438,7 +438,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
         <input
           class="checkbox__input"
           data-bootstrap-override="checkbox"
-          id="35"
+          id="18"
           readonly=""
           type="checkbox"
         />
@@ -460,7 +460,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--lg"
         data-bootstrap-override="label"
-        for="35"
+        for="18"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -474,7 +474,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
         <input
           class="checkbox__input"
           data-bootstrap-override="checkbox"
-          id="37"
+          id="19"
           readonly=""
           type="checkbox"
         />
@@ -496,7 +496,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--md checkbox__label--md"
         data-bootstrap-override="label"
-        for="37"
+        for="19"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -511,7 +511,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
           class="checkbox__input"
           data-bootstrap-override="checkbox"
           disabled=""
-          id="39"
+          id="20"
           type="checkbox"
         />
         <svg
@@ -532,7 +532,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--lg label--disabled"
         data-bootstrap-override="label"
-        for="39"
+        for="20"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -547,7 +547,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
           class="checkbox__input"
           data-bootstrap-override="checkbox"
           disabled=""
-          id="41"
+          id="21"
           type="checkbox"
         />
         <svg
@@ -568,7 +568,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--md label--disabled checkbox__label--md"
         data-bootstrap-override="label"
-        for="41"
+        for="21"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -590,7 +590,7 @@ exports[`<Checkbox /> Medium story renders snapshot 1`] = `
       <input
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="5"
+        id="3"
         type="checkbox"
       />
       <svg
@@ -611,7 +611,7 @@ exports[`<Checkbox /> Medium story renders snapshot 1`] = `
     <label
       class="label label--md checkbox__label--md"
       data-bootstrap-override="label"
-      for="5"
+      for="3"
     >
       Checkbox
     </label>
@@ -633,7 +633,7 @@ exports[`<Checkbox /> MediumChecked story renders snapshot 1`] = `
         checked=""
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="7"
+        id="4"
         type="checkbox"
       />
       <svg
@@ -654,7 +654,7 @@ exports[`<Checkbox /> MediumChecked story renders snapshot 1`] = `
     <label
       class="label label--md checkbox__label--md"
       data-bootstrap-override="label"
-      for="7"
+      for="4"
     >
       Checkbox
     </label>
@@ -718,7 +718,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         aria-label="a checkbox has no name"
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="23"
+        id="12"
         readonly=""
         type="checkbox"
       />
@@ -749,7 +749,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         checked=""
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="25"
+        id="13"
         readonly=""
         type="checkbox"
       />
@@ -781,7 +781,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         checked=""
         class="checkbox__input"
         data-bootstrap-override="checkbox"
-        id="27"
+        id="14"
         readonly=""
         type="checkbox"
       />
@@ -812,7 +812,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         class="checkbox__input"
         data-bootstrap-override="checkbox"
         disabled=""
-        id="29"
+        id="15"
         type="checkbox"
       />
       <svg
@@ -843,7 +843,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         class="checkbox__input"
         data-bootstrap-override="checkbox"
         disabled=""
-        id="31"
+        id="16"
         type="checkbox"
       />
       <svg
@@ -875,7 +875,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
         class="checkbox__input"
         data-bootstrap-override="checkbox"
         disabled=""
-        id="33"
+        id="17"
         type="checkbox"
       />
       <svg

--- a/src/components/Drawer/__snapshots__/Drawer.test.ts.snap
+++ b/src/components/Drawer/__snapshots__/Drawer.test.ts.snap
@@ -37,9 +37,7 @@ exports[`<Drawer /> Default story renders snapshot 1`] = `
           width="1.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="1"
-          >
+          <title>
             Close
           </title>
           <path

--- a/src/components/Fieldset/__snapshots__/Fieldset.test.ts.snap
+++ b/src/components/Fieldset/__snapshots__/Fieldset.test.ts.snap
@@ -57,6 +57,41 @@ exports[`<Fieldset /> Default story renders snapshot 1`] = `
         <input
           class="checkbox__input"
           data-bootstrap-override="checkbox"
+          id="2"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          class="icon checkbox__icon"
+          fill="currentColor"
+          height="1.5rem"
+          style="--icon-size: 1.5rem;"
+          viewBox="0 0 24 24"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--lg"
+        data-bootstrap-override="label"
+        for="2"
+      >
+        Checkbox label 2
+      </label>
+    </div>
+    <div
+      class="checkbox"
+    >
+      <span
+        class="input__wrapper"
+      >
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
           id="3"
           type="checkbox"
         />
@@ -80,7 +115,42 @@ exports[`<Fieldset /> Default story renders snapshot 1`] = `
         data-bootstrap-override="label"
         for="3"
       >
-        Checkbox label 2
+        Checkbox label 3
+      </label>
+    </div>
+    <div
+      class="checkbox"
+    >
+      <span
+        class="input__wrapper"
+      >
+        <input
+          class="checkbox__input"
+          data-bootstrap-override="checkbox"
+          id="4"
+          type="checkbox"
+        />
+        <svg
+          aria-hidden="true"
+          class="icon checkbox__icon"
+          fill="currentColor"
+          height="1.5rem"
+          style="--icon-size: 1.5rem;"
+          viewBox="0 0 24 24"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+          />
+        </svg>
+      </span>
+      <label
+        class="label label--lg"
+        data-bootstrap-override="label"
+        for="4"
+      >
+        Checkbox label 4
       </label>
     </div>
     <div
@@ -114,76 +184,6 @@ exports[`<Fieldset /> Default story renders snapshot 1`] = `
         class="label label--lg"
         data-bootstrap-override="label"
         for="5"
-      >
-        Checkbox label 3
-      </label>
-    </div>
-    <div
-      class="checkbox"
-    >
-      <span
-        class="input__wrapper"
-      >
-        <input
-          class="checkbox__input"
-          data-bootstrap-override="checkbox"
-          id="7"
-          type="checkbox"
-        />
-        <svg
-          aria-hidden="true"
-          class="icon checkbox__icon"
-          fill="currentColor"
-          height="1.5rem"
-          style="--icon-size: 1.5rem;"
-          viewBox="0 0 24 24"
-          width="1.5rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-          />
-        </svg>
-      </span>
-      <label
-        class="label label--lg"
-        data-bootstrap-override="label"
-        for="7"
-      >
-        Checkbox label 4
-      </label>
-    </div>
-    <div
-      class="checkbox"
-    >
-      <span
-        class="input__wrapper"
-      >
-        <input
-          class="checkbox__input"
-          data-bootstrap-override="checkbox"
-          id="9"
-          type="checkbox"
-        />
-        <svg
-          aria-hidden="true"
-          class="icon checkbox__icon"
-          fill="currentColor"
-          height="1.5rem"
-          style="--icon-size: 1.5rem;"
-          viewBox="0 0 24 24"
-          width="1.5rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-          />
-        </svg>
-      </span>
-      <label
-        class="label label--lg"
-        data-bootstrap-override="label"
-        for="9"
       >
         Checkbox label 5
       </label>

--- a/src/components/FiltersDrawer/__snapshots__/FiltersDrawer.test.tsx.snap
+++ b/src/components/FiltersDrawer/__snapshots__/FiltersDrawer.test.tsx.snap
@@ -36,9 +36,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
           width="1.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="3"
-          >
+          <title>
             close filters
           </title>
           <path
@@ -62,6 +60,76 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
         <div
           class="fieldset-items filters-fieldset__checkboxes"
         >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="2"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="2"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="3"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="3"
+            >
+              Filters label 2
+            </label>
+          </div>
           <div
             class="checkbox"
           >
@@ -94,76 +162,6 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
               data-bootstrap-override="label"
               for="4"
             >
-              Filters label 1
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="6"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="6"
-            >
-              Filters label 2
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="8"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="8"
-            >
               Filters label 3
             </label>
           </div>
@@ -180,7 +178,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
   class="drawer__container drawer__container--is-active filters-drawer__container"
 >
   <article
-    aria-labelledby="37"
+    aria-labelledby="16"
     aria-modal="true"
     class="drawer filters-drawer"
     role="dialog"
@@ -191,7 +189,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
     >
       <h3
         class="heading heading--size-headline-sm filters-drawer__title"
-        id="37"
+        id="16"
       >
         Filters
       </h3>
@@ -210,9 +208,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
           width="1.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="39"
-          >
+          <title>
             close filters
           </title>
           <path
@@ -245,7 +241,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <input
                 class="checkbox__input"
                 data-bootstrap-override="checkbox"
-                id="40"
+                id="17"
                 type="checkbox"
               />
               <svg
@@ -266,856 +262,9 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
             <label
               class="label label--lg"
               data-bootstrap-override="label"
-              for="40"
+              for="17"
             >
               Filters long label 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="42"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="42"
-            >
-              Filters label 2
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="44"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="44"
-            >
-              Filters label 3
-            </label>
-          </div>
-        </div>
-      </fieldset>
-      <fieldset
-        class="fieldset filters-fieldset"
-      >
-        <legend
-          class="fieldset-legend filters-fieldset__legend"
-        >
-          Filters Segment 2
-           
-        </legend>
-        <div
-          class="fieldset-items filters-fieldset__checkboxes"
-        >
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="46"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="46"
-            >
-              Filters label 1
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="48"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="48"
-            >
-              Filters long label 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="50"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="50"
-            >
-              Filters label 3
-            </label>
-          </div>
-        </div>
-      </fieldset>
-      <fieldset
-        class="fieldset filters-fieldset"
-      >
-        <legend
-          class="fieldset-legend filters-fieldset__legend"
-        >
-          Filters Segment 3
-           
-        </legend>
-        <div
-          class="fieldset-items filters-fieldset__checkboxes"
-        >
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="52"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="52"
-            >
-              Filters label 1
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="54"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="54"
-            >
-              Filters label 2
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="56"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="56"
-            >
-              Filters long label 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-            </label>
-          </div>
-        </div>
-      </fieldset>
-      <fieldset
-        class="fieldset filters-fieldset"
-      >
-        <legend
-          class="fieldset-legend filters-fieldset__legend"
-        >
-          Filters Segment 4
-           
-        </legend>
-        <div
-          class="fieldset-items filters-fieldset__checkboxes"
-        >
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="58"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="58"
-            >
-              Filters label 1
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="60"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="60"
-            >
-              Filters label 2
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="62"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="62"
-            >
-              Filters label 3
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="64"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="64"
-            >
-              Filters label 4
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="66"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="66"
-            >
-              Filters label 5
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="68"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="68"
-            >
-              Filters label 6
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-    <footer
-      class="drawer__footer filters-drawer__footer"
-    >
-      <div
-        class="button-group button-group--spacing-1x footer__button-group"
-      >
-        <button
-          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary footer__button"
-          data-bootstrap-override="clickable-style-secondary"
-          type="button"
-        >
-          Clear All
-        </button>
-        <button
-          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary footer__button"
-          data-bootstrap-override="clickable-style-primary"
-          type="button"
-        >
-          Apply
-        </button>
-      </div>
-    </footer>
-  </article>
-</div>
-`;
-
-exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] = `
-<div
-  aria-hidden="false"
-  class="drawer__container drawer__container--is-active filters-drawer__container"
->
-  <article
-    aria-labelledby="25"
-    aria-modal="true"
-    class="drawer filters-drawer"
-    role="dialog"
-    tabindex="0"
-  >
-    <header
-      class="drawer__header"
-    >
-      <h3
-        class="heading heading--size-headline-sm filters-drawer__title"
-        id="25"
-      >
-        Filters
-      </h3>
-      <button
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button button--icon"
-        data-bootstrap-override="clickable-style-icon"
-        type="button"
-      >
-        <svg
-          class="icon"
-          fill="currentColor"
-          height="1.5rem"
-          role="img"
-          style="--icon-size: 1.5rem;"
-          viewBox="0 0 24 24"
-          width="1.5rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title
-            id="27"
-          >
-            close filters
-          </title>
-          <path
-            d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"
-          />
-        </svg>
-      </button>
-    </header>
-    <div
-      class="drawer__body filters-drawer__body"
-    >
-      <fieldset
-        class="fieldset filters-fieldset"
-      >
-        <legend
-          class="fieldset-legend filters-fieldset__legend"
-        >
-          Filters Segment 1
-           
-        </legend>
-        <div
-          class="fieldset-items filters-fieldset__checkboxes"
-        >
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="28"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="28"
-            >
-              Filters label 1
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="30"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="30"
-            >
-              Filters label 2
-            </label>
-          </div>
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="32"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="32"
-            >
-              Filters label 3
-            </label>
-          </div>
-        </div>
-      </fieldset>
-    </div>
-    <footer
-      class="drawer__footer filters-drawer__footer"
-    >
-      <div
-        class="button-group button-group--spacing-1x footer__button-group button-group__apply-only"
-      >
-        <button
-          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary footer__button"
-          data-bootstrap-override="clickable-style-primary"
-          type="button"
-        >
-          Apply
-        </button>
-      </div>
-    </footer>
-  </article>
-</div>
-`;
-
-exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
-<div
-  aria-hidden="false"
-  class="drawer__container drawer__container--is-active filters-drawer__container"
->
-  <article
-    aria-labelledby="13"
-    aria-modal="true"
-    class="drawer filters-drawer"
-    role="dialog"
-    tabindex="0"
-  >
-    <header
-      class="drawer__header"
-    >
-      <h3
-        class="heading heading--size-headline-sm filters-drawer__title"
-        id="13"
-      >
-        Filters
-      </h3>
-      <button
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button button--icon"
-        data-bootstrap-override="clickable-style-icon"
-        type="button"
-      >
-        <svg
-          class="icon"
-          fill="currentColor"
-          height="1.5rem"
-          role="img"
-          style="--icon-size: 1.5rem;"
-          viewBox="0 0 24 24"
-          width="1.5rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title
-            id="15"
-          >
-            close filters
-          </title>
-          <path
-            d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"
-          />
-        </svg>
-      </button>
-    </header>
-    <div
-      class="drawer__body filters-drawer__body"
-    >
-      <fieldset
-        class="fieldset filters-fieldset"
-      >
-        <legend
-          class="fieldset-legend filters-fieldset__legend"
-        >
-          Filters Segment 1
-           
-        </legend>
-        <div
-          class="fieldset-items filters-fieldset__checkboxes"
-        >
-          <div
-            class="checkbox"
-          >
-            <span
-              class="input__wrapper"
-            >
-              <input
-                class="checkbox__input"
-                data-bootstrap-override="checkbox"
-                id="16"
-                type="checkbox"
-              />
-              <svg
-                aria-hidden="true"
-                class="icon checkbox__icon"
-                fill="currentColor"
-                height="1.5rem"
-                style="--icon-size: 1.5rem;"
-                viewBox="0 0 24 24"
-                width="1.5rem"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
-                />
-              </svg>
-            </span>
-            <label
-              class="label label--lg"
-              data-bootstrap-override="label"
-              for="16"
-            >
-              Filters label 1
             </label>
           </div>
           <div
@@ -1162,6 +311,55 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
               <input
                 class="checkbox__input"
                 data-bootstrap-override="checkbox"
+                id="19"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="19"
+            >
+              Filters label 3
+            </label>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset
+        class="fieldset filters-fieldset"
+      >
+        <legend
+          class="fieldset-legend filters-fieldset__legend"
+        >
+          Filters Segment 2
+           
+        </legend>
+        <div
+          class="fieldset-items filters-fieldset__checkboxes"
+        >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
                 id="20"
                 type="checkbox"
               />
@@ -1184,6 +382,800 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
               class="label label--lg"
               data-bootstrap-override="label"
               for="20"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="21"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="21"
+            >
+              Filters long label 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="22"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="22"
+            >
+              Filters label 3
+            </label>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset
+        class="fieldset filters-fieldset"
+      >
+        <legend
+          class="fieldset-legend filters-fieldset__legend"
+        >
+          Filters Segment 3
+           
+        </legend>
+        <div
+          class="fieldset-items filters-fieldset__checkboxes"
+        >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="23"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="23"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="24"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="24"
+            >
+              Filters label 2
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="25"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="25"
+            >
+              Filters long label 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+            </label>
+          </div>
+        </div>
+      </fieldset>
+      <fieldset
+        class="fieldset filters-fieldset"
+      >
+        <legend
+          class="fieldset-legend filters-fieldset__legend"
+        >
+          Filters Segment 4
+           
+        </legend>
+        <div
+          class="fieldset-items filters-fieldset__checkboxes"
+        >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="26"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="26"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="27"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="27"
+            >
+              Filters label 2
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="28"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="28"
+            >
+              Filters label 3
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="29"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="29"
+            >
+              Filters label 4
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="30"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="30"
+            >
+              Filters label 5
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="31"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="31"
+            >
+              Filters label 6
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <footer
+      class="drawer__footer filters-drawer__footer"
+    >
+      <div
+        class="button-group button-group--spacing-1x footer__button-group"
+      >
+        <button
+          class="clickable-style clickable-style--lg clickable-style--secondary clickable-style--brand button button--secondary footer__button"
+          data-bootstrap-override="clickable-style-secondary"
+          type="button"
+        >
+          Clear All
+        </button>
+        <button
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary footer__button"
+          data-bootstrap-override="clickable-style-primary"
+          type="button"
+        >
+          Apply
+        </button>
+      </div>
+    </footer>
+  </article>
+</div>
+`;
+
+exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] = `
+<div
+  aria-hidden="false"
+  class="drawer__container drawer__container--is-active filters-drawer__container"
+>
+  <article
+    aria-labelledby="11"
+    aria-modal="true"
+    class="drawer filters-drawer"
+    role="dialog"
+    tabindex="0"
+  >
+    <header
+      class="drawer__header"
+    >
+      <h3
+        class="heading heading--size-headline-sm filters-drawer__title"
+        id="11"
+      >
+        Filters
+      </h3>
+      <button
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button button--icon"
+        data-bootstrap-override="clickable-style-icon"
+        type="button"
+      >
+        <svg
+          class="icon"
+          fill="currentColor"
+          height="1.5rem"
+          role="img"
+          style="--icon-size: 1.5rem;"
+          viewBox="0 0 24 24"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            close filters
+          </title>
+          <path
+            d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"
+          />
+        </svg>
+      </button>
+    </header>
+    <div
+      class="drawer__body filters-drawer__body"
+    >
+      <fieldset
+        class="fieldset filters-fieldset"
+      >
+        <legend
+          class="fieldset-legend filters-fieldset__legend"
+        >
+          Filters Segment 1
+           
+        </legend>
+        <div
+          class="fieldset-items filters-fieldset__checkboxes"
+        >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="12"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="12"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="13"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="13"
+            >
+              Filters label 2
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="14"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="14"
+            >
+              Filters label 3
+            </label>
+          </div>
+        </div>
+      </fieldset>
+    </div>
+    <footer
+      class="drawer__footer filters-drawer__footer"
+    >
+      <div
+        class="button-group button-group--spacing-1x footer__button-group button-group__apply-only"
+      >
+        <button
+          class="clickable-style clickable-style--lg clickable-style--primary clickable-style--brand button button--primary footer__button"
+          data-bootstrap-override="clickable-style-primary"
+          type="button"
+        >
+          Apply
+        </button>
+      </div>
+    </footer>
+  </article>
+</div>
+`;
+
+exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
+<div
+  aria-hidden="false"
+  class="drawer__container drawer__container--is-active filters-drawer__container"
+>
+  <article
+    aria-labelledby="6"
+    aria-modal="true"
+    class="drawer filters-drawer"
+    role="dialog"
+    tabindex="0"
+  >
+    <header
+      class="drawer__header"
+    >
+      <h3
+        class="heading heading--size-headline-sm filters-drawer__title"
+        id="6"
+      >
+        Filters
+      </h3>
+      <button
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral button button--icon"
+        data-bootstrap-override="clickable-style-icon"
+        type="button"
+      >
+        <svg
+          class="icon"
+          fill="currentColor"
+          height="1.5rem"
+          role="img"
+          style="--icon-size: 1.5rem;"
+          viewBox="0 0 24 24"
+          width="1.5rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            close filters
+          </title>
+          <path
+            d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z"
+          />
+        </svg>
+      </button>
+    </header>
+    <div
+      class="drawer__body filters-drawer__body"
+    >
+      <fieldset
+        class="fieldset filters-fieldset"
+      >
+        <legend
+          class="fieldset-legend filters-fieldset__legend"
+        >
+          Filters Segment 1
+           
+        </legend>
+        <div
+          class="fieldset-items filters-fieldset__checkboxes"
+        >
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="7"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="7"
+            >
+              Filters label 1
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="8"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="8"
+            >
+              Filters label 2
+            </label>
+          </div>
+          <div
+            class="checkbox"
+          >
+            <span
+              class="input__wrapper"
+            >
+              <input
+                class="checkbox__input"
+                data-bootstrap-override="checkbox"
+                id="9"
+                type="checkbox"
+              />
+              <svg
+                aria-hidden="true"
+                class="icon checkbox__icon"
+                fill="currentColor"
+                height="1.5rem"
+                style="--icon-size: 1.5rem;"
+                viewBox="0 0 24 24"
+                width="1.5rem"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M3 21V3H21V21H3ZM5 19H19V5H5V19Z"
+                />
+              </svg>
+            </span>
+            <label
+              class="label label--lg"
+              data-bootstrap-override="label"
+              for="9"
             >
               Filters label 3
             </label>

--- a/src/components/FiltersPopover/__snapshots__/FiltersPopover.test.tsx.snap
+++ b/src/components/FiltersPopover/__snapshots__/FiltersPopover.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="5"
+                  id="1"
                   type="checkbox"
                 />
                 <svg
@@ -85,7 +85,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="5"
+                for="1"
               >
                 Filters label 1
               </label>
@@ -99,7 +99,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="7"
+                  id="2"
                   type="checkbox"
                 />
                 <svg
@@ -120,7 +120,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="7"
+                for="2"
               >
                 Filters label 2
               </label>
@@ -134,7 +134,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="9"
+                  id="3"
                   type="checkbox"
                 />
                 <svg
@@ -155,7 +155,7 @@ exports[`<Filters /> Default story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="9"
+                for="3"
               >
                 Filters label 3
               </label>
@@ -234,7 +234,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="38"
+                  id="10"
                   type="checkbox"
                 />
                 <svg
@@ -255,7 +255,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="38"
+                for="10"
               >
                 Filters long label 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
               </label>
@@ -269,7 +269,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="40"
+                  id="11"
                   type="checkbox"
                 />
                 <svg
@@ -290,7 +290,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="40"
+                for="11"
               >
                 Filters label 2
               </label>
@@ -304,7 +304,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="42"
+                  id="12"
                   type="checkbox"
                 />
                 <svg
@@ -325,7 +325,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="42"
+                for="12"
               >
                 Filters label 3
               </label>
@@ -353,7 +353,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="44"
+                  id="13"
                   type="checkbox"
                 />
                 <svg
@@ -374,7 +374,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="44"
+                for="13"
               >
                 Filters label 1
               </label>
@@ -388,7 +388,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="46"
+                  id="14"
                   type="checkbox"
                 />
                 <svg
@@ -409,7 +409,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="46"
+                for="14"
               >
                 Filters long label 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
               </label>
@@ -423,7 +423,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="48"
+                  id="15"
                   type="checkbox"
                 />
                 <svg
@@ -444,7 +444,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="48"
+                for="15"
               >
                 Filters label 3
               </label>
@@ -472,7 +472,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="50"
+                  id="16"
                   type="checkbox"
                 />
                 <svg
@@ -493,7 +493,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="50"
+                for="16"
               >
                 Filters label 1
               </label>
@@ -507,7 +507,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="52"
+                  id="17"
                   type="checkbox"
                 />
                 <svg
@@ -528,7 +528,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="52"
+                for="17"
               >
                 Filters label 2
               </label>
@@ -542,7 +542,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="54"
+                  id="18"
                   type="checkbox"
                 />
                 <svg
@@ -563,7 +563,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="54"
+                for="18"
               >
                 Filters long label 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
               </label>
@@ -591,7 +591,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="56"
+                  id="19"
                   type="checkbox"
                 />
                 <svg
@@ -612,7 +612,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="56"
+                for="19"
               >
                 Filters label 1
               </label>
@@ -626,7 +626,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="58"
+                  id="20"
                   type="checkbox"
                 />
                 <svg
@@ -647,7 +647,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="58"
+                for="20"
               >
                 Filters label 2
               </label>
@@ -661,7 +661,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="60"
+                  id="21"
                   type="checkbox"
                 />
                 <svg
@@ -682,7 +682,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="60"
+                for="21"
               >
                 Filters label 3
               </label>
@@ -696,7 +696,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="62"
+                  id="22"
                   type="checkbox"
                 />
                 <svg
@@ -717,7 +717,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="62"
+                for="22"
               >
                 Filters label 4
               </label>
@@ -731,7 +731,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="64"
+                  id="23"
                   type="checkbox"
                 />
                 <svg
@@ -752,7 +752,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="64"
+                for="23"
               >
                 Filters label 5
               </label>
@@ -766,7 +766,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="66"
+                  id="24"
                   type="checkbox"
                 />
                 <svg
@@ -787,7 +787,7 @@ exports[`<Filters /> OverflowInteractive story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="66"
+                for="24"
               >
                 Filters label 6
               </label>
@@ -882,7 +882,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="27"
+                  id="7"
                   type="checkbox"
                 />
                 <svg
@@ -903,7 +903,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="27"
+                for="7"
               >
                 Filters label 1
               </label>
@@ -917,7 +917,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="29"
+                  id="8"
                   type="checkbox"
                 />
                 <svg
@@ -938,7 +938,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="29"
+                for="8"
               >
                 Filters label 2
               </label>
@@ -952,7 +952,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="31"
+                  id="9"
                   type="checkbox"
                 />
                 <svg
@@ -973,7 +973,7 @@ exports[`<Filters /> WithOnApplyAndCustomButtonGroup story renders snapshot 1`] 
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="31"
+                for="9"
               >
                 Filters label 3
               </label>
@@ -1061,7 +1061,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="16"
+                  id="4"
                   type="checkbox"
                 />
                 <svg
@@ -1082,7 +1082,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="16"
+                for="4"
               >
                 Filters label 1
               </label>
@@ -1096,7 +1096,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="18"
+                  id="5"
                   type="checkbox"
                 />
                 <svg
@@ -1117,7 +1117,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="18"
+                for="5"
               >
                 Filters label 2
               </label>
@@ -1131,7 +1131,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
                 <input
                   class="checkbox__input"
                   data-bootstrap-override="checkbox"
-                  id="20"
+                  id="6"
                   type="checkbox"
                 />
                 <svg
@@ -1152,7 +1152,7 @@ exports[`<Filters /> WithOnClear story renders snapshot 1`] = `
               <label
                 class="label label--lg"
                 data-bootstrap-override="label"
-                for="20"
+                for="6"
               >
                 Filters label 3
               </label>

--- a/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
+++ b/src/components/HorizontalStepper/__snapshots__/HorizontalStepper.test.tsx.snap
@@ -45,9 +45,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="20"
-          >
+          <title>
             incomplete step 2 Step 2
           </title>
           <path
@@ -83,9 +81,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="21"
-          >
+          <title>
             incomplete step 3 Step 3
           </title>
           <path
@@ -121,9 +117,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="22"
-          >
+          <title>
             incomplete step 4 Step 4
           </title>
           <path
@@ -159,9 +153,7 @@ exports[`<HorizontalStepper /> CappedLine story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="23"
-          >
+          <title>
             incomplete step 5 Step 5
           </title>
           <path
@@ -199,9 +191,7 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="13"
-        >
+        <title>
           completed step 1 Step 1
         </title>
         <path
@@ -231,9 +221,7 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="14"
-        >
+        <title>
           completed step 2 Step 2
         </title>
         <path
@@ -263,9 +251,7 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="15"
-        >
+        <title>
           completed step 3 Step 3
         </title>
         <path
@@ -295,9 +281,7 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="16"
-        >
+        <title>
           completed step 4 Step 4
         </title>
         <path
@@ -327,9 +311,7 @@ exports[`<HorizontalStepper /> CompletedAllSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="17"
-        >
+        <title>
           completed step 5 Step 5
         </title>
         <path
@@ -371,9 +353,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="18"
-          >
+          <title>
             incomplete step 1 Horizontal step
           </title>
           <path
@@ -416,9 +396,7 @@ exports[`<HorizontalStepper /> HorizontalSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="19"
-        >
+        <title>
           completed step 1 Horizontal step
         </title>
         <path
@@ -731,9 +709,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="1"
-          >
+          <title>
             incomplete step 2 Step 2
           </title>
           <path
@@ -769,9 +745,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="2"
-          >
+          <title>
             incomplete step 3 Step 3
           </title>
           <path
@@ -807,9 +781,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="3"
-          >
+          <title>
             incomplete step 4 Step 4
           </title>
           <path
@@ -845,9 +817,7 @@ exports[`<HorizontalStepper /> OnFirstStep story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="4"
-          >
+          <title>
             incomplete step 5 Step 5
           </title>
           <path
@@ -885,9 +855,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="9"
-        >
+        <title>
           completed step 1 Step 1
         </title>
         <path
@@ -917,9 +885,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="10"
-        >
+        <title>
           completed step 2 Step 2
         </title>
         <path
@@ -949,9 +915,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="11"
-        >
+        <title>
           completed step 3 Step 3
         </title>
         <path
@@ -981,9 +945,7 @@ exports[`<HorizontalStepper /> OnLastStep story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="12"
-        >
+        <title>
           completed step 4 Step 4
         </title>
         <path
@@ -1040,9 +1002,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="5"
-        >
+        <title>
           completed step 1 Step 1
         </title>
         <path
@@ -1072,9 +1032,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="6"
-        >
+        <title>
           completed step 2 Step 2
         </title>
         <path
@@ -1129,9 +1087,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="7"
-          >
+          <title>
             incomplete step 4 Step 4
           </title>
           <path
@@ -1167,9 +1123,7 @@ exports[`<HorizontalStepper /> SomeCompletedSteps story renders snapshot 1`] = `
           width="0.5rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="8"
-          >
+          <title>
             incomplete step 5 Step 5
           </title>
           <path

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode, CSSProperties } from 'react';
 import React, { useEffect } from 'react';
-import { useUID } from 'react-uid';
 import svg4everybody from 'svg4everybody';
 import styles from './Icon.module.css';
 import icons, { type IconName } from '../../icons/spritemap';
@@ -112,8 +111,6 @@ export const Icon = (props: IconProps) => {
     size,
     viewBox,
   } = props;
-  const generatedId = useUID();
-  const idVar = id || generatedId;
 
   useEffect(() => {
     svg4everybody(); // Required to get IE to render icon sprites
@@ -148,7 +145,7 @@ export const Icon = (props: IconProps) => {
   if (purpose === 'informative') {
     return (
       <svg {...svgCommonProps} role="img">
-        <title id={idVar}>{props.title}</title>
+        <title id={id}>{props.title}</title>
         {computedSvg}
       </svg>
     );

--- a/src/components/Icon/__snapshots__/Icon.test.ts.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.ts.snap
@@ -2734,9 +2734,7 @@ exports[`<Icon /> InText story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="6"
-    >
+    <title>
       icon with 1em line height
     </title>
     <path
@@ -2754,9 +2752,7 @@ exports[`<Icon /> InText story renders snapshot 1`] = `
     width="2em"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="7"
-    >
+    <title>
       icon with 2em line height
     </title>
     <path

--- a/src/components/InlineNotification/__snapshots__/InlineNotification.test.ts.snap
+++ b/src/components/InlineNotification/__snapshots__/InlineNotification.test.ts.snap
@@ -14,9 +14,7 @@ exports[`<InlineNotification /> FullWidthLongText story renders snapshot 1`] = `
     width="1.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="12"
-    >
+    <title>
       success
     </title>
     <path
@@ -48,9 +46,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="18"
-      >
+      <title>
         info
       </title>
       <path
@@ -76,9 +72,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="19"
-      >
+      <title>
         success
       </title>
       <path
@@ -104,9 +98,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="20"
-      >
+      <title>
         alert
       </title>
       <path
@@ -132,9 +124,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="21"
-      >
+      <title>
         yield
       </title>
       <circle
@@ -166,9 +156,7 @@ exports[`<InlineNotification /> FullWidthStrongVariants story renders snapshot 1
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="22"
-      >
+      <title>
         success
       </title>
       <path
@@ -198,9 +186,7 @@ exports[`<InlineNotification /> FullWidthSuccess story renders snapshot 1`] = `
     width="1.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="11"
-    >
+    <title>
       success
     </title>
     <path
@@ -232,9 +218,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="13"
-      >
+      <title>
         info
       </title>
       <path
@@ -260,9 +244,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="14"
-      >
+      <title>
         success
       </title>
       <path
@@ -288,9 +270,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="15"
-      >
+      <title>
         alert
       </title>
       <path
@@ -316,9 +296,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="16"
-      >
+      <title>
         yield
       </title>
       <circle
@@ -350,9 +328,7 @@ exports[`<InlineNotification /> FullWidthVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="17"
-      >
+      <title>
         success
       </title>
       <path
@@ -382,9 +358,7 @@ exports[`<InlineNotification /> LongText story renders snapshot 1`] = `
     width="1.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="2"
-    >
+    <title>
       success
     </title>
     <path
@@ -416,9 +390,7 @@ exports[`<InlineNotification /> StrongVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="7"
-      >
+      <title>
         info
       </title>
       <path
@@ -444,9 +416,7 @@ exports[`<InlineNotification /> StrongVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="8"
-      >
+      <title>
         success
       </title>
       <path
@@ -472,9 +442,7 @@ exports[`<InlineNotification /> StrongVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="9"
-      >
+      <title>
         alert
       </title>
       <path
@@ -500,9 +468,7 @@ exports[`<InlineNotification /> StrongVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="10"
-      >
+      <title>
         yield
       </title>
       <circle
@@ -541,9 +507,7 @@ exports[`<InlineNotification /> SubtleVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="3"
-      >
+      <title>
         info
       </title>
       <path
@@ -569,9 +533,7 @@ exports[`<InlineNotification /> SubtleVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="4"
-      >
+      <title>
         success
       </title>
       <path
@@ -597,9 +559,7 @@ exports[`<InlineNotification /> SubtleVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="5"
-      >
+      <title>
         alert
       </title>
       <path
@@ -625,9 +585,7 @@ exports[`<InlineNotification /> SubtleVariants story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="6"
-      >
+      <title>
         yield
       </title>
       <circle
@@ -663,9 +621,7 @@ exports[`<InlineNotification /> Success story renders snapshot 1`] = `
     width="1.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="1"
-    >
+    <title>
       success
     </title>
     <path

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -64,9 +64,7 @@ exports[`<Link /> IconClickableStyleIconOnly story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="10"
-    >
+    <title>
       go back
     </title>
     <path
@@ -89,9 +87,7 @@ exports[`<Link /> IconClickableStyleIconOnlySmall story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="13"
-    >
+    <title>
       go back
     </title>
     <path
@@ -327,9 +323,7 @@ exports[`<Link /> LinkRightIcon story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="1"
-    >
+    <title>
       opens in a new tab
     </title>
     <path

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -19,9 +19,7 @@ exports[`Modal Brand story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="4"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -97,9 +95,7 @@ exports[`Modal Default story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="1"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -178,9 +174,7 @@ exports[`Modal DefaultInteractive story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="17"
-        >
+        <title>
           close modal
         </title>
         <path
@@ -249,9 +243,7 @@ exports[`Modal Medium story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="2"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -317,9 +309,7 @@ exports[`Modal Mobile story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="5"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -385,9 +375,7 @@ exports[`Modal MobileBrand story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="7"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -463,9 +451,7 @@ exports[`Modal MobileLandscape story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="6"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -531,9 +517,7 @@ exports[`Modal MobileLandscapeBrand story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="8"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -605,9 +589,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     width="0.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="21"
-    >
+    <title>
       Active Step 1
     </title>
     <path
@@ -624,9 +606,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     width="0.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="22"
-    >
+    <title>
       Step 2
     </title>
     <circle
@@ -651,9 +631,7 @@ exports[`Modal ModalStepper story renders snapshot 1`] = `
     width="0.5rem"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="23"
-    >
+    <title>
       Step 3
     </title>
     <circle
@@ -690,9 +668,7 @@ exports[`Modal Small story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="3"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -758,9 +734,7 @@ exports[`Modal Tablet story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="9"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -826,9 +800,7 @@ exports[`Modal TabletBrand story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="10"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -917,9 +889,7 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="18"
-        >
+        <title>
           close modal
         </title>
         <path
@@ -1019,9 +989,7 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="19"
-        >
+        <title>
           close modal
         </title>
         <path
@@ -1109,9 +1077,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="11"
-      >
+      <title>
         close modal
       </title>
       <path
@@ -1149,9 +1115,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
         width="0.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="12"
-        >
+        <title>
           Step 1
         </title>
         <circle
@@ -1176,9 +1140,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
         width="0.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="13"
-        >
+        <title>
           Active Step 2
         </title>
         <path
@@ -1195,9 +1157,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
         width="0.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="14"
-        >
+        <title>
           Step 3
         </title>
         <circle
@@ -1222,9 +1182,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
         width="0.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="15"
-        >
+        <title>
           Step 4
         </title>
         <circle
@@ -1249,9 +1207,7 @@ exports[`Modal WithStepper story renders snapshot 1`] = `
         width="0.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="16"
-        >
+        <title>
           Step 5
         </title>
         <circle
@@ -1321,9 +1277,7 @@ exports[`Modal WithoutHeaderAndFooter story renders snapshot 1`] = `
         width="1.5rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="20"
-        >
+        <title>
           close modal
         </title>
         <path

--- a/src/components/PageHeader/__snapshots__/PageHeader.test.ts.snap
+++ b/src/components/PageHeader/__snapshots__/PageHeader.test.ts.snap
@@ -107,7 +107,6 @@ exports[`<PageHeader /> WithBreadcrumbs story renders snapshot 1`] = `
     <nav
       aria-label="breadcrumbs links"
       class="breadcrumbs"
-      id="1"
     >
       <ul
         class="breadcrumbs__list"
@@ -126,9 +125,7 @@ exports[`<PageHeader /> WithBreadcrumbs story renders snapshot 1`] = `
               viewBox="0 0 24 24"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title
-                id="2"
-              >
+              <title>
                 My Courses
               </title>
               <path

--- a/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.ts.snap
+++ b/src/components/PageLevelBanner/__snapshots__/PageLevelBanner.test.ts.snap
@@ -11,9 +11,7 @@ exports[`<PageLevelBanner /> Brand story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="1"
-    >
+    <title>
       attention
     </title>
     <path
@@ -54,9 +52,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="7"
-    >
+    <title>
       attention
     </title>
     <path
@@ -95,9 +91,7 @@ exports[`<PageLevelBanner /> BrandDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="8"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -119,9 +113,7 @@ exports[`<PageLevelBanner /> Error story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="4"
-    >
+    <title>
       error
     </title>
     <path
@@ -162,9 +154,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="13"
-    >
+    <title>
       error
     </title>
     <path
@@ -203,9 +193,7 @@ exports[`<PageLevelBanner /> ErrorDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="14"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -227,9 +215,7 @@ exports[`<PageLevelBanner /> NoDescription story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="5"
-    >
+    <title>
       attention
     </title>
     <path
@@ -257,9 +243,7 @@ exports[`<PageLevelBanner /> NoTitle story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="6"
-    >
+    <title>
       attention
     </title>
     <path
@@ -295,9 +279,7 @@ exports[`<PageLevelBanner /> Success story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="2"
-    >
+    <title>
       success
     </title>
     <path
@@ -338,9 +320,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="9"
-    >
+    <title>
       success
     </title>
     <path
@@ -379,9 +359,7 @@ exports[`<PageLevelBanner /> SuccessDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="10"
-      >
+      <title>
         dismiss notification
       </title>
       <path
@@ -403,9 +381,7 @@ exports[`<PageLevelBanner /> Warning story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="3"
-    >
+    <title>
       warning
     </title>
     <path
@@ -446,9 +422,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
   >
-    <title
-      id="11"
-    >
+    <title>
       warning
     </title>
     <path
@@ -487,9 +461,7 @@ exports[`<PageLevelBanner /> WarningDismissable story renders snapshot 1`] = `
       viewBox="0 0 24 24"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="12"
-      >
+      <title>
         dismiss notification
       </title>
       <path

--- a/src/components/PrimaryNav/PrimaryNav.tsx
+++ b/src/components/PrimaryNav/PrimaryNav.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import { useUID } from 'react-uid';
 import styles from './PrimaryNav.module.css';
 import PrimaryNavItem from '../PrimaryNavItem';
 
@@ -36,16 +35,13 @@ export const PrimaryNav = ({
   'aria-label': ariaLabel,
   ...other
 }: Props) => {
-  const generatedId = useUID();
-  const idVar = id || generatedId;
-
   const componentClassName = clsx(styles['primary-nav'], className);
 
   return (
     <nav
       aria-label={ariaLabel}
       className={componentClassName}
-      id={idVar}
+      id={id}
       role="navigation"
       title="Primary navigation"
       {...other}

--- a/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.ts.snap
+++ b/src/components/PrimaryNav/__snapshots__/PrimaryNav.test.ts.snap
@@ -6,7 +6,6 @@ exports[`<PrimaryNav /> Default story renders snapshot 1`] = `
 >
   <nav
     class="primary-nav"
-    id="1"
     role="navigation"
     title="Primary navigation"
   >

--- a/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<Radio /> Checked story renders snapshot 1`] = `
         checked=""
         class="radio__input"
         data-bootstrap-override="radio"
-        id="5"
+        id="3"
         type="radio"
       />
       <svg
@@ -35,7 +35,7 @@ exports[`<Radio /> Checked story renders snapshot 1`] = `
     <label
       class="label label--lg radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="5"
+      for="3"
     >
       Option 1
     </label>
@@ -57,7 +57,7 @@ exports[`<Radio /> CheckedMedium story renders snapshot 1`] = `
         checked=""
         class="radio__input"
         data-bootstrap-override="radio"
-        id="7"
+        id="4"
         type="radio"
       />
       <svg
@@ -78,7 +78,7 @@ exports[`<Radio /> CheckedMedium story renders snapshot 1`] = `
     <label
       class="label label--md radio__label radio__label--md"
       data-bootstrap-override="label"
-      for="7"
+      for="4"
     >
       Option 1
     </label>
@@ -142,7 +142,7 @@ exports[`<Radio /> Disabled story renders snapshot 1`] = `
         class="radio__input"
         data-bootstrap-override="radio"
         disabled=""
-        id="9"
+        id="5"
         type="radio"
       />
       <svg
@@ -163,7 +163,7 @@ exports[`<Radio /> Disabled story renders snapshot 1`] = `
     <label
       class="label label--lg label--disabled radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="9"
+      for="5"
     >
       Option 1
     </label>
@@ -187,7 +187,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
         <input
           class="radio__input"
           data-bootstrap-override="radio"
-          id="19"
+          id="10"
           readonly=""
           type="radio"
         />
@@ -209,7 +209,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--lg radio__label radio__label--lg"
         data-bootstrap-override="label"
-        for="19"
+        for="10"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -223,7 +223,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
         <input
           class="radio__input"
           data-bootstrap-override="radio"
-          id="21"
+          id="11"
           readonly=""
           type="radio"
         />
@@ -245,7 +245,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--md radio__label radio__label--md"
         data-bootstrap-override="label"
-        for="21"
+        for="11"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -260,7 +260,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
           class="radio__input"
           data-bootstrap-override="radio"
           disabled=""
-          id="23"
+          id="12"
           type="radio"
         />
         <svg
@@ -281,7 +281,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--lg label--disabled radio__label radio__label--lg"
         data-bootstrap-override="label"
-        for="23"
+        for="12"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -296,7 +296,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
           class="radio__input"
           data-bootstrap-override="radio"
           disabled=""
-          id="25"
+          id="13"
           type="radio"
         />
         <svg
@@ -317,7 +317,7 @@ exports[`<Radio /> LongLabels story renders snapshot 1`] = `
       <label
         class="label label--md label--disabled radio__label radio__label--md"
         data-bootstrap-override="label"
-        for="25"
+        for="13"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -339,7 +339,7 @@ exports[`<Radio /> Medium story renders snapshot 1`] = `
       <input
         class="radio__input"
         data-bootstrap-override="radio"
-        id="3"
+        id="2"
         type="radio"
       />
       <svg
@@ -360,7 +360,7 @@ exports[`<Radio /> Medium story renders snapshot 1`] = `
     <label
       class="label label--md radio__label radio__label--md"
       data-bootstrap-override="label"
-      for="3"
+      for="2"
     >
       Option 1
     </label>
@@ -425,7 +425,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
         aria-label="unchecked radio"
         class="radio__input"
         data-bootstrap-override="radio"
-        id="11"
+        id="6"
         readonly=""
         type="radio"
       />
@@ -447,7 +447,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
     <label
       class="label label--lg radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="11"
+      for="6"
     />
   </div>
   <div
@@ -461,7 +461,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
         checked=""
         class="radio__input"
         data-bootstrap-override="radio"
-        id="13"
+        id="7"
         readonly=""
         type="radio"
       />
@@ -483,7 +483,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
     <label
       class="label label--lg radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="13"
+      for="7"
     />
   </div>
   <div
@@ -497,7 +497,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
         class="radio__input"
         data-bootstrap-override="radio"
         disabled=""
-        id="15"
+        id="8"
         type="radio"
       />
       <svg
@@ -518,7 +518,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
     <label
       class="label label--lg label--disabled radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="15"
+      for="8"
     />
   </div>
   <div
@@ -533,7 +533,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
         class="radio__input"
         data-bootstrap-override="radio"
         disabled=""
-        id="17"
+        id="9"
         type="radio"
       />
       <svg
@@ -554,7 +554,7 @@ exports[`<Radio /> WithoutVisibleLabel story renders snapshot 1`] = `
     <label
       class="label label--lg label--disabled radio__label radio__label--lg"
       data-bootstrap-override="label"
-      for="17"
+      for="9"
     />
   </div>
 </div>

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.ts.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.ts.snap
@@ -32,9 +32,7 @@ exports[`<SearchField /> Custom story renders snapshot 1`] = `
         width="1.25rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="3"
-        >
+        <title>
           search
         </title>
         <path
@@ -62,9 +60,7 @@ exports[`<SearchField /> Custom story renders snapshot 1`] = `
         width="1.25rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="4"
-        >
+        <title>
           search
         </title>
         <path
@@ -108,9 +104,7 @@ exports[`<SearchField /> Default story renders snapshot 1`] = `
         width="1.25rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="1"
-        >
+        <title>
           search
         </title>
         <path
@@ -155,9 +149,7 @@ exports[`<SearchField /> Disabled story renders snapshot 1`] = `
         width="1.25rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="2"
-        >
+        <title>
           search
         </title>
         <path
@@ -214,9 +206,7 @@ exports[`<SearchField /> SearchField story renders snapshot 1`] = `
       width="1.25rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="5"
-      >
+      <title>
         search
       </title>
       <path

--- a/src/components/Section/__snapshots__/Section.test.ts.snap
+++ b/src/components/Section/__snapshots__/Section.test.ts.snap
@@ -245,9 +245,7 @@ exports[`<Section /> WithTitleAfter story renders snapshot 1`] = `
                 width="1.375rem"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title
-                  id="1"
-                >
+                <title>
                   help
                 </title>
                 <path
@@ -294,9 +292,7 @@ exports[`<Section /> WithTitleBefore story renders snapshot 1`] = `
             width="1.375rem"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="2"
-            >
+            <title>
               help
             </title>
             <path

--- a/src/components/Table/__snapshots__/Table.test.ts.snap
+++ b/src/components/Table/__snapshots__/Table.test.ts.snap
@@ -586,9 +586,7 @@ exports[`<Table /> SortableInteractive story renders snapshot 1`] = `
               width="1rem"
               xmlns="http://www.w3.org/2000/svg"
             >
-              <title
-                id="1"
-              >
+              <title>
                 Sort
               </title>
               <path

--- a/src/components/TextField/__snapshots__/TextField.test.ts.snap
+++ b/src/components/TextField/__snapshots__/TextField.test.ts.snap
@@ -48,7 +48,7 @@ exports[`<TextField /> Disabled story renders snapshot 1`] = `
     >
       <label
         class="label"
-        for="6"
+        for="5"
       >
         Disabled text field
          
@@ -58,18 +58,18 @@ exports[`<TextField /> Disabled story renders snapshot 1`] = `
       class="text-field__body"
     >
       <input
-        aria-describedby="7"
+        aria-describedby="6"
         aria-invalid="false"
         class="input-field"
         data-bootstrap-override="inputfield"
         disabled=""
-        id="6"
+        id="5"
         type="text"
       />
     </div>
     <div
       class="field-note field-note--disabled"
-      id="7"
+      id="6"
     >
       This TextField is disabled
     </div>
@@ -100,7 +100,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="50"
+          for="45"
         >
           Label text
            
@@ -110,19 +110,19 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="51"
+          aria-describedby="46"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="50"
+          id="45"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="51"
+        id="46"
       >
         fieldNote text
       </div>
@@ -133,7 +133,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="52"
+          for="47"
         >
           Label text
            
@@ -143,18 +143,18 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="53"
+          aria-describedby="48"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="52"
+          id="47"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="53"
+        id="48"
       >
         fieldNote text
       </div>
@@ -168,7 +168,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="54"
+          for="49"
         >
           Label text
            
@@ -182,7 +182,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="54"
+          id="49"
           placeholder="placeholder"
           type="text"
         />
@@ -194,7 +194,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="56"
+          for="51"
         >
           Label text
            
@@ -208,7 +208,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="56"
+          id="51"
           type="text"
         />
       </div>
@@ -221,20 +221,20 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="59"
+          aria-describedby="54"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="58"
+          id="53"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="59"
+        id="54"
       >
         fieldNote text
       </div>
@@ -244,19 +244,19 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="61"
+          aria-describedby="56"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="60"
+          id="55"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="61"
+        id="56"
       >
         fieldNote text
       </div>
@@ -274,7 +274,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="62"
+          id="57"
           placeholder="placeholder"
           type="text"
         />
@@ -290,7 +290,7 @@ exports[`<TextField /> DisabledVariants story renders snapshot 1`] = `
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="64"
+          id="59"
           type="text"
         />
       </div>
@@ -341,9 +341,7 @@ exports[`<TextField /> Error story renders snapshot 1`] = `
         width="1rem"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="5"
-        >
+        <title>
           error
         </title>
         <path
@@ -379,7 +377,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="30"
+          for="29"
         >
           Label text
            
@@ -389,18 +387,18 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="31"
+          aria-describedby="30"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="30"
+          id="29"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="31"
+        id="30"
       >
         <svg
           class="icon field-note__icon"
@@ -412,9 +410,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="32"
-          >
+          <title>
             error
           </title>
           <path
@@ -430,7 +426,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="33"
+          for="31"
         >
           Label text
            
@@ -440,17 +436,17 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="34"
+          aria-describedby="32"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="33"
+          id="31"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="34"
+        id="32"
       >
         <svg
           class="icon field-note__icon"
@@ -462,9 +458,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="35"
-          >
+          <title>
             error
           </title>
           <path
@@ -483,7 +477,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="36"
+          for="33"
         >
           Label text
            
@@ -496,7 +490,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="36"
+          id="33"
           placeholder="placeholder"
           type="text"
         />
@@ -508,7 +502,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="38"
+          for="35"
         >
           Label text
            
@@ -521,7 +515,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="38"
+          id="35"
           type="text"
         />
       </div>
@@ -534,19 +528,19 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="41"
+          aria-describedby="38"
           aria-invalid="true"
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="40"
+          id="37"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="41"
+        id="38"
       >
         <svg
           class="icon field-note__icon"
@@ -558,9 +552,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="42"
-          >
+          <title>
             error
           </title>
           <path
@@ -575,18 +567,18 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="44"
+          aria-describedby="40"
           aria-invalid="true"
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="43"
+          id="39"
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="44"
+        id="40"
       >
         <svg
           class="icon field-note__icon"
@@ -598,9 +590,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="45"
-          >
+          <title>
             error
           </title>
           <path
@@ -622,7 +612,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="46"
+          id="41"
           placeholder="placeholder"
           type="text"
         />
@@ -637,7 +627,7 @@ exports[`<TextField /> ErrorVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="48"
+          id="43"
           type="text"
         />
       </div>
@@ -656,7 +646,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
     >
       <label
         class="label"
-        for="12"
+        for="11"
       >
         Input field with button inside
          
@@ -669,7 +659,7 @@ exports[`<TextField /> InputWithin story renders snapshot 1`] = `
         aria-invalid="false"
         class="input-field"
         data-bootstrap-override="inputfield"
-        id="12"
+        id="11"
         type="text"
       />
       <div
@@ -711,7 +701,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="14"
+          for="13"
         >
           Label text
            
@@ -721,18 +711,18 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="15"
+          aria-describedby="14"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="14"
+          id="13"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="15"
+        id="14"
       >
         fieldNote text
       </div>
@@ -743,7 +733,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="16"
+          for="15"
         >
           Label text
            
@@ -753,17 +743,17 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="17"
+          aria-describedby="16"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="16"
+          id="15"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="17"
+        id="16"
       >
         fieldNote text
       </div>
@@ -777,7 +767,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="18"
+          for="17"
         >
           Label text
            
@@ -790,7 +780,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="18"
+          id="17"
           placeholder="placeholder"
           type="text"
         />
@@ -802,7 +792,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="20"
+          for="19"
         >
           Label text
            
@@ -815,7 +805,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="20"
+          id="19"
           type="text"
         />
       </div>
@@ -828,19 +818,19 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="23"
+          aria-describedby="22"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="22"
+          id="21"
           placeholder="placeholder"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="23"
+        id="22"
       >
         fieldNote text
       </div>
@@ -850,18 +840,18 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="25"
+          aria-describedby="24"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="24"
+          id="23"
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="25"
+        id="24"
       >
         fieldNote text
       </div>
@@ -878,7 +868,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="26"
+          id="25"
           placeholder="placeholder"
           type="text"
         />
@@ -893,7 +883,7 @@ exports[`<TextField /> LabelFieldnoteVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="28"
+          id="27"
           type="text"
         />
       </div>
@@ -920,19 +910,19 @@ exports[`<TextField /> NoVisibleLabel story renders snapshot 1`] = `
       class="text-field__body"
     >
       <input
-        aria-describedby="11"
+        aria-describedby="10"
         aria-invalid="false"
         aria-label="Input for no visible label"
         class="input-field"
         data-bootstrap-override="inputfield"
-        id="10"
+        id="9"
         required=""
         type="text"
       />
     </div>
     <div
       class="field-note"
-      id="11"
+      id="10"
     >
       This text field has no visible label
     </div>
@@ -950,7 +940,7 @@ exports[`<TextField /> Required story renders snapshot 1`] = `
     >
       <label
         class="label"
-        for="8"
+        for="7"
       >
         Text field with fieldNote
          
@@ -965,18 +955,18 @@ exports[`<TextField /> Required story renders snapshot 1`] = `
       class="text-field__body"
     >
       <input
-        aria-describedby="9"
+        aria-describedby="8"
         aria-invalid="false"
         class="input-field"
         data-bootstrap-override="inputfield"
-        id="8"
+        id="7"
         required=""
         type="text"
       />
     </div>
     <div
       class="field-note"
-      id="9"
+      id="8"
     >
       This is a fieldnote for a required text field.
     </div>
@@ -1007,7 +997,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="66"
+          for="61"
         >
           Label text
            
@@ -1022,11 +1012,11 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="67"
+          aria-describedby="62"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="66"
+          id="61"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1034,7 +1024,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note"
-        id="67"
+        id="62"
       >
         fieldNote text
       </div>
@@ -1045,7 +1035,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="68"
+          for="63"
         >
           Label text
            
@@ -1060,18 +1050,18 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="69"
+          aria-describedby="64"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="68"
+          id="63"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="69"
+        id="64"
       >
         fieldNote text
       </div>
@@ -1085,7 +1075,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="70"
+          for="65"
         >
           Label text
            
@@ -1103,7 +1093,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="70"
+          id="65"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1116,7 +1106,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="72"
+          for="67"
         >
           Label text
            
@@ -1134,7 +1124,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="72"
+          id="67"
           required=""
           type="text"
         />
@@ -1157,12 +1147,12 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="75"
+          aria-describedby="70"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="74"
+          id="69"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1170,7 +1160,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note"
-        id="75"
+        id="70"
       >
         fieldNote text
       </div>
@@ -1189,19 +1179,19 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="77"
+          aria-describedby="72"
           aria-invalid="false"
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="76"
+          id="71"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note"
-        id="77"
+        id="72"
       >
         fieldNote text
       </div>
@@ -1227,7 +1217,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="78"
+          id="73"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1252,7 +1242,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           aria-label="Label text"
           class="input-field"
           data-bootstrap-override="inputfield"
-          id="80"
+          id="75"
           required=""
           type="text"
         />
@@ -1267,7 +1257,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="82"
+          for="77"
         >
           Label text
            
@@ -1282,11 +1272,11 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="83"
+          aria-describedby="78"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="82"
+          id="77"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1294,7 +1284,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note field-note--error"
-        id="83"
+        id="78"
       >
         <svg
           class="icon field-note__icon"
@@ -1306,9 +1296,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="84"
-          >
+          <title>
             error
           </title>
           <path
@@ -1324,7 +1312,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="85"
+          for="79"
         >
           Label text
            
@@ -1339,18 +1327,18 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="86"
+          aria-describedby="80"
           aria-invalid="true"
           class="input-field error"
           data-bootstrap-override="inputfield"
-          id="85"
+          id="79"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note field-note--error"
-        id="86"
+        id="80"
       >
         <svg
           class="icon field-note__icon"
@@ -1362,9 +1350,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
           width="1rem"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <title
-            id="87"
-          >
+          <title>
             error
           </title>
           <path
@@ -1383,7 +1369,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="88"
+          for="81"
         >
           Label text
            
@@ -1398,12 +1384,12 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="89"
+          aria-describedby="82"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="88"
+          id="81"
           placeholder="placeholder"
           required=""
           type="text"
@@ -1411,7 +1397,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       </div>
       <div
         class="field-note field-note--disabled"
-        id="89"
+        id="82"
       >
         fieldNote text
       </div>
@@ -1422,7 +1408,7 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
       >
         <label
           class="label"
-          for="90"
+          for="83"
         >
           Label text
            
@@ -1437,19 +1423,19 @@ exports[`<TextField /> RequiredVariants story renders snapshot 1`] = `
         class="text-field__body"
       >
         <input
-          aria-describedby="91"
+          aria-describedby="84"
           aria-invalid="false"
           class="input-field"
           data-bootstrap-override="inputfield"
           disabled=""
-          id="90"
+          id="83"
           required=""
           type="text"
         />
       </div>
       <div
         class="field-note field-note--disabled"
-        id="91"
+        id="84"
       >
         fieldNote text
       </div>

--- a/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
+++ b/src/components/TimelineNav/__snapshots__/TimelineNav.test.ts.snap
@@ -43,9 +43,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
                 width="0.5rem"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title
-                  id="2"
-                >
+                <title>
                   incomplete step
                 </title>
                 <path
@@ -69,9 +67,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="3"
-            >
+            <title>
               forward
             </title>
             <path
@@ -121,9 +117,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
                 width="1.5em"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title
-                  id="4"
-                >
+                <title>
                   29 students have completed
                 </title>
                 <path
@@ -142,9 +136,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="5"
-            >
+            <title>
               forward
             </title>
             <path
@@ -196,9 +188,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="7"
-            >
+            <title>
               forward
             </title>
             <path
@@ -254,9 +244,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
                 width="1.5em"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title
-                  id="9"
-                >
+                <title>
                   2 students need feedback
                 </title>
                 <path
@@ -275,9 +263,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="10"
-            >
+            <title>
               forward
             </title>
             <path
@@ -329,9 +315,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="12"
-            >
+            <title>
               forward
             </title>
             <path
@@ -371,9 +355,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
                 width="0.5rem"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title
-                  id="13"
-                >
+                <title>
                   incomplete step
                 </title>
                 <path
@@ -397,9 +379,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="14"
-            >
+            <title>
               forward
             </title>
             <path
@@ -447,9 +427,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="15"
-            >
+            <title>
               forward
             </title>
             <path
@@ -503,9 +481,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
             width="var(--eds-size-2-and-half)"
             xmlns="http://www.w3.org/2000/svg"
           >
-            <title
-              id="17"
-            >
+            <title>
               forward
             </title>
             <path
@@ -531,9 +507,7 @@ exports[`<TimelineNav /> Default story renders snapshot 1`] = `
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <title
-          id="18"
-        >
+        <title>
           back
         </title>
         <path

--- a/src/components/Toast/__snapshots__/Toast.test.ts.snap
+++ b/src/components/Toast/__snapshots__/Toast.test.ts.snap
@@ -17,9 +17,7 @@ exports[`<Toast /> Error story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="2"
-      >
+      <title>
         error
       </title>
       <path
@@ -52,9 +50,7 @@ exports[`<Toast /> NotDismissable story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="3"
-      >
+      <title>
         success
       </title>
       <path
@@ -87,9 +83,7 @@ exports[`<Toast /> Success story renders snapshot 1`] = `
       width="1.5rem"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <title
-        id="1"
-      >
+      <title>
         success
       </title>
       <path


### PR DESCRIPTION
### Summary:

Removed usage of `useUID` from the three following components: `<Icon />`, `<PrimaryNav />` , and `<Breadcrumbs />`. Note, the `id` prop can still be passed to the components.

Why are we making this change?
To remove `console.error` messages from SSR in remix-run. Rendering these components would log errors like
> Warning: Prop `id` did not match. Server: "1" Client: "2"


### Test Plan:
- [x] Built library locally and validated the `console.error` message no longer appear when rendering these components


Follow-up, there is still a fair bit of usage of `react-uid` in the EDS repo. Those IDs are being used for accessibility and will be dealt with in a separate PR. This PR removes unnecessary usages
