### PR TITLE
test(Popover): remove redundant test

### DIFF
--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -17,15 +17,6 @@ describe('<Popover />', () => {
     },
   });
 
-  it('should open Popover with trigger button', async () => {
-    const user = userEvent.setup();
-    render(<Default />);
-    expect(screen.queryByTestId('popover-content')).not.toBeInTheDocument();
-    const triggerButton = screen.getByTestId('popover-trigger-button');
-    await user.click(triggerButton);
-    expect(screen.getByTestId('popover-content')).toBeInTheDocument();
-  });
-
   it('should close Popover via escape key', async () => {
     const user = userEvent.setup();
     render(<Default />);


### PR DESCRIPTION
### Summary:

- re #1389 , remove an old and redundant test. `getElement` already verifies you can attach to the element from the trigger

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
    -  verify all tests continue passing (no dependency on this test)