### PR TITLE
ci: bump gh action checkout and commitlint

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node 😻
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -1,4 +1,4 @@
-name: "Bundle Size"
+name: 'Bundle Size'
 on:
   pull_request:
     branches:
@@ -10,7 +10,7 @@ jobs:
     env:
       CI_JOB_NUMBER: 1
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: andresz1/size-limit-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Lint Commit Messages 👕
-        uses: wagoid/commitlint-github-action@v1
+        uses: wagoid/commitlint-github-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node 😻
         uses: actions/setup-node@v3
         with:
@@ -28,7 +28,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node 😻
         uses: actions/setup-node@v3
         with:
@@ -70,7 +70,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
### Summary:
Was getting warnings about deprecations in ci jobs:
![image](https://user-images.githubusercontent.com/86632227/224232601-2ebe80be-4b5d-403d-aa0c-edc1d27fdaeb.png)
Bumps actions/checkout to v3 and commitlint-github-action to v5

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable
  - Deprecation messages now gone
  - CI tests run without fail
  - [x] size limit still works
