### PR TITLE
feat(tokens): add t2 color bg-brand-primary-subtle

### DIFF
--- a/.storybook/data/tokens.json
+++ b/.storybook/data/tokens.json
@@ -135,6 +135,7 @@
   "eds-theme-color-background-neutral-medium": "#E7E8EA",
   "eds-theme-color-background-neutral-medium-hover": "#C0C4C8",
   "eds-theme-color-background-brand-primary-default": "#F0F0FC",
+  "eds-theme-color-background-brand-primary-subtle": "#F0F0FC",
   "eds-theme-color-background-brand-primary-strong": "#6B65E2",
   "eds-theme-color-background-brand-primary-strong-hover": "#3E42B1",
   "eds-theme-color-background-utility-success": "#ECFFF5",

--- a/src/design-tokens/tier-2-usage/colors-background.json
+++ b/src/design-tokens/tier-2-usage/colors-background.json
@@ -34,6 +34,9 @@
               "default": {
                 "value": "{eds.color.brand.grape.100}"
               },
+              "subtle": {
+                "value": "{eds.color.brand.grape.100}"
+              },
               "strong": {
                 "@": {
                   "value": "{eds.color.brand.grape.600}"

--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -135,6 +135,7 @@
   --eds-theme-color-background-neutral-medium: #E7E8EA;
   --eds-theme-color-background-neutral-medium-hover: #C0C4C8;
   --eds-theme-color-background-brand-primary-default: #F0F0FC;
+  --eds-theme-color-background-brand-primary-subtle: #F0F0FC;
   --eds-theme-color-background-brand-primary-strong: #6B65E2;
   --eds-theme-color-background-brand-primary-strong-hover: #3E42B1;
   --eds-theme-color-background-utility-success: #ECFFF5;

--- a/src/tokens-dist/json/variables-nested.json
+++ b/src/tokens-dist/json/variables-nested.json
@@ -201,6 +201,7 @@
           "brand": {
             "primary": {
               "default": "#F0F0FC",
+              "subtle": "#F0F0FC",
               "strong": {
                 "@": "#6B65E2",
                 "hover": "#3E42B1"

--- a/src/tokens-dist/ts/colors.ts
+++ b/src/tokens-dist/ts/colors.ts
@@ -70,6 +70,7 @@ export const EdsThemeColorBackgroundNeutralSubtleHover = '#E7E8EA';
 export const EdsThemeColorBackgroundNeutralMedium = '#E7E8EA';
 export const EdsThemeColorBackgroundNeutralMediumHover = '#C0C4C8';
 export const EdsThemeColorBackgroundBrandPrimaryDefault = '#F0F0FC';
+export const EdsThemeColorBackgroundBrandPrimarySubtle = '#F0F0FC';
 export const EdsThemeColorBackgroundBrandPrimaryStrong = '#6B65E2';
 export const EdsThemeColorBackgroundBrandPrimaryStrongHover = '#3E42B1';
 export const EdsThemeColorBackgroundUtilitySuccess = '#ECFFF5';


### PR DESCRIPTION
[EDS-1042]

### Summary:
- adds t2 color token background/brand-primary-subtle
- along request and adds a subtle token for background-brand-primary
- currently maps to grape-100 which is same as background-brand-primary-default but it's the lightest grape we have and not using internally or in SLP theme so for use in products only and they can map the default / subtle to different colors for their own use as said by design team

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable

[EDS-1042]: https://czi-tech.atlassian.net/browse/EDS-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ