### PR TITLE
refactor(breadcrumbs): use useEffect over useLayoutEffect

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -43,11 +43,7 @@ export const Breadcrumbs = ({
 
   const ref = React.useRef<HTMLUListElement>(null);
 
-  /**
-   * Needs useLayoutEffect over useEffect since it needs to be run before paint.
-   * Note: with React 18, might be able to use useEffect https://github.com/reactjs/reactjs.org/blob/d14cbdca2445cd676526c4c52e1e106342ff7bb3/content/docs/hooks-reference.md?plain=1#L155
-   */
-  React.useLayoutEffect(() => {
+  React.useEffect(() => {
     const updateShouldTruncate = () => {
       const willOverflow = ref.current
         ? ref.current.clientWidth < ref.current.scrollWidth


### PR DESCRIPTION
### Summary:
- with react 18, [useEffect fires synchronously before layout](https://github.com/reactjs/reactjs.org/blob/d14cbdca2445cd676526c4c52e1e106342ff7bb3/content/docs/hooks-reference.md?plain=1#L155) so can use useEffect over useLayoutEffect

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
