### PR TITLE
chore: make `.module.css` class names human readable in local development

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,7 @@
       "files": [
         "config.js",
         "*.config.js",
-        "main.js",
+        "main.ts",
         "plopfile.js",
         "src/**/*.js"
       ],

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -104,7 +104,7 @@ function updateCSSLoaderPlugin(config: Configuration): Configuration {
                 // @ts-expect-error css-loader doesn't accept "string" options
                 // and will either be an object or undefined
                 ...ruleSetRule.options?.modules,
-                localIdentName: '[name]__[local]',
+                localIdentName: '[name]__[local]--[hash:base64:5]',
               },
             };
           }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,3 +1,6 @@
+import type { StorybookConfig } from '@storybook/react-webpack5';
+import type { Configuration } from 'webpack';
+
 /**
  * Although `--static-dir` is marked as deprecated. The The Chromatic CLI
  * currently pulls the staticDir from the build script, but does not support
@@ -6,7 +9,7 @@
  * We should refrain from using the staticDirs option in this configuration until
  * https://github.com/chromaui/chromatic-cli/issues/462 is resolved.
  */
-module.exports = {
+const config: StorybookConfig = {
   stories: [
     './components/**/*.stories.mdx',
     './components/**/*.stories.@(js|jsx|ts|tsx)',
@@ -70,4 +73,47 @@ module.exports = {
       plugins: [],
     };
   },
+  webpackFinal(config, { configType }) {
+    if (configType === 'DEVELOPMENT') {
+      updateCSSLoaderPlugin(config);
+    }
+    return config;
+  },
 };
+
+/**
+ * Updates the `css-loader` webpack plugin to make class names human readable.
+ *
+ * NOTE: This should only be used for local development.
+ */
+function updateCSSLoaderPlugin(config: Configuration): Configuration {
+  config.module?.rules?.forEach((rule) => {
+    if (rule && typeof rule === 'object' && Array.isArray(rule.use)) {
+      const isRuleForCSS = rule.test?.toString() === '/\\.css$/';
+      if (isRuleForCSS) {
+        rule.use.forEach((ruleSetRule) => {
+          if (
+            typeof ruleSetRule === 'object' &&
+            ruleSetRule?.loader?.includes('node_modules/css-loader')
+          ) {
+            ruleSetRule.options = {
+              // @ts-expect-error css-loader doesn't accept "string" options
+              // and will either be an object or undefined
+              ...ruleSetRule.options,
+              modules: {
+                // @ts-expect-error css-loader doesn't accept "string" options
+                // and will either be an object or undefined
+                ...ruleSetRule.options?.modules,
+                localIdentName: '[name]__[local]',
+              },
+            };
+          }
+        });
+      }
+    }
+  });
+
+  return config;
+}
+
+export default config;


### PR DESCRIPTION
### Summary:

I noticed that classnames are hashed while working on #1742. This makes finding the origin of styles in the codebase harder and is straightforward to toggle off via webpack.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Manual testing, observe the classnames before and after

**Before:**
![image](https://github.com/chanzuckerberg/edu-design-system/assets/94476616/c86f9d10-d0c7-46f4-9a3d-b4deca93d805)


**After:**
![image](https://github.com/chanzuckerberg/edu-design-system/assets/94476616/5170de22-9835-4759-85b8-d1577bf04a68)
