### PR TITLE
Use our shared prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "trailingComma": "all",
-  "singleQuote": true,
-  "plugins": ["@chanzuckerberg/prettier-config-edu"]
-}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,9 @@
+const config = require('@chanzuckerberg/prettier-config-edu');
+
+module.exports = {
+  ...config,
+
+  // Override of our shared config. Should we remove this and use the same config as our other
+  // repos? Doing so would result in a large diff (every file would be updated).
+  bracketSpacing: true,
+};


### PR DESCRIPTION
### Summary:

Not sure if this was intended from #1457 or not, but it turns out we aren't actually using our shared prettier config. More deets inline.

This PR
- Fixes that so we're using prettier-config-edu.
- Introduces an override to avoid a large diff. We may want to remove this override at some point, though.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Introduced prettier violations
  - Observed prettier complaining/fixing
