### PR TITLE
fix(Avatar): improve support for generating initials

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@tippyjs/react": "^4.2.6",
     "@types/lodash": "^4.14.197",
     "clsx": "^1.2.1",
+    "graphemer": "^1.4.0",
     "lodash": "^4.17.21",
     "react-beautiful-dnd": "^13.1.1",
     "react-children-by-type": "^1.1.0",

--- a/src/components/Avatar/Avatar.test.ts
+++ b/src/components/Avatar/Avatar.test.ts
@@ -1,6 +1,37 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { getInitials } from './Avatar';
 import * as stories from './Avatar.stories';
 
 describe('<Avatar />', () => {
   generateSnapshots(stories);
+
+  // Testing handling of surrogate pairs, et al
+  // https://javascript.info/unicode#surrogate-pairs
+  describe('.getInitials', () => {
+    it.each`
+      givenName                     | expectedInitials
+      ${'John Smith'}               | ${'JS'}
+      ${'Jenny C. Sallow'}          | ${'JS'}
+      ${'Thomas Stroughton-Felton'} | ${'TS'}
+      ${'Young Yarn Lad'}           | ${'YL'}
+      ${'Tim 肇廷'}                 | ${'T肇'}
+      ${'Ãndrew 🙂'}                | ${'Ã🙂'}
+      ${'你好世界'}                 | ${'你'}
+      ${'🧶👦🏽'}                     | ${'🧶'}
+      ${'𩷶'}                       | ${'𩷶'}
+      ${'𝒳'}                        | ${'𝒳'}
+      ${'☹️ 🙂'}                    | ${'☹️🙂'}
+      ${'👦🏽🧶'}                     | ${'👦🏽'}
+      ${'🧙‍♂️'}                       | ${'🧙‍♂️'}
+      ${''}                         | ${''}
+      ${' Leading Space'}           | ${'LS'}
+      ${'Trailing Space '}          | ${'TS'}
+      ${'Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍A̴̵̜̰͔ͫ͗͢L̠ͨͧͩ͘G̴̻͈͍͔̹̑͗̎̅͛́Ǫ̵̹̻̝̳͂̌̌͘'}                    | ${'Z͑ͫ̓ͪ̂ͫ̽͏̴̙̤̞͉͚̯̞̠͍'}
+    `(
+      'generates initials $expectedInitials when given $givenName',
+      ({ givenName, expectedInitials }) => {
+        expect(getInitials(givenName)).toEqual(expectedInitials);
+      },
+    );
+  });
 });

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,6 @@
 import clsx from 'clsx';
+import Graphemer from 'graphemer';
+
 import React from 'react';
 import Icon from '../Icon';
 import styles from './Avatar.module.css';
@@ -53,16 +55,25 @@ export interface Props {
   variant?: 'icon' | 'initials' | 'image';
 }
 
-function getInitials(fromName: string): string {
+/**
+ * Use graphemer to take a name part, and select the first grapheme (emoji, surrogate pair, ASCII character)
+ */
+function produceAbbreviation(fromName: string): string {
+  const splitter = new Graphemer();
+  return fromName ? splitter.splitGraphemes(fromName)[0] : '?';
+}
+
+export function getInitials(fromName: string): string {
   /**
    * Scenarios:
-   * - User's name is spelled as first and last name: John Smith
-   * - User's name has a middle name or initial: John C. Smith
-   * - User's Name has dashes in it
+   * - User's name is spelled as first and last name: John Smith => JS
+   * - User's name has a middle name or initial: John C. Smith => JS
+   * - User's Name has dashes in it: Kelly Davis-Johnson => KD
    */
   const initials = fromName
     .split(' ')
-    .map((part) => part[0])
+    .filter((part) => part !== '')
+    .map(produceAbbreviation)
     .reduce(
       (prev, curr, idx, arr) =>
         idx === 0 || idx === arr.length - 1 ? prev + curr : prev,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,6 +1912,7 @@ __metadata:
     eslint-plugin-prettier: ^4.2.1
     eslint-plugin-storybook: ^0.6.13
     eslint-plugin-testing-library: ^5.11.1
+    graphemer: ^1.4.0
     husky: ^8.0.3
     identity-obj-proxy: ^3.0.0
     jest: ^29.6.2


### PR DESCRIPTION
### Summary:

use [Graphemer](https://github.com/flmnt/graphemer) to:
- add handling for unicode surrogate pairs (mark1)
- handling for extended BMP (Basic Multilingual Plane) characters

### Test Plan:

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
