### PR TITLE
Generate valid tab ids

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -4,6 +4,7 @@ import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './Tabs.stories';
+import Tab from '../Tab';
 
 const { Default } = composeStories(stories);
 
@@ -58,5 +59,20 @@ describe('<Tabs />', () => {
 
     rerender(<Default activeIndex={1} />);
     expect(screen.getByRole('heading', { name: 'Tab 2' })).toBeInTheDocument();
+  });
+
+  it('does not include invalid characters in tab ids', () => {
+    render(
+      <Default id="foo">
+        <Tab data-testid="tab-1" title="Tab Title 1">
+          Tab numero uno
+        </Tab>
+      </Default>,
+    );
+
+    expect(screen.getByTestId('tab-1')).toHaveAttribute(
+      'aria-labelledby',
+      'foo-Tab-Title-1',
+    );
   });
 });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -81,7 +81,10 @@ export const Tabs = ({
   const generatedId = useId();
   const tabIdPrefix = other.id || generatedId;
   const tabIds = useMemo(
-    () => tabs.map((tab) => `${tabIdPrefix}-${tab.props.title}`),
+    () =>
+      tabs.map(
+        (tab) => `${tabIdPrefix}-${tab.props.title.replace(/\s/g, '-')}`,
+      ),
     [tabs, tabIdPrefix],
   );
 

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="true"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 1"
+          id=":r1:-Tab-Title-1"
           role="tab"
           tabindex="0"
         >
@@ -36,7 +36,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 2"
+          id=":r1:-Tab-Title-2"
           role="tab"
           tabindex="-1"
         >
@@ -52,7 +52,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 3"
+          id=":r1:-Tab-Title-3"
           role="tab"
           tabindex="-1"
         >
@@ -68,7 +68,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 4"
+          id=":r1:-Tab-Title-4"
           role="tab"
           tabindex="-1"
         >
@@ -84,7 +84,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 5"
+          id=":r1:-Tab-Title-5"
           role="tab"
           tabindex="-1"
         >
@@ -100,7 +100,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 6"
+          id=":r1:-Tab-Title-6"
           role="tab"
           tabindex="-1"
         >
@@ -116,7 +116,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 7"
+          id=":r1:-Tab-Title-7"
           role="tab"
           tabindex="-1"
         >
@@ -132,7 +132,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 8"
+          id=":r1:-Tab-Title-8"
           role="tab"
           tabindex="-1"
         >
@@ -148,7 +148,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
           aria-selected="false"
           class="tabs__link"
           href="#:r0:"
-          id=":r1:-Tab Title 9"
+          id=":r1:-Tab-Title-9"
           role="tab"
           tabindex="-1"
         >
@@ -160,7 +160,7 @@ exports[`<Tabs /> Default story renders snapshot 1`] = `
   <div>
     <div
       aria-hidden="false"
-      aria-labelledby=":r1:-Tab Title 1"
+      aria-labelledby=":r1:-Tab-Title-1"
       id=":r0:"
       role="tabpanel"
     >


### PR DESCRIPTION
### Summary:

Noted in https://czi-edu.slack.com/archives/CTFV79JH4/p1693505461086869, we're generating invalid ids for tabs. Here we fix that.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
