### PR TITLE
docs: use args.defaultValue instead of argTypes.prop.defaultValue

### DIFF
--- a/.storybook/recipes/MenuWithIconButton.stories.tsx
+++ b/.storybook/recipes/MenuWithIconButton.stories.tsx
@@ -13,11 +13,13 @@ export default {
     badges: [BADGE.BETA],
     layout: 'centered',
   },
+  args: {
+    iconName: 'dots-vertical',
+  },
   argTypes: {
     iconName: {
       control: 'radio',
       options: Object.keys(icons),
-      defaultValue: 'dots-vertical',
     },
   },
 } as Meta<{ iconName: IconName }>;


### PR DESCRIPTION
### Summary:

Storybook 7.0 deprecates using argTypes.$propName.defaultValue to infer what control value to select. Use the migration guide to fix up the cases in EDS that violate that (just one).

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Verify the vertical dots icon is selected when refreshing story "?path=/docs/recipes-menuwithiconbutton--with-vertical-dots-button"