### PR TITLE
refactor(tailwind): configure tw config for export

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Install Dependencies ⬆️
         run: yarn install --immutable
 
+      - name: Build design tokens # required since there are references to built tokens
+        run: yarn build:tokens
+
       - name: Lint Commit Messages 👕
         uses: wagoid/commitlint-github-action@v1
         env:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "yarn build:clean && yarn build:tokens && yarn build:js && yarn build:styles && yarn copy-fonts-to-lib",
     "build:clean": "rm -rf lib/",
-    "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn prettier-tokens-dist && yarn copy-tokens-to-lib",
+    "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn copy-tokens-to-lib && yarn prettier-tokens-dist",
     "build:js": "tsc --project tsconfig.build.json",
     "build:storybook": "build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",
     "build:styles": "postcss \"src/components/**/*.css\" --dir lib/ --base src/ --verbose",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,12 +23,15 @@ module.exports = {
       ...colorTokens,
     },
     backgroundColor: {
+      ...colorTokens,
       ...backgroundColorTokens,
     },
     borderColor: {
+      ...colorTokens,
       ...borderColorTokens,
     },
     textColor: {
+      ...colorTokens,
       ...textColorTokens,
     },
     fontSize: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,17 +22,16 @@ module.exports = {
     colors: {
       ...colorTokens,
     },
-    backgroundColor: {
-      ...colorTokens,
-      ...backgroundColorTokens,
-    },
-    borderColor: {
-      ...colorTokens,
-      ...borderColorTokens,
-    },
-    textColor: {
-      ...colorTokens,
-      ...textColorTokens,
+    extend: {
+      backgroundColor: {
+        ...backgroundColorTokens,
+      },
+      borderColor: {
+        ...borderColorTokens,
+      },
+      textColor: {
+        ...textColorTokens,
+      },
     },
     fontSize: {
       // provide values for both font-size and line-height

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,11 @@
-const variableTokens = require('./src/tokens-dist/json/css-variables-nested.json');
-const staticTokens = require('./src/tokens-dist/json/variables-nested.json');
+const edsTokens = require('./lib/tokens/json/css-variables-nested.json').eds;
 
 const {
   background: backgroundColorTokens,
   border: borderColorTokens,
   text: textColorTokens,
   ...colorTokens
-} = variableTokens.eds.theme.color;
+} = edsTokens.theme.color;
 
 module.exports = {
   /**
@@ -35,22 +34,22 @@ module.exports = {
     fontSize: {
       // provide values for both font-size and line-height
       // sync with src/design-tokens/tier-1-definitions/typography-presets.css
-      body: [staticTokens.eds['font-size']['16'], '1.5'],
-      h1: [staticTokens.eds['font-size']['40'], '1.2'],
-      h2: [staticTokens.eds['font-size']['32'], '1.25'],
-      h3: [staticTokens.eds['font-size']['24'], '1.333'],
-      h4: [staticTokens.eds['font-size']['18'], '1.333'],
-      h5: [staticTokens.eds['font-size']['16'], '1.5'],
-      h6: [staticTokens.eds['font-size']['14'], '1.57'],
-      h7: [staticTokens.eds['font-size']['12'], '1.666'],
-      sm: [staticTokens.eds['font-size']['14'], '1.57'],
-      xs: [staticTokens.eds['font-size']['12'], '1.666'],
-      caption: [staticTokens.eds['font-size']['12'], '1.666'],
+      body: [edsTokens['font-size']['16'], '1.5'],
+      h1: [edsTokens['font-size']['40'], '1.2'],
+      h2: [edsTokens['font-size']['32'], '1.25'],
+      h3: [edsTokens['font-size']['24'], '1.333'],
+      h4: [edsTokens['font-size']['18'], '1.333'],
+      h5: [edsTokens['font-size']['16'], '1.5'],
+      h6: [edsTokens['font-size']['14'], '1.57'],
+      h7: [edsTokens['font-size']['12'], '1.666'],
+      sm: [edsTokens['font-size']['14'], '1.57'],
+      xs: [edsTokens['font-size']['12'], '1.666'],
+      caption: [edsTokens['font-size']['12'], '1.666'],
     },
     fontWeight: {
-      normal: staticTokens.eds['font-weight'].light,
-      medium: staticTokens.eds['font-weight'].medium,
-      bold: staticTokens.eds['font-weight'].bold,
+      normal: edsTokens['font-weight'].light,
+      medium: edsTokens['font-weight'].medium,
+      bold: edsTokens['font-weight'].bold,
     },
     // sync with src/design-tokens/tier-1-definitions/breakpoints.js
     screens: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,13 @@
 const variableTokens = require('./src/tokens-dist/json/css-variables-nested.json');
 const staticTokens = require('./src/tokens-dist/json/variables-nested.json');
 
+const {
+  background: backgroundColorTokens,
+  border: borderColorTokens,
+  text: textColorTokens,
+  ...colorTokens
+} = variableTokens.eds.theme.color;
+
 module.exports = {
   /**
    * The main value in TW utility classes is for Storybook stories & recipes.
@@ -14,9 +21,16 @@ module.exports = {
   ],
   theme: {
     colors: {
-      transparent: 'transparent',
-      ...variableTokens.eds.color,
-      ...variableTokens.eds.theme.color,
+      ...colorTokens,
+    },
+    backgroundColor: {
+      ...backgroundColorTokens,
+    },
+    borderColor: {
+      ...borderColorTokens,
+    },
+    textColor: {
+      ...textColorTokens,
     },
     fontSize: {
       // provide values for both font-size and line-height


### PR DESCRIPTION
[EDS-813]

### Summary:
- dedupes words for TW utility classes
![image](https://user-images.githubusercontent.com/86632227/223955216-26d39abe-dc1d-4c52-bb03-4692a51f7bcf.png)
- in screenshot: 
  - can see it's no longer `border-border-link-neutral` and simply `border-link-neutral`
  - `bg-link-neutral` is not associated with any styles because `link-neutral` is border specific
  - `bg-icon-neutral-default` is still applicable since `icon-neutral-default` is not bg/border/text specific
- grabs tokens from one file in `lib` instead of `src` since `lib` is part of EDS package

- purpose is so pilots can import eds tw config and use out of the box with only adding `content` property to config
- does not provide primary color tokens for use 

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.


[EDS-813]: https://czi-tech.atlassian.net/browse/EDS-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ