### PR TITLE
fix: ensure @import rules are before any other styles

### DIFF
--- a/src/design-tokens/external-fonts.css
+++ b/src/design-tokens/external-fonts.css
@@ -1,0 +1,1 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600&display=swap');

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -1,5 +1,4 @@
 @import '../design-tokens/tier-2-usage/typography-usage.css';
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600&display=swap');
 
 /**
  * Link button styles

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -26,7 +26,7 @@
 
   &:focus-visible {
     /**
-     * Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
+     * Make the focus outline invisible but don't remove it. High contrast mode will remove the background
      * color, but it will also make borders 100% opacity black.
      */
     outline: 1px solid transparent;
@@ -40,7 +40,7 @@
   @supports not selector(:focus-visible) {
     &:focus {
       /**
-       * Make the focus outline invisible but don't remove it. High contrast mode will remove the background 
+       * Make the focus outline invisible but don't remove it. High contrast mode will remove the background
        * color, but it will also make borders 100% opacity black.
        */
       outline: 1px solid transparent;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Ensure @import rules for fonts are before anything else. Otherwise build tools can show warnings
+// in consuming apps.
+import './design-tokens/external-fonts.css';
 // This brings the style tokens that are css custom variables into the built stylesheet so only one stylesheet for EDS has to be imported.
 import './tokens-dist/css/variables.css';
 


### PR DESCRIPTION
### Summary:

https://czi-tech.atlassian.net/browse/EFI-1094

Resolves:
- Warnings from build tools in consuming apps (see [this slack convo from May 5, 2023](https://czi-edu.slack.com/archives/CTFV79JH4/p1683306915376259))
- 40 duplicate `@import` entries for the same font in index.css

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Inspected `yarn build` output
  - Used `npm link` to run in edu-stack
