### PR TITLE
fix: make menu, popover, select ssr friendly

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -159,7 +159,7 @@ const MenuItems = (props: MenuItemsProps) => {
     ...props,
     ...popperAttributes,
   };
-  if (typeof window === 'object') {
+  if (typeof document !== 'undefined') {
     return (
       <>
         {createPortal(<HeadlessMenu.Items {...optionProps} />, document.body)}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -159,10 +159,14 @@ const MenuItems = (props: MenuItemsProps) => {
     ...props,
     ...popperAttributes,
   };
-
-  return (
-    <>{createPortal(<HeadlessMenu.Items {...optionProps} />, document.body)}</>
-  );
+  if (typeof window === 'object') {
+    return (
+      <>
+        {createPortal(<HeadlessMenu.Items {...optionProps} />, document.body)}
+      </>
+    );
+  }
+  return null;
 };
 
 /**

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -138,7 +138,7 @@ const PopoverContent = ({
   };
 
   const componentClassName = clsx(styles['popover-content'], className);
-  if (typeof window === 'object') {
+  if (typeof document !== 'undefined') {
     return (
       <>
         {createPortal(

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -138,23 +138,25 @@ const PopoverContent = ({
   };
 
   const componentClassName = clsx(styles['popover-content'], className);
-
-  return (
-    <>
-      {createPortal(
-        <HeadlessPopover.Panel
-          {...allProps}
-          as="article"
-          className={componentClassName}
-        >
-          <PopoverContainer className={bodyClassName}>
-            {children as React.ReactNode}
-          </PopoverContainer>
-        </HeadlessPopover.Panel>,
-        document.body,
-      )}
-    </>
-  );
+  if (typeof window === 'object') {
+    return (
+      <>
+        {createPortal(
+          <HeadlessPopover.Panel
+            {...allProps}
+            as="article"
+            className={componentClassName}
+          >
+            <PopoverContainer className={bodyClassName}>
+              {children as React.ReactNode}
+            </PopoverContainer>
+          </HeadlessPopover.Panel>,
+          document.body,
+        )}
+      </>
+    );
+  }
+  return null;
 };
 
 /**

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -247,7 +247,7 @@ const SelectOptions = function (props: PropsWithRenderProp<{ open: boolean }>) {
     ...popperAttributes,
     ...other,
   };
-  if (typeof window === 'object') {
+  if (typeof document !== 'undefined') {
     return (
       <>{createPortal(<Listbox.Options {...optionProps} />, document.body)}</>
     );

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -247,10 +247,12 @@ const SelectOptions = function (props: PropsWithRenderProp<{ open: boolean }>) {
     ...popperAttributes,
     ...other,
   };
-
-  return (
-    <>{createPortal(<Listbox.Options {...optionProps} />, document.body)}</>
-  );
+  if (typeof window === 'object') {
+    return (
+      <>{createPortal(<Listbox.Options {...optionProps} />, document.body)}</>
+    );
+  }
+  return null;
 };
 
 type SelectOptionProps = {


### PR DESCRIPTION
### Summary:
- wraps `createportal` used in the Menu, Popover, and Select components in a conditional checking for `window`
- tested working with v12.2.0-alpha.2 release on running edu-stack locally
- tried wrapping `document.body` in `useEffect` but still got ssr errors

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
