### PR TITLE
refactor(breadcrumbs): use menu over deprecated buttondropdown

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -133,5 +133,6 @@ export const LongTextMenu: StoryObj<Args> = {
     const canvas = within(canvasElement);
     const dropdownMenuTrigger = await canvas.findByRole('button');
     userEvent.click(dropdownMenuTrigger);
+    // TODO: capture open menu in Chromatic
   },
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -117,6 +117,7 @@ export const LongTextMenu: StoryObj<Args> = {
   args: {
     ...LongText.args,
   },
+  decorators: [(Story) => <div className="pb-28">{Story()}</div>],
   parameters: {
     viewport: {
       defaultViewport: 'ipadMini',
@@ -133,6 +134,5 @@ export const LongTextMenu: StoryObj<Args> = {
     const canvas = within(canvasElement);
     const dropdownMenuTrigger = await canvas.findByRole('button');
     userEvent.click(dropdownMenuTrigger);
-    // TODO: capture open menu in Chromatic
   },
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -82,9 +82,9 @@ export const Breadcrumbs = ({
       : null;
 
   /**
-   * Finds all the breadcrumb items between the first and last breadcrumb items so they can be placed in the dropdown.
+   * Finds all the breadcrumb items between the first and last breadcrumb items so they can be placed in the Menu.
    */
-  const dropdownMenuItems = breadcrumbsItems
+  const menuItems = breadcrumbsItems
     .slice(1, breadcrumbsItems.length - 1)
     .map((breadcrumbItem, index) => {
       const menuItem = breadcrumbItem as JSX.Element;
@@ -115,14 +115,14 @@ export const Breadcrumbs = ({
          */}
         {backBreadCrumb}
         {/**
-         * The ellipsis breadcrumb with dropdown only exists if there would be overflow and there are 3 or more breadcrumb items.
+         * The ellipsis breadcrumb with Menu only exists if there would be overflow and there are 3 or more breadcrumb items.
          */}
         {shouldTruncate && breadcrumbsItems.length > 2 ? (
           <>
             {breadcrumbsItems[0]}
             <BreadcrumbsItem
-              dropdownMenuItems={dropdownMenuItems}
               href={null}
+              menuItems={menuItems}
               variant="collapsed"
             />
             {breadcrumbsItems[breadcrumbsItems.length - 1]}

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -3,7 +3,7 @@ import debounce from 'lodash.debounce';
 import React, { type ReactNode } from 'react';
 import { flattenReactChildren } from '../../util/flattenReactChildren';
 import BreadcrumbsItem from '../BreadcrumbsItem';
-import DropdownMenuItem from '../DropdownMenuItem';
+import Menu from '../Menu';
 import styles from './Breadcrumbs.module.css';
 
 type Props = {
@@ -89,14 +89,15 @@ export const Breadcrumbs = ({
     .map((breadcrumbItem, index) => {
       const menuItem = breadcrumbItem as JSX.Element;
       return (
-        <DropdownMenuItem
+        <Menu.Item
           href={menuItem.props.href}
+          icon="link"
           // FIXME
           // eslint-disable-next-line react/no-array-index-key
           key={`breadcrumb-menu-item-${index}`}
         >
           {menuItem.props.text}
-        </DropdownMenuItem>
+        </Menu.Item>
       );
     });
 

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -56,9 +56,15 @@
  * Ellipsis variant of the breadcrumbs list item.
  */
 .breadcrumbs__ellipsis {
+  min-height: unset;
+  min-width: unset;
+
   border: none;
+  border-radius: unset;
   background-color: transparent;
-  cursor: pointer;
+}
+.breadcrumbs__ellipsis:hover {
+  background-color: transparent;
 }
 
 /**

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.module.css
@@ -10,7 +10,7 @@
 .breadcrumbs__item {
   @mixin eds-theme-typography-body-xs;
   max-width: 100%;
-  /* Required for dropdown menu to absolutely position relative to this container. */
+  /* Required for the Menu to absolutely position relative to this container. */
   position: relative;
 
   /* Hides all breadcrumbs except the last breadcrumb in smaller breakpoints. */

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import React from 'react';
-import ButtonDropdown from '../ButtonDropdown';
 import Icon from '../Icon';
+import Menu from '../Menu';
 import styles from './BreadcrumbsItem.module.css';
 
 type Props = {
@@ -60,19 +60,15 @@ export const BreadcrumbsItem = ({
     if (variant === 'collapsed') {
       /* The collapsed variant is a button with ellipsis. Interaction spawns a dropdown containing the collapsed breadcrumb links. */
       return (
-        <ButtonDropdown
-          dropdownMenuTrigger={
-            <button
-              aria-label="Show more breadcrumbs"
-              className={ellipsisButtonClassName}
-            >
-              ...
-            </button>
-          }
-          position="bottom-right"
-        >
-          {dropdownMenuItems}
-        </ButtonDropdown>
+        <Menu>
+          <Menu.PlainButton
+            aria-label="Show more breadcrumbs"
+            className={ellipsisButtonClassName}
+          >
+            ...
+          </Menu.PlainButton>
+          <Menu.Items>{dropdownMenuItems}</Menu.Items>
+        </Menu>
       );
     } else if (variant === 'back') {
       /* The back variant is a left pointing icon that usually links to the second last breadcrumb href. */

--- a/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/src/components/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -12,14 +12,14 @@ type Props = {
   /**
    * URL for the breadcrumbs item.
    * Required since breadcrumbs should reroute user.
-   * Null case is used for the collapsed variant, which uses dropdownMenuItems which has hrefs.
+   * Null case is used for the collapsed variant, which uses Menu Items which has hrefs.
    */
   href: string | null;
   /**
    * URLs for the collapsed breadcrumbs variant.
-   * Should be <DropdownMenuItem href={href}>{text}</DropdownMenuItem>.
+   * Should be <Menu.Item href={href}>{text}</Menu.Item>.
    */
-  dropdownMenuItems?: React.ReactNode[];
+  menuItems?: React.ReactNode[];
   /**
    * Breadcrumbs item text.
    */
@@ -27,7 +27,7 @@ type Props = {
   /**
    * Behavior variations for the breadcrumbs item.
    * - **back** - results in a left facing icon, usually denoting the second last breadcrumb item in a mobile breakpoint.
-   * - **collapsed** - results in an ellipsis, where interaction spawns a dropdown menu containing more links.
+   * - **collapsed** - results in an ellipsis, where interaction spawns a Menu containing more links.
    */
   variant?: 'back' | 'collapsed';
 };
@@ -38,7 +38,7 @@ type Props = {
  * A single breadcrumb subcomponent, to be used in the Breadcrumbs component.
  */
 export const BreadcrumbsItem = ({
-  dropdownMenuItems,
+  menuItems,
   className,
   href,
   text,
@@ -58,7 +58,7 @@ export const BreadcrumbsItem = ({
 
   const getInteractionElement = () => {
     if (variant === 'collapsed') {
-      /* The collapsed variant is a button with ellipsis. Interaction spawns a dropdown containing the collapsed breadcrumb links. */
+      /* The collapsed variant is a button with ellipsis. Interaction spawns a Menu containing the collapsed breadcrumb links. */
       return (
         <Menu>
           <Menu.PlainButton
@@ -67,7 +67,7 @@ export const BreadcrumbsItem = ({
           >
             ...
           </Menu.PlainButton>
-          <Menu.Items>{dropdownMenuItems}</Menu.Items>
+          <Menu.Items>{menuItems}</Menu.Items>
         </Menu>
       );
     } else if (variant === 'back') {


### PR DESCRIPTION
[EFI-1002]

### Summary:
- uses the supported Menu component over the deprecated ButtonDropdown/DropdownMenu component
- #1647 removes old ButtonDropdown use in the recipes/pages
![Screenshot 2023-06-01 at 4 06 59 PM](https://github.com/chanzuckerberg/edu-design-system/assets/86632227/72fc9e0d-e831-487a-82fc-5b283f42aff8)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Manually tested my changes, and here are the details:
  - Ellipsis breadcrumbs works with the links in Storybook


[EDS-1002]: https://czi-tech.atlassian.net/browse/EDS-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EFI-1002]: https://czi-tech.atlassian.net/browse/EFI-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ