### PR TITLE
chore(omlet): only scan components in src directory

### DIFF
--- a/.omletrc.json
+++ b/.omletrc.json
@@ -1,0 +1,5 @@
+{
+  "ignore": ["lib/**", ".storybook/**"],
+  "include": ["src/components/**/*.tsx"],
+  "tsconfigPath": "tsconfig.json"
+}


### PR DESCRIPTION
### Summary:

this prevents bifurcation of components so that it doesn't confuse built versions with their typescript equivalents

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - validate scan result using `--dry-run`