### PR TITLE
fix: polyfill for useid for react <18

### DIFF
--- a/.storybook/pages/AlongDemo/AlongDemo.tsx
+++ b/.storybook/pages/AlongDemo/AlongDemo.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
-import React, { useId, useState } from 'react';
-
+import React, { useState } from 'react';
 import {
   Button,
   ButtonGroup,
@@ -14,6 +13,7 @@ import {
   Text,
   Tooltip,
 } from '../../../src';
+import { useId } from '../../../src/util/useId';
 
 import AlongFooterPaper from '../../static/along-footer-paper.svg';
 import AlongLogoBulb from '../../static/along-logo-bulb.svg';

--- a/.storybook/pages/WireframeDemo/WireframeDemo.tsx
+++ b/.storybook/pages/WireframeDemo/WireframeDemo.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import React, { useId, useState } from 'react';
+import React, { useState } from 'react';
 
 import {
   Button,
@@ -14,6 +14,7 @@ import {
   Text,
   Tooltip,
 } from '../../../src';
+import { useId } from '../../../src/util/useId';
 
 import PlaceholderImage from '../../static/placeholder-image.svg';
 import PlaceholderVideo from '../../static/placeholder-video.svg';

--- a/docs/CODE_GUIDELINES.md
+++ b/docs/CODE_GUIDELINES.md
@@ -597,7 +597,9 @@ The default option should be the one most commonly used in order to reduce frict
 
 ID attributes used for accessibility (e.g. associating `<label>` and `<input>` elements) should be unique and stable.
 
-We currently use the [`useId` hook](https://reactjs.org/docs/hooks-reference.html#useid) for ID generation. To ensure stable results, they cannot be invoked within conditionals or callbacks.
+We currently use the [`useId` hook](https://reactjs.org/docs/hooks-reference.html#useid) for ID generation for React 18, and polyfill with an incrementing number for React <18.
+The polyfill is not ssr friendly as id generation is render timing dependent.
+To ensure stable results, they cannot be invoked within conditionals or callbacks.
 
 ```tsx
 const generatedId = useId();

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     }
   ],
   "peerDependencies": {
-    "react": ">= 18"
+    "react": ">= 17"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.14",

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import React, { forwardRef, useId } from 'react';
+import React, { forwardRef } from 'react';
+import { useId } from '../../util/useId';
 import type {
   EitherInclusive,
   ForwardedRefComponent,

--- a/src/components/DataBar/DataBar.tsx
+++ b/src/components/DataBar/DataBar.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import React, { useId } from 'react';
+import React from 'react';
+import { useId } from '../../util/useId';
 
 import DataBarSegment from '../DataBarSegment';
 import type { Variants } from '../DataBarSegment';

--- a/src/components/FiltersDrawer/FiltersDrawer.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ReactElement, ReactNode } from 'react';
-import React, { useEffect, useId, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useId } from '../../util/useId';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Drawer from '../Drawer';

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef, useId } from 'react';
+import React, { forwardRef } from 'react';
+import { useId } from '../../util/useId';
 import type {
   EitherInclusive,
   ForwardedRefComponent,

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,5 @@
-import React, { useId } from 'react';
+import React from 'react';
+import { useId } from '../../util/useId';
 import Text from '../Text';
 import styles from './ProgressBar.module.css';
 

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
-import React, { useId } from 'react';
+import React from 'react';
+import { useId } from '../../util/useId';
 import type { EitherInclusive } from '../../util/utility-types';
 import type { RadioInputProps } from '../RadioInput';
 import RadioInput from '../RadioInput';

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -1,11 +1,11 @@
 import clsx from 'clsx';
 import React, {
-  useId,
   useRef,
   type ChangeEventHandler,
   type CSSProperties,
 } from 'react';
 import { findLowestTenMultiplier } from '../../util/findLowestTenMultiplier';
+import { useId } from '../../util/useId';
 import type { EitherInclusive } from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Label from '../Label';

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -4,7 +4,6 @@ import React, {
   type ReactNode,
   useCallback,
   useEffect,
-  useId,
   useMemo,
   useRef,
   useState,
@@ -17,6 +16,7 @@ import {
   R_ARROW_KEYCODE,
   D_ARROW_KEYCODE,
 } from '../../util/keycodes';
+import { useId } from '../../util/useId';
 import Tab from '../Tab';
 import styles from './Tabs.module.css';
 

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -15,6 +15,7 @@ export default {
     label: 'Textarea Field',
     rows: 5,
     fieldNote: 'Longer Field description',
+    spellcheck: false,
   },
   parameters: {
     badges: ['1.3'],

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
-import React, { forwardRef, useState, useId } from 'react';
+import React, { forwardRef, useState } from 'react';
+import { useId } from '../../util/useId';
 import type {
   EitherInclusive,
   ForwardedRefComponent,

--- a/src/components/TimelineNav/TimelineNav.tsx
+++ b/src/components/TimelineNav/TimelineNav.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import type { KeyboardEventHandler, ReactNode } from 'react';
-import React, { useCallback, useId, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { allByType } from 'react-children-by-type';
 import {
   L_ARROW_KEYCODE,
@@ -10,6 +10,7 @@ import {
   ENTER_KEYCODE,
   SPACEBAR_KEYCODE,
 } from '../../util/keycodes';
+import { useId } from '../../util/useId';
 import Button from '../Button';
 import Icon from '../Icon';
 import NumberIcon from '../NumberIcon';

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -5,9 +5,10 @@ function genId() {
   return ++id;
 }
 
-// Warning: probably not ssr friendly if using React <18
+console.warn(
+  'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
+);
 export const useId =
-  // Prefer React's `useId` if it's available.
   React.useId ??
   function useId() {
     const id = 'eds-' + genId();

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+let id = 0;
+function genId() {
+  return ++id;
+}
+
+// Warning: probably not ssr friendly if using React <18
+export const useId =
+  // Prefer React's `useId` if it's available.
+  React.useId ??
+  function useId() {
+    const id = genId();
+    return id;
+  };

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -10,6 +10,6 @@ export const useId =
   // Prefer React's `useId` if it's available.
   React.useId ??
   function useId() {
-    const id = genId();
+    const id = 'eds-' + genId();
     return id;
   };

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -5,9 +5,12 @@ function genId() {
   return ++id;
 }
 
-console.warn(
-  'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
-);
+if (process.env.NODE_ENV !== 'production') {
+  console.warn(
+    'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
+  );
+}
+
 export const useId =
   React.useId ??
   function useId() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,7 +1732,7 @@ __metadata:
     ts-jest: ^29.1.0
     typescript: ^4.9.5
   peerDependencies:
-    react: ">= 18"
+    react: ">= 17"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Summary:
- attempts to polyfill useid for react <18 with incremental numbers
  - uses default React.useId from react 18 if exists
  - polyfill is not ssr safe since it's generated upon usage, which is render timing dependent
  - prefixes with `eds-` to avoid collision with other number id's if number id's are used elsewhere

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
    - `12.0.1-alpha.1` created and tested in https://github.com/chanzuckerberg/along/pull/5942
