### PR TITLE
feat: export some subcomponents

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,6 +1,9 @@
 import clsx from 'clsx';
 import React, { useId } from 'react';
-import type { EitherInclusive } from '../../util/utility-types';
+import type {
+  EitherInclusive,
+  ForwardedRefComponent,
+} from '../../util/utility-types';
 import type { CheckboxInputProps } from '../CheckboxInput';
 import CheckboxInput from '../CheckboxInput';
 import type { CheckboxLabelProps } from '../CheckboxLabel';
@@ -34,6 +37,11 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
     }
   >;
 
+type CheckboxType = ForwardedRefComponent<HTMLInputElement, CheckboxProps> & {
+  Input?: typeof CheckboxInput;
+  Label?: typeof CheckboxLabel;
+};
+
 /**
  * `import {Checkbox} from "@chanzuckerberg/eds";`
  *
@@ -43,37 +51,25 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
  *
  * NOTE: Requires either a visible label or `aria-label` prop.
  */
-export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => {
-    // All remaining props are passed to the `input` element
-    const { className, id, label, size = 'lg', disabled, ...other } = props;
+export const Checkbox: CheckboxType = React.forwardRef((props, ref) => {
+  // All remaining props are passed to the `input` element
+  const { className, id, label, size = 'lg', disabled, ...other } = props;
 
-    const generatedId = useId();
-    const checkboxId = id || generatedId;
+  const generatedId = useId();
+  const checkboxId = id || generatedId;
 
-    return (
-      <div className={clsx(className, styles.checkbox)}>
-        <CheckboxInput
-          disabled={disabled}
-          id={checkboxId}
-          ref={ref}
-          {...other}
-        />
-        {label && (
-          <CheckboxLabel disabled={disabled} htmlFor={checkboxId} size={size}>
-            {label}
-          </CheckboxLabel>
-        )}
-      </div>
-    );
-  },
-);
+  return (
+    <div className={clsx(className, styles.checkbox)}>
+      <CheckboxInput disabled={disabled} id={checkboxId} ref={ref} {...other} />
+      {label && (
+        <CheckboxLabel disabled={disabled} htmlFor={checkboxId} size={size}>
+          {label}
+        </CheckboxLabel>
+      )}
+    </div>
+  );
+});
 
-/**
- * NOTE: usually, we would re-export subcomponents with
- *   Checkbox.Input = CheckboxInput;
- *   Checkbox.Label = CheckboxLabel;
- * but this does not compile with Typescript since Checkbox itself is a
- * forwarded ref component. Thus Input and Label must be imported separately.
- */
 Checkbox.displayName = 'Checkbox';
+Checkbox.Input = CheckboxInput;
+Checkbox.Label = CheckboxLabel;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useId } from 'react';
+import React, { forwardRef, useId } from 'react';
 import type {
   EitherInclusive,
   ForwardedRefComponent,
@@ -39,7 +39,6 @@ export type CheckboxProps = Omit<CheckboxInputProps, 'id'> & {
 
 type CheckboxType = ForwardedRefComponent<HTMLInputElement, CheckboxProps> & {
   Input?: typeof CheckboxInput;
-  Label?: typeof CheckboxLabel;
 };
 
 /**
@@ -51,7 +50,7 @@ type CheckboxType = ForwardedRefComponent<HTMLInputElement, CheckboxProps> & {
  *
  * NOTE: Requires either a visible label or `aria-label` prop.
  */
-export const Checkbox: CheckboxType = React.forwardRef((props, ref) => {
+export const Checkbox: CheckboxType = forwardRef((props, ref) => {
   // All remaining props are passed to the `input` element
   const { className, id, label, size = 'lg', disabled, ...other } = props;
 
@@ -72,4 +71,3 @@ export const Checkbox: CheckboxType = React.forwardRef((props, ref) => {
 
 Checkbox.displayName = 'Checkbox';
 Checkbox.Input = CheckboxInput;
-Checkbox.Label = CheckboxLabel;

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -126,13 +126,14 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
 
 type InputFieldType = ForwardedRefComponent<HTMLInputElement, Props> & {
   Input?: typeof Input;
-  Label?: typeof Label;
 };
 
 /**
  * `import {InputField} from "@chanzuckerberg/eds";`
  *
  * An input with optional labels and error messaging built-in.
+ *
+ * NOTE: This component requires `label` or `aria-label` prop
  */
 export const InputField: InputFieldType = forwardRef(
   (
@@ -217,4 +218,3 @@ export const InputField: InputFieldType = forwardRef(
 );
 InputField.displayName = 'InputField';
 InputField.Input = Input;
-InputField.Label = Label;

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,7 +1,10 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
-import type { EitherInclusive } from '../../util/utility-types';
+import type {
+  EitherInclusive,
+  ForwardedRefComponent,
+} from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Input from '../Input';
 import Label from '../Label';
@@ -121,12 +124,17 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
     }
   >;
 
+type InputFieldType = ForwardedRefComponent<HTMLInputElement, Props> & {
+  Input?: typeof Input;
+  Label?: typeof Label;
+};
+
 /**
  * `import {InputField} from "@chanzuckerberg/eds";`
  *
  * An input with optional labels and error messaging built-in.
  */
-export const InputField = forwardRef<HTMLInputElement, Props>(
+export const InputField: InputFieldType = forwardRef(
   (
     {
       'aria-describedby': ariaDescribedBy,
@@ -208,3 +216,5 @@ export const InputField = forwardRef<HTMLInputElement, Props>(
   },
 );
 InputField.displayName = 'InputField';
+InputField.Input = Input;
+InputField.Label = Label;

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -53,7 +53,6 @@ export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
 
 type TextareaFieldType = ForwardedRefComponent<HTMLTextAreaElement, Props> & {
   TextArea?: typeof TextArea;
-  Label?: typeof Label;
 };
 
 /**
@@ -138,5 +137,4 @@ export const TextareaField: TextareaFieldType = forwardRef(
 );
 
 TextareaField.displayName = 'TextareaField';
-TextareaField.Label = Label;
 TextareaField.TextArea = TextArea;

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,7 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef, useId } from 'react';
-import type { EitherInclusive } from '../../util/utility-types';
+import type {
+  EitherInclusive,
+  ForwardedRefComponent,
+} from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Label from '../Label';
 import Text from '../Text';
@@ -48,6 +51,11 @@ export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
     }
   >;
 
+type TextareaFieldType = ForwardedRefComponent<HTMLTextAreaElement, Props> & {
+  TextArea?: typeof TextArea;
+  Label?: typeof Label;
+};
+
 /**
  * `import {TextareaField} from "@chanzuckerberg/eds";`
  *
@@ -57,7 +65,7 @@ export type Props = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
  *
  * NOTE: This component requires `label` or `aria-label` prop
  */
-export const TextareaField = forwardRef<HTMLTextAreaElement, Props>(
+export const TextareaField: TextareaFieldType = forwardRef(
   (
     {
       'aria-describedby': ariaDescribedBy,
@@ -128,3 +136,7 @@ export const TextareaField = forwardRef<HTMLTextAreaElement, Props>(
     );
   },
 );
+
+TextareaField.displayName = 'TextareaField';
+TextareaField.Label = Label;
+TextareaField.TextArea = TextArea;

--- a/src/util/utility-types.ts
+++ b/src/util/utility-types.ts
@@ -1,3 +1,5 @@
+import type React from 'react';
+
 /**
  * HeadlessUI 1.6.0 changed the way components were typed, such that React.ComponentProps no longer correctly inferred props https://github.com/tailwindlabs/headlessui/issues/1394#issuecomment-1120911944.
  * Workaround is to declare own utility type https://github.com/tailwindlabs/headlessui/discussions/601#discussioncomment-1959631
@@ -32,3 +34,11 @@ export type EitherExclusive<T, U> = Only<T, U> | Only<U, T>;
  * TypeScript will hint to apply the first type, T, if both are missing
  */
 export type EitherInclusive<T, U> = EitherExclusive<T, U> | (T & U);
+
+/**
+ * The return type of React.forwardRef, and utilized similarly by passing <RefAttachedElement, Props>.
+ * Used to be extended to include subcomponents. i.e.: type InputFieldType = ForwardedRefComponent<HTMLInputElement, Props> * {Input?: typeof Input};
+ */
+export type ForwardedRefComponent<T, P> = React.ForwardRefExoticComponent<
+  React.PropsWithoutRef<P> & React.RefAttributes<T>
+>;


### PR DESCRIPTION
[EDS-893]

### Summary:
- with upcoming conditional exports of EDS, we have to be explicit about what we want to export
- this adds subcomponents of `InputField`, `TextareaField`, and `Checkbox` to their respective parent components as object values
- adds `ForwardedRefComponent` type, which is the return type of `forwardRef` to make this possible
### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable


[EDS-893]: https://czi-tech.atlassian.net/browse/EDS-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ