### PR TITLE
docs: add clearer warning and recommendation for useId

### DIFF
--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -12,7 +12,7 @@ export const useId =
   function useId() {
     if (process.env.NODE_ENV !== 'production' && showWarning) {
       console.warn(
-        'EDS useId is not ssr friendly if using React <18 as it uses the native React.useId hook if available https://react.dev/reference/react/useId.',
+        "React < 18: EDS's `useId` is not SSR friendly. We recommend applying an ID package like `uniqueId` or using React 18's built-in `React.useId` https://react.dev/reference/react/useId",
       );
       showWarning = false;
     }

--- a/src/util/useId.ts
+++ b/src/util/useId.ts
@@ -12,7 +12,7 @@ export const useId =
   function useId() {
     if (process.env.NODE_ENV !== 'production' && showWarning) {
       console.warn(
-        "React < 18: EDS's `useId` is not SSR friendly. We recommend applying an ID package like `uniqueId` or using React 18's built-in `React.useId` https://react.dev/reference/react/useId",
+        "React < 18: EDS's `useId` is not SSR friendly and can lead to race conditions. We recommend importing `uniqueId` and setting the id prop directly, or using React 18's built-in `React.useId` https://react.dev/reference/react/useId",
       );
       showWarning = false;
     }


### PR DESCRIPTION
### Summary:

This updates the emitted warning message when using the built-in fallback for `useId` in react < 18 projects. Includes a recommendation as well.

### Test Plan:

- n/a (documentation only change)
