### PR TITLE
refactor(inputfield): use inputlabel and re-export as subcomp

### DIFF
--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -15,8 +15,8 @@
 }
 
 /**
-* Input field body
-*/
+ * Input field body
+ */
 .input-field__body {
   position: relative;
 }

--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -9,24 +9,29 @@
   display: flex;
   justify-content: space-between;
   margin-bottom: var(--eds-size-half);
-  color: var(--eds-theme-color-form-label);
 }
 .input-field__overline--no-label {
   justify-content: flex-end;
 }
-.input-field__overline--disabled {
-  color: var(--eds-theme-color-text-disabled);
-}
 
 /**
- * Input field body
- */
+* Input field body
+*/
 .input-field__body {
   position: relative;
 }
 
+.input-field__label {
+  color: var(--eds-theme-color-form-label);
+  font: var(--eds-theme-typography-form-label);
+}
+.input-field__label--disabled {
+  color: var(--eds-theme-color-text-disabled);
+}
+
 .input-field__required-text {
   color: var(--eds-theme-color-text-neutral-subtle);
+  font: var(--eds-theme-typography-body-sm);
 }
 
 .input-field--has-fieldNote {

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -8,7 +8,7 @@ import type {
 } from '../../util/utility-types';
 import FieldNote from '../FieldNote';
 import Input from '../Input';
-import Label from '../Label';
+import InputLabel from '../InputLabel';
 import Text from '../Text';
 import styles from './InputField.module.css';
 
@@ -127,6 +127,7 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
 
 type InputFieldType = ForwardedRefComponent<HTMLInputElement, Props> & {
   Input?: typeof Input;
+  Label?: typeof InputLabel;
 };
 
 /**
@@ -157,7 +158,11 @@ export const InputField: InputFieldType = forwardRef(
     const overlineClassName = clsx(
       styles['input-field__overline'],
       !label && styles['input-field__overline--no-label'],
-      disabled && styles['input-field__overline--disabled'],
+    );
+
+    const labelClassName = clsx(
+      styles['input-field__label'],
+      disabled && styles['input-field__label--disabled'],
     );
 
     const inputBodyClassName = clsx(
@@ -177,7 +182,11 @@ export const InputField: InputFieldType = forwardRef(
       <div className={className}>
         {shouldRenderOverline && (
           <div className={overlineClassName}>
-            {label && <Label htmlFor={idVar} text={label} />}
+            {label && (
+              <InputLabel className={labelClassName} htmlFor={idVar}>
+                {label}
+              </InputLabel>
+            )}
             {required && (
               <Text
                 as="span"
@@ -224,3 +233,4 @@ export const InputField: InputFieldType = forwardRef(
 
 InputField.displayName = 'InputField';
 InputField.Input = Input;
+InputField.Label = InputLabel;

--- a/src/components/InputField/__snapshots__/InputField.test.ts.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.ts.snap
@@ -9,11 +9,10 @@ exports[`<InputField /> Default story renders snapshot 1`] = `
       class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label"
         for=":r0:"
       >
         Default input field
-         
       </label>
     </div>
     <div
@@ -43,14 +42,13 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
 >
   <div>
     <div
-      class="input-field__overline input-field__overline--disabled"
+      class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label input-field__label--disabled"
         for=":r6:"
       >
         Disabled input field
-         
       </label>
     </div>
     <div
@@ -94,14 +92,13 @@ exports[`<InputField /> DisabledVariants story renders snapshot 1`] = `
     </p>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r1e:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -126,14 +123,13 @@ exports[`<InputField /> DisabledVariants story renders snapshot 1`] = `
     </div>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r1g:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -160,14 +156,13 @@ exports[`<InputField /> DisabledVariants story renders snapshot 1`] = `
     </p>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r1i:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -185,14 +180,13 @@ exports[`<InputField /> DisabledVariants story renders snapshot 1`] = `
     </div>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r1k:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -298,11 +292,10 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
       class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label"
         for=":r4:"
       >
         Error input field
-         
       </label>
     </div>
     <div
@@ -365,11 +358,10 @@ exports[`<InputField /> ErrorVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":ru:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -413,11 +405,10 @@ exports[`<InputField /> ErrorVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r10:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -463,11 +454,10 @@ exports[`<InputField /> ErrorVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r12:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -487,11 +477,10 @@ exports[`<InputField /> ErrorVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r14:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -626,11 +615,10 @@ exports[`<InputField /> InputWithin story renders snapshot 1`] = `
       class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label"
         for=":rc:"
       >
         Input field with button inside
-         
       </label>
     </div>
     <div
@@ -679,11 +667,10 @@ exports[`<InputField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":re:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -710,11 +697,10 @@ exports[`<InputField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":rg:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -743,11 +729,10 @@ exports[`<InputField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":ri:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -767,11 +752,10 @@ exports[`<InputField /> LabelFieldnoteVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":rk:"
         >
           Label text
-           
         </label>
       </div>
       <div
@@ -872,11 +856,10 @@ exports[`<InputField /> NoFieldnote story renders snapshot 1`] = `
       class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label"
         for=":r2:"
       >
         Default input field
-         
       </label>
     </div>
     <div
@@ -939,11 +922,10 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
       class="input-field__overline"
     >
       <label
-        class="label"
+        class="label label--lg input-field__label"
         for=":r8:"
       >
         Input field with fieldNote
-         
       </label>
       <span
         class="text text--sm input-field__required-text"
@@ -995,11 +977,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r1u:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1032,11 +1013,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r20:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1071,11 +1051,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r22:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1101,11 +1080,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r24:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1247,11 +1225,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r2e:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1301,11 +1278,10 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
         class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label"
           for=":r2g:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1354,14 +1330,13 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
     </p>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r2i:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"
@@ -1392,14 +1367,13 @@ exports[`<InputField /> RequiredVariants story renders snapshot 1`] = `
     </div>
     <div>
       <div
-        class="input-field__overline input-field__overline--disabled"
+        class="input-field__overline"
       >
         <label
-          class="label"
+          class="label label--lg input-field__label input-field__label--disabled"
           for=":r2k:"
         >
           Label text
-           
         </label>
         <span
           class="text text--sm input-field__required-text"


### PR DESCRIPTION
[EFI-1228]

### Summary:
- after some discussion we're keeping `Input` component as its not a subcomponent for just `InputField` and possibly has use as utility component in other areas
- using `InputLabel` component over `Label` component be in line with `Checkbox` and `Radio`
- aligns closer to the mocks for font

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] CI tests / new tests are not applicable
  - no visual regression


[EFI-1228]: https://czi-tech.atlassian.net/browse/EFI-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ