### PR TITLE
refactor: remove unused unnecessary resets

### DIFF
--- a/.storybook/recipes/PrimaryNav/PrimaryNav.module.css
+++ b/.storybook/recipes/PrimaryNav/PrimaryNav.module.css
@@ -77,7 +77,6 @@
  The actual list of nav items.
  */
 .primary-nav__list {
-  @mixin reset;
   list-style: none;
   display: flex;
   flex-direction: column;

--- a/.storybook/recipes/PrimaryNav/PrimaryNav.stories.tsx
+++ b/.storybook/recipes/PrimaryNav/PrimaryNav.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { PrimaryNav } from './PrimaryNav';
 
 export default {
-  title: 'Components/PrimaryNav',
+  title: 'Recipes/PrimaryNav',
   component: PrimaryNav,
   subcomponents: { 'PrimaryNav.Item': PrimaryNav.Item },
   decorators: [

--- a/src/components/Breadcrumbs/Breadcrumbs.module.css
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.css
@@ -1,5 +1,3 @@
-@import '../../design-tokens/mixins.css';
-
 /*------------------------------------*\
     # BREADCRUMBS
 \*------------------------------------*/
@@ -14,7 +12,6 @@
  * Breadcrumbs list
  */
 .breadcrumbs__list {
-  @mixin reset;
   list-style: none;
   display: flex;
 }

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -56,8 +56,6 @@
  * Ellipsis variant of the breadcrumbs list item.
  */
 .breadcrumbs__ellipsis {
-  /* Remove default browser styles for <button> and make more like a link. */
-  @mixin reset;
   border: none;
   background-color: transparent;
   cursor: pointer;

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -41,7 +41,6 @@
  * Dropdown menu list.
  */
 .dropdown-menu__list {
-  @mixin reset;
   list-style: none;
 }
 

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -1,5 +1,3 @@
-@import '../../design-tokens/mixins.css';
-
 /*------------------------------------*\
     # MODAL
 \*------------------------------------*/
@@ -130,7 +128,6 @@
  * The modal close button.
  */
 .modal__close-button {
-  @mixin reset;
   border: 0;
   background-color: transparent;
 

--- a/src/components/PageHeader/PageHeader.module.css
+++ b/src/components/PageHeader/PageHeader.module.css
@@ -1,5 +1,3 @@
-@import '../../design-tokens/mixins.css';
-
 /*------------------------------------*\
     # PAGE HEADER
 \*------------------------------------*/
@@ -70,12 +68,8 @@
 /**
  * Page header title
  */
-.page-header__title {
-  @mixin reset;
-
-  .page-header--center & {
-    text-align: center;
-  }
+.page-header--center .page-header__title {
+  text-align: center;
 }
 
 /**
@@ -92,7 +86,6 @@
  * Page description
  */
 .page-header__description {
-  @mixin reset;
   color: var(--eds-theme-color-text-neutral-subtle);
   margin-top: var(--eds-size-1);
 

--- a/src/components/Tabs/Tabs.module.css
+++ b/src/components/Tabs/Tabs.module.css
@@ -57,7 +57,6 @@
  * Actual unordered list of tabs.
  */
 .tabs__list {
-  @mixin reset;
   list-style: none;
   /* Set to display flex to place tabs side by side. */
   display: flex;

--- a/src/components/TimelineNav/TimelineNav.module.css
+++ b/src/components/TimelineNav/TimelineNav.module.css
@@ -125,8 +125,6 @@
  * Actual unordered list of timeline-nav.
  */
 .timeline-nav__list {
-  @mixin reset;
-  list-style: none;
   @mixin eds-theme-typography-body-text;
 
   @media all and (min-width: $eds-bp-lg) {

--- a/src/components/Toast/Toast.module.css
+++ b/src/components/Toast/Toast.module.css
@@ -65,7 +65,6 @@
  * The text in the toast. Styled via mixins over using Text component.
  */
 .toast__text {
-  @mixin reset;
   @mixin eds-typography-preset-007;
 
   color: inherit;

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -1,23 +1,6 @@
 @import '../design-tokens/tier-2-usage/typography-usage.css';
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600&display=swap');
 
-@define-mixin reset {
-  margin: 0;
-  padding: 0;
-}
-
-/**
-* Reset all
-*
-* The 'all' shorthand CSS property resets all of an element's properties except unicode-bidi,
-* direction, and CSS Custom Properties. The value 'unset' specifies that all of an element's
-* properties should be changed to their inherited values if they inherit by default, or to their
-* initial values if not.
-*/
-@define-mixin resetAll {
-  all: unset !important;
-}
-
 /**
  * Link button styles
  */


### PR DESCRIPTION
[EDS-835]

### Summary:
- removes reset mixin which is duplicative of tailwind preflight 
- also removes resetAll mixin which was never used

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
  - No visual regression expected
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Checked on storybook of changed stories and saw that the styles were being applied from preflight after removing


[EDS-835]: https://czi-tech.atlassian.net/browse/EDS-835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ