### PR TITLE
test(courseplannermodal): disable flaky rule for all steps

### DIFF
--- a/.storybook/pages/CoursePlannerModal/CoursePlannerModal.stories.tsx
+++ b/.storybook/pages/CoursePlannerModal/CoursePlannerModal.stories.tsx
@@ -7,6 +7,14 @@ import { ModalFirstStep } from './ModalFirstStep';
 
 export default {
   title: 'Pages/Course Planner/Modal',
+  parameters: {
+    axe: {
+      /**
+       * Axe testing is flaky here, but is tested across the component modal stories and would be testing Headless Dialog functionality anyways.
+       */
+      disabledRules: ['aria-dialog-name'],
+    },
+  },
 };
 
 export const FirstStep: StoryObj = {
@@ -19,12 +27,4 @@ export const Brand: StoryObj = {
 
 export const FinalStep: StoryObj = {
   render: () => <ModalFinalStep />,
-  parameters: {
-    axe: {
-      /**
-       * Axe testing is flaky here, but is tested across the other modal stories and would be testing Headless Dialog functionality anyways.
-       */
-      disabledRules: ['aria-dialog-name'],
-    },
-  },
 };


### PR DESCRIPTION
### Summary:
- since it seems this flakes across all CAD modal page stories,  now disabling `aria-dialog-name` axe rule across all CAD modal page stories

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable