### PR TITLE
fix: allow all valid input types

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -71,20 +71,7 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   /**
    * HTML type attribute, allowing switching between text, password, and other HTML5 input field types
    */
-  type?:
-    | 'text'
-    | 'password'
-    | 'datetime'
-    | 'datetime-local'
-    | 'date'
-    | 'month'
-    | 'time'
-    | 'week'
-    | 'number'
-    | 'email'
-    | 'url'
-    | 'search'
-    | 'tel';
+  type?: React.HTMLInputTypeAttribute;
   /**
    * The value of the input
    */


### PR DESCRIPTION
### Summary:

Allow all valid input type attributes.

Needed so the type `conform.input` returns matches EDS's. Without this, we run into type errors with the latest version of React's types -> https://github.com/chanzuckerberg/edu-stack/pull/129/files#r1215506643

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
