### PR TITLE
feat(Menu): update centering with plain button

### DIFF
--- a/.storybook/recipes/MenuWithAvatarButton.stories.tsx
+++ b/.storybook/recipes/MenuWithAvatarButton.stories.tsx
@@ -3,25 +3,15 @@ import type { StoryObj, Meta } from '@storybook/react';
 import { userEvent } from '@storybook/testing-library';
 import React from 'react';
 
-import { Icon, type IconName } from '../../src';
+import { Avatar } from '../../src';
 import { Menu } from '../../src/components/Menu/Menu';
-import icons from '../../src/icons/spritemap';
 
 export default {
-  title: 'Recipes/MenuWithIconButton',
+  title: 'Recipes/MenuWithAvatarButton',
   component: Menu,
   parameters: {
     badges: [BADGE.BETA],
     layout: 'centered',
-  },
-  args: {
-    iconName: 'dots-vertical',
-  },
-  argTypes: {
-    iconName: {
-      control: 'radio',
-      options: Object.keys(icons),
-    },
   },
   decorators: [
     (Story) => (
@@ -30,15 +20,10 @@ export default {
       </div>
     ),
   ],
-  render: ({ iconName }) => (
+  render: () => (
     <Menu>
       <Menu.PlainButton>
-        <Icon
-          name={iconName}
-          purpose="informative"
-          size="2rem"
-          title="show more"
-        />
+        <Avatar user={{ fullName: 'Josie Sandberg' }} />
       </Menu.PlainButton>
       <Menu.Items data-testid="menu-content">
         <Menu.Item
@@ -63,9 +48,11 @@ export default {
       </Menu.Items>
     </Menu>
   ),
-} as Meta<{ iconName: IconName }>;
+} as Meta<Args>;
 
-export const WithVerticalDotsButton: StoryObj = {};
+type Args = React.ComponentProps<typeof Avatar>;
+
+export const WithAvatarButton: StoryObj = {};
 
 export const Focused: StoryObj = {
   play: () => {

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -33,6 +33,10 @@
   min-height: 44px;
   min-width: 44px;
 
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+
   border-radius: var(--eds-border-radius-md);
 }
 .menu__plain-button:hover {


### PR DESCRIPTION
### Summary:

- icons and other items within .PlainButton should be centered
- add recipe showing use of menu with Avatar component

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - adding new snapshot for avatar story in `Menu`