### PR TITLE
fix: include tailwind config in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "files": [
     "/lib",
-    "tailwind.config.js"
+    "tailwind.config.*"
   ],
   "scripts": {
     "build": "yarn build:clean && yarn build:tokens && yarn build:js && yarn build:styles && yarn copy-fonts-to-lib",


### PR DESCRIPTION
### Summary:

In #1568 I converted the `tailwind.config.js` to typescript, but forgot to update the `files` entry to include the TS version in the package 😐.

So now consuming apps can no longer access the EDS tailwind config to get theme variables.

This PR fixes that.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - `npm publish --dry-run`
