### PR TITLE
refactor(text): deprecate text passage and spacing variants

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -115,6 +115,9 @@ export const Spacing: StoryObj<Args> = {
       </Text>
     </div>
   ),
+  parameters: {
+    badges: [BADGE.DEPRECATED],
+  },
 };
 
 /**

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import clsx from 'clsx';
 import React from 'react';
@@ -271,12 +272,21 @@ const TextPassageTemplate = (args: Args) => (
 
 export const TextPassage: StoryObj<Args> = {
   render: (args) => <TextPassageTemplate {...args} as="div" />,
+  parameters: {
+    badges: [BADGE.DEPRECATED],
+  },
 };
 
 export const TextPassageSmall: StoryObj<Args> = {
   render: (args) => <TextPassageTemplate {...args} as="div" size="sm" />,
+  parameters: {
+    badges: [BADGE.DEPRECATED],
+  },
 };
 
 export const TextPassageLarge: StoryObj<Args> = {
   render: (args) => <TextPassageTemplate {...args} as="div" size="lg" />,
+  parameters: {
+    badges: [BADGE.DEPRECATED],
+  },
 };

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -46,7 +46,8 @@ export type Props = {
   variant?: Variant;
   size?: Size;
   /**
-   * Adds margin bottom spacing to the <Text> component.
+   * Deprecated. Adds margin bottom spacing to the <Text> component. Use utility classes instead.
+   * @deprecated
    */
   spacing?: 'half' | '1x' | '2x';
   tabIndex?: number;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -31,9 +31,9 @@ export type Variant =
 
 export type Props = {
   /**
-   * Controls whether to render text inline (defaults to "p");
-   * Use "div" to indicate usage of `<Text>` as a text passage,
-   * (i.e. wraps <p>, <h1>-<h6>, <a>, <ol>, <ul>, <blockquote>, <hr>)
+   * Controls whether to render text inline (defaults to "p").
+   *
+   * "div" variant is deprecated.
    */
   as?: 'p' | 'span' | 'div';
   /**
@@ -56,20 +56,18 @@ export type Props = {
 /**
  * `import {Text} from "@chanzuckerberg/eds";`
  *
- * There are two perceived use cases for the text component.
- * One is to decorate `<p>` and `<span>` with thematic variants.
+ * The Text component decorates `<p>` and `<span>` with thematic variants.
  * Defaults to `<p>` and should pass `as="span"` to set as `<span>`.
- *
- * The second is to provide a wrapper for multiple text elements in usage as a text passage.
- * For such use, should pass as="div" and wrap various elements like `<p>`, `<h1>`-`<h6>`, `<a>`, `<ol>`, `<ul>`, `<blockquote>`, and `<hr>`.
  *
  * Example usage:
  *
  * ```tsx
- * <Text as="div">
- *   <h1>Heading for the text passage</h1>
- *   <p>First paragraph copy of the text passage</p>
- *   <p>Second paragraph copy of the text passage</p>
+ * <Text>
+ *  Text paragraph copy
+ * </Text>
+ *
+ * <Text as="span">
+ *  Text inline copy
  * </Text>
  * ```
  */


### PR DESCRIPTION
### Summary:
- deprecates the `as="div"` aka Text Passage variant of the Text component since its utility can be easily replicated with utility classes
- deprecates the `spacing` variants of the Text component since its utility can be easily replicated with utility classes, of which there are more options
### Test Plan:
- Text passage stories have the `deprecated` badge
- Text spacing story has the `deprecated` badge
- Text docstrings render fine in storybook