### PR TITLE
refactor: lower clickable style specificity by importing css module last

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
         "groups": ["builtin", "external", "sibling", "parent", "index"],
         "pathGroups": [
           {
-            "pattern": "*.css",
+            "pattern": "*.module.css",
             "group": "index",
             "patternOptions": { "matchBase": true },
             "position": "after"

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,15 @@
         "alphabetize": {
           "order": "asc"
         },
-        "groups": ["builtin", "external", "sibling", "parent", "index"]
+        "groups": ["builtin", "external", "sibling", "parent", "index"],
+        "pathGroups": [
+          {
+            "pattern": "*.css",
+            "group": "index",
+            "patternOptions": { "matchBase": true },
+            "position": "after"
+          }
+        ]
       }
     ],
     "@typescript-eslint/no-unused-vars": "warn",

--- a/.storybook/components/DesignTokens/Tier1/TypographyPresets.jsx
+++ b/.storybook/components/DesignTokens/Tier1/TypographyPresets.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import styles from './TypographyPresets.module.css';
 import { Grid } from '../../../../src';
 import { TokenSpecimen } from '../../TokenSpecimen/TokenSpecimen';
+import styles from './TypographyPresets.module.css';
 
 export const PRESET_SIZE_MAP = {
   '001': {

--- a/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
+++ b/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
-import styles from './TypographyUsage.module.css';
 import { Grid, Section } from '../../../../src';
 import { TokenSpecimen } from '../../TokenSpecimen/TokenSpecimen';
 import { PRESET_SIZE_MAP } from '../Tier1/TypographyPresets';
+import styles from './TypographyUsage.module.css';
 
 export class Tier2TypographyUsage extends Component {
   render() {

--- a/.storybook/pages/AlongDemo/AlongDemo.tsx
+++ b/.storybook/pages/AlongDemo/AlongDemo.tsx
@@ -1,9 +1,6 @@
 import clsx from 'clsx';
 import React, { useId, useState } from 'react';
 
-import styles from './AlongDemo.module.css';
-import globalStyles from './GlobalStyles.module.css';
-
 import {
   Button,
   ButtonGroup,
@@ -25,6 +22,8 @@ import AlongUserIllustration2 from '../../static/along-user-illustration-2.png';
 import GoogleLogo from '../../static/google-logo.svg';
 import MicrosoftLogo from '../../static/microsoft-logo.svg';
 import Sprout from '../../static/sprout.svg';
+import styles from './AlongDemo.module.css';
+import globalStyles from './GlobalStyles.module.css';
 
 const GlobalFooter = ({ className }: { className?: string }) => (
   <ul className={clsx(styles['wireframe-demo__footer'], className)}>

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import styles from './CoursePlannerEdit.module.css';
 
 import ProjectCard from './ProjectCard';
 
@@ -31,6 +30,7 @@ import CardWithNotification from '../../recipes/CardWithNotification';
 import TableCard from '../../recipes/TableCard';
 
 import EmptyImage from '../../static/hand-pencil.svg';
+import styles from './CoursePlannerEdit.module.css';
 
 const CognitiveSkillColumns = [
   {

--- a/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
+++ b/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './ProjectCard.module.css';
 
 import {
   Card,
@@ -15,6 +14,7 @@ import {
 import type { HeadingElement } from '../../../../src/components/Heading';
 
 import type { IconName } from '../../../../src/components/Icon';
+import styles from './ProjectCard.module.css';
 
 export interface Props {
   /**

--- a/.storybook/pages/CoursePlannerStep1/CoursePlannerStep1.tsx
+++ b/.storybook/pages/CoursePlannerStep1/CoursePlannerStep1.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './CoursePlannerStep1.module.css';
 
 import {
   Button,
@@ -19,6 +18,7 @@ import {
 } from '../../../src';
 
 import CompassCenter from '../../static/compass-center.svg';
+import styles from './CoursePlannerStep1.module.css';
 
 export const CoursePlannerStep1 = () => {
   const textClassName = clsx(styles['course-planner-step1__text'], '!mb-2');

--- a/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
+++ b/.storybook/pages/FeedbackOverview/FeedbackOverview.tsx
@@ -1,6 +1,5 @@
 import debounce from 'lodash.debounce';
 import React, { useEffect, useState } from 'react';
-import styles from './FeedbackOverview.module.css';
 import {
   Button,
   Breadcrumbs,
@@ -29,6 +28,7 @@ import {
 } from '../../../src/tokens-dist/ts/colors';
 import NumberIconList from '../../recipes/NumberIconList';
 import { PageShell } from '../../recipes/PageShell/PageShell';
+import styles from './FeedbackOverview.module.css';
 
 export interface Props {
   /**

--- a/.storybook/pages/ProjectOverview/ProjectOverview.tsx
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './ProjectOverview.module.css';
 
 import {
   Breadcrumbs,
@@ -22,6 +21,7 @@ import {
 import ButtonActionCalloutCard from '../../recipes/ButtonActionCalloutCard';
 
 import { PageShell } from '../../recipes/PageShell/PageShell';
+import styles from './ProjectOverview.module.css';
 
 export interface Props {
   /**

--- a/.storybook/pages/StudentRefinement/StudentRefinement.tsx
+++ b/.storybook/pages/StudentRefinement/StudentRefinement.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import debounce from 'lodash.debounce';
 import React, { useEffect, useState } from 'react';
-import styles from './StudentRefinement.module.css';
 
 import {
   Breadcrumbs,
@@ -30,6 +29,7 @@ import { EdsThemeColorIconUtilityWarning } from '../../../src/tokens-dist/ts/col
 
 import { DataSummaryCard } from '../../recipes/DataSummaryCard/DataSummaryCard';
 import { PageShell } from '../../recipes/PageShell/PageShell';
+import styles from './StudentRefinement.module.css';
 
 export const StudentRefinement = () => {
   const [isTable, setIsTable] = useState(false);

--- a/.storybook/pages/WireframeDemo/WireframeDemo.tsx
+++ b/.storybook/pages/WireframeDemo/WireframeDemo.tsx
@@ -1,9 +1,6 @@
 import clsx from 'clsx';
 import React, { useId, useState } from 'react';
 
-import globalStyles from './GlobalStyles.module.css';
-import styles from './WireframeDemo.module.css';
-
 import {
   Button,
   ButtonGroup,
@@ -20,6 +17,8 @@ import {
 
 import PlaceholderImage from '../../static/placeholder-image.svg';
 import PlaceholderVideo from '../../static/placeholder-video.svg';
+import globalStyles from './GlobalStyles.module.css';
+import styles from './WireframeDemo.module.css';
 
 const GlobalFooter = () => (
   <ul className={styles['wireframe-demo__footer']}>

--- a/.storybook/recipes/BaselineCard/BaselineCard.tsx
+++ b/.storybook/recipes/BaselineCard/BaselineCard.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import React, { type ReactNode, useEffect, useRef } from 'react';
-import styles from './BaselineCard.module.css';
 
 import { Card, CardBody, CardFooter, CardHeader, Score } from '../../../src';
 import type { Variant } from '../../../src/components/Score/Score';
+import styles from './BaselineCard.module.css';
 
 interface Metadata {
   /**

--- a/.storybook/recipes/ButtonActionCalloutCard/ButtonActionCalloutCard.tsx
+++ b/.storybook/recipes/ButtonActionCalloutCard/ButtonActionCalloutCard.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './ButtonActionCalloutCard.module.css';
 import { Card, Heading } from '../../../src';
+import styles from './ButtonActionCalloutCard.module.css';
 
 export interface Props {
   /**

--- a/.storybook/recipes/CalendarCard/CalendarCard.tsx
+++ b/.storybook/recipes/CalendarCard/CalendarCard.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './CalendarCard.module.css';
 
 import { Card, Heading, Icon, Tag, Text } from '../../../src';
 import type { Variant as TagVariant } from '../../../src/components/Tag/Tag';
+import styles from './CalendarCard.module.css';
 
 export const VARIANTS = ['brand', 'revise', 'success'] as const;
 

--- a/.storybook/recipes/CardWithNotification/CardWithNotification.tsx
+++ b/.storybook/recipes/CardWithNotification/CardWithNotification.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './CardWithNotification.module.css';
 
 import {
   Card,
@@ -11,6 +10,7 @@ import {
   InlineNotification,
 } from '../../../src';
 import type { VARIANTS } from '../../../src/components/InlineNotification/InlineNotification';
+import styles from './CardWithNotification.module.css';
 
 export interface Props {
   /**

--- a/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
+++ b/.storybook/recipes/DataSummaryCard/DataSummaryCard.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './DataSummaryCard.module.css';
 
 import { Card, Text } from '../../../src';
 import type { HeadingElement } from '../../../src/components/Heading';
 import Heading from '../../../src/components/Heading';
+import styles from './DataSummaryCard.module.css';
 
 export interface Props {
   /**

--- a/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
+++ b/.storybook/recipes/GlobalHeader/GlobalHeader.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import styles from './GlobalHeader.module.css';
 import { Button, Icon, Heading, Link, Popover } from '../../../src';
 
 import breakpoint from '../../../src/design-tokens/tier-1-definitions/breakpoints';
 import { EdsThemeColorIconNeutralDefaultInverse } from '../../../src/tokens-dist/ts/colors';
 import { NotificationLists } from '../NotificationListPopover/NotificationListPopover';
 import { PrimaryNav } from '../PrimaryNav/PrimaryNav';
+import styles from './GlobalHeader.module.css';
 
 type HeaderProps = {
   /**

--- a/.storybook/recipes/NotificationListPopover/NotificationListPopover.tsx
+++ b/.storybook/recipes/NotificationListPopover/NotificationListPopover.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React, { useState } from 'react';
-import styles from './NotificationListPopover.module.css';
 import { Button, Heading, Popover } from '../../../src';
+import styles from './NotificationListPopover.module.css';
 
 type NotificationListItemProps = {
   /**

--- a/.storybook/recipes/PageShell/PageShell.tsx
+++ b/.storybook/recipes/PageShell/PageShell.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './PageShell.module.css';
 import { Link, Layout, LayoutContainer, LayoutSection } from '../../../src';
 
 import { GlobalHeader } from '../GlobalHeader/GlobalHeader';
+import styles from './PageShell.module.css';
 
 export interface Props {
   /**

--- a/.storybook/recipes/PrimaryNav/PrimaryNav.tsx
+++ b/.storybook/recipes/PrimaryNav/PrimaryNav.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './PrimaryNav.module.css';
 import type { IconName } from '../../../src';
 import { Icon } from '../../../src';
+import styles from './PrimaryNav.module.css';
 
 export type PrimaryNavItemProps = {
   /**

--- a/.storybook/recipes/TableCard/TableCard.tsx
+++ b/.storybook/recipes/TableCard/TableCard.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './TableCard.module.css';
 
 import {
   Card,
@@ -19,6 +18,7 @@ import {
 } from '../../../src';
 
 import NumberIconList from '../NumberIconList';
+import styles from './TableCard.module.css';
 
 export interface Props {
   /**

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React, { createContext } from 'react';
-import styles from './Accordion.module.css';
 import AccordionButton from '../AccordionButton';
 import AccordionPanel from '../AccordionPanel';
 import AccordionRow from '../AccordionRow';
 import type { HeadingElement } from '../Heading';
+import styles from './Accordion.module.css';
 
 type Props = {
   /**

--- a/src/components/AccordionButton/AccordionButton.module.css
+++ b/src/components/AccordionButton/AccordionButton.module.css
@@ -7,7 +7,7 @@
 /**
  * Accordion Button, wraps the heading and open indicator icon.
  */
-.accordion-button.accordion-button {
+.accordion-button {
   display: flex;
   justify-content: space-between;
 
@@ -21,7 +21,7 @@
 /**
  * Small variant.
  */
-.accordion-button--sm.accordion-button--sm {
+.accordion-button--sm {
   padding: var(--eds-size-1);
   height: 2.25rem;
 }
@@ -29,7 +29,7 @@
 /**
  * Outline variant.
  */
-.accordion-button--outline.accordion-button--outline {
+.accordion-button--outline {
   padding: var(--eds-size-2) var(--eds-size-3);
 }
 
@@ -43,7 +43,7 @@
 /**
  * The heading text.
  */
-.accordion-button__heading.accordion-button__heading {
+.accordion-button__heading {
   @mixin eds-theme-typography-body-text-sm;
   color: var(--eds-theme-color-text-neutral-strong);
 }
@@ -51,7 +51,7 @@
 /**
  * Small variant of the heading text.
  */
-.accordion-button__heading--sm.accordion-button__heading--sm {
+.accordion-button__heading--sm {
   @mixin eds-theme-typography-body-text-xs;
 }
 

--- a/src/components/AccordionButton/AccordionButton.tsx
+++ b/src/components/AccordionButton/AccordionButton.tsx
@@ -1,13 +1,13 @@
 import { Disclosure } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useContext } from 'react';
-import styles from './AccordionButton.module.css';
 import { ENTER_KEYCODE, SPACEBAR_KEYCODE } from '../../util/keycodes';
 import { AccordionContext } from '../Accordion';
 import Button from '../Button';
 import type { HeadingElement } from '../Heading';
 import Heading from '../Heading';
 import Icon from '../Icon';
+import styles from './AccordionButton.module.css';
 
 export type Props = {
   /**

--- a/src/components/AccordionPanel/AccordionPanel.tsx
+++ b/src/components/AccordionPanel/AccordionPanel.tsx
@@ -1,8 +1,8 @@
 import { Disclosure } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useContext } from 'react';
-import styles from './AccordionPanel.module.css';
 import { AccordionContext } from '../Accordion';
+import styles from './AccordionPanel.module.css';
 
 export type Props = {
   /**

--- a/src/components/AccordionRow/AccordionRow.tsx
+++ b/src/components/AccordionRow/AccordionRow.tsx
@@ -1,8 +1,8 @@
 import { Disclosure } from '@headlessui/react';
 import clsx from 'clsx';
 import React, { useContext } from 'react';
-import styles from './AccordionRow.module.css';
 import { AccordionContext } from '../Accordion';
+import styles from './AccordionRow.module.css';
 
 type Props = {
   /**

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './Badge.module.css';
 import Icon from '../Icon';
 import type { IconName, IconProps } from '../Icon';
+import styles from './Badge.module.css';
 
 type BadgeProps = {
   /**

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -4,9 +4,9 @@ import React from 'react';
 
 import type { Variant } from './Banner';
 import { Banner } from './Banner';
-import styles from './Banner.stories.module.css';
 import Button from '../Button';
 import Heading from '../Heading';
+import styles from './Banner.stories.module.css';
 
 export default {
   title: 'Components/Banner',

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Banner.module.css';
 import Button from '../Button';
 import type { HeadingElement } from '../Heading';
 import Heading from '../Heading';
 import Icon from '../Icon';
 import Text from '../Text';
+import styles from './Banner.module.css';
 
 export type Variant = 'brand' | 'neutral' | 'success' | 'warning' | 'error';
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import debounce from 'lodash.debounce';
 import React, { type ReactNode } from 'react';
-import styles from './Breadcrumbs.module.css';
 import { flattenReactChildren } from '../../util/flattenReactChildren';
 import BreadcrumbsItem from '../BreadcrumbsItem';
 import DropdownMenuItem from '../DropdownMenuItem';
+import styles from './Breadcrumbs.module.css';
 
 type Props = {
   /**

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './BreadcrumbsItem.module.css';
 import ButtonDropdown from '../ButtonDropdown';
 import Icon from '../Icon';
+import styles from './BreadcrumbsItem.module.css';
 
 type Props = {
   /**

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -14,10 +14,8 @@
 
 /**
  * Primary disabled button styles
- *
- * Class is doubled to increase specificity.
  */
-.button--primary.button--primary {
+.button--primary {
   &:disabled,
   &:disabled:hover {
     border-color: var(--eds-theme-color-border-disabled);
@@ -28,10 +26,8 @@
 
 /**
  * Secondary disabled button styles
- *
- * Class is doubled to increase specificity.
  */
-.button--secondary.button--secondary {
+.button--secondary {
   &:disabled,
   &:disabled:hover {
     border-color: var(--eds-theme-color-border-disabled);
@@ -46,10 +42,8 @@
 
 /**
  * Link disabled button styles
- *
- * Class is doubled to increase specificity.
  */
-.button--link.button--link {
+.button--link {
   &:disabled,
   &:disabled:hover {
     color: var(--eds-theme-color-text-disabled);
@@ -59,10 +53,8 @@
 
 /**
  * Icon disabled button styles
- *
- * Class is doubled to increase specificity.
  */
-.button--icon.button--icon {
+.button--icon {
   &:disabled,
   &:disabled:hover {
     border-color: var(--eds-theme-color-button-icon-brand-border);

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import styles from './Button.module.css';
 import ClickableStyle from '../ClickableStyle';
 import type { ClickableStyleProps, VariantStatus } from '../ClickableStyle';
 import Icon from '../Icon';
+import styles from './Button.module.css';
 
 type ButtonHTMLElementProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
 

--- a/src/components/ButtonDropdown/ButtonDropdown.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './ButtonDropdown.module.css';
 import { DropdownMenu } from '../..';
 import type { ClickableStyleProps } from '../ClickableStyle';
+import styles from './ButtonDropdown.module.css';
 
 export interface Props {
   /**

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Card.module.css';
 import CardBody from '../CardBody';
 import CardFooter from '../CardFooter';
 import CardHeader from '../CardHeader';
+import styles from './Card.module.css';
 
 export interface Props {
   /**

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,9 +1,9 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Checkbox } from './Checkbox';
-import styles from './Checkbox.stories.module.css';
 import CheckboxInput from '../CheckboxInput';
 import CheckboxLabel from '../CheckboxLabel';
+import styles from './Checkbox.stories.module.css';
 
 const defaultArgs = {
   disabled: false,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
-import styles from './Checkbox.module.css';
 import type { CheckboxInputProps } from '../CheckboxInput';
 import CheckboxInput from '../CheckboxInput';
 import type { CheckboxLabelProps } from '../CheckboxLabel';
 import CheckboxLabel from '../CheckboxLabel';
+import styles from './Checkbox.module.css';
 
 // id is required in CheckboxInputProps but optional in CheckboxProps, so we
 // first remove `id` from CheckboxInputProps before intersecting.

--- a/src/components/CheckboxInput/CheckboxInput.tsx
+++ b/src/components/CheckboxInput/CheckboxInput.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './CheckboxInput.module.css';
 import Icon from '../Icon';
+import styles from './CheckboxInput.module.css';
 
 type CheckboxHTMLElementProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/CheckboxLabel/CheckboxLabel.tsx
+++ b/src/components/CheckboxLabel/CheckboxLabel.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './CheckboxLabel.module.css';
 import type { InputLabelProps } from '../InputLabel/InputLabel';
 import { InputLabel } from '../InputLabel/InputLabel';
+import styles from './CheckboxLabel.module.css';
 
 export type CheckboxLabelProps = InputLabelProps;
 

--- a/src/components/ClickableStyle/ClickableStyle.module.css
+++ b/src/components/ClickableStyle/ClickableStyle.module.css
@@ -24,7 +24,7 @@
   transition-duration: var(--eds-anim-fade-quick);
   transition-timing-function: var(--eds-anim-ease);
 
-  svg {
+  :where(svg) {
     /* Adds default size for icons passed in for consistency. */
     --icon-size-default: 2em;
     transition: color var(--eds-anim-fade-quick) var(--eds-anim-ease);
@@ -61,7 +61,7 @@
 /**
  * Primary brand clickable style
  */
-.clickable-style--primary.clickable-style--brand {
+:where(.clickable-style--primary).clickable-style--brand {
   border-color: var(--eds-theme-color-button-primary-brand-border);
   background-color: var(--eds-theme-color-button-primary-brand-background);
   color: var(--eds-theme-color-button-primary-brand-text);
@@ -86,7 +86,7 @@
 /**
  * Primary error clickable style
  */
-.clickable-style--primary.clickable-style--error {
+:where(.clickable-style--primary).clickable-style--error {
   border-color: var(--eds-theme-color-button-primary-error-border);
   background-color: var(--eds-theme-color-button-primary-error-background);
   color: var(--eds-theme-color-button-primary-error-text);
@@ -111,12 +111,12 @@
 /**
  * Secondary brand clickable style
  */
-.clickable-style--secondary.clickable-style--brand {
+:where(.clickable-style--secondary).clickable-style--brand {
   border-color: var(--eds-theme-color-button-secondary-brand-border);
   background-color: var(--eds-theme-color-button-secondary-brand-background);
   color: var(--eds-theme-color-button-secondary-brand-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-secondary-brand-icon);
   }
 
@@ -126,7 +126,7 @@
       --eds-theme-color-button-secondary-brand-background-hover
     );
     color: var(--eds-theme-color-button-secondary-brand-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-brand-icon-hover);
     }
   }
@@ -137,7 +137,7 @@
       --eds-theme-color-button-secondary-brand-background-active
     );
     color: var(--eds-theme-color-button-secondary-brand-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-brand-icon-focus);
     }
   }
@@ -146,12 +146,12 @@
 /**
  * Secondary neutral clickable style
  */
-.clickable-style--secondary.clickable-style--neutral {
+:where(.clickable-style--secondary).clickable-style--neutral {
   border-color: var(--eds-theme-color-button-secondary-neutral-border);
   background-color: var(--eds-theme-color-button-secondary-neutral-background);
   color: var(--eds-theme-color-button-secondary-neutral-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-secondary-neutral-icon);
   }
 
@@ -161,7 +161,7 @@
       --eds-theme-color-button-secondary-neutral-background-hover
     );
     color: var(--eds-theme-color-button-secondary-neutral-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-neutral-icon-hover);
     }
   }
@@ -172,7 +172,7 @@
       --eds-theme-color-button-secondary-neutral-background-active
     );
     color: var(--eds-theme-color-button-secondary-neutral-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-neutral-icon-active);
     }
   }
@@ -181,12 +181,12 @@
 /**
  * Secondary success clickable style
  */
-.clickable-style--secondary.clickable-style--success {
+:where(.clickable-style--secondary).clickable-style--success {
   border-color: var(--eds-theme-color-button-secondary-success-border);
   background-color: var(--eds-theme-color-button-secondary-success-background);
   color: var(--eds-theme-color-button-secondary-success-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-secondary-success-icon);
   }
 
@@ -196,7 +196,7 @@
       --eds-theme-color-button-secondary-success-background-hover
     );
     color: var(--eds-theme-color-button-secondary-success-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-success-icon-hover);
     }
   }
@@ -207,7 +207,7 @@
       --eds-theme-color-button-secondary-success-background-active
     );
     color: var(--eds-theme-color-button-secondary-success-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-success-icon-active);
     }
   }
@@ -216,12 +216,12 @@
 /**
  * Secondary warning clickable style
  */
-.clickable-style--secondary.clickable-style--warning {
+:where(.clickable-style--secondary).clickable-style--warning {
   border-color: var(--eds-theme-color-button-secondary-warning-border);
   background-color: var(--eds-theme-color-button-secondary-warning-background);
   color: var(--eds-theme-color-button-secondary-warning-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-secondary-warning-icon);
   }
 
@@ -231,7 +231,7 @@
       --eds-theme-color-button-secondary-warning-background-hover
     );
     color: var(--eds-theme-color-button-secondary-warning-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-warning-icon-hover);
     }
   }
@@ -242,7 +242,7 @@
       --eds-theme-color-button-secondary-warning-background-active
     );
     color: var(--eds-theme-color-button-secondary-warning-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-warning-icon-active);
     }
   }
@@ -251,12 +251,12 @@
 /**
  * Secondary error clickable style
  */
-.clickable-style--secondary.clickable-style--error {
+:where(.clickable-style--secondary).clickable-style--error {
   border-color: var(--eds-theme-color-button-secondary-error-border);
   background-color: var(--eds-theme-color-button-secondary-error-background);
   color: var(--eds-theme-color-button-secondary-error-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-secondary-error-icon);
   }
 
@@ -266,7 +266,7 @@
       --eds-theme-color-button-secondary-error-background-hover
     );
     color: var(--eds-theme-color-button-secondary-error-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-error-icon-hover);
     }
   }
@@ -277,7 +277,7 @@
       --eds-theme-color-button-secondary-error-background-active
     );
     color: var(--eds-theme-color-button-secondary-error-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-secondary-error-icon-active);
     }
   }
@@ -290,12 +290,12 @@
  *
  * Use for Close "X" buttons, tooltip icons, and other.
  */
-.clickable-style--icon.clickable-style--brand {
+:where(.clickable-style--icon).clickable-style--brand {
   border-color: var(--eds-theme-color-button-icon-brand-border);
   background-color: var(--eds-theme-color-button-icon-brand-background);
   color: var(--eds-theme-color-button-icon-brand-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-icon-brand);
   }
 
@@ -303,7 +303,7 @@
     border-color: var(--eds-theme-color-button-icon-brand-border-hover);
     background-color: var(--eds-theme-color-button-icon-brand-background-hover);
     color: var(--eds-theme-color-button-icon-brand-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-brand-hover);
     }
   }
@@ -314,7 +314,7 @@
       --eds-theme-color-button-icon-brand-background-active
     );
     color: var(--eds-theme-color-button-icon-brand-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-brand-active);
     }
   }
@@ -327,12 +327,12 @@
  *
  * Use for Close "X" buttons, tooltip icons, and other.
  */
-.clickable-style--icon.clickable-style--neutral {
+:where(.clickable-style--icon).clickable-style--neutral {
   border-color: var(--eds-theme-color-button-icon-neutral-border);
   background-color: var(--eds-theme-color-button-icon-neutral-background);
   color: var(--eds-theme-color-button-icon-neutral-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-icon-neutral);
   }
 
@@ -342,7 +342,7 @@
       --eds-theme-color-button-icon-neutral-background-hover
     );
     color: var(--eds-theme-color-button-icon-neutral-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-neutral-hover);
     }
   }
@@ -353,7 +353,7 @@
       --eds-theme-color-button-icon-neutral-background-active
     );
     color: var(--eds-theme-color-button-icon-neutral-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-neutral-active);
     }
   }
@@ -366,12 +366,12 @@
  *
  * Use for Close "X" buttons, tooltip icons, and other.
  */
-.clickable-style--icon.clickable-style--success {
+:where(.clickable-style--icon).clickable-style--success {
   border-color: var(--eds-theme-color-button-icon-success-border);
   background-color: var(--eds-theme-color-button-icon-success-background);
   color: var(--eds-theme-color-button-icon-success-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-icon-success);
   }
 
@@ -381,7 +381,7 @@
       --eds-theme-color-button-icon-success-background-hover
     );
     color: var(--eds-theme-color-button-icon-success-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-success-hover);
     }
   }
@@ -392,7 +392,7 @@
       --eds-theme-color-button-icon-success-background-active
     );
     color: var(--eds-theme-color-button-icon-success-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-success-active);
     }
   }
@@ -405,12 +405,12 @@
  *
  * Use for Close "X" buttons, tooltip icons, and other.
  */
-.clickable-style--icon.clickable-style--warning {
+:where(.clickable-style--icon).clickable-style--warning {
   border-color: var(--eds-theme-color-button-icon-warning-border);
   background-color: var(--eds-theme-color-button-icon-warning-background);
   color: var(--eds-theme-color-button-icon-warning-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-icon-warning);
   }
 
@@ -420,7 +420,7 @@
       --eds-theme-color-button-icon-warning-background-hover
     );
     color: var(--eds-theme-color-button-icon-warning-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-warning-hover);
     }
   }
@@ -431,7 +431,7 @@
       --eds-theme-color-button-icon-warning-background-active
     );
     color: var(--eds-theme-color-button-icon-warning-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-warning-active);
     }
   }
@@ -444,12 +444,12 @@
  *
  * Use for Close "X" buttons, tooltip icons, and other.
  */
-.clickable-style--icon.clickable-style--error {
+:where(.clickable-style--icon).clickable-style--error {
   border-color: var(--eds-theme-color-button-icon-error-border);
   background-color: var(--eds-theme-color-button-icon-error-background);
   color: var(--eds-theme-color-button-icon-error-text);
 
-  svg {
+  :where(svg) {
     color: var(--eds-theme-color-button-icon-error);
   }
 
@@ -457,7 +457,7 @@
     border-color: var(--eds-theme-color-button-icon-error-border-hover);
     background-color: var(--eds-theme-color-button-icon-error-background-hover);
     color: var(--eds-theme-color-button-icon-error-text-hover);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-error-hover);
     }
   }
@@ -468,7 +468,7 @@
       --eds-theme-color-button-icon-error-background-active
     );
     color: var(--eds-theme-color-button-icon-error-text-active);
-    svg {
+    :where(svg) {
       color: var(--eds-theme-color-button-icon-error-active);
     }
   }
@@ -510,7 +510,7 @@ button:where(.clickable-style--link) {
 /**
  * Link neutral clickable style
  */
-.clickable-style--link.clickable-style--neutral {
+:where(.clickable-style--link).clickable-style--neutral {
   text-decoration-color: var(--eds-theme-color-border-link-neutral);
 
   &:hover {

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
-import styles from './DataBar.module.css';
 
 import DataBarSegment from '../DataBarSegment';
 import type { Variants } from '../DataBarSegment';
 import Text from '../Text';
+import styles from './DataBar.module.css';
 
 type Segment = {
   /**

--- a/src/components/DataBarSegment/DataBarSegment.tsx
+++ b/src/components/DataBarSegment/DataBarSegment.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './DataBarSegment.module.css';
 import Tooltip from '../Tooltip';
+import styles from './DataBarSegment.module.css';
 
 export type Variants = 'brand' | 'success';
 

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -3,8 +3,6 @@ import type { ComponentProps } from 'react';
 import React, { useState } from 'react';
 import type { NewState } from './DragDrop';
 import { DragDrop } from './DragDrop';
-import styles from './DragDrop.stories.module.css';
-
 import {
   Button,
   Card,
@@ -14,6 +12,7 @@ import {
   Text,
   Toolbar,
 } from '../..';
+import styles from './DragDrop.stories.module.css';
 
 export default {
   title: 'Components/Drag and Drop',

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -8,9 +8,9 @@ import React, {
 } from 'react';
 import type { DropResult, DroppableProvided } from 'react-beautiful-dnd';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import styles from './DragDrop.module.css';
 import type { Items, Containers } from './DragDropTypes';
 import DragDropContainer from '../DragDropContainer';
+import styles from './DragDrop.module.css';
 
 export interface Props {
   /**

--- a/src/components/DragDropContainer/DragDropContainer.tsx
+++ b/src/components/DragDropContainer/DragDropContainer.tsx
@@ -4,10 +4,10 @@ import React from 'react';
 import type { DroppableProvided } from 'react-beautiful-dnd';
 import { Droppable } from 'react-beautiful-dnd';
 import { oneByType } from 'react-children-by-type';
-import styles from '../DragDrop/DragDrop.module.css';
 import type { ContainerType, ItemType } from '../DragDrop/DragDropTypes';
 import DragDropContainerHeader from '../DragDropContainerHeader';
 import DragDropItem from '../DragDropItem';
+import styles from '../DragDrop/DragDrop.module.css';
 
 export interface Props {
   /**

--- a/src/components/DragDropItem/DragDropItem.tsx
+++ b/src/components/DragDropItem/DragDropItem.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { DraggableProvided } from 'react-beautiful-dnd';
 import { Draggable } from 'react-beautiful-dnd';
-import styles from '../DragDrop/DragDrop.module.css';
 import type { ItemType } from '../DragDrop/DragDropTypes';
 import Icon from '../Icon';
+import styles from '../DragDrop/DragDrop.module.css';
 
 export interface Props {
   /**

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -10,11 +10,11 @@ import React, {
 import { oneByType } from 'react-children-by-type';
 import FocusLock from 'react-focus-lock';
 import { Portal } from 'react-portal';
-import styles from './Drawer.module.css';
 import { ESCAPE_KEYCODE } from '../../util/keycodes';
 import DrawerBody from '../DrawerBody';
 import DrawerFooter from '../DrawerFooter';
 import DrawerHeader from '../DrawerHeader';
+import styles from './Drawer.module.css';
 
 export type Props = {
   /**

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -5,9 +5,9 @@ import clsx from 'clsx';
 import React from 'react';
 import type { OptionsAlignType, VariantType } from './Dropdown';
 import { Dropdown } from './Dropdown';
-import styles from './Dropdown.stories.module.css';
 import DropdownButton from '../DropdownButton';
 import Icon from '../Icon';
+import styles from './Dropdown.stories.module.css';
 
 export default {
   title: 'Components/Dropdown',

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -2,12 +2,12 @@ import { Listbox } from '@headlessui/react';
 import clsx from 'clsx';
 import type { ReactElement, ReactNode, ElementType } from 'react';
 import React, { useContext } from 'react';
-import styles from './Dropdown.module.css';
 
 import type { ExtractProps } from '../../util/utility-types';
 
 import DropdownButton from '../DropdownButton';
 import Icon from '../Icon';
+import styles from './Dropdown.module.css';
 
 export type OptionsAlignType = 'left' | 'right';
 export type VariantType = 'compact' | 'full';

--- a/src/components/DropdownButton/DropdownButton.tsx
+++ b/src/components/DropdownButton/DropdownButton.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import styles from './DropdownButton.module.css';
 import Icon from '../Icon';
+import styles from './DropdownButton.module.css';
 
 type Props = {
   /**

--- a/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.tsx
@@ -6,7 +6,6 @@ import type {
   MouseEventHandler,
 } from 'react';
 import React, { createContext, useRef, useEffect } from 'react';
-import styles from './DropdownMenu.module.css';
 import {
   L_ARROW_KEYCODE,
   U_ARROW_KEYCODE,
@@ -17,6 +16,7 @@ import {
   END_KEYCODE,
   TAB_KEYCODE,
 } from '../../util/keycodes';
+import styles from './DropdownMenu.module.css';
 
 // This component is deprecated and will be replaced by the Menu component
 export type Props = {

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './FieldNote.module.css';
 import Icon from '../Icon';
+import styles from './FieldNote.module.css';
 
 export interface Props {
   /**

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Fieldset.module.css';
 import FieldsetItems from '../FieldsetItems';
 import FieldsetLegend from '../FieldsetLegend';
+import styles from './Fieldset.module.css';
 
 type FieldsetProps = {
   /**

--- a/src/components/FiltersButton/FiltersButton.tsx
+++ b/src/components/FiltersButton/FiltersButton.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
-import styles from './FiltersButton.module.css';
 import Button, { type ButtonProps } from '../Button';
 import type { VariantStatus } from '../ClickableStyle';
 import Icon from '../Icon';
+import styles from './FiltersButton.module.css';
 
 export type FiltersButtonProps = {
   /**

--- a/src/components/FiltersCheckboxField/FiltersCheckboxField.tsx
+++ b/src/components/FiltersCheckboxField/FiltersCheckboxField.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './FiltersCheckboxField.module.css';
 import Fieldset from '../Fieldset';
 import FieldsetLegend from '../FieldsetLegend';
+import styles from './FiltersCheckboxField.module.css';
 
 export type Props = {
   /**

--- a/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
@@ -5,9 +5,9 @@ import isChromatic from 'chromatic/isChromatic';
 import React from 'react';
 
 import { FiltersDrawer } from './FiltersDrawer';
-import styles from './FiltersDrawer.stories.module.css';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { FiltersCheckboxField } from '../FiltersCheckboxField/FiltersCheckboxField';
+import styles from './FiltersDrawer.stories.module.css';
 
 export default {
   title: 'Components/FiltersDrawer',

--- a/src/components/FiltersDrawer/FiltersDrawer.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import type { ReactElement, ReactNode } from 'react';
 import React, { useEffect, useId, useRef, useState } from 'react';
-import styles from './FiltersDrawer.module.css';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Drawer from '../Drawer';
 import FiltersButton from '../FiltersButton';
 import Heading from '../Heading';
+import styles from './FiltersDrawer.module.css';
 
 export type FiltersDrawerProps = {
   /**

--- a/src/components/FiltersPopover/FiltersPopover.stories.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.stories.tsx
@@ -6,9 +6,9 @@ import React from 'react';
 
 import type { FiltersPopoverProps } from './FiltersPopover';
 import { FiltersPopover } from './FiltersPopover';
-import styles from './FiltersPopover.stories.module.css';
 import { Checkbox } from '../Checkbox/Checkbox';
 import { FiltersCheckboxField } from '../FiltersCheckboxField/FiltersCheckboxField';
+import styles from './FiltersPopover.stories.module.css';
 
 export default {
   title: 'Components/FiltersPopover',

--- a/src/components/FiltersPopover/FiltersPopover.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import React, { type ReactNode, useEffect, useRef } from 'react';
-import styles from './FiltersPopover.module.css';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import FiltersButton from '../FiltersButton';
 import type { PopoverProps } from '../Popover';
 import Popover from '../Popover';
+import styles from './FiltersPopover.module.css';
 
 export type FiltersPopoverProps = {
   /**

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Grid.module.css';
 import GridItem from '../GridItem';
+import styles from './Grid.module.css';
 
 export interface Props {
   /**

--- a/src/components/HorizontalStep/HorizontalStep.tsx
+++ b/src/components/HorizontalStep/HorizontalStep.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './HorizontalStep.module.css';
 import Icon from '../Icon';
 import NumberIcon from '../NumberIcon';
 import Text from '../Text';
+import styles from './HorizontalStep.module.css';
 
 export type Props = {
   /**

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './HorizontalStepper.module.css';
 import HorizontalStep from '../HorizontalStep';
+import styles from './HorizontalStepper.module.css';
 
 export type Props = {
   /**

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,11 +1,11 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Icon } from './Icon';
-import styles from './Icon.stories.module.css';
 import icons, { type IconName } from '../../icons/spritemap';
 import * as ColorTokens from '../../tokens-dist/ts/colors';
 import Link from '../Link';
 import Text from '../Text';
+import styles from './Icon.stories.module.css';
 
 export default {
   title: 'Components/Icon',

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode, CSSProperties } from 'react';
 import React from 'react';
-import styles from './Icon.module.css';
 import icons, { type IconName } from '../../icons/spritemap';
+import styles from './Icon.module.css';
 
 export type { IconName } from '../../icons/spritemap';
 

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './InlineNotification.module.css';
 import { Icon, Text } from '../../';
+import styles from './InlineNotification.module.css';
 
 export const VARIANTS = ['brand', 'success', 'warning', 'yield'] as const;
 

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
-import styles from './InputField.module.css';
 import FieldNote from '../FieldNote';
 import Input from '../Input';
 import Label from '../Label';
 import Text from '../Text';
+import styles from './InputField.module.css';
 
 export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
   /**

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef } from 'react';
-import styles from './Link.module.css';
 import ClickableStyle from '../ClickableStyle';
 import type { ClickableStyleProps, VariantStatus } from '../ClickableStyle';
+import styles from './Link.module.css';
 
 type LinkHTMLElementProps = Omit<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -19,7 +19,7 @@
   width: 100%;
 }
 
-.menu__button.menu__button {
+.menu__button {
   @mixin eds-theme-typography-body-text-md;
 
   color: var(--eds-theme-text-neutral-subtle);
@@ -29,7 +29,7 @@
 }
 
 /* Needed to create higher specificity than ClickableStyle. */
-.menu__button--icon.menu__button--icon.menu__button--icon.menu__button--icon {
+.menu__button--icon {
   color: var(--eds-theme-color-icon-neutral-default);
 }
 

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -3,7 +3,6 @@ import clsx from 'clsx';
 import React from 'react';
 import type { MouseEventHandler } from 'react';
 
-import styles from './Menu.module.css';
 import type { ExtractProps } from '../../util/utility-types';
 
 import ClickableStyle from '../ClickableStyle';
@@ -11,6 +10,7 @@ import Icon from '../Icon';
 import type { IconName } from '../Icon';
 import PopoverContainer from '../PopoverContainer';
 import PopoverListItem from '../PopoverListItem';
+import styles from './Menu.module.css';
 
 // Note: added className here to prevent private interface collision within HeadlessUI
 export type MenuProps = ExtractProps<typeof HeadlessMenu> & {

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -4,10 +4,10 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import { useState } from 'react';
 import { Modal, ModalContent } from './Modal';
-import styles from './Modal.stories.module.css';
 import { Button, ButtonGroup, Heading, Text, Tooltip } from '../../';
 import { chromaticViewports, storybookViewports } from '../../util/viewports';
 import { VARIANTS } from '../Heading/Heading';
+import styles from './Modal.stories.module.css';
 
 export default {
   title: 'Components/Modal',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,6 @@ import { Dialog, Transition } from '@headlessui/react';
 import clsx from 'clsx';
 import type { MutableRefObject, ReactNode } from 'react';
 import React from 'react';
-import styles from './Modal.module.css';
 import { Icon } from '../Icon/Icon';
 import type { Props as ModalBodyProps } from '../ModalBody/ModalBody';
 import { ModalBody } from '../ModalBody/ModalBody';
@@ -12,6 +11,7 @@ import type { Props as ModalHeaderProps } from '../ModalHeader/ModalHeader';
 import { ModalHeader } from '../ModalHeader/ModalHeader';
 import { ModalStepper } from '../ModalStepper/ModalStepper';
 import { ModalTitle } from '../ModalTitle/ModalTitle';
+import styles from './Modal.module.css';
 
 type Variant = 'brand' | undefined;
 

--- a/src/components/ModalStepper/ModalStepper.tsx
+++ b/src/components/ModalStepper/ModalStepper.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './ModalStepper.module.css';
 import { Icon } from '../Icon/Icon';
+import styles from './ModalStepper.module.css';
 
 export interface Props {
   /**

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './NumberIcon.module.css';
 import Icon from '../Icon';
 import Text from '../Text';
+import styles from './NumberIcon.module.css';
 
 export interface Props {
   /**

--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './PageHeader.module.css';
 import type { HeadingSize, HeadingElement } from '../Heading';
 import Heading from '../Heading';
+import styles from './PageHeader.module.css';
 
 export interface Props {
   /**

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './PageLevelBanner.module.css';
 import Button from '../Button';
 import type { HeadingElement } from '../Heading';
 import Heading from '../Heading';
 import Icon from '../Icon';
 import Text from '../Text';
+import styles from './PageLevelBanner.module.css';
 
 export type Variant = 'brand' | 'success' | 'warning' | 'error';
 

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -4,10 +4,10 @@ import clsx from 'clsx';
 import React from 'react';
 import { useState, createContext, useContext } from 'react';
 import { usePopper } from 'react-popper';
-import styles from './Popover.module.css';
 import type { ExtractProps } from '../../util/utility-types';
 import { defaultPopoverModifiers } from '../PopoverContainer';
 import PopoverContainer from '../PopoverContainer';
+import styles from './Popover.module.css';
 
 export type PopoverProps = ExtractProps<typeof HeadlessPopover> & {
   /**

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React from 'react';
 import type { ReactNode } from 'react';
-import styles from './PopoverListItem.module.css';
 
 import Icon from '../Icon';
 import type { IconName } from '../Icon';
+import styles from './PopoverListItem.module.css';
 
 export interface Props {
   /**

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import React, { useId } from 'react';
-import styles from './ProgressBar.module.css';
 import Text from '../Text';
+import styles from './ProgressBar.module.css';
 
 export type Props = {
   /**

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,10 +1,10 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
-import styles from './Radio.module.css';
 import type { RadioInputProps } from '../RadioInput';
 import RadioInput from '../RadioInput';
 import type { RadioLabelProps } from '../RadioLabel';
 import RadioLabel from '../RadioLabel';
+import styles from './Radio.module.css';
 
 export type RadioProps = RadioInputProps & {
   /**

--- a/src/components/RadioInput/RadioInput.tsx
+++ b/src/components/RadioInput/RadioInput.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './RadioInput.module.css';
 import Icon from '../Icon';
+import styles from './RadioInput.module.css';
 
 export type RadioInputProps = Omit<
   React.InputHTMLAttributes<HTMLInputElement>,

--- a/src/components/RadioLabel/RadioLabel.tsx
+++ b/src/components/RadioLabel/RadioLabel.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './RadioLabel.module.css';
 import type { InputLabelProps } from '../InputLabel/InputLabel';
 import { InputLabel } from '../InputLabel/InputLabel';
+import styles from './RadioLabel.module.css';
 
 export type RadioLabelProps = InputLabelProps;
 

--- a/src/components/Score/Score.tsx
+++ b/src/components/Score/Score.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './Score.module.css';
 import Tag from '../Tag';
+import styles from './Score.module.css';
 
 export const VARIANTS = ['table', 'error', 'success'] as const;
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './SearchBar.module.css';
 import SearchButton from '../SearchButton';
 import SearchField from '../SearchField';
+import styles from './SearchBar.module.css';
 
 export type Props = {
   /**

--- a/src/components/SearchButton/SearchButton.tsx
+++ b/src/components/SearchButton/SearchButton.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { MouseEventHandler } from 'react';
 import React from 'react';
-import styles from './SearchButton.module.css';
 import Button from '../Button';
+import styles from './SearchButton.module.css';
 
 export type SearchButtonProps = {
   /**

--- a/src/components/SearchField/SearchField.tsx
+++ b/src/components/SearchField/SearchField.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './SearchField.module.css';
 import Icon from '../Icon';
 import type { InputProps } from '../Input';
 import Input from '../Input';
+import styles from './SearchField.module.css';
 
 /**
  * BETA: This component is still a work in progress and is subject to change.

--- a/src/components/Section/Section.stories.tsx
+++ b/src/components/Section/Section.stories.tsx
@@ -1,10 +1,10 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Section } from './Section';
-import styles from './Section.stories.module.css';
 import Button from '../Button';
 import Icon from '../Icon';
 import Text from '../Text';
+import styles from './Section.stories.module.css';
 
 export default {
   title: 'Components/Section',

--- a/src/components/Section/Section.tsx
+++ b/src/components/Section/Section.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Section.module.css';
 import type { HeadingElement, HeadingSize } from '../Heading';
 import Heading from '../Heading';
+import styles from './Section.module.css';
 export interface Props {
   /**
    * Align variations:

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 import React from 'react';
 import type { OptionsAlignType, VariantType } from './Select';
 import { Select } from './Select';
-import styles from './Select.stories.module.css';
 import Icon from '../Icon';
+import styles from './Select.stories.module.css';
 
 export default {
   title: 'Components/Select',

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -2,7 +2,6 @@ import { Listbox } from '@headlessui/react';
 import clsx from 'clsx';
 import type { ReactElement, ReactNode, ElementType } from 'react';
 import React, { useContext } from 'react';
-import styles from './Select.module.css';
 
 import type { ExtractProps } from '../../util/utility-types';
 
@@ -10,6 +9,7 @@ import Icon from '../Icon';
 
 import PopoverContainer from '../PopoverContainer';
 import PopoverListItem from '../PopoverListItem';
+import styles from './Select.module.css';
 
 export type OptionsAlignType = 'left' | 'right';
 export type VariantType = 'compact' | 'full';

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -3,12 +3,12 @@ import type { StoryObj, Meta } from '@storybook/react';
 import React, { useState } from 'react';
 
 import { Table } from './Table';
-import styles from './Table.stories.module.css';
 import TableBody from '../TableBody';
 import TableCell from '../TableCell';
 import TableHeader from '../TableHeader';
 import type { SortDirectionsType } from '../TableHeaderCell';
 import TableRow from '../TableRow';
+import styles from './Table.stories.module.css';
 
 export default {
   title: 'Components/Table',

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Table.module.css';
 import TableBody from '../TableBody';
 import TableCaption from '../TableCaption';
 import TableCell from '../TableCell';
@@ -9,6 +8,7 @@ import TableFooter from '../TableFooter';
 import TableHeader from '../TableHeader';
 import TableHeaderCell from '../TableHeaderCell';
 import TableRow from '../TableRow';
+import styles from './Table.module.css';
 
 export type Props = React.TableHTMLAttributes<HTMLTableElement> & {
   /**

--- a/src/components/TableHeaderCell/TableHeaderCell.tsx
+++ b/src/components/TableHeaderCell/TableHeaderCell.tsx
@@ -1,9 +1,9 @@
 import clsx from 'clsx';
 import React from 'react';
 import type { ReactNode, MouseEventHandler } from 'react';
-import styles from './TableHeaderCell.module.css';
 import Button from '../Button';
 import Icon from '../Icon';
+import styles from './TableHeaderCell.module.css';
 
 export type Props = React.ThHTMLAttributes<HTMLTableCellElement> & {
   /**

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -11,7 +11,6 @@ import React, {
   type KeyboardEvent,
 } from 'react';
 import { allByType } from 'react-children-by-type';
-import styles from './Tabs.module.css';
 import {
   L_ARROW_KEYCODE,
   U_ARROW_KEYCODE,
@@ -19,6 +18,7 @@ import {
   D_ARROW_KEYCODE,
 } from '../../util/keycodes';
 import Tab from '../Tab';
+import styles from './Tabs.module.css';
 
 export interface Props {
   /**

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -1,8 +1,8 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 import { Tag, VARIANTS } from './Tag';
-import styles from './Tag.stories.module.css';
 import Icon from '../Icon';
+import styles from './Tag.stories.module.css';
 
 export default {
   title: 'Components/Tag',

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './Tag.module.css';
 import Text from '../Text';
+import styles from './Tag.module.css';
 
 export const VARIANTS = [
   'neutral',

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
-import styles from './TextareaField.module.css';
 import FieldNote from '../FieldNote';
 import Label from '../Label';
 import Text from '../Text';
 import TextArea from '../TextArea';
+import styles from './TextareaField.module.css';
 
 export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   /**

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -2,7 +2,6 @@ import clsx from 'clsx';
 import type { KeyboardEventHandler, ReactNode } from 'react';
 import React, { useCallback, useId, useEffect, useRef, useState } from 'react';
 import { allByType } from 'react-children-by-type';
-import styles from './TimelineNav.module.css';
 import {
   L_ARROW_KEYCODE,
   U_ARROW_KEYCODE,
@@ -16,6 +15,7 @@ import Icon from '../Icon';
 import NumberIcon from '../NumberIcon';
 import type { TimelineNavPanelVariant } from '../TimelineNavPanel';
 import TimelineNavPanel from '../TimelineNavPanel';
+import styles from './TimelineNav.module.css';
 
 export interface Props {
   /**

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import React from 'react';
-import styles from './Toast.module.css';
 import Button from '../Button';
 import Icon from '../Icon';
+import styles from './Toast.module.css';
 
 export type Variant = 'success' | 'error';
 

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -1,8 +1,8 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
-import styles from './Toolbar.module.css';
 import ToolbarItem from '../ToolbarItem';
+import styles from './Toolbar.module.css';
 
 export interface Props {
   /**

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -3,8 +3,8 @@ import type { Meta, Story, StoryObj } from '@storybook/react';
 import clsx from 'clsx';
 import React from 'react';
 import { Tooltip } from './Tooltip';
-import styles from './Tooltip.stories.module.css';
 import { Button } from '../Button/Button';
+import styles from './Tooltip.stories.module.css';
 
 const defaultArgs = {
   text: (


### PR DESCRIPTION
### Summary:
- found out that css modules get loaded on demand, meaning if a component specific style sheet is imported before a subcomponent, the subcomponent style sheet will be imported into the html farther down than the component style sheet, causing specificity issues
  - we generally want the component styles to have priority over the styles of the consumed component
- added lint rule to ensure css module style sheet is imported after the components
- removed doubling of AccordionButton, Button, Menu Button class selectors in their css files
- added `:where` pseudoselectors to `ClickableStyle.module.css` to keep specificity to (0,1,0) so they can be overriden via class styling
- ran `yarn lint --fix` to push css module imports to the end of imports
### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
  - new lint rule 
- [x] CI tests pass
  - no visual regression, despite some styles specificity updates
