### PR TITLE
fix: allow css-variables-nested.json to be imported from the EDS package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     },
     "./index.css": "./lib/index.css",
     "./fonts.css": "./lib/tokens/fonts.css",
+    "./css-variables-nested.json": "./lib/json/css-variables-nested.json",
     "./tailwind.config": "./tailwind.config.ts"
   },
   "types": "lib/index.d.ts",


### PR DESCRIPTION
### Summary:

Let consumers import `css-variables-nested.json` from EDS. Useful for theming Tailwind with our EDS values.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
