### PR TITLE
TS module interop

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -22,6 +22,7 @@ export default {
       preserveModulesRoot: 'src',
       sourcemap: true,
       entryFileNames: '[name].cjs',
+      interop: 'auto',
     },
   ],
   /**


### PR DESCRIPTION
### Summary:

This PR attempts (still needs to be verified) to fix a weird issue in Along with EDS's dependency with Graphemer (same thing #1745 is fixing).

Here we tell Rollup to explicitly add an es module compatibility layer to the CJS build, just like TS does.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
