### PR TITLE
docs: hide non-functional children controls in stories

### DIFF
--- a/.storybook/recipes/CardWithNotification/CardWithNotification.stories.tsx
+++ b/.storybook/recipes/CardWithNotification/CardWithNotification.stories.tsx
@@ -18,6 +18,13 @@ export default {
       </div>
     ),
   ],
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof CardWithNotification>;

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -31,6 +31,13 @@ export default {
       </Accordion.Row>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ margin: '0.5rem' }}>

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -16,6 +16,13 @@ export default {
     layout: 'centered',
     badges: ['1.2', BADGE.BETA],
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Badge>;

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -18,6 +18,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   parameters: {
     badges: ['1.0'],
   },

--- a/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
+++ b/src/components/ButtonDropdown/ButtonDropdown.stories.tsx
@@ -40,6 +40,18 @@ export default {
       <Button data-testid="trigger-button">Open Dropdown</Button>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+    dropdownMenuTrigger: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof ButtonDropdown>;

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -16,6 +16,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   parameters: {
     badges: ['1.0'],
   },

--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -20,6 +20,13 @@ export default {
   parameters: {
     badges: ['1.0'],
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div

--- a/src/components/Drawer/Drawer.stories.tsx
+++ b/src/components/Drawer/Drawer.stories.tsx
@@ -39,6 +39,11 @@ export default {
     ),
   },
   argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
     onClose: {
       action: 'on close',
     },

--- a/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -13,6 +13,13 @@ export default {
   parameters: {
     badges: ['1.0', BADGE.DEPRECATED],
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof DropdownMenu>;

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -13,6 +13,13 @@ export default {
     badges: ['1.0'],
   },
   subcomponents: { FieldsetLegend, FieldsetItems },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Fieldset>;

--- a/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
@@ -26,6 +26,13 @@ export default {
       </FiltersCheckboxField>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ margin: '0.25rem', height: '100vh' }}>

--- a/src/components/FiltersPopover/FiltersPopover.stories.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.stories.tsx
@@ -29,6 +29,13 @@ export default {
     ),
     placement: 'bottom-start',
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ margin: '0.25rem', height: '100vh' }}>

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -30,6 +30,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   parameters: {
     badges: ['1.0'],
   },

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -22,6 +22,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Layout>;

--- a/src/components/LayoutContainer/LayoutContainer.stories.tsx
+++ b/src/components/LayoutContainer/LayoutContainer.stories.tsx
@@ -15,6 +15,13 @@ export default {
   args: {
     children: <div className="fpo">Layout container</div>,
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof LayoutContainer>;

--- a/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
+++ b/src/components/LayoutLinelengthContainer/LayoutLinelengthContainer.stories.tsx
@@ -25,6 +25,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof LayoutLinelengthContainer>;

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -16,6 +16,13 @@ export default {
     badges: ['1.2'],
     layout: 'centered',
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<MenuProps>;
 
 export const Default: StoryObj<MenuProps> = {

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -18,6 +18,13 @@ export default {
     chromatic: { disableSnapshot: true },
     badges: ['1.0'],
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Modal>;

--- a/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
@@ -27,6 +27,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    description: {
+      control: {
+        type: 'text',
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof PageLevelBanner>;

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -36,6 +36,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<PopoverProps>;
 
 export const Default: StoryObj<PopoverProps> = {

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -17,6 +17,13 @@ export default {
       </div>
     ),
   ],
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof SearchBar>;

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -16,6 +16,13 @@ export default {
   parameters: {
     badges: ['1.1'],
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -146,6 +146,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Tabs>;

--- a/src/components/TimelineNav/TimelineNav.stories.tsx
+++ b/src/components/TimelineNav/TimelineNav.stories.tsx
@@ -168,6 +168,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta;
 
 type Args = React.ComponentProps<typeof TimelineNavPanel>;

--- a/src/components/Toolbar/Toolbar.stories.tsx
+++ b/src/components/Toolbar/Toolbar.stories.tsx
@@ -32,6 +32,13 @@ export default {
       </>
     ),
   },
+  argTypes: {
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Toolbar>;

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -30,6 +30,18 @@ export default {
   title: 'Components/Tooltip',
   component: Tooltip,
   args: defaultArgs,
+  argTypes: {
+    text: {
+      control: {
+        type: 'text',
+      },
+    },
+    children: {
+      control: {
+        type: null,
+      },
+    },
+  },
   parameters: {
     badges: ['1.0'],
     chromatic: {


### PR DESCRIPTION
### Summary:

Storybook is showing stringified versions of some of the components' `children` and other props. Trying to edit any of these will break the storybook UI and require a page refresh. This disables those ones in the controls, which appears not to be a global option.

![Screenshot 2023-04-06 at 14 07 09](https://user-images.githubusercontent.com/3056447/230507170-988ed51e-8a02-4cdd-b690-0dbe17472d80.png)
![Screenshot 2023-04-06 at 14 07 26](https://user-images.githubusercontent.com/3056447/230507183-e9e9cdb2-8a60-4034-b0eb-d56634d0b99c.png)


### Test Plan:

- n/a (only affects storybook)