### PR TITLE
fix: correct misspelled color token names

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -22,7 +22,7 @@
 .menu__button {
   @mixin eds-theme-typography-body-md;
 
-  color: var(--eds-theme-text-neutral-subtle);
+  color: var(--eds-theme-color-text-neutral-subtle);
   background-color: var(--eds-theme-color-form-background);
   border-color: var(--eds-theme-color-form-border);
   font-weight: var(--eds-font-weight-light);

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -88,7 +88,7 @@
   @mixin eds-theme-typography-body-md;
   /* Allow select component font to shrink in contexts where body font size is smaller. */
   font-size: inherit;
-  color: var(--eds-theme-text-neutral-subtle);
+  color: var(--eds-theme-color-text-neutral-subtle);
 
   height: var(--eds-size-5);
   width: 100%;


### PR DESCRIPTION
### Summary:
- for menu, it was falling back to an incorrect, tho similar, color value
- for select, it was inheriting the correct hex value b/c the specific theme value was not defined

Following the naming conventions defined in [this file][variables-link]

### Test Plan:

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.

[variables-link]: https://github.com/chanzuckerberg/edu-design-system/blob/main/src/tokens-dist/css/variables.css#L203