### PR TITLE
chore(Menu): add chromatic delay to interactive story

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -203,6 +203,11 @@ export const MenuWithAvatarButton: StoryObj<MenuProps> = {
 
 export const Opened: StoryObj<MenuProps> = {
   ...Default,
+  parameters: {
+    ...Default.parameters,
+    // Sets the delay (in milliseconds) for a specific story.
+    chromatic: { delay: 300 },
+  },
   play: () => {
     userEvent.tab();
     userEvent.keyboard(' ');


### PR DESCRIPTION

### Summary:

- this is to help prevent storybook flakiness. The menu opens but for a brief moment, it will be in a repositioning state, which causes it to slip left and right on some snapshots.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - re-run chromatic a few times with this delay to see if that prevents the snapshot from changing