### PR TITLE
fix(build): build type declarations separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,9 @@
     "tailwind.config.*"
   ],
   "scripts": {
-    "build": "yarn build:clean && yarn build:tokens && yarn build:js && yarn copy-fonts-to-lib",
+    "build": "yarn build:clean && yarn build:tokens && yarn build:declarations && yarn build:js && yarn copy-fonts-to-lib",
     "build:clean": "rm -rf lib/",
+    "build:declarations": "tsc --emitDeclarationOnly --project tsconfig.build.json",
     "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn prettier-tokens-dist",
     "build:js": "rollup --config",
     "build:storybook": "build-storybook -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "12.0.3",
+  "version": "12.0.4-alpha.1",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -39,11 +39,11 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   /**
    * Maximum number the input can take.
    */
-  max?: number | string | undefined;
+  max?: number | string;
   /**
    * Minimum number the input can take.
    */
-  min?: number | string | undefined;
+  min?: number | string;
   /**
    * HTML name attribute for the input
    */

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -37,13 +37,13 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   isError?: boolean;
   /**
-   * Maximum number the input can take. When this number equals the input value, the plus button becomes disabled.
+   * Maximum number the input can take.
    */
-  max?: number;
+  max?: number | string | undefined;
   /**
-   * Minimum number the input can take. When this number equals the input value, the minus button becomes disabled.
+   * Minimum number the input can take.
    */
-  min?: number;
+  min?: number | string | undefined;
   /**
    * HTML name attribute for the input
    */

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -50,13 +50,13 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   isError?: boolean;
   /**
-   * Maximum value allowed for the input, if type is 'number'. When the input value matches this maximum, the plus button becomes disabled.
+   * Maximum value allowed for the input, if type is 'number'.
    */
-  max?: number;
+  max?: number | string | undefined;
   /**
-   * Minimum value allowed for the input, if type is 'number'. When the input value matches this minimum, the minus button becomes disabled.
+   * Minimum value allowed for the input, if type is 'number'.
    */
-  min?: number;
+  min?: number | string | undefined;
   /**
    * HTML name attribute for the input
    */

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -52,11 +52,11 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
   /**
    * Maximum value allowed for the input, if type is 'number'.
    */
-  max?: number | string | undefined;
+  max?: number | string;
   /**
    * Minimum value allowed for the input, if type is 'number'.
    */
-  min?: number | string | undefined;
+  min?: number | string;
   /**
    * HTML name attribute for the input
    */


### PR DESCRIPTION
[EFI-1103]

### Summary:
- builds declaration files separately since with the typescript rollup config the files exporting only types get pruned 

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
    - `v12.0.4-alpha.1`: ![Screenshot 2023-05-24 at 11 18 33 PM](https://github.com/chanzuckerberg/edu-design-system/assets/86632227/22f29336-22ec-4698-a6da-8d9250665c9a) shows the `onChange` type being inherited properly and can navigate `node_modules/eds` to find the missing utility types in `edu-stack`
      - https://github.com/chanzuckerberg/edu-stack/tree/jlee/edsAlpha14.0.4


[EFI-1103]: https://czi-tech.atlassian.net/browse/EFI-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ