### PR TITLE
fix: suppress warnings from useId imports and prop usage

### DIFF
--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -15,7 +15,7 @@ export default {
     label: 'Textarea Field',
     rows: 5,
     fieldNote: 'Longer Field description',
-    spellcheck: false,
+    spellCheck: false,
   },
   parameters: {
     badges: ['1.3'],

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -20,7 +20,7 @@ export default {
   parameters: {
     badges: ['1.3'],
   },
-} as Meta<Args>;
+} satisfies Meta<Args>;
 
 type Args = React.ComponentProps<typeof TextareaField>;
 

--- a/src/components/TextareaField/__snapshots__/TextareaField.test.ts.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField.test.ts.snap
@@ -22,6 +22,7 @@ exports[`<TextareaField /> AfterDelete story renders snapshot 1`] = `
     maxlength="209"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -74,6 +75,7 @@ exports[`<TextareaField /> Default story renders snapshot 1`] = `
     id=":r0:"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -113,6 +115,7 @@ exports[`<TextareaField /> UsingChildren story renders snapshot 1`] = `
     id=":r2:"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -154,6 +157,7 @@ exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
     placeholder="Enter long-form text here"
     readonly=""
     rows="2"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -193,6 +197,7 @@ exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
     id=":r8:"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -250,6 +255,7 @@ exports[`<TextareaField /> WhenInvalid story renders snapshot 1`] = `
     maxlength="10"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -324,6 +330,7 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
     placeholder="Enter long-form text here"
     required=""
     rows="5"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -363,6 +370,7 @@ exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
     id=":re:"
     placeholder="Enter long-form text here"
     rows="10"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -409,6 +417,7 @@ exports[`<TextareaField /> WithAMaxLength story renders snapshot 1`] = `
     placeholder="Enter long-form text here"
     required=""
     rows="10"
+    spellcheck="false"
   >
     Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
     dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
@@ -476,6 +485,7 @@ exports[`<TextareaField /> WithNoDefaultValue story renders snapshot 1`] = `
     id=":r4:"
     placeholder="Enter long-form text here"
     rows="5"
+    spellcheck="false"
   />
 </div>
 `;

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -5,15 +5,14 @@ function genId() {
   return ++id;
 }
 
-if (process.env.NODE_ENV !== 'production') {
-  console.warn(
-    'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
-  );
-}
-
 export const useId =
   React.useId ??
   function useId() {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
+      );
+    }
     const id = 'eds-' + genId();
     return id;
   };

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -1,6 +1,8 @@
 import React from 'react';
 
 let id = 0;
+let showWarning = true;
+
 function genId() {
   return ++id;
 }
@@ -8,10 +10,11 @@ function genId() {
 export const useId =
   React.useId ??
   function useId() {
-    if (process.env.NODE_ENV !== 'production') {
+    if (process.env.NODE_ENV !== 'production' && showWarning) {
       console.warn(
         'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
       );
+      showWarning = false;
     }
     const id = 'eds-' + genId();
     return id;


### PR DESCRIPTION
### Summary:

- move the `console.warn` inside the function usage ~(TODO: consider deduping its output)~
- use proper camelCase prop name in textarea tests

### Test Plan:

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
