### PR TITLE
feat(Text): add support for caption-md and caption-lg

### DIFF
--- a/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
+++ b/.storybook/components/DesignTokens/Tier2/TypographyUsage.jsx
@@ -54,16 +54,16 @@ export class Tier2TypographyUsage extends Component {
 
         <Section title="Body Text">
           <Grid>
-            {renderTypeToken('body-lg', '004')}
-            {renderTypeToken('body-md', '005')}
-            {renderTypeToken('body-sm', '006')}
-            {renderTypeToken('body-xs', '008')}
+            {renderTypeToken('body-lg', '004-light')}
+            {renderTypeToken('body-md', '005-light')}
+            {renderTypeToken('body-sm', '006-light')}
+            {renderTypeToken('body-xs', '008-light')}
           </Grid>
         </Section>
 
         <Section title="Caption">
           <Grid>
-            {renderTypeToken('caption-lg', '006')}
+            {renderTypeToken('caption-lg', '006-light')}
             {renderTypeToken('caption-md', '008')}
             {renderTypeToken('caption-sm', '010')}
           </Grid>

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -20,8 +20,11 @@
 .text--xs {
   @mixin eds-theme-typography-body-xs;
 }
-.text--caption {
+.text--caption, .text--caption-md {
   @mixin eds-theme-typography-caption-md;
+}
+.text--caption-lg {
+  @mixin eds-theme-typography-caption-lg;
 }
 .text--overline {
   @mixin eds-theme-typography-overline;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -9,9 +9,15 @@ export type Size =
   | 'md'
   | 'lg'
   | 'xs'
-  | 'caption'
+  | 'caption-md'
+  | 'caption-lg'
   | 'overline'
   | 'callout';
+
+/**
+ * @deprecated  Please use `caption-md` instead
+ */
+export type DeprecatedSize = 'caption';
 
 export type Variant =
   | 'inherit'
@@ -22,11 +28,12 @@ export type Variant =
   | 'success'
   | 'warning'
   | 'error'
-  | 'white'
-  /**
-   * @deprecated Info variant is deprecated.
-   */
-  | 'info';
+  | 'white';
+
+/**
+ * @deprecated Info variant is deprecated.
+ */
+export type DeprecatedVariant = 'info';
 
 export type Props = {
   /**
@@ -35,8 +42,8 @@ export type Props = {
   as?: 'p' | 'span';
   children: React.ReactNode;
   className?: string;
-  variant?: Variant;
-  size?: Size;
+  variant?: Variant | DeprecatedVariant;
+  size?: Size | DeprecatedSize;
   tabIndex?: number;
   weight?: 'bold' | 'normal' | null;
 } & React.HTMLAttributes<HTMLElement>;
@@ -96,4 +103,5 @@ export const Text = forwardRef(
     );
   },
 );
+
 Text.displayName = 'Text'; // Satisfy eslint

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { Tooltip } from './Tooltip';
@@ -8,10 +7,10 @@ import { Tooltip } from './Tooltip';
 const diffThreshold = 0.75;
 const defaultArgs = {
   text: (
-    <span data-testid="tooltip-content">
+    <span>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit.{' '}
-      <b>Donec a erat eu augue consequat eleifend non vel sem.</b> Praesent
-      efficitur mauris ac leo semper accumsan.
+      <strong>Donec a erat eu augue consequat eleifend non vel sem.</strong>{' '}
+      Praesent efficitur mauris ac leo semper accumsan.
     </span>
   ),
   children: <div className="fpo w-3 p-1">&bull;</div>,
@@ -52,15 +51,6 @@ export default {
 type Args = React.ComponentProps<typeof Tooltip>;
 
 export const LightVariant: StoryObj<Args> = {};
-
-export const DarkVariant: StoryObj<Args> = {
-  args: {
-    variant: 'dark',
-  },
-  parameters: {
-    badges: [BADGE.DEPRECATED],
-  },
-};
 
 export const LeftPlacement: StoryObj<Args> = {
   args: {

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import type { TippyProps } from '@tippyjs/react';
 import Tippy from '@tippyjs/react';
 import clsx from 'clsx';
 import * as React from 'react';
+import { Text } from '../Text/Text';
 import styles from './Tooltip.module.css';
 
 // Full list of Tippy props: https://atomiks.github.io/tippyjs/v6/all-props/
@@ -150,6 +151,12 @@ export const Tooltip = ({
     );
   }
 
+  const textContent = (
+    <Text as="span" data-testid="tooltip-content" size="caption-lg">
+      {text}
+    </Text>
+  );
+
   return (
     <Tippy
       {...rest}
@@ -159,7 +166,7 @@ export const Tooltip = ({
         variant === 'dark' && styles['tooltip--dark'],
         className,
       )}
-      content={text}
+      content={textContent}
       duration={duration}
       placement={align}
       plugins={[hideOnEsc]}

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
       class="p-16"
     >
       <div
-        aria-describedby="tippy-5"
+        aria-describedby="tippy-4"
         class="fpo w-3 p-1"
       >
         •
@@ -16,7 +16,7 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
   </div>
   <div
     data-tippy-root=""
-    id="tippy-5"
+    id="tippy-4"
     style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(0px, 10px);"
   >
     <div
@@ -37,77 +37,24 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
       >
         <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>
       <div
         class="tippy-arrow"
         style="position: absolute; left: 0px; transform: translate(3px, 0px);"
-      />
-    </div>
-  </div>
-</body>
-`;
-
-exports[`<Tooltip /> DarkVariant story renders snapshot 1`] = `
-<body>
-  <div>
-    <div
-      class="p-16"
-    >
-      <div
-        aria-describedby="tippy-2"
-        class="fpo w-3 p-1"
-      >
-        •
-      </div>
-    </div>
-  </div>
-  <div
-    data-tippy-root=""
-    id="tippy-2"
-    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
-  >
-    <div
-      class="tippy-box tooltip tooltip--dark"
-      data-animation="fade"
-      data-escaped=""
-      data-placement="right"
-      data-reference-hidden=""
-      data-state="visible"
-      role="tooltip"
-      style="max-width: 350px; transition-duration: 0ms;"
-      tabindex="-1"
-    >
-      <div
-        class="tippy-content"
-        data-state="visible"
-        style="transition-duration: 0ms;"
-      >
-        <div>
-          <span
-            data-testid="tooltip-content"
-          >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
-          </span>
-        </div>
-      </div>
-      <div
-        class="tippy-arrow"
-        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
       />
     </div>
   </div>
@@ -168,7 +115,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
       class="p-16"
     >
       <div
-        aria-describedby="tippy-3"
+        aria-describedby="tippy-2"
         class="fpo w-3 p-1"
       >
         •
@@ -177,7 +124,7 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
   </div>
   <div
     data-tippy-root=""
-    id="tippy-3"
+    id="tippy-2"
     style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; right: 0px; transform: translate(-10px, 0px);"
   >
     <div
@@ -198,14 +145,18 @@ exports[`<Tooltip /> LeftPlacement story renders snapshot 1`] = `
       >
         <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>
@@ -255,14 +206,18 @@ exports[`<Tooltip /> LightVariant story renders snapshot 1`] = `
       >
         <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>
@@ -282,10 +237,70 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
       class="p-16"
     >
       <div
-        aria-describedby="tippy-6"
+        aria-describedby="tippy-5"
         class="fpo w-3 p-1"
       >
         •
+      </div>
+    </div>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-5"
+    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
+  >
+    <div
+      class="tippy-box tooltip tooltip--light"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="right"
+      data-reference-hidden=""
+      data-state="visible"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 0ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 0ms;"
+      >
+        <div>
+          <span
+            class="text text--caption-lg"
+            data-testid="tooltip-content"
+          >
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <b>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </b>
+               Praesent efficitur mauris ac leo semper accumsan. Donec posuere semper fermentum. Vivamus venenatis laoreet venenatis. Sed consectetur, dolor sed tristique vehicula, sapien nulla convallis odio, et tempus urna mi eu leo. Phasellus a venenatis sapien. Cras massa lectus, sollicitudin id nulla id, laoreet facilisis est.
+            </span>
+          </span>
+        </div>
+      </div>
+      <div
+        class="tippy-arrow"
+        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
+      />
+    </div>
+  </div>
+</body>
+`;
+
+exports[`<Tooltip /> LongTriggerText story renders snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="p-16"
+    >
+      <div
+        aria-describedby="tippy-6"
+        class="fpo p-1"
+      >
+        Longer text to test placement
       </div>
     </div>
   </div>
@@ -311,70 +326,19 @@ exports[`<Tooltip /> LongText story renders snapshot 1`] = `
         style="transition-duration: 0ms;"
       >
         <div>
-          <span>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan. Donec posuere semper fermentum. Vivamus venenatis laoreet venenatis. Sed consectetur, dolor sed tristique vehicula, sapien nulla convallis odio, et tempus urna mi eu leo. Phasellus a venenatis sapien. Cras massa lectus, sollicitudin id nulla id, laoreet facilisis est.
-          </span>
-        </div>
-      </div>
-      <div
-        class="tippy-arrow"
-        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
-      />
-    </div>
-  </div>
-</body>
-`;
-
-exports[`<Tooltip /> LongTriggerText story renders snapshot 1`] = `
-<body>
-  <div>
-    <div
-      class="p-16"
-    >
-      <div
-        aria-describedby="tippy-7"
-        class="fpo p-1"
-      >
-        Longer text to test placement
-      </div>
-    </div>
-  </div>
-  <div
-    data-tippy-root=""
-    id="tippy-7"
-    style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(10px, 0px);"
-  >
-    <div
-      class="tippy-box tooltip tooltip--light"
-      data-animation="fade"
-      data-escaped=""
-      data-placement="right"
-      data-reference-hidden=""
-      data-state="visible"
-      role="tooltip"
-      style="max-width: 350px; transition-duration: 0ms;"
-      tabindex="-1"
-    >
-      <div
-        class="tippy-content"
-        data-state="visible"
-        style="transition-duration: 0ms;"
-      >
-        <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>
@@ -394,7 +358,7 @@ exports[`<Tooltip /> TextChild story renders snapshot 1`] = `
       class="p-16"
     >
       <span
-        aria-describedby="tippy-8"
+        aria-describedby="tippy-7"
         data-testid="disabled-child-tooltip-wrapper"
         tabindex="0"
       >
@@ -406,7 +370,7 @@ exports[`<Tooltip /> TextChild story renders snapshot 1`] = `
   </div>
   <div
     data-tippy-root=""
-    id="tippy-8"
+    id="tippy-7"
     style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
   >
     <div
@@ -427,14 +391,18 @@ exports[`<Tooltip /> TextChild story renders snapshot 1`] = `
       >
         <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>
@@ -454,7 +422,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
       class="p-16"
     >
       <div
-        aria-describedby="tippy-4"
+        aria-describedby="tippy-3"
         class="fpo w-3 p-1"
       >
         •
@@ -463,7 +431,7 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
   </div>
   <div
     data-tippy-root=""
-    id="tippy-4"
+    id="tippy-3"
     style="pointer-events: none; z-index: 9999; visibility: visible; position: absolute; left: 0px; top: 0px; margin: 0px; bottom: 0px; transform: translate(0px, -10px);"
   >
     <div
@@ -484,14 +452,18 @@ exports[`<Tooltip /> TopPlacement story renders snapshot 1`] = `
       >
         <div>
           <span
+            class="text text--caption-lg"
             data-testid="tooltip-content"
           >
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-             
-            <b>
-              Donec a erat eu augue consequat eleifend non vel sem.
-            </b>
-             Praesent efficitur mauris ac leo semper accumsan.
+            <span>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+               
+              <strong>
+                Donec a erat eu augue consequat eleifend non vel sem.
+              </strong>
+               
+              Praesent efficitur mauris ac leo semper accumsan.
+            </span>
           </span>
         </div>
       </div>


### PR DESCRIPTION
### Summary:

- [feat(Text): add support for caption-md and caption-lg](https://github.com/chanzuckerberg/edu-design-system/commit/53fd4e04ea1845d614b505ef1da25d288b13543f)
- [fix(Tooltip): use caption-lg for tooltip text](https://github.com/chanzuckerberg/edu-design-system/commit/f0772c7e148051fd3c3b16af874bcb74831e1b4f)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - review chromatic diffs to make sure they comply with design
