### PR TITLE
feat(TextareaField): add TextArea base component and TextareaField

### DIFF
--- a/src/components/TextArea/TextArea.module.css
+++ b/src/components/TextArea/TextArea.module.css
@@ -1,0 +1,16 @@
+@import '../../design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # TEXTAREA 
+\*------------------------------------*/
+
+/**
+ * Default input styles 
+ */
+.textarea {
+  @mixin inputStyles;
+}
+
+.textarea--disabled:focus {
+  outline: none;
+}

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,56 @@
+import clsx from 'clsx';
+import React, { forwardRef } from 'react';
+import styles from './TextArea.module.css';
+
+export interface Props
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  /**
+   * CSS class names that can be appended to the component
+   */
+  className?: string;
+  /**
+   * Text default contents of the field
+   */
+  children?: string;
+  /**
+   * Whether the disabled stat is active
+   */
+  disabled?: boolean;
+  /**
+   * Whether the error state is active
+   */
+  isError?: boolean;
+}
+
+/**
+ * Base component, applying styles to a <textarea> tag
+ */
+export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
+  (
+    {
+      className,
+      children,
+      disabled,
+      defaultValue = '',
+      isError = false,
+      ...other
+    },
+    ref,
+  ) => {
+    const componentClassName = clsx(
+      styles['textarea'],
+      isError && styles['error'],
+      disabled && styles['textarea--disabled'],
+      className,
+    );
+
+    return (
+      <textarea
+        className={componentClassName}
+        defaultValue={children || defaultValue}
+        ref={ref}
+        {...other}
+      ></textarea>
+    );
+  },
+);

--- a/src/components/TextArea/index.ts
+++ b/src/components/TextArea/index.ts
@@ -1,0 +1,1 @@
+export { TextArea as default } from './TextArea';

--- a/src/components/TextareaField/TextareaField.module.css
+++ b/src/components/TextareaField/TextareaField.module.css
@@ -1,0 +1,21 @@
+/*------------------------------------*\
+    # TEXTAREA FIELD
+\*------------------------------------*/
+
+/**
+ * Wraps the Label and the optional/required indicator.
+ */
+.textarea-field__overline {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: var(--eds-size-half);
+  color: var(--eds-theme-color-form-label);
+}
+
+.textarea-field__overline--no-label {
+  justify-content: flex-end;
+}
+
+.textarea-field__overline--disabled {
+  color: var(--eds-theme-color-text-disabled);
+}

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -1,0 +1,83 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
+import type { StoryObj, Meta } from '@storybook/react';
+import React from 'react';
+
+import { TextareaField } from './TextareaField';
+
+export default {
+  title: 'Components/TextareaField',
+  component: TextareaField,
+  args: {
+    placeholder: 'Enter long-form text here',
+    defaultValue: `Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.`,
+    label: 'Textarea Field',
+    rows: 5,
+    fieldNote: 'Longer Field description',
+  },
+  parameters: {
+    badges: [BADGE.BETA],
+  },
+} as Meta<Args>;
+
+type Args = React.ComponentProps<typeof TextareaField>;
+
+export const Default: StoryObj<Args> = {
+  render: (args) => (
+    <TextareaField aria-label="Text Label" {...args}></TextareaField>
+  ),
+};
+
+export const UsingChildren: StoryObj<Args> = {
+  args: {
+    children: `Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.`,
+    defaultValue: '',
+  },
+};
+
+export const WithNoDefaultValue: StoryObj<Args> = {
+  args: {
+    defaultValue: '',
+  },
+};
+
+export const WhenDisabled: StoryObj<Args> = {
+  args: {
+    disabled: true,
+    rows: 2,
+  },
+  parameters: {
+    axe: {
+      // Disabled input does not need to meet color contrast
+      disabledRules: ['color-contrast'],
+    },
+  },
+};
+
+export const WhenError: StoryObj<Args> = {
+  args: {
+    isError: true,
+    fieldNote: 'Text should be at least 100 characters',
+  },
+};
+
+export const WhenInvalid: StoryObj<Args> = {
+  args: {
+    maxLength: 10,
+  },
+};
+
+export const WhenRequired: StoryObj<Args> = {
+  args: {
+    required: true,
+  },
+};
+
+export const WithADifferentSize: StoryObj<Args> = {
+  args: {
+    rows: 10,
+  },
+};

--- a/src/components/TextareaField/TextareaField.test.ts
+++ b/src/components/TextareaField/TextareaField.test.ts
@@ -1,0 +1,6 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import * as stories from './TextareaField.stories';
+
+describe('<TextareaField />', () => {
+  generateSnapshots(stories);
+});

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,0 +1,132 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+import React, { forwardRef, useId } from 'react';
+import styles from './TextareaField.module.css';
+import FieldNote from '../FieldNote';
+import Label from '../Label';
+import Text from '../Text';
+import TextArea from '../TextArea';
+
+export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  /**
+   * Aria-label to provide an accesible name for the text input if no visible label is provided.
+   */
+  'aria-label'?: string;
+  /**
+   * Text content of the field upon instantiation
+   */
+  children?: string;
+  /**
+   * CSS class names that can be appended to the component.
+   */
+  className?: string;
+  /**
+   * Disables the field and prevents editing the contents
+   */
+  disabled?: boolean;
+  /**
+   * Text under the textarea used to provide a description or error message to describe the input.
+   */
+  fieldNote?: ReactNode;
+  /**
+   * HTML id for the component. Can be used with a custom Label component
+   */
+  id?: string;
+  /**
+   * Error state of the form field
+   */
+  isError?: boolean;
+  /**
+   * HTML label text (used in an accessory label component)
+   */
+  label?: string;
+};
+
+/**
+ * BETA: This component is still a work in progress and is subject to change.
+ *
+ * `import {TextareaField} from "@chanzuckerberg/eds";`
+ *
+ * Multi-line text input field with built-in labeling and accessory text to describe
+ * the content. When a maximum text count is specified, component also shows relevant
+ * text up to the maximum.
+ */
+export const TextareaField = forwardRef<HTMLTextAreaElement, Props>(
+  (
+    {
+      'aria-describedby': ariaDescribedBy,
+      children,
+      className,
+      disabled,
+      fieldNote,
+      id,
+      isError,
+      label,
+      required,
+      ...other
+    },
+    ref,
+  ) => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      !label &&
+      !other['aria-label']
+    ) {
+      throw new Error('You must provide a visible label or aria-label');
+    }
+
+    const shouldRenderOverline = !!(label || required);
+    const overlineClassName = clsx(
+      styles['textarea-field__overline'],
+      !label && styles['textarea-field__overline--no-label'],
+      disabled && styles['textarea-field__overline--disabled'],
+    );
+
+    const generatedIdVar = useId();
+    const idVar = id || generatedIdVar;
+
+    const generatedAriaDescribedById = useId();
+    const ariaDescribedByVar = fieldNote
+      ? ariaDescribedBy || generatedAriaDescribedById
+      : undefined;
+
+    const componentClassName = clsx(styles['textarea-field'], className);
+
+    return (
+      <div className={componentClassName}>
+        {shouldRenderOverline && (
+          <div className={overlineClassName}>
+            {label && <Label htmlFor={idVar} text={label} />}
+            {required && (
+              <Text as="p" size="sm">
+                Required
+              </Text>
+            )}
+          </div>
+        )}
+        <TextArea
+          aria-describedby={ariaDescribedByVar}
+          aria-disabled={disabled}
+          disabled={disabled}
+          id={idVar}
+          isError={isError}
+          readOnly={disabled}
+          ref={ref}
+          required={required}
+          {...other}
+        >
+          {children}
+        </TextArea>
+        {fieldNote && (
+          <FieldNote
+            disabled={disabled}
+            id={ariaDescribedByVar}
+            isError={isError}
+          >
+            {fieldNote}
+          </FieldNote>
+        )}
+      </div>
+    );
+  },
+);

--- a/src/components/TextareaField/__snapshots__/TextareaField.test.ts.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField.test.ts.snap
@@ -1,0 +1,304 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<TextareaField /> Default story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":r0:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":r1:"
+    aria-label="Text Label"
+    class="textarea"
+    id=":r0:"
+    placeholder="Enter long-form text here"
+    rows="5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note"
+    id=":r1:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> UsingChildren story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":r2:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":r3:"
+    class="textarea"
+    id=":r2:"
+    placeholder="Enter long-form text here"
+    rows="5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note"
+    id=":r3:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline textarea-field__overline--disabled"
+  >
+    <label
+      class="label"
+      for=":r6:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":r7:"
+    aria-disabled="true"
+    class="textarea textarea--disabled"
+    id=":r6:"
+    placeholder="Enter long-form text here"
+    readonly=""
+    rows="2"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note field-note--disabled"
+    id=":r7:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":r8:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":r9:"
+    class="textarea error"
+    id=":r8:"
+    placeholder="Enter long-form text here"
+    rows="5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note field-note--error"
+    id=":r9:"
+  >
+    <svg
+      class="icon field-note__icon"
+      fill="currentColor"
+      height="1rem"
+      role="img"
+      style="--icon-size: 1rem;"
+      viewBox="0 0 24 24"
+      width="1rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>
+        error
+      </title>
+      <path
+        d="M8.25 21L3 15.75V8.25L8.25 3H15.75L21 8.25V15.75L15.75 21H8.25ZM9.15 16.25L12 13.4L14.85 16.25L16.25 14.85L13.4 12L16.25 9.15L14.85 7.75L12 10.6L9.15 7.75L7.75 9.15L10.6 12L7.75 14.85L9.15 16.25Z"
+      />
+    </svg>
+    Text should be at least 100 characters
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WhenInvalid story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":ra:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":rb:"
+    class="textarea"
+    id=":ra:"
+    maxlength="10"
+    placeholder="Enter long-form text here"
+    rows="5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note"
+    id=":rb:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":rc:"
+    >
+      Textarea Field
+       
+    </label>
+    <p
+      class="text text--sm"
+    >
+      Required
+    </p>
+  </div>
+  <textarea
+    aria-describedby=":rd:"
+    class="textarea"
+    id=":rc:"
+    placeholder="Enter long-form text here"
+    required=""
+    rows="5"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note"
+    id=":rd:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":re:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":rf:"
+    class="textarea"
+    id=":re:"
+    placeholder="Enter long-form text here"
+    rows="10"
+  >
+    Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+    dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+    praesentium, commodi eligendi asperiores quis dolorum porro.
+  </textarea>
+  <div
+    class="field-note"
+    id=":rf:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WithNoDefaultValue story renders snapshot 1`] = `
+<div
+  class="textarea-field"
+>
+  <div
+    class="textarea-field__overline"
+  >
+    <label
+      class="label"
+      for=":r4:"
+    >
+      Textarea Field
+       
+    </label>
+  </div>
+  <textarea
+    aria-describedby=":r5:"
+    class="textarea"
+    id=":r4:"
+    placeholder="Enter long-form text here"
+    rows="5"
+  />
+  <div
+    class="field-note"
+    id=":r5:"
+  >
+    Longer Field description
+  </div>
+</div>
+`;

--- a/src/components/TextareaField/index.ts
+++ b/src/components/TextareaField/index.ts
@@ -1,0 +1,1 @@
+export { TextareaField as default } from './TextareaField';

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -133,13 +133,15 @@
    * Input error state
    */
   &.error {
+    /* TODO: should this color be applied when a field is in an :invalid state */
     border-color: var(--eds-theme-color-border-utility-error-strong);
   }
 
   /**
-   * Disabled state
+   * Disabled/read-only state
    */
   &:disabled,
+  &:read-only,
   &:disabled::placeholder {
     border-color: var(--eds-theme-color-border-disabled);
     color: var(--eds-theme-color-text-disabled);

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,7 @@ export { default as TableRow } from './components/TableRow';
 export { default as Tabs } from './components/Tabs';
 export { default as Tag } from './components/Tag';
 export { default as Text } from './components/Text';
+export { default as TextareaField } from './components/TextareaField';
 export { default as TimelineNav } from './components/TimelineNav';
 export { default as TimelineNavPanel } from './components/TimelineNavPanel';
 export { default as Toast } from './components/Toast';


### PR DESCRIPTION
### Summary:

- create TextArea component
- for now exporting, but we would want to treat this similar to how we do the input base component
- will sync with latest design before merging

### Test Plan:

- [x] add snapshots and base tests
- [x] verify no other snapshots change

### TODO

- [x] create proper exportable component (implementing label, error message, counting when maxlength used, etc.)
- [x] brief discussion on how to (re-)organize such base components (atoms that map directly to HTML tags)