### PR TITLE
fix(Menu): reset menu item hover and defer to popover

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -53,3 +53,8 @@
   text-decoration: none;
   color: inherit;
 }
+
+/* Unset the hover on the menu item, as this is handled by the PopoverListItem */
+.menu__item:hover {
+  color: unset;
+}

--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -14,6 +14,7 @@
 }
 
 .popover-list-item--active {
+  color: var(--eds-theme-color-text-neutral-default);
   background-color: var(--eds-theme-color-background-neutral-default-hover);
 }
 


### PR DESCRIPTION
### Summary:

- reset any color set directly on the menu item line
- set the state color to our text/neutral-default color

### Test Plan:

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - apply override of `a:hover` in storybook to make sure it doesn't override component text color
  - no snapshots should change
