### PR TITLE
refactor(toast): deprecate component

### DIFF
--- a/src/components/Toast/Toast.stories.ts
+++ b/src/components/Toast/Toast.stories.ts
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import type { ComponentProps } from 'react';
 import { Toast } from './Toast';
@@ -6,7 +7,7 @@ export default {
   title: 'Components/Toast',
   component: Toast,
   parameters: {
-    badges: ['1.0'],
+    badges: ['1.0', BADGE.DEPRECATED],
   },
   argTypes: { onDismiss: { action: 'dismissed' } },
   args: {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -32,6 +32,8 @@ export type Props = {
  * A toast used to provide information on the state of the page, usually in response to a
  * user action. Ex: The user updates their profile, and a toast pop-up informs them that the
  * data was successfully saved.
+ *
+ * @deprecated
  */
 export const Toast = ({
   children,


### PR DESCRIPTION
### Summary:
marks the Toast component as deprecated, an AI result of 6/6 design pairing

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Manually tested my changes, and here are the details:
  - attempting to use it has the TS warnings and strikethrough
  - `deprecated` tag added to stories
  - not used in other EDS components in code
