### PR TITLE
docs: clarify hotfix release process

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -10,8 +10,6 @@ Look to [this helpful document](https://designsystem.morningstar.com/getting-sta
 
 We currently use [standard-version](https://github.com/conventional-changelog/standard-version) to increment the version number in `package.json`, create a git tag for the new release, and update `CHANGELOG.md` based on the commit log.
 
-**NOTE**: `standard-version` is deprecated. Soon, we may move to an alternative script to handle releases.
-
 ---
 
 ## Releasing a new version of EDS
@@ -40,14 +38,16 @@ We follow a [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)
 4. Run `git checkout -b release-v<version>`
 5. Run `yarn release` if the recommended version is correct. If it isn't, use `yarn release:` followed by the proper version type (patch, minor, major)
 
-#### Cutting a hotfix branch
+<details><summary>If working on a hotfix for the latest version</summary>
 
 0. Before beginning, run `git fetch origin` to ensure you have the latest remote changes.
 1. Run `git checkout main && git pull origin main && yarn install` to update your local copy of `main`.
 2. Run `git checkout -b hotfix-v<currentVersion>`
-3. Create a new commit with the fix, merging into the above branch
+3. Create a new commit with the fix on this branch
 4. Determine the next version that will be released. An easy way to do this is with `yarn release --dry-run`
 5. Run `yarn release` if the recommended version is correct. If it isn't, use `yarn release:patch` (hotfix commits should not be minor or major)
+
+</details>
 
 **NOTE**: The package is not published, yet. If needed, you can [make additional changes to CHANGELOG.md now](#editing-the-changelog).
 
@@ -63,6 +63,8 @@ git push --follow-tags origin <branch> # this will also push tags
 
 For the commit message, use the new version's content in the [CHANGELOG.md](../CHANGELOG.md) (e.g., all the changes for version 1.2.3). Review the content in the changelog to make sure the notes, and the from-version and to-version are correct. Note the link to the storybook on this PR CI/CD. You will add this link to the GitHub release notes later.
 
+**NOTE**: if this is a hotfix release for an older version of EDS (not latest), skip to step 9.
+
 Merge the PR through a **merge commit**:
 
 ![github user interface showing a dropdown with the different merge options. the option "create a merge commit" is highlighted](https://user-images.githubusercontent.com/15840841/170514789-4f936ba2-c63d-486c-827a-b9e9e86b612e.png)
@@ -74,6 +76,10 @@ Once merged, wait until the [builds complete on `main`](https://github.com/chanz
 8. Pull down the most up-to-date version of main: `git checkout main && git pull && yarn install && yarn build`
 9. Publish the package: `npm publish`
 10. Create a [new release](https://github.com/chanzuckerberg/edu-design-system/releases) based on the new tag. Use the same text used for the pull request description above (from CHANGELOG.md). Also include the link for the built storybook in the description. This will automatically post to [relevant slack channels](https://slack.github.com/):
+
+
+#### Finishing the release
+
 11. Lastly, run the following to "back merge" release changes to `next`:
     - `git checkout main && git pull origin main && git checkout next && git merge main && git push`
 


### PR DESCRIPTION
### Summary:

it's possible to hotfix an older version of EDS. in those cases, we don't necessarily want to merge back into `main`. add a note explaining this situation (which should be rare). Also diminish the hotfix instructions so that the document is easier to follow at a glance.

### Test Plan:

- n/a (documentation only changes)