### PR TITLE
docs: point Layout storybook to Zeroheight

### DIFF
--- a/.storybook/components/Docs/Guidelines/Layout.stories.mdx
+++ b/.storybook/components/Docs/Guidelines/Layout.stories.mdx
@@ -1,92 +1,35 @@
 <Meta title="Documentation/Guidelines/Layout" />
 
+import {InlineNotification} from "../../../../src";
+
 # Layout
 
-EDS provides several layout-specific components to accomplish specific design outcomes.
+<InlineNotification text="The layout components are being deprecated in favor of using TailwindCSS" variant="warning" />
 
-## Using layout
+This includes the following:
 
-EDS provides the following components and conventions:
+* `Grid` and `GridItem`
+* `Layout` and `LayoutSection`
+* `LayoutContainer`
+* `LayoutLinelength`
 
-1. [Layout Container](#layoutcontainer)
-2. [Page Layout](#pagelayout)
-3. [Grid](#grid)
-4. [Spacing](#spacing)
+Please refer to our documentation [on ZeroHeight](https://eds.czi.design/styleguide/s/36770/p/17f0a9-layout/b/66febf)
+for suggested alternatives and patterns.
 
-### LayoutContainer
+For more information on what TailwindCSS supplies, check out the following links:
 
-`LayoutContainer` is used to cap the width of the content to the defined maximum width, so that content doesn't always span the full width of the viewport.
+* https://tailwindcss.com/docs/columns
+* https://tailwindcss.com/docs/container
+* https://tailwindcss.com/docs/display
 
-```jsx
-<LayoutContainer>
-  // content inside will be capped at the defined maximum width
-</LayoutContainer>
-```
+## Spacing and alignment
 
-### Page Layout
+EDS components do not include margin properties as spacing between components should be handled primarily with 
+tailwind utility classes or similar custom classes.
 
-The `Layout` component (together with the `LayoutSection` subcomponent) is a component dedicated to achieving page-level layouts, such as a main content container and a sidebar container.
-
-These components control the responsive behavior for the page and can control fixed or sticky page sections.
-
-```jsx
-<Layout variant="right-sidebar">
-  <LayoutSection>Main content</LayoutSection>
-  <LayoutSection>Sidebar content</LayoutSection>
-</Layout>
-```
-
-View the `Layout` component in Storybook to view all available variants.
-
-### Grid
-
-The `Grid` component (together with its `Grid.Item` subcomponent) arranges content in specific configurations and controls the responsive behavior for content inside grid items.
-
-For instance, `<Grid variant="side-by-side">` will render grid items that always occupy 50% of their container regardless of the viewport size:
+However, it's important to be able to control spacing between components, so EDS works well with tailwind utility 
+classes like [margin](https://tailwindcss.com/docs/margin).
 
 ```jsx
-<Grid variant="side-by-side">
-  <Grid.Item></Grid.Item>
-  <Grid.Item></Grid.Item>
-</Grid>
+<InlineNotification text="lorem ipsum dolor sit amet" variant="success" className="mb-5" />
 ```
-
-Whereas `<Grid variant="2up">` will render grid items that stack on small viewports but will occupy 50% of their container when the viewport becomes large enough to accommodate that layout:
-
-```jsx
-<Grid variant="2up">
-  <Grid.Item></Grid.Item>
-  <Grid.Item></Grid.Item>
-</Grid>
-```
-
-View the `Grid` component in Storybook to view all available variants.
-
-## Spacing
-
-Most EDS components do not include `margin` properties as spacing between components should be handled primarily with the `Grid` and `Layout` components described above.
-
-However, it's important to be able to control spacing between components, so EDS uses [tailwind margin utility classes](https://tailwindcss.com/docs/margin) that can be added to any component. For instance:
-
-```jsx
-<Heading className="mb-2">Heading with small margin bottom</Heading>
-```
-
-Margin bottom utility classes should be primarily used in order to embrace a [single-direction margin flow](https://csswizardry.com/2012/06/single-direction-margin-declarations/) that leads to more predictable and maintainable outcomes.
-
----
-
-## Working with layout
-
-1. [Layout Container](#layoutcontainer)
-2. [Page Layout](#pagelayout)
-3. [Grid](#grid)
-4. [Spacing](#spacing)
-
-### Updating LayoutContainer
-
-`LayoutContainer`'s is controlled by the `l-max-width` token. Updating this token value will change the maximum width for content. Altering this value would constitute a breaking change.
-
-### Adding or Modifying Layouts or Grids
-
-`Layout` and `Grid` components should contain the minimum number of patterns to build most product layouts and compositions. Adding additional variants should be handled with careful consideration. Be sure to determine the additional layout/variant is really needed before adding.

--- a/src/design-tokens/tier-1-definitions/layout.json
+++ b/src/design-tokens/tier-1-definitions/layout.json
@@ -2,13 +2,16 @@
   "eds": {
     "l": {
       "max-width": {
-        "value": "71.25rem"
+        "value": "71.25rem",
+        "comment": "Layout tokens are deprecated and will be removed in a future release"
       },
       "sidebar-width": {
-        "value": "13.5rem"
+        "value": "13.5rem",
+        "comment": "Layout tokens are deprecated and will be removed in a future release"
       },
       "linelength-width": {
-        "value": "36rem"
+        "value": "36rem",
+        "comment": "Layout tokens are deprecated and will be removed in a future release"
       }
     }
   }

--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -79,9 +79,9 @@
   --eds-color-info-500: #328EFB; /* legacy token, will be removed */
   --eds-color-info-600: #1977CD; /* legacy token, will be removed */
   --eds-color-info-700: #0563B8; /* legacy token, will be removed */
-  --eds-l-max-width: 71.25rem;
-  --eds-l-sidebar-width: 13.5rem;
-  --eds-l-linelength-width: 36rem;
+  --eds-l-max-width: 71.25rem; /* Layout tokens are deprecated and will be removed in a future release */
+  --eds-l-sidebar-width: 13.5rem; /* Layout tokens are deprecated and will be removed in a future release */
+  --eds-l-linelength-width: 36rem; /* Layout tokens are deprecated and will be removed in a future release */
   --eds-outline-width-sm: 1px;
   --eds-outline-width-md: 2px;
   --eds-outline-width-lg: 4px;


### PR DESCRIPTION
### Summary:

- remove Grid and Layout component examples
- add deprecation warning
- provide useful links to tailwind documentation

### Test Plan:

- n/a (documentation-only changes)