### PR TITLE
docs: show more code in component stories docs

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -230,5 +230,21 @@ export const UsingRenderProp: StoryObj<Args> = {
   ),
   parameters: {
     chromatic: { disableSnapshot: true },
+    docs: {
+      source: {
+        code: `<Accordion headingAs="h2">
+  <Accordion.Row>
+    {({ open }) => (
+      <>
+        <Accordion.Button data-testid="accordion-button">
+          Accordion Button {(open && 'open') || 'closed'}
+        </Accordion.Button>
+        <Accordion.Panel>Accordion Panel</Accordion.Panel>
+      </>
+    )}
+  </Accordion.Row>
+</Accordion>`,
+      },
+    },
   },
 };

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -153,6 +153,13 @@ export const LongLabels = {
 };
 
 export const WithCustomPositioning = {
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
   render: () => (
     <div className="flex items-center">
       <Checkbox.Label className="mr-2" htmlFor="test">

--- a/src/components/DataBar/DataBar.stories.tsx
+++ b/src/components/DataBar/DataBar.stories.tsx
@@ -62,70 +62,75 @@ export const NoSegments: StoryObj<Args> = {
   },
 };
 
-const Interactive = () => {
-  const [max, setMax] = React.useState(100);
-  const [segments, setSegments] = React.useState([
-    { value: 90, text: 'Segment value 90' },
-    { value: 1, text: 'Segment value 1' },
-    { value: 1, text: 'Segment value 1' },
-  ]);
-
-  const [segmentValue, setSegmentValue] = React.useState(1);
-
-  const onPush = () => {
-    segments.push({
-      value: segmentValue || 1,
-      text: `Segment value ${segmentValue}`,
-    });
-    setSegments([...segments]);
-  };
-  const onPop = () => {
-    if (segments.length > 0) {
-      segments.pop();
-      setSegments([...segments]);
-    }
-  };
-  return (
-    <div>
-      <DataBar label="Interactive data bar" max={max} segments={segments} />
-      <br />
-      <label htmlFor="segment-value-input">Value add: </label>
-      <input
-        id="segment-value-input"
-        onChange={(e) => {
-          setSegmentValue(Number(e?.target?.value));
-        }}
-        value={segmentValue}
-      ></input>
-      <br />
-      <ButtonGroup>
-        <Button onClick={onPush} variant="primary">
-          Push segment
-        </Button>
-        <Button onClick={onPop} variant="secondary">
-          Pop segment
-        </Button>
-      </ButtonGroup>
-      <br />
-      <label htmlFor="max-value-input">Max: </label>
-      <input
-        id="max-value-input"
-        onChange={(e) => {
-          setMax(Number(e?.target?.value) || 100);
-        }}
-        value={max}
-      ></input>
-    </div>
-  );
-};
-
 export const InteractiveExample: StoryObj<Args> = {
-  render: () => <Interactive />,
+  render: () => {
+    /* eslint-disable react-hooks/rules-of-hooks */
+    const [max, setMax] = React.useState(100);
+    const [segments, setSegments] = React.useState([
+      { value: 90, text: 'Segment value 90' },
+      { value: 1, text: 'Segment value 1' },
+      { value: 1, text: 'Segment value 1' },
+    ]);
+
+    const [segmentValue, setSegmentValue] = React.useState(1);
+    /* eslint-enable react-hooks/rules-of-hooks */
+
+    const onPush = () => {
+      segments.push({
+        value: segmentValue || 1,
+        text: `Segment value ${segmentValue}`,
+      });
+      setSegments([...segments]);
+    };
+    const onPop = () => {
+      if (segments.length > 0) {
+        segments.pop();
+        setSegments([...segments]);
+      }
+    };
+    return (
+      <div>
+        <DataBar label="Interactive data bar" max={max} segments={segments} />
+        <br />
+        <label htmlFor="segment-value-input">Value add: </label>
+        <input
+          id="segment-value-input"
+          onChange={(e) => {
+            setSegmentValue(Number(e?.target?.value));
+          }}
+          value={segmentValue}
+        ></input>
+        <br />
+        <ButtonGroup>
+          <Button onClick={onPush} variant="primary">
+            Push segment
+          </Button>
+          <Button onClick={onPop} variant="secondary">
+            Pop segment
+          </Button>
+        </ButtonGroup>
+        <br />
+        <label htmlFor="max-value-input">Max: </label>
+        <input
+          id="max-value-input"
+          onChange={(e) => {
+            setMax(Number(e?.target?.value) || 100);
+          }}
+          value={max}
+        ></input>
+      </div>
+    );
+  },
   parameters: {
     /**
      * For interactive purposes only, low value in snapping or checking for visual regression since they should be covered in the other stories.
      */
     chromatic: { disableSnapshot: true },
     snapshot: { skip: true },
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
   },
 };

--- a/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.stories.tsx
@@ -68,159 +68,166 @@ export const WithOnApplyAndCustomButtonGroup: StoryObj<Args> = {
   },
 };
 
-const OverflowCheckboxFields = () => {
-  const initialCheckedState = [
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-    false,
-  ];
-  const [transientChecked, setTransientChecked] =
-    React.useState(initialCheckedState);
-  const onCheckboxChange = (index: number) => {
-    const newTransientChecked = [...transientChecked];
-    newTransientChecked[index] = !transientChecked[index];
-    setTransientChecked(newTransientChecked);
-  };
-
-  const [appliedChecked, setAppliedChecked] =
-    React.useState(initialCheckedState);
-  const onClear = () => {
-    setTransientChecked(initialCheckedState);
-    setAppliedChecked(initialCheckedState);
-  };
-  const onClose = () => {
-    setTransientChecked([...appliedChecked]);
-  };
-  const onApply = () => {
-    setAppliedChecked([...transientChecked]);
-  };
-
-  /**
-   * Counts how many filters have been applied.
-   */
-  const filterCount = Object.values(appliedChecked).reduce(
-    (count: number, status) => {
-      if (status) return count + 1;
-      else return count;
-    },
-    0,
-  );
-
-  const hasSelectedFilters = filterCount > 0;
-  const triggerText = hasSelectedFilters
-    ? `Filters (${filterCount})`
-    : 'Filters';
-
-  return (
-    <FiltersDrawer
-      className={styles['filters-drawer']}
-      hasSelectedFilters={hasSelectedFilters}
-      onApply={onApply}
-      onClear={onClear}
-      onClose={onClose}
-      triggerText={triggerText}
-    >
-      <FiltersCheckboxField legend="Filters Segment 1">
-        <Checkbox
-          checked={transientChecked[0]}
-          label="Filters long label 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
-          onChange={() => onCheckboxChange(0)}
-        />
-        <Checkbox
-          checked={transientChecked[1]}
-          label="Filters label 2"
-          onChange={() => onCheckboxChange(1)}
-        />
-        <Checkbox
-          checked={transientChecked[2]}
-          label="Filters label 3"
-          onChange={() => onCheckboxChange(2)}
-        />
-      </FiltersCheckboxField>
-      <FiltersCheckboxField legend="Filters Segment 2">
-        <Checkbox
-          checked={transientChecked[3]}
-          label="Filters label 1"
-          onChange={() => onCheckboxChange(3)}
-        />
-        <Checkbox
-          checked={transientChecked[4]}
-          label="Filters long label 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
-          onChange={() => onCheckboxChange(4)}
-        />
-        <Checkbox
-          checked={transientChecked[5]}
-          label="Filters label 3"
-          onChange={() => onCheckboxChange(5)}
-        />
-      </FiltersCheckboxField>
-      <FiltersCheckboxField legend="Filters Segment 3">
-        <Checkbox
-          checked={transientChecked[6]}
-          label="Filters label 1"
-          onChange={() => onCheckboxChange(6)}
-        />
-        <Checkbox
-          checked={transientChecked[7]}
-          label="Filters label 2"
-          onChange={() => onCheckboxChange(7)}
-        />
-        <Checkbox
-          checked={transientChecked[8]}
-          label="Filters long label 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
-          onChange={() => onCheckboxChange(8)}
-        />
-      </FiltersCheckboxField>
-      <FiltersCheckboxField legend="Filters Segment 4">
-        <Checkbox
-          checked={transientChecked[9]}
-          label="Filters label 1"
-          onChange={() => onCheckboxChange(9)}
-        />
-        <Checkbox
-          checked={transientChecked[10]}
-          label="Filters label 2"
-          onChange={() => onCheckboxChange(10)}
-        />
-        <Checkbox
-          checked={transientChecked[11]}
-          label="Filters label 3"
-          onChange={() => onCheckboxChange(11)}
-        />
-        <Checkbox
-          checked={transientChecked[12]}
-          label="Filters label 4"
-          onChange={() => onCheckboxChange(12)}
-        />
-        <Checkbox
-          checked={transientChecked[13]}
-          label="Filters label 5"
-          onChange={() => onCheckboxChange(13)}
-        />
-        <Checkbox
-          checked={transientChecked[14]}
-          label="Filters label 6"
-          onChange={() => onCheckboxChange(14)}
-        />
-      </FiltersCheckboxField>
-    </FiltersDrawer>
-  );
-};
-
 export const OverflowInteractive: StoryObj<Args> = {
-  render: () => <OverflowCheckboxFields />,
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
+  render: () => {
+    const initialCheckedState = [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ];
+    const [transientChecked, setTransientChecked] =
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useState(initialCheckedState);
+    const onCheckboxChange = (index: number) => {
+      const newTransientChecked = [...transientChecked];
+      newTransientChecked[index] = !transientChecked[index];
+      setTransientChecked(newTransientChecked);
+    };
+
+    const [appliedChecked, setAppliedChecked] =
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useState(initialCheckedState);
+    const onClear = () => {
+      setTransientChecked(initialCheckedState);
+      setAppliedChecked(initialCheckedState);
+    };
+    const onClose = () => {
+      setTransientChecked([...appliedChecked]);
+    };
+    const onApply = () => {
+      setAppliedChecked([...transientChecked]);
+    };
+
+    /**
+     * Counts how many filters have been applied.
+     */
+    const filterCount = Object.values(appliedChecked).reduce(
+      (count: number, status) => {
+        if (status) return count + 1;
+        else return count;
+      },
+      0,
+    );
+
+    const hasSelectedFilters = filterCount > 0;
+    const triggerText = hasSelectedFilters
+      ? `Filters (${filterCount})`
+      : 'Filters';
+
+    return (
+      <FiltersDrawer
+        className={styles['filters-drawer']}
+        hasSelectedFilters={hasSelectedFilters}
+        onApply={onApply}
+        onClear={onClear}
+        onClose={onClose}
+        triggerText={triggerText}
+      >
+        <FiltersCheckboxField legend="Filters Segment 1">
+          <Checkbox
+            checked={transientChecked[0]}
+            label="Filters long label 1 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
+            onChange={() => onCheckboxChange(0)}
+          />
+          <Checkbox
+            checked={transientChecked[1]}
+            label="Filters label 2"
+            onChange={() => onCheckboxChange(1)}
+          />
+          <Checkbox
+            checked={transientChecked[2]}
+            label="Filters label 3"
+            onChange={() => onCheckboxChange(2)}
+          />
+        </FiltersCheckboxField>
+        <FiltersCheckboxField legend="Filters Segment 2">
+          <Checkbox
+            checked={transientChecked[3]}
+            label="Filters label 1"
+            onChange={() => onCheckboxChange(3)}
+          />
+          <Checkbox
+            checked={transientChecked[4]}
+            label="Filters long label 2 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
+            onChange={() => onCheckboxChange(4)}
+          />
+          <Checkbox
+            checked={transientChecked[5]}
+            label="Filters label 3"
+            onChange={() => onCheckboxChange(5)}
+          />
+        </FiltersCheckboxField>
+        <FiltersCheckboxField legend="Filters Segment 3">
+          <Checkbox
+            checked={transientChecked[6]}
+            label="Filters label 1"
+            onChange={() => onCheckboxChange(6)}
+          />
+          <Checkbox
+            checked={transientChecked[7]}
+            label="Filters label 2"
+            onChange={() => onCheckboxChange(7)}
+          />
+          <Checkbox
+            checked={transientChecked[8]}
+            label="Filters long label 3 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod"
+            onChange={() => onCheckboxChange(8)}
+          />
+        </FiltersCheckboxField>
+        <FiltersCheckboxField legend="Filters Segment 4">
+          <Checkbox
+            checked={transientChecked[9]}
+            label="Filters label 1"
+            onChange={() => onCheckboxChange(9)}
+          />
+          <Checkbox
+            checked={transientChecked[10]}
+            label="Filters label 2"
+            onChange={() => onCheckboxChange(10)}
+          />
+          <Checkbox
+            checked={transientChecked[11]}
+            label="Filters label 3"
+            onChange={() => onCheckboxChange(11)}
+          />
+          <Checkbox
+            checked={transientChecked[12]}
+            label="Filters label 4"
+            onChange={() => onCheckboxChange(12)}
+          />
+          <Checkbox
+            checked={transientChecked[13]}
+            label="Filters label 5"
+            onChange={() => onCheckboxChange(13)}
+          />
+          <Checkbox
+            checked={transientChecked[14]}
+            label="Filters label 6"
+            onChange={() => onCheckboxChange(14)}
+          />
+        </FiltersCheckboxField>
+      </FiltersDrawer>
+    );
+  },
   play: async ({ canvasElement }) => {
     // We want to test visual regression for the drawer as well as the button, but don't want the drawer open initally outside Chromatic
     if (isChromatic()) {

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -73,6 +73,14 @@ export const NoVisibleLabel: StoryObj<Args> = {
 };
 
 export const InputWithin: StoryObj<Args> = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
   render: () => (
     <InputField
       inputWithin={

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -165,18 +165,76 @@ const selectCat: StoryObj['play'] = async (playOptions) => {
 };
 
 export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// props: {aria-label: 'Favorite Animal'}
+function InteractiveExampleUsingChildren(props: Props) {
+  const { variant, optionsAlign, optionsClassName, disabled, value } = props;
+  const compact = variant === 'compact';
+
+  const [selectedOption, setSelectedOption] = React.useState<
+    SelectOption | undefined
+  >(value);
+
+  return (
+    <div className="mb-10 p-8">
+      <Select
+        aria-label={props['aria-label']}
+        className={clsx(!compact && 'w-60')}
+        data-testid="dropdown"
+        disabled={disabled}
+        onChange={setSelectedOption}
+        optionsAlign={optionsAlign}
+        optionsClassName={optionsClassName}
+        value={selectedOption}
+        variant={variant}
+      >
+        {props.labelComponent}
+        <Select.Button>{selectedOption?.label || 'Select'}</Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </Select>
+    </div>
+  );
+}`,
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
   ),
 };
 
 export const Disabled: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "Default" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" disabled />
   ),
 };
 
 export const DefaultWithVisibleLabel: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// refer to "Default" story code with:
+// props: {aria-label: 'Favorite Animal', labelComponent: <Select.Label>Favorite Animal</Select.Label>}`,
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
@@ -186,6 +244,13 @@ export const DefaultWithVisibleLabel: StoryObj = {
 };
 
 export const Compact: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "Default" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
@@ -195,12 +260,26 @@ export const Compact: StoryObj = {
 };
 
 export const NoVisibleLabel: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "Default" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
   ),
 };
 
 export const OptionsRightAligned: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "Default" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
@@ -212,6 +291,13 @@ export const OptionsRightAligned: StoryObj = {
 };
 
 export const OptionsLeftAligned: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "Default" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren
       aria-label="Favorite Animal"
@@ -235,11 +321,23 @@ export const SeparateButtonAndMenuWidth: StoryObj = {
     chromatic: {
       diffIncludeAntiAliasing: false,
       diffThreshold: 0.72,
+      docs: {
+        source: {
+          code: '// refer to "Default" story code',
+        },
+      },
     },
   },
 };
 
 export const UsingChildrenProp: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: '// refer to "DefaultWithVisibleLabel" story code',
+      },
+    },
+  },
   render: () => (
     <InteractiveExampleUsingChildren
       labelComponent={<Select.Label>Favorite Animal</Select.Label>}
@@ -248,6 +346,62 @@ export const UsingChildrenProp: StoryObj = {
 };
 
 export const UsingFunctionChildrenProp: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+function InteractiveExampleUsingFunctionChildren() {
+  const [selectedOption, setSelectedOption] =
+    React.useState<(typeof exampleOptions)[0]>();
+
+  return (
+    <div className="mb-10 p-8">
+      <Select
+        aria-label="Favorite Animal"
+        as="div"
+        className="w-60"
+        data-testid="dropdown"
+        onChange={setSelectedOption}
+        value={selectedOption}
+      >
+        {({ open }) => (
+          <>
+            <Select.Button
+              // Because we're using a render prop to completely control the styling and icon of the
+              // button, we need to configure this component to render as a Fragment. Otherwise we'd
+              // render two, nested buttons.
+              as={React.Fragment}
+            >
+              {() => (
+                <button
+                  aria-expanded={open}
+                  className={styles['function-children__button']}
+                >
+                  {selectedOption?.label || 'Select'}
+                  <Icon
+                    className="ml-4"
+                    name="filter-list"
+                    purpose="decorative"
+                  />
+                </button>
+              )}
+            </Select.Button>
+            <Select.Options>
+              {exampleOptions.map((option) => (
+                <Select.Option key={option.key} value={option}>
+                  {option.label}
+                </Select.Option>
+              ))}
+            </Select.Options>
+          </>
+        )}
+      </Select>
+    </div>
+  );
+}`,
+      },
+    },
+  },
   render: () => <InteractiveExampleUsingFunctionChildren />,
 };
 
@@ -258,6 +412,15 @@ export const OpenByDefault: StoryObj = {
 };
 
 export const WithSelectedOption: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// refer to "Default" story code with:
+// props: {aria-label: 'Favorite Animal', labelComponent: <Select.Label>Favorite Animal</Select.Label>, value}`,
+      },
+    },
+  },
   args: {
     value: exampleOptions[0],
   },

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -275,75 +275,81 @@ export const AlignTableCellContentRight: StoryObj<Args> = {
   },
 };
 
-const SortableExample = () => {
-  const values = [
-    { col1: 'Value 1', col2: 'Value A' },
-    { col1: 'Value 3', col2: 'Value B' },
-    { col1: 'Value 2', col2: 'Value C' },
-    { col1: 'Value 4', col2: 'Value D' },
-  ];
-  const [sortDirection, setSortDirection] =
-    useState<SortDirectionsType>('default');
-  const onSortClick = () => {
-    if (sortDirection === 'descending') {
-      setSortDirection('default');
-    }
-    if (sortDirection === 'default') {
-      setSortDirection('ascending');
-    }
-    if (sortDirection === 'ascending') {
-      setSortDirection('descending');
-    }
-  };
-  const sortedValues = values.slice().sort((a, b) => {
-    if (sortDirection === 'default') {
-      if (a.col2 < b.col2) {
-        return -1;
-      } else {
-        return 1;
-      }
-    }
-    if (sortDirection === 'ascending') {
-      if (a.col1 < b.col1) {
-        return -1;
-      } else {
-        return 1;
-      }
-    }
-    if (sortDirection === 'descending') {
-      if (b.col1 < a.col1) {
-        return -1;
-      } else {
-        return 1;
-      }
-    }
-    return 0;
-  });
-  return (
-    <Table>
-      <Table.Header>
-        <Table.Row variant="header">
-          <Table.HeaderCell
-            onSortClick={onSortClick}
-            sortDirection={sortDirection}
-          >
-            Sortable
-          </Table.HeaderCell>
-          <Table.HeaderCell>Not sortable</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
-      <Table.Body>
-        {sortedValues.map(({ col1, col2 }) => (
-          <Table.Row key={`row-${col1}-${col2}`}>
-            <Table.Cell>{col1}</Table.Cell>
-            <Table.Cell>{col2}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  );
-};
-
 export const SortableInteractive: StoryObj<Args> = {
-  render: () => <SortableExample />,
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
+  render: () => {
+    const values = [
+      { col1: 'Value 1', col2: 'Value A' },
+      { col1: 'Value 3', col2: 'Value B' },
+      { col1: 'Value 2', col2: 'Value C' },
+      { col1: 'Value 4', col2: 'Value D' },
+    ];
+    const [sortDirection, setSortDirection] =
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useState<SortDirectionsType>('default');
+    const onSortClick = () => {
+      if (sortDirection === 'descending') {
+        setSortDirection('default');
+      }
+      if (sortDirection === 'default') {
+        setSortDirection('ascending');
+      }
+      if (sortDirection === 'ascending') {
+        setSortDirection('descending');
+      }
+    };
+    const sortedValues = values.slice().sort((a, b) => {
+      if (sortDirection === 'default') {
+        if (a.col2 < b.col2) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+      if (sortDirection === 'ascending') {
+        if (a.col1 < b.col1) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+      if (sortDirection === 'descending') {
+        if (b.col1 < a.col1) {
+          return -1;
+        } else {
+          return 1;
+        }
+      }
+      return 0;
+    });
+    return (
+      <Table>
+        <Table.Header>
+          <Table.Row variant="header">
+            <Table.HeaderCell
+              onSortClick={onSortClick}
+              sortDirection={sortDirection}
+            >
+              Sortable
+            </Table.HeaderCell>
+            <Table.HeaderCell>Not sortable</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {sortedValues.map(({ col1, col2 }) => (
+            <Table.Row key={`row-${col1}-${col2}`}>
+              <Table.Cell>{col1}</Table.Cell>
+              <Table.Cell>{col2}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    );
+  },
 };

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -53,20 +53,27 @@ export const WithoutLabel: StoryObj<Args> = {
   },
 };
 
-const CustomPositionExample = () => {
-  const [selected, setSelected] = useState(false);
-  return (
-    <Toggle.Wrapper as="div" className="flex flex-col items-center">
-      <Toggle.Label>Custom positioned label</Toggle.Label>
-      <Toggle.Button
-        checked={selected}
-        onChange={() => {
-          setSelected(!selected);
-        }}
-      />
-    </Toggle.Wrapper>
-  );
-};
 export const CustomPositioning: StoryObj<Args> = {
-  render: () => <CustomPositionExample />,
+  parameters: {
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
+  render: () => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selected, setSelected] = useState(false);
+    return (
+      <Toggle.Wrapper as="div" className="flex flex-col items-center">
+        <Toggle.Label>Custom positioned label</Toggle.Label>
+        <Toggle.Button
+          checked={selected}
+          onChange={() => {
+            setSelected(!selected);
+          }}
+        />
+      </Toggle.Wrapper>
+    );
+  },
 };


### PR DESCRIPTION
[EDS-1074]

### Summary:
- found some [documentation](https://storybook.js.org/docs/react/api/doc-block-source#type) on how to show the code more properly with the docs addon: 
  - `parameters: {docs: {source: 'dynamic'}}` renders the story source with dynamically updated arg values, allowing stories with `render` functions to show the code
  - `parameters: {docs: {code: '*code string*'}}` allows custom code to be shown
- addresses Along want for "Show Code" working for Sortable Interactive story for the Table component
- Makes "Show Code" working for some more components
  - stories used for visual regression only were not addressed

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Manually tested my changes, and here are the details:
  - "Show Code" in docs addon shows code
<img width="1069" alt="image" src="https://github.com/chanzuckerberg/edu-design-system/assets/86632227/6e578e6c-71b1-468a-aa86-759b075a816c">


[EDS-1074]: https://czi-tech.atlassian.net/browse/EDS-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ