### PR TITLE
fix(Avatar): add fallback workaround to graphemer import class

### DIFF
--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -55,12 +55,14 @@ export interface Props {
    */
   variant?: 'icon' | 'initials' | 'image';
 }
-
 /**
  * Use graphemer to take a name part, and select the first grapheme (emoji, surrogate pair, ASCII character)
  */
 function produceAbbreviation(fromName: string): string {
-  const splitter = new Graphemer();
+  // @see https://github.com/flmnt/graphemer/issues/11
+  // @ts-expect-error handles case where this library adds .default to the export inappropriately in CJS context
+  const G = Graphemer['default'] ? Graphemer.default : Graphemer;
+  const splitter = new G();
   return fromName ? splitter.splitGraphemes(fromName)[0] : '?';
 }
 


### PR DESCRIPTION
### Summary:

Related to https://github.com/flmnt/graphemer/issues/11, we have an issue in some consumers where the commonJS module is imported in such a way that we get the wrong object format. (instead of `[Graphemer class]` we get `{default: [Graphemer class]}`, which causes the code to fail).

Check for double-`default` wrapping as a workaround until graphemer is fixed. This will also unblock work on the theming tooling

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - ensure tests pass locally
  - test with project that has the import problem, to ensure tests / storybook work properly