### PR TITLE
fix: group all font imports together

### DIFF
--- a/src/design-tokens/external-fonts.css
+++ b/src/design-tokens/external-fonts.css
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600&display=swap');

--- a/src/design-tokens/tier-1-definitions/fonts.css
+++ b/src/design-tokens/tier-1-definitions/fonts.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;500;600&display=swap');
+
 @font-face {
   font-family: 'Graphik';
   font-weight: 400;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-// Ensure @import rules for fonts are before anything else. Otherwise build tools can show warnings
-// in consuming apps.
-import './design-tokens/external-fonts.css';
 // This brings the style tokens that are css custom variables into the built stylesheet so only one stylesheet for EDS has to be imported.
 import './tokens-dist/css/variables.css';
 


### PR DESCRIPTION
### Summary:

- removing the font import from mixins caused Open Sans to stop appearing in storybook
- similar to Graphik, we should import the fonts from our fonts.css file
- existing instructions won't need changing, as they specify using this file already (README, storybook, etc.)

I think our Chromatic setting to do TurboSnaps meant that it didn't detect this change as a snapshot diff, so there was no clue the font had disappeared :( 

Busted snapshots start appearing later: #1613, #1614 

More long term, we should revisit [getting fonts from google anyway](https://wpspeedmatters.com/self-host-google-fonts/)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - verify lib/ contents are correct:
  - no import lines in index.css
  - import for google font in fonts.css
  - no snapshot updates for typography page
