### PR TITLE
fix(build): add css as having side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "main": "lib/index.js",
   "sideEffects": [
-    "*.css"
+    "lib/tokens/css/variables.css",
+    "lib/tokens/fonts.css"
   ],
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",
   "license": "MIT",
   "main": "lib/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Summary:
- tokens are not being provided since css marked as side effect free https://614b969675171d003ac6f98a-jstsqkayzt.chromatic.com/?path=/story/core-components-projectcard--default
- adds css files as having side effects
### Test Plan:
- LP storybook unbroken
  - install `@chanzuckerberg/eds: 8.1.0-alpha.4` in LP, where `8.1.0-alpha.4` is the latest alpha publish off next
  - in `traject/node_modules/@chanzuckerberg/eds/package.json` change `sideEffects: false` to 
  ```
  "sideEffects": [
    "lib/tokens/css/variables.css",
    "lib/tokens/fonts.css"
  ]
  ```
  - run `npm run storybook` and see that storybook is unbroken
    - chromatic: https://www.chromatic.com/build?appId=614b969675171d003ac6f98a&number=16062
  - alternatively install `8.1.0-alpha.5` which is alpha publish off of this branch
    - chromatic: https://www.chromatic.com/build?appId=614b969675171d003ac6f98a&number=16065
  - chromatic without `lib/tokens/fonts.css` in `sideEffects`: https://www.chromatic.com/build?appId=614b969675171d003ac6f98a&number=16064