### PR TITLE
feat: add utility types to enforce either label or aria-label 

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -11,16 +11,6 @@ const { Default } = composeStories(stories);
 describe('<Checkbox />', () => {
   generateSnapshots(stories);
 
-  test('throws an error if no label or aria-label', () => {
-    // expect console error from react, suppressed.
-    const consoleErrorMock = jest.spyOn(console, 'error');
-    consoleErrorMock.mockImplementation();
-    expect(() => {
-      render(<Checkbox />);
-    }).toThrow(/must provide a visible label or aria-label/);
-    consoleErrorMock.mockRestore();
-  });
-
   test('Disabled story renders snapshot', () => {
     const { container } = render(<Checkbox disabled label="Disabled" />);
     // eslint-disable-next-line testing-library/no-node-access

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
+import type { EitherInclusive } from '../../util/utility-types';
 import type { CheckboxInputProps } from '../CheckboxInput';
 import CheckboxInput from '../CheckboxInput';
 import type { CheckboxLabelProps } from '../CheckboxLabel';
@@ -15,14 +16,23 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
    */
   id?: string;
   /**
-   * Visible text label for the checkbox.
-   */
-  label?: React.ReactNode;
-  /**
    * Size of the checkbox label.
    */
   size?: CheckboxLabelProps['size'];
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: React.ReactNode;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 /**
  * `import {Checkbox} from "@chanzuckerberg/eds";`
@@ -31,29 +41,13 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
  *
  * Checkbox control indicating if something is selected or unselected.
  *
- * Requires either a visible label or an accessible name.
- *
- * NOTE: usually, we would re-export subcomponents with
- *   Checkbox.Input = CheckboxInput;
- *   Checkbox.Label = CheckboxLabel;
- * but this does not compile with Typescript since Checkbox itself is a
- * forwarded ref component. Thus Input and Label must be imported separately.
+ * NOTE: Requires either a visible label or `aria-label` prop.
  */
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
     // All remaining props are passed to the `input` element
     const { className, id, label, size = 'lg', disabled, ...other } = props;
 
-    // When possible, use a visible label through the `label` prop instead.
-    // In rare cases where there's no visible label, you must provide an
-    // `aria-label` for screen readers.
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      !label &&
-      !props['aria-label']
-    ) {
-      throw new Error('You must provide a visible label or aria-label');
-    }
     const generatedId = useId();
     const checkboxId = id || generatedId;
 
@@ -75,4 +69,11 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   },
 );
 
+/**
+ * NOTE: usually, we would re-export subcomponents with
+ *   Checkbox.Input = CheckboxInput;
+ *   Checkbox.Label = CheckboxLabel;
+ * but this does not compile with Typescript since Checkbox itself is a
+ * forwarded ref component. Thus Input and Label must be imported separately.
+ */
 Checkbox.displayName = 'Checkbox';

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
+import type { EitherInclusive } from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Input from '../Input';
 import Label from '../Label';
@@ -8,10 +9,6 @@ import Text from '../Text';
 import styles from './InputField.module.css';
 
 export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
-  /**
-   * Aria-label to provide an accesible name for the text input if no visible label is provided.
-   */
-  'aria-label'?: string;
   /**
    * CSS class names that can be appended to the component.
    */
@@ -48,10 +45,6 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    * Error state of the form field
    */
   isError?: boolean;
-  /**
-   * HTML label text
-   */
-  label?: string;
   /**
    * Maximum value allowed for the input, if type is 'number'. When the input value matches this maximum, the plus button becomes disabled.
    */
@@ -113,7 +106,20 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    * Default value passed down from higher levels for initial state
    */
   defaultValue?: string | number;
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: string;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 /**
  * `import {InputField} from "@chanzuckerberg/eds";`
@@ -137,14 +143,6 @@ export const InputField = forwardRef<HTMLInputElement, Props>(
     },
     ref,
   ) => {
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      !label &&
-      !other['aria-label']
-    ) {
-      throw new Error('You must provide a visible label or aria-label');
-    }
-
     const shouldRenderOverline = !!(label || required);
     const overlineClassName = clsx(
       styles['input-field__overline'],

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -3,22 +3,12 @@ import { composeStories } from '@storybook/testing-react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Radio } from './Radio';
 import * as stories from './Radio.stories';
 
 const { Default } = composeStories(stories);
 
 describe('<Radio />', () => {
   generateSnapshots(stories);
-  test('throws an error if no label or aria-label', () => {
-    // expect console error from react, suppressed.
-    const consoleErrorMock = jest.spyOn(console, 'error');
-    consoleErrorMock.mockImplementation();
-    expect(() => {
-      render(<Radio />);
-    }).toThrow(/must provide a visible label or aria-label/);
-    consoleErrorMock.mockRestore();
-  });
 
   test('should toggle the radio with space', async () => {
     const user = userEvent.setup();

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
+import type { EitherInclusive } from '../../util/utility-types';
 import type { RadioInputProps } from '../RadioInput';
 import RadioInput from '../RadioInput';
 import type { RadioLabelProps } from '../RadioLabel';
@@ -13,14 +14,23 @@ export type RadioProps = RadioInputProps & {
    */
   id?: string;
   /**
-   * Visible text label for the radio.
-   */
-  label?: React.ReactNode;
-  /**
    * Size of the radio label.
    */
   size?: RadioLabelProps['size'];
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: React.ReactNode;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 /**
  * BETA: This component is still a work in progress and is subject to change.
@@ -28,6 +38,8 @@ export type RadioProps = RadioInputProps & {
  * `import {Radio} from "@chanzuckerberg/eds";`
  *
  * This component provides a radio component and a label for form selection.
+ *
+ * NOTE: This component requires `label` or `aria-label` prop
  */
 export const Radio = ({
   className,
@@ -37,13 +49,6 @@ export const Radio = ({
   size,
   ...other
 }: RadioProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    !label &&
-    !('aria-label' in other)
-  ) {
-    throw new Error('You must provide a visible label or aria-label');
-  }
   const generatedId = useId();
   const radioId = id || generatedId;
 

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -7,15 +7,6 @@ import Slider from './';
 describe('<Slider />', () => {
   generateSnapshots(stories);
   describe('error throws', () => {
-    it('throws an error if no label or aria-label', () => {
-      // expect console error from react, suppressed.
-      const consoleErrorMock = jest.spyOn(console, 'error');
-      consoleErrorMock.mockImplementation();
-      expect(() => {
-        render(<Slider max={5} min={0} step={1} value={2} />);
-      }).toThrow(/You must provide a visible label or aria-label/);
-      consoleErrorMock.mockRestore();
-    });
     it('throws an error if told to generate markers, but steps are not integers', () => {
       // expect console error from react, suppressed.
       const consoleErrorMock = jest.spyOn(console, 'error');

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -5,16 +5,13 @@ import React, {
   type CSSProperties,
 } from 'react';
 import { findLowestTenMultiplier } from '../../util/findLowestTenMultiplier';
+import type { EitherInclusive } from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Label from '../Label';
 import Text from '../Text';
 import styles from './Slider.module.css';
 
 export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
-  /**
-   * Aria-label to provide an accesible name for the text input if no visible label is provided.
-   */
-  'aria-label'?: string;
   /**
    * CSS class names that can be appended to the component.
    */
@@ -32,10 +29,6 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    * HTML id for the component
    */
   id?: string;
-  /**
-   * HTML label text
-   */
-  label?: string;
   /**
    * List of markers to imply slider value.
    * As 'number', will automatically generate markers based on min, max, and step.
@@ -62,7 +55,20 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    * Value denoted by the slider.
    */
   value: number;
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: string;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 /**
  * BETA: This component is still a work in progress and is subject to change.
@@ -72,6 +78,8 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
  * Allows input of a value via dragging a thumb along a track.
  * Strict: This slider requires a visual indicator of value/markers.
  * Please check out our recipes for possible ideas.
+ *
+ * NOTE: This component requires `label` or `aria-label` prop
  */
 export const Slider = ({
   className,
@@ -86,10 +94,6 @@ export const Slider = ({
   value,
   ...other
 }: Props) => {
-  if (process.env.NODE_ENV !== 'production' && !label && !other['aria-label']) {
-    throw new Error('You must provide a visible label or aria-label');
-  }
-
   // Required due to 0.1 + 0.2 != 0.3
   const multiplier = findLowestTenMultiplier([max, min, step]);
   const markersCount =

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
+import type { EitherInclusive } from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Label from '../Label';
 import Text from '../Text';
@@ -8,10 +9,6 @@ import TextArea from '../TextArea';
 import styles from './TextareaField.module.css';
 
 export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
-  /**
-   * Aria-label to provide an accesible name for the text input if no visible label is provided.
-   */
-  'aria-label'?: string;
   /**
    * Text content of the field upon instantiation
    */
@@ -36,11 +33,20 @@ export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
    * Error state of the form field
    */
   isError?: boolean;
-  /**
-   * HTML label text (used in an accessory label component)
-   */
-  label?: string;
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: string;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 /**
  * BETA: This component is still a work in progress and is subject to change.
@@ -50,6 +56,8 @@ export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
  * Multi-line text input field with built-in labeling and accessory text to describe
  * the content. When a maximum text count is specified, component also shows relevant
  * text up to the maximum.
+ *
+ * NOTE: This component requires `label` or `aria-label` prop
  */
 export const TextareaField = forwardRef<HTMLTextAreaElement, Props>(
   (
@@ -67,14 +75,6 @@ export const TextareaField = forwardRef<HTMLTextAreaElement, Props>(
     },
     ref,
   ) => {
-    if (
-      process.env.NODE_ENV !== 'production' &&
-      !label &&
-      !other['aria-label']
-    ) {
-      throw new Error('You must provide a visible label or aria-label');
-    }
-
     const shouldRenderOverline = !!(label || required);
     const overlineClassName = clsx(
       styles['textarea-field__overline'],

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,7 +1,7 @@
 import { Switch } from '@headlessui/react';
 import clsx from 'clsx';
 import React from 'react';
-import type { ExtractProps } from '../../util/utility-types';
+import type { EitherInclusive, ExtractProps } from '../../util/utility-types';
 import styles from './Toggle.module.css';
 
 type ToggleLabelProps = {
@@ -35,21 +35,21 @@ type ToggleButtonProps = {
 };
 
 type ToggleProps = ToggleButtonProps & {
-  /**
-   * When possible, use a visible label through the `label` prop instead.
-   * In rare cases where there's no visible label, you must provide an
-   * `aria-label` for screen readers.
-   */
-  'aria-label'?: string;
-  /**
-   * Visible text label for the toggle.
-   */
   children?: React.ReactNode;
-  /**
-   * Visible text label for the toggle.
-   */
-  label?: React.ReactNode;
-};
+} & EitherInclusive<
+    {
+      /**
+       * Visible text label for the component.
+       */
+      label: React.ReactNode;
+    },
+    {
+      /**
+       * Aria-label to provide an accesible name for the text input if no visible label is provided.
+       */
+      'aria-label': string;
+    }
+  >;
 
 const ToggleLabel = ({ children, className }: ToggleLabelProps) => {
   const componentClassName = clsx(styles['toggle__label'], className);
@@ -100,16 +100,10 @@ const ToggleWrapper = (props: ExtractProps<typeof Switch.Group>) => (
  *   <Toggle.Button onChange={onChange} checked={checked} className={customCssModulesClassname} />
  * </Toggle.Wrapper>
  * ```
+ *
+ * NOTE: This component requires `label` or `aria-label` prop
  */
 export const Toggle = ({ label, ...other }: ToggleProps) => {
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    !label &&
-    !('aria-label' in other)
-  ) {
-    throw new Error('You must provide a visible label or aria-label');
-  }
-
   return label ? (
     <ToggleWrapper as="div" className={styles['toggle__wrapper']}>
       <ToggleButton {...other} />

--- a/src/util/utility-types.ts
+++ b/src/util/utility-types.ts
@@ -4,3 +4,31 @@
  * Required since React.ComponentProps doesn't think it's a JSXElementConstructor/ReactElement. https://github.com/FB-PLP/traject/pull/11929/files#r948531375
  */
 export type ExtractProps<T> = T extends React.ComponentType<infer P> ? P : T;
+
+/**
+ * Given two object types, only the first is a valid object type.
+ *
+ * @example
+ * Given A { keyA: string } and B { keyB: number }, Only<A, B> becomes
+ *
+ * { keyA: string, keyB?: never }
+ */
+export type Only<T, U> = {
+  [P in keyof T]: T[P];
+} & {
+  [P in keyof U]?: never;
+};
+
+/**
+ * Given two object types, specify that only one of them can be in
+ * the structure at a given time.
+ */
+export type EitherExclusive<T, U> = Only<T, U> | Only<U, T>;
+
+/**
+ * Given two object types, specify that one or both of them can be in
+ * the structure at a given time.
+ *
+ * TypeScript will hint to apply the first type, T, if both are missing
+ */
+export type EitherInclusive<T, U> = EitherExclusive<T, U> | (T & U);


### PR DESCRIPTION
### Summary:

- we have a chunk of boilerplate code for checking labels on some components. since the text was the same from component to component, there was some confusion on which component was causing the error. use types to assert the needed props (1 of 2 labeling props as necessary), and document this in the intellisense popups as a component note
 
### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - existing test suite with language updates