### PR TITLE
docs: add clarification on alpha publishing process

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -117,6 +117,8 @@ git push --follow-tags origin <branch> && npm publish --tag alpha
 npm publish --tag alpha --registry=https://npm.pkg.github.com/
 ```
 
+**NOTE**: running `npm publish` with `--registry` may edit your .npmrc file and force all subsequent publishes to go to the GH Registry. Remove the scope/registry map from `~/.npmrc` after publishing.
+
 #### Editing the CHANGELOG
 
 1. Run `git log` and note the version tag on the latest (release) commit


### PR DESCRIPTION
### Summary:

When performing a regular release, I noticed it only published to GH registry when it used to publish to NPM at the CLI. It was related to a new line added to my `~/.npmrc` after testing an alpha version. This adds doc.s to explain this may happen. 

### Test Plan:

- n/a (documentation-only change