### PR TITLE
fix(Typography): update type ramp to sync with design 

### DIFF
--- a/.storybook/components/DesignTokens/Tier1/TypographyPresets.jsx
+++ b/.storybook/components/DesignTokens/Tier1/TypographyPresets.jsx
@@ -5,50 +5,62 @@ import styles from './TypographyPresets.module.css';
 
 export const PRESET_SIZE_MAP = {
   '001': {
+    weights: ['regular', 'bold'],
     fontSize: 40,
     lineHeight: 48,
   },
   '002': {
+    weights: ['light', 'regular', 'bold'],
     fontSize: 32,
     lineHeight: 40,
   },
   '003': {
+    weights: ['regular', 'bold'],
     fontSize: 24,
     lineHeight: 32,
   },
   '004': {
+    weights: ['regular', 'bold'],
     fontSize: 18,
     lineHeight: 24,
   },
   '005': {
+    weights: ['light', 'regular', 'bold'],
     fontSize: 16,
     lineHeight: 24,
   },
   '006': {
+    weights: ['light', 'regular', 'bold'],
     fontSize: 14,
-    lineHeight: 24,
+    lineHeight: 22,
   },
   '007': {
+    weights: ['regular', 'bold'],
     fontSize: 14,
     lineHeight: 18,
   },
   '008': {
+    weights: ['light', 'bold'],
     fontSize: 12,
     lineHeight: 20,
   },
   '009': {
+    weights: ['regular', 'bold'],
     fontSize: 12,
     lineHeight: 16,
   },
   '010': {
+    weights: ['regular', 'bold'],
     fontSize: 11,
     lineHeight: 14,
   },
   '011': {
+    weights: ['regular', 'bold'],
     fontSize: 12,
     lineHeight: 16,
   },
   '012': {
+    weights: ['regular', 'bold'],
     fontSize: 11,
     lineHeight: 14,
   },
@@ -56,12 +68,8 @@ export const PRESET_SIZE_MAP = {
 
 export class Tier1TypographyPresets extends Component {
   render() {
-    const renderTypeToken = (
-      preset,
-      index,
-      { boldVariant = true, lightVariant = false } = {},
-    ) => {
-      const { fontSize, lineHeight } = PRESET_SIZE_MAP[preset];
+    const renderTypeToken = (preset, index) => {
+      const { fontSize, lineHeight, weights } = PRESET_SIZE_MAP[preset];
       const commonProps = {
         comment: 'font size / line height (px)',
         value: `${fontSize} / ${lineHeight}`,
@@ -70,19 +78,21 @@ export class Tier1TypographyPresets extends Component {
 
       return (
         <Grid key={`tier-1-typography-preset-${index}`}>
-          <TokenSpecimen
-            name={`eds-typography-preset-${preset}`}
-            specimenClassName={styles[`typography-presets--${preset}`]}
-            {...commonProps}
-          />
-          {lightVariant && (
+          {weights.includes('regular') && (
+            <TokenSpecimen
+              name={`eds-typography-preset-${preset}`}
+              specimenClassName={styles[`typography-presets--${preset}`]}
+              {...commonProps}
+            />
+          )}
+          {weights.includes('light') && (
             <TokenSpecimen
               name={`eds-typography-preset-${preset}-light`}
               specimenClassName={styles[`typography-presets--${preset}-light`]}
               {...commonProps}
             />
           )}
-          {boldVariant && (
+          {weights.includes('bold') && (
             <TokenSpecimen
               name={`eds-typography-preset-${preset}-bold`}
               specimenClassName={styles[`typography-presets--${preset}-bold`]}
@@ -96,9 +106,7 @@ export class Tier1TypographyPresets extends Component {
     return (
       <Grid>
         {Object.keys(PRESET_SIZE_MAP).map((preset, index) => {
-          if (preset === '005') {
-            return renderTypeToken(preset, index, { lightVariant: true });
-          }
+          // TODO: simplify this file to avoid custom mappings to type ramp
           return renderTypeToken(preset, index);
         })}
       </Grid>

--- a/.storybook/components/DesignTokens/Tier1/TypographyPresets.module.css
+++ b/.storybook/components/DesignTokens/Tier1/TypographyPresets.module.css
@@ -4,7 +4,8 @@
 \*------------------------------------*/
 
 /**
- *  Use typography mixins to display the type ramp
+ * Use typography mixins to display the type ramp
+ * TODO: revisit type ramp definitions to simplify this layout 
  */
 
 .typography-presets--001 {
@@ -19,6 +20,10 @@
   @mixin eds-typography-preset-002;
 }
 
+.typography-presets--002-light {
+  @mixin eds-typography-preset-002-light;
+}
+
 .typography-presets--002-bold {
   @mixin eds-typography-preset-002-bold;
 }
@@ -29,6 +34,10 @@
 
 .typography-presets--003-bold {
   @mixin eds-typography-preset-003-bold;
+}
+
+.typography-presets--004-light {
+  @mixin eds-typography-preset-004-light;
 }
 
 .typography-presets--004 {
@@ -51,6 +60,10 @@
   @mixin eds-typography-preset-005-bold;
 }
 
+.typography-presets--006-light {
+  @mixin eds-typography-preset-006-light;
+}
+
 .typography-presets--006 {
   @mixin eds-typography-preset-006;
 }
@@ -67,12 +80,12 @@
   @mixin eds-typography-preset-007-bold;
 }
 
-.typography-presets--008 {
-  @mixin eds-typography-preset-008;
-}
-
 .typography-presets--008-bold {
   @mixin eds-typography-preset-008-bold;
+}
+
+.typography-presets--008-light {
+  @mixin eds-typography-preset-008-light;
 }
 
 .typography-presets--009 {

--- a/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
+++ b/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
@@ -54,10 +54,10 @@ export class Tier2TypographyUsage extends Component {
 
         <Section title="Body Text">
           <Grid>
-            {renderTypeToken('body-text-lg', '004')}
-            {renderTypeToken('body-text-md', '005')}
-            {renderTypeToken('body-text-sm', '006')}
-            {renderTypeToken('body-text-xs', '008')}
+            {renderTypeToken('body-lg', '004')}
+            {renderTypeToken('body-md', '005')}
+            {renderTypeToken('body-sm', '006')}
+            {renderTypeToken('body-xs', '008')}
           </Grid>
         </Section>
 

--- a/.storybook/components/DesignTokens/Tier2/TypographyUsage.module.css
+++ b/.storybook/components/DesignTokens/Tier2/TypographyUsage.module.css
@@ -48,31 +48,31 @@
   @mixin eds-typography-preset-009-bold;
 }
 
-.typography-usage--body-text-lg {
+.typography-usage--body-lg {
   @mixin eds-typography-preset-004;
 }
 
-.typography-usage--body-text-md {
+.typography-usage--body-md {
   @mixin eds-typography-preset-005-light;
 }
 
-.typography-usage--body-text-sm {
+.typography-usage--body-sm {
   @mixin eds-typography-preset-006;
 }
 
-.typography-usage--body-text-xs {
+.typography-usage--body-xs {
   @mixin eds-typography-preset-008;
 }
 
-.typography-usage--caption-text-lg {
+.typography-usage--caption-lg {
   @mixin eds-typography-preset-006;
 }
 
-.typography-usage--caption-text-md {
+.typography-usage--caption-md {
   @mixin eds-typography-preset-008;
 }
 
-.typography-usage--caption-text-sm {
+.typography-usage--caption-sm {
   @mixin eds-typography-preset-010;
 }
 
@@ -111,29 +111,29 @@
 /**
  * Body text bold
  */
-.typography-usage--body-text-bold {
-  @mixin eds-theme-typography-body-text-md;
+.typography-usage--body-bold {
+  @mixin eds-theme-typography-body-md;
 }
 
 /**
  *  Body text sm bold
  */
-.typography-usage--body-text-sm-bold {
-  @mixin eds-theme-typography-body-text-sm;
+.typography-usage--body-sm-bold {
+  @mixin eds-theme-typography-body-sm;
 }
 
 /**
  *  Body text xs bold
  */
-.typography-usage--body-text-xs-bold {
-  @mixin eds-theme-typography-body-text-xs-bold;
+.typography-usage--body-xs-bold {
+  @mixin eds-theme-typography-body-xs-bold;
 }
 
 /**
  *  Body text lg bold
  */
-.typography-usage--body-text-lg-bold {
-  @mixin eds-theme-typography-body-text-lg-bold;
+.typography-usage--body-lg-bold {
+  @mixin eds-theme-typography-body-lg-bold;
 }
 
 /**

--- a/.storybook/components/TokenSpecimen/TokenSpecimen.css
+++ b/.storybook/components/TokenSpecimen/TokenSpecimen.css
@@ -22,7 +22,7 @@
 }
 
 .token-specimen__info {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 
 .token-specimen__name {

--- a/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.module.css
+++ b/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.module.css
@@ -50,7 +50,7 @@
 }
 
 .project-card__meta {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
   color: var(--eds-theme-color-text-neutral-subtle);
 }
 

--- a/.storybook/pages/ProjectOverview/ProjectOverview.module.css
+++ b/.storybook/pages/ProjectOverview/ProjectOverview.module.css
@@ -4,7 +4,7 @@
  *  Utility classes to apply typography usage mixins to Project Overview in body text xs bold
  */
 .project-overview__text {
-  @mixin eds-theme-typography-body-text-xs-bold;
+  @mixin eds-theme-typography-body-xs-bold;
 }
 
 .project-overview__link-description {

--- a/.storybook/pages/StudentRefinement/StudentRefinement.module.css
+++ b/.storybook/pages/StudentRefinement/StudentRefinement.module.css
@@ -118,7 +118,7 @@
  * The Description provides more elucidation for the data.
  */
 .data-summary-card__description {
-  @mixin eds-theme-typography-caption-text-sm;
+  @mixin eds-theme-typography-caption-sm;
   font-weight: var(--eds-font-weight-light);
 }
 

--- a/docs/TYPOGRAPHY.md
+++ b/docs/TYPOGRAPHY.md
@@ -31,7 +31,7 @@ These token values are _never to be used_ directly by components; these token va
 
 Just as with other Tier 1 tokens, typography presets shouldn't be used directly by components. Typography presets are mapped to specific semantic usage at the Tier 2 level.
 
-Note: line-height values are [unitless](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#prefer_unitless_numbers_for_line-height_values) and are specific to each preset, which is why the decision was made to exclude line height values from  tokens. 
+Note: line-height values are [unitless](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#prefer_unitless_numbers_for_line-height_values) and are specific to each preset, which is why the decision was made to exclude line height values from tokens.
 
 ## Tier 2: Typography usage
 
@@ -39,8 +39,8 @@ Tier 2 typography values take the typography presets defined at the Tier 2 level
 
 ```css
 /* typography-usage.css */
-@define-mixin eds-theme-typography-body-text-sm {
-  @mixin eds-typography-preset-6;
+@define-mixin eds-theme-typography-body-sm {
+  @mixin eds-typography-preset-006;
 }
 ```
 
@@ -48,6 +48,6 @@ These semantic values are then included in each component's style file:
 
 ```css
 .breadcrumbs {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 ```

--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -55,7 +55,7 @@
  * The heading text.
  */
 .accordion-button__heading {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
   color: var(--eds-theme-color-text-neutral-strong);
 }
 
@@ -63,7 +63,7 @@
  * Small variant of the heading text.
  */
 .accordion-button__heading--sm {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
 }
 
 /**
@@ -101,7 +101,7 @@
   padding-right: var(--eds-size-3);
   padding-bottom: 1.625rem;
 
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
   color: var(--eds-theme-color-text-neutral-strong);
 }
 
@@ -109,7 +109,7 @@
  * Small variant.
  */
 .accordion-panel--sm {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
 }
 
 /**

--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -47,7 +47,7 @@
   background-color: var(--eds-theme-color-background-brand-primary-strong);
   color: var(--eds-theme-color-text-neutral-default-inverse);
 
-  @mixin eds-theme-typography-caption-text-sm;
+  @mixin eds-theme-typography-caption-sm;
 }
 
 /**

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -8,7 +8,7 @@
  * Breadcrumbs list item.
  */
 .breadcrumbs__item {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
   max-width: 100%;
   /* Required for dropdown menu to absolutely position relative to this container. */
   position: relative;

--- a/src/components/Dropdown/Dropdown.module.css
+++ b/src/components/Dropdown/Dropdown.module.css
@@ -42,7 +42,7 @@
  * The container for the individual dropdown options. 
  */
 .dropdown__options {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
   /* Allow Dropdown font to shrink in contexts where body font size is smaller. */
   font-size: inherit;
 
@@ -105,7 +105,7 @@
 .dropdown__option--selected {
   padding-left: 0;
 
-  @mixin eds-theme-typography-body-text-bold;
+  @mixin eds-theme-typography-body-bold;
 }
 
 /**

--- a/src/components/DropdownButton/DropdownButton.module.css
+++ b/src/components/DropdownButton/DropdownButton.module.css
@@ -8,9 +8,9 @@
  * The button to trigger the display of the dropdown.
  */
 .dropdown-button {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
   /* Allow Dropdown font to shrink in contexts where body font size is smaller. */
-  font-size: inherit; 
+  font-size: inherit;
 
   width: 100%;
   padding: var(--eds-size-1);
@@ -21,7 +21,7 @@
 
   display: flex;
   /* Place button text on the left and the expand more icon on the right. */
-  justify-content: space-between; 
+  justify-content: space-between;
   align-items: center;
 
   cursor: pointer;
@@ -38,7 +38,7 @@
   transition: transform var(--eds-anim-move-medium) ease-out;
   @media (prefers-reduced-motion) {
     /* Turns off animation if user prefers reduced motion. */
-    transition: none; 
+    transition: none;
   }
 }
 

--- a/src/components/DropdownMenu/DropdownMenu.module.css
+++ b/src/components/DropdownMenu/DropdownMenu.module.css
@@ -56,7 +56,7 @@
  * Dropdown menu link.
  */
 .dropdown-menu__link {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
   display: grid;
   grid-template-columns: auto 1fr;
   gap: var(--eds-size-1);

--- a/src/components/FieldNote/FieldNote.module.css
+++ b/src/components/FieldNote/FieldNote.module.css
@@ -8,7 +8,7 @@
  * Fieldnote
  */
 .field-note {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 
 /**

--- a/src/components/FieldsetLegend/FieldsetLegend.module.css
+++ b/src/components/FieldsetLegend/FieldsetLegend.module.css
@@ -11,9 +11,9 @@
  */
 .fieldset-legend {
   /* Removes some default browser styles. */
-  @mixin legendReset; 
+  @mixin legendReset;
   @mixin eds-theme-typography-form-label;
-   /* Adjust margin between legend and option list */
+  /* Adjust margin between legend and option list */
   margin-bottom: var(--eds-size-2);
 }
 
@@ -22,5 +22,5 @@
  * or optional. Currently a flag is only present for optional fields
  */
 .fieldset-legend__flag {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }

--- a/src/components/Heading/Heading.module.css
+++ b/src/components/Heading/Heading.module.css
@@ -31,12 +31,12 @@
 
 /* Deprecated; not in figma */
 .heading--size-body-sm {
-  @mixin eds-theme-typography-body-text-sm-bold;
+  @mixin eds-theme-typography-body-sm-bold;
 }
 
 /* Deprecated; not in figma */
 .heading--size-body-xs {
-  @mixin eds-theme-typography-body-text-xs-bold;
+  @mixin eds-theme-typography-body-xs-bold;
 }
 
 /**

--- a/src/components/InputLabel/InputLabel.module.css
+++ b/src/components/InputLabel/InputLabel.module.css
@@ -22,8 +22,8 @@
  * Input label size variants.
  */
 .label--md {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 .label--lg {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
 }

--- a/src/components/Label/Label.module.css
+++ b/src/components/Label/Label.module.css
@@ -21,7 +21,7 @@
  * is only present for optional fields.
  */
 .label__flag {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 
 /**

--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -20,7 +20,7 @@
 }
 
 .menu__button {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
 
   color: var(--eds-theme-text-neutral-subtle);
   background-color: var(--eds-theme-color-form-background);

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -9,7 +9,7 @@
  * Centers the number text in the circle.
  */
 .number-icon {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
   /* Line height set to 1 here since this should only ever be on 1 line and it evens out padding in circle. */
   line-height: 1;
   display: flex;
@@ -37,7 +37,7 @@
  * Size Variants.
  */
 .number-icon--sm {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
   /* Line height set to 1 here since this should only ever be on 1 line and it evens out padding in circle. */
   line-height: 1;
   /* Height and width should be the same to make the icon a circle and not oblong. */

--- a/src/components/Section/Section.stories.module.css
+++ b/src/components/Section/Section.stories.module.css
@@ -4,5 +4,5 @@
  *  Body text xs bold
  */
 .section__text {
-    @mixin eds-theme-typography-body-text-xs-bold;
-  }
+  @mixin eds-theme-typography-body-xs-bold;
+}

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -85,7 +85,7 @@
  * The button to trigger the display of the select field.
  */
 .select-button {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
   /* Allow select component font to shrink in contexts where body font size is smaller. */
   font-size: inherit;
   color: var(--eds-theme-text-neutral-subtle);

--- a/src/components/Slider/Slider.module.css
+++ b/src/components/Slider/Slider.module.css
@@ -152,7 +152,7 @@
  * Slider Marker 
  */
 .slider__marker {
-  @mixin eds-theme-typography-caption-text-sm;
+  @mixin eds-theme-typography-caption-sm;
 
   /* Centers the text to the marker location */
   width: 0px;

--- a/src/components/TableCell/TableCell.module.css
+++ b/src/components/TableCell/TableCell.module.css
@@ -9,7 +9,7 @@
  * The `:where` pseudo class function allows easy overriding via className.
  */
 :where(.table-cell) {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 
   padding: var(--eds-size-2) var(--eds-size-1);
 }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -9,19 +9,19 @@
  */
 .text--body,
 .text--md {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
 }
 .text--lg {
-  @mixin eds-theme-typography-body-text-lg;
+  @mixin eds-theme-typography-body-lg;
 }
 .text--sm {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 }
 .text--xs {
-  @mixin eds-theme-typography-body-text-xs;
+  @mixin eds-theme-typography-body-xs;
 }
 .text--caption {
-  @mixin eds-theme-typography-caption-text-md;
+  @mixin eds-theme-typography-caption-md;
 }
 .text--overline {
   @mixin eds-theme-typography-overline;

--- a/src/components/TextareaField/TextareaField.module.css
+++ b/src/components/TextareaField/TextareaField.module.css
@@ -36,7 +36,7 @@
 }
 
 .textarea-field__character-counter {
-  @mixin eds-theme-typography-body-text-sm;
+  @mixin eds-theme-typography-body-sm;
 
   color: var(--eds-theme-color-text-neutral-default);
   flex: 1 0 50%;

--- a/src/components/Toggle/Toggle.module.css
+++ b/src/components/Toggle/Toggle.module.css
@@ -71,7 +71,7 @@
   margin-bottom: 0;
 
   color: var(--eds-theme-color-text-neutral-default);
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
 }
 
 /**

--- a/src/design-tokens/css/base/body.css
+++ b/src/design-tokens/css/base/body.css
@@ -1,7 +1,7 @@
 @import '../../mixins.css';
 
 body {
-  @mixin eds-theme-typography-body-text-md;
+  @mixin eds-theme-typography-body-md;
   display: flex;
   flex-direction: column;
   min-height: 100vh;

--- a/src/design-tokens/tier-1-definitions/typography-presets.css
+++ b/src/design-tokens/tier-1-definitions/typography-presets.css
@@ -50,14 +50,15 @@
   }
 }
 
-@define-mixin eds-typography-preset-002-bold $important {
-  @mixin eds-typography-preset-002 $important;
-  font-weight: var(--eds-font-weight-bold) $important;
-}
-
+/* TODO: Verify whether this one should be removed */
 @define-mixin eds-typography-preset-002-light $important {
   @mixin eds-typography-preset-002 $important;
   font-weight: var(--eds-font-weight-light) $important;
+}
+
+@define-mixin eds-typography-preset-002-bold $important {
+  @mixin eds-typography-preset-002 $important;
+  font-weight: var(--eds-font-weight-bold) $important;
 }
 
 /**
@@ -67,7 +68,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-24) $important;
-  line-height: 1.333 $important;
+  line-height: 1.333333333 $important;
 
   @mixin eds-typography-preset-003-mobile $important;
 }
@@ -93,7 +94,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-18) $important;
-  line-height: 1.333 $important;
+  line-height: 1.333333333 $important;
 }
 
 @define-mixin eds-typography-preset-004-light $important {
@@ -133,7 +134,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-14) $important;
-  line-height: 1.57 $important;
+  line-height: 1.57142857 $important;
 }
 
 @define-mixin eds-typography-preset-006-light $important {
@@ -153,7 +154,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-14) $important;
-  line-height: 1.28 $important;
+  line-height: 1.28571429 $important;
 }
 
 @define-mixin eds-typography-preset-007-bold $important {
@@ -162,13 +163,17 @@
 }
 
 /**
- * Typography Preset 008: Light & Bold
+ * Typography Preset 008: Regular, Light & Bold
  */
 @define-mixin eds-typography-preset-008 $important {
   font-family: var(--eds-font-family-primary) $important;
-  font-weight: var(--eds-font-weight-light) $important;
   font-size: var(--eds-font-size-12) $important;
-  line-height: 1.666 $important;
+  line-height: 1.666666667 $important;
+}
+
+@define-mixin eds-typography-preset-008-light $important {
+  @mixin eds-typography-preset-008 $important;
+  font-weight: var(--eds-font-weight-light) $important;
 }
 
 @define-mixin eds-typography-preset-008-bold $important {
@@ -183,7 +188,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-12) $important;
-  line-height: 1.333 $important;
+  line-height: 1.333333333 $important;
 }
 
 @define-mixin eds-typography-preset-009-bold $important {
@@ -198,7 +203,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-11) $important;
-  line-height: 1.27 $important;
+  line-height: 1.272727272 $important;
 }
 
 @define-mixin eds-typography-preset-010-bold $important {
@@ -213,7 +218,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-12) $important;
-  line-height: 1.333 $important;
+  line-height: 1.333333333 $important;
   text-transform: uppercase $important;
 }
 
@@ -229,7 +234,7 @@
   font-family: var(--eds-font-family-primary) $important;
   font-weight: var(--eds-font-weight-medium) $important;
   font-size: var(--eds-font-size-11) $important;
-  line-height: 1.27 $important;
+  line-height: 1.272727272 $important;
   text-transform: uppercase $important;
 }
 

--- a/src/design-tokens/tier-1-definitions/typography.json
+++ b/src/design-tokens/tier-1-definitions/typography.json
@@ -41,7 +41,7 @@
         "value": "0.75rem"
       },
       "11": {
-        "value": "0.688rem"
+        "value": "0.6875rem"
       }
     },
     "font-weight": {

--- a/src/design-tokens/tier-2-usage/typography-usage.css
+++ b/src/design-tokens/tier-2-usage/typography-usage.css
@@ -40,31 +40,32 @@
   @mixin eds-typography-preset-009-bold $important;
 }
 
-@define-mixin eds-theme-typography-body-text-lg $important {
+@define-mixin eds-theme-typography-body-lg $important {
   @mixin eds-typography-preset-004-light $important;
 }
 
-@define-mixin eds-theme-typography-body-text-md $important {
+@define-mixin eds-theme-typography-body-md $important {
   @mixin eds-typography-preset-005-light $important;
 }
 
-@define-mixin eds-theme-typography-body-text-sm $important {
+@define-mixin eds-theme-typography-body-sm $important {
   @mixin eds-typography-preset-006-light $important;
 }
 
-@define-mixin eds-theme-typography-body-text-xs $important {
-  @mixin eds-typography-preset-008 $important;
+@define-mixin eds-theme-typography-body-xs $important {
+  @mixin eds-typography-preset-008-light $important;
 }
 
-@define-mixin eds-theme-typography-caption-text-lg $important {
+@define-mixin eds-theme-typography-caption-lg $important {
   @mixin eds-typography-preset-006-light $important;
 }
 
-@define-mixin eds-theme-typography-caption-text-md $important {
+/* TODO: This does not exist on the type ramp currently */
+@define-mixin eds-theme-typography-caption-md $important {
   @mixin eds-typography-preset-008 $important;
 }
 
-@define-mixin eds-theme-typography-caption-text-sm $important {
+@define-mixin eds-theme-typography-caption-sm $important {
   @mixin eds-typography-preset-010 $important;
 }
 
@@ -130,11 +131,11 @@
 }
 
 @define-mixin eds-theme-typography-heading-6 $important {
-  @mixin eds-theme-typography-body-text-sm-bold $important;
+  @mixin eds-theme-typography-body-sm-bold $important;
 }
 
 @define-mixin eds-theme-typography-heading-7 $important {
-  @mixin eds-theme-typography-body-text-xs-bold $important;
+  @mixin eds-theme-typography-body-xs-bold $important;
 }
 
 /**
@@ -145,18 +146,18 @@
   @mixin eds-typography-preset-005 $important;
 }
 
-@define-mixin eds-theme-typography-body-text-bold $important {
+@define-mixin eds-theme-typography-body-bold $important {
   @mixin eds-typography-preset-005-bold $important;
 }
 
-@define-mixin eds-theme-typography-body-text-lg-bold $important {
+@define-mixin eds-theme-typography-body-lg-bold $important {
   @mixin eds-typography-preset-003-bold $important;
 }
 
-@define-mixin eds-theme-typography-body-text-sm-bold $important {
+@define-mixin eds-theme-typography-body-sm-bold $important {
   @mixin eds-typography-preset-006-bold $important;
 }
 
-@define-mixin eds-theme-typography-body-text-xs-bold $important {
+@define-mixin eds-theme-typography-body-xs-bold $important {
   @mixin eds-typography-preset-008-bold $important;
 }


### PR DESCRIPTION
### Summary:

- add additional precision to the coded type ramp, to help pixel sizes resolve to whole numbers in the CSS engine (prevents browsers from resolving 2- and 3-digit sizes as partial pixel values like 31.98px vs 32px)
- sync up all font-size and line-height values between design and coded typography ramp
- flag any items that need further attention
- this is 1/n ... there may be future updates as we find any other discrepancies

### Test Plan:
- [x] Manually tested my changes, and here are the details:
  - Review with design