### PR TITLE
refactor(projectcard): use menu component over buttondropdown

### DIFF
--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.module.css
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.module.css
@@ -16,6 +16,22 @@
   }
 }
 
+/**
+ * Individual Menu item that displays when clicking the vertical dots.
+ */
+.menu-item {
+  padding: var(--eds-size-1-and-half) var(--eds-size-2);
+}
+
+/**
+ * Destructive variant of the Menu item.
+ *
+ * For indicating deletion of the project.
+ */
+.menu-item--destructive {
+  color: var(--eds-theme-color-text-utility-error);
+}
+
 /*------------------------------------*\
     # TABLE CARD
 \*------------------------------------*/

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.module.css
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.module.css
@@ -17,13 +17,6 @@
 }
 
 /**
- * Individual Menu item that displays when clicking the vertical dots.
- */
-.menu-item {
-  padding: var(--eds-size-1-and-half) var(--eds-size-2);
-}
-
-/**
  * Destructive variant of the Menu item.
  *
  * For indicating deletion of the project.

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -403,39 +403,21 @@ export const CoursePlannerEdit = () => {
   const projectCardMenuItems = () => {
     return (
       <>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move to other section
-        </Menu.Item>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move up
-        </Menu.Item>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move down
-        </Menu.Item>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move view details
-        </Menu.Item>
+        <Menu.Item icon="schedule">Move to other section</Menu.Item>
+        <Menu.Item icon="schedule">Move up</Menu.Item>
+        <Menu.Item icon="schedule">Move down</Menu.Item>
+        <Menu.Item icon="schedule">Move view details</Menu.Item>
       </>
     );
   };
 
   const projectCardMenuItemsWithDelete = () => {
-    const destructiveMenuItem = clsx(
-      styles['menu-item'],
-      styles['menu-item--destructive'],
-    );
     return (
       <>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move to other section
-        </Menu.Item>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move up
-        </Menu.Item>
-        <Menu.Item className={styles['menu-item']} icon="schedule">
-          Move down
-        </Menu.Item>
-        <Menu.Item className={destructiveMenuItem} icon="delete">
+        <Menu.Item icon="schedule">Move to other section</Menu.Item>
+        <Menu.Item icon="schedule">Move up</Menu.Item>
+        <Menu.Item icon="schedule">Move down</Menu.Item>
+        <Menu.Item className={styles['menu-item--destructive']} icon="delete">
           Delete item
         </Menu.Item>
       </>

--- a/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
+++ b/.storybook/pages/CoursePlannerEdit/CoursePlannerEdit.tsx
@@ -5,35 +5,35 @@ import type { ReactNode } from 'react';
 import ProjectCard from './ProjectCard';
 
 import {
-  PageHeader,
-  Panel,
-  ButtonGroup,
   Button,
-  Heading,
-  LayoutContainer,
-  Layout,
-  LayoutSection,
-  DragDrop,
-  DragDropContainerHeader,
-  Icon,
-  HorizontalStepper,
-  DataBar,
-  Toolbar,
-  ToolbarItem,
-  Grid,
-  GridItem,
-  Text,
-  DropdownMenuItem,
+  ButtonGroup,
   Card,
   CardBody,
+  CardFooter,
+  DataBar,
+  DragDrop,
+  DragDropContainerHeader,
+  Grid,
+  GridItem,
+  Heading,
+  HorizontalStepper,
+  Icon,
+  Layout,
+  LayoutContainer,
+  LayoutSection,
+  Menu,
   NumberIcon,
-  TableHeader,
-  TableRow,
+  PageHeader,
+  Panel,
   Table,
   TableBody,
   TableCell,
+  TableHeader,
   TableHeaderCell,
-  CardFooter,
+  TableRow,
+  Text,
+  Toolbar,
+  ToolbarItem,
 } from '../../../src';
 
 import type { NewState } from '../../../src/components/DragDrop/DragDrop';
@@ -403,45 +403,41 @@ export const CoursePlannerEdit = () => {
   const projectCardMenuItems = () => {
     return (
       <>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move to other section
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move up
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move down
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move view details
-        </DropdownMenuItem>
+        </Menu.Item>
       </>
     );
   };
 
   const projectCardMenuItemsWithDelete = () => {
+    const destructiveMenuItem = clsx(
+      styles['menu-item'],
+      styles['menu-item--destructive'],
+    );
     return (
       <>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move to other section
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move up
-        </DropdownMenuItem>
-        <DropdownMenuItem>
-          <Icon name="schedule" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={styles['menu-item']} icon="schedule">
           Move down
-        </DropdownMenuItem>
-        <DropdownMenuItem status="error">
-          <Icon name="delete" purpose="decorative" size="1.25rem" />
+        </Menu.Item>
+        <Menu.Item className={destructiveMenuItem} icon="delete">
           Delete item
-        </DropdownMenuItem>
+        </Menu.Item>
       </>
     );
   };
@@ -497,7 +493,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItemsWithDelete()}
+          menuItems={projectCardMenuItemsWithDelete()}
           meta="12 days"
           metaIconName="event-note"
           number={1}
@@ -511,7 +507,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItems()}
+          menuItems={projectCardMenuItems()}
           meta="12 days"
           metaIconName="event-note"
           number={indexState}
@@ -525,7 +521,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItems()}
+          menuItems={projectCardMenuItems()}
           meta="12 days"
           metaIconName="event-note"
           number={3}
@@ -539,7 +535,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItems()}
+          menuItems={projectCardMenuItems()}
           meta="12 days"
           metaIconName="event-note"
           number={4}
@@ -553,8 +549,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItems()}
-          buttonDropdownPosition="top-left"
+          menuItems={projectCardMenuItems()}
           meta="12 days"
           metaIconName="event-note"
           number={5}
@@ -568,8 +563,7 @@ export const CoursePlannerEdit = () => {
       children: (
         <ProjectCard
           behavior="draggable"
-          buttonDropdownItems={projectCardMenuItems()}
-          buttonDropdownPosition="top-left"
+          menuItems={projectCardMenuItems()}
           meta="12 days"
           metaIconName="event-note"
           number={6}

--- a/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
+++ b/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
@@ -7,9 +7,8 @@ import {
   CardHeader,
   Heading,
   Icon,
-  Button,
+  Menu,
   NumberIcon,
-  ButtonDropdown,
 } from '../../../../src';
 import type { HeadingElement } from '../../../../src/components/Heading';
 
@@ -23,19 +22,11 @@ export interface Props {
    */
   behavior?: 'draggable';
   /**
-   * Button dropdown items
+   * Menu items
    *
-   * If not declared, the button dropdown does not render.
+   * If not declared, the menu does not render.
    */
-  buttonDropdownItems?: ReactNode;
-  /**
-   * Determines type of clickable
-   * - default renders a dropdown menu to the bottom left of the button
-   * - **top-left** renders a dropdown menu to the top left of the button
-   * - **top-right** renders a dropdown menu to the top right of the button
-   * - **bottom-right** renders a dropdown menu to the bottom right of the button
-   */
-  buttonDropdownPosition?: 'top-left' | 'top-right' | 'bottom-right';
+  menuItems?: ReactNode;
   /**
    * CSS class names that can be appended to the component.
    */
@@ -82,8 +73,7 @@ export const ProjectCard = ({
   metaIconName,
   number,
   headingAs = 'h3',
-  buttonDropdownItems,
-  buttonDropdownPosition,
+  menuItems,
   numberAriaLabel,
   isDragging,
   ...other
@@ -139,24 +129,27 @@ export const ProjectCard = ({
           </div>
         )}
       </Card.Body>
-      {buttonDropdownItems && (
+      {menuItems && (
         <Card.Footer className={styles['project-card__footer']}>
-          <ButtonDropdown
-            dropdownMenuTrigger={
-              <Button
-                aria-label="Open project dropdown"
-                className={styles['project-card__menu-button']}
-                size="sm"
-                status="neutral"
-                variant="icon"
-              >
-                <Icon name="dots-vertical" purpose="decorative" />
-              </Button>
-            }
-            position={buttonDropdownPosition}
+          <Menu
+            modifiers={[
+              {
+                name: 'offset',
+                options: { offset: [0, 0] },
+              },
+            ]}
+            placement="bottom-end"
           >
-            {buttonDropdownItems}
-          </ButtonDropdown>
+            <Menu.PlainButton>
+              <Icon
+                name="dots-vertical"
+                purpose="informative"
+                size="1.5rem"
+                title="Open project dropdown"
+              />
+            </Menu.PlainButton>
+            <Menu.Items>{menuItems}</Menu.Items>
+          </Menu>
         </Card.Footer>
       )}
     </Card>

--- a/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
+++ b/.storybook/pages/CoursePlannerEdit/ProjectCard/ProjectCard.tsx
@@ -133,6 +133,7 @@ export const ProjectCard = ({
         <Card.Footer className={styles['project-card__footer']}>
           <Menu
             modifiers={[
+              // Brings the Menu closer to the dots-vertical icon trigger button
               {
                 name: 'offset',
                 options: { offset: [0, 0] },


### PR DESCRIPTION
[EDS-1002]

### Summary:
- uses the supported Menu component over the deprecated ButtonDropdown/DropdownMenu component
- along with #1646 completes removal of usage of the deprecated ButtonDropdown/DropdownMenu component to be set for removal
![image](https://github.com/chanzuckerberg/edu-design-system/assets/86632227/b6ae02dd-64d4-4a66-a649-922312296abb)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Manually tested my changes, and here are the details:
  - The project cards in the course planner edit page in storybook has working menu functionality


[EDS-1002]: https://czi-tech.atlassian.net/browse/EDS-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ