### PR TITLE
test(courseplannermodal): disable flaky rule for final step

### DIFF
--- a/.storybook/pages/CoursePlannerModal/CoursePlannerModal.stories.tsx
+++ b/.storybook/pages/CoursePlannerModal/CoursePlannerModal.stories.tsx
@@ -19,4 +19,12 @@ export const Brand: StoryObj = {
 
 export const FinalStep: StoryObj = {
   render: () => <ModalFinalStep />,
+  parameters: {
+    axe: {
+      /**
+       * Axe testing is flaky here, but is tested across the other modal stories and would be testing Headless Dialog functionality anyways.
+       */
+      disabledRules: ['aria-dialog-name'],
+    },
+  },
 };


### PR DESCRIPTION
### Summary:
- disables flaky axe test for cad modal final step page
### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
