### PR TITLE
docs(Accordion): add implementation example for accordion, icon, text

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -263,6 +263,50 @@ export const UsingRenderProp: StoryObj<Args> = {
 export const UsingComplexHeaders: StoryObj<Args> = {
   parameters: {
     badges: ['1.2', 'implementationExample'],
+    docs: {
+      source: {
+        code: `<Accordion>
+  <Accordion.Row>
+    <Accordion.Button>
+      <Text size="lg" variant="neutral-subtle">
+        <Icon
+          className="m-2"
+          name="check-circle"
+          purpose="decorative"
+          size="1rem"
+        />
+        Step 1
+      </Text>
+    </Accordion.Button>
+    <Accordion.Panel>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+    </Accordion.Panel>
+  </Accordion.Row>
+  <Accordion.Row>
+    <Accordion.Button>
+      <Text size="lg" variant="neutral-subtle">
+        <Icon
+          className="m-2"
+          name="check-circle"
+          purpose="decorative"
+          size="1rem"
+        />
+        Step 2
+      </Text>
+    </Accordion.Button>
+    <Accordion.Panel>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+    </Accordion.Panel>
+  </Accordion.Row>
+</Accordion>`,
+      },
+    },
   },
   args: {
     children: (
@@ -295,45 +339,7 @@ export const UsingComplexHeaders: StoryObj<Args> = {
                 purpose="decorative"
                 size="1rem"
               />
-              Step 1
-            </Text>
-          </Accordion.Button>
-          <Accordion.Panel>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-          </Accordion.Panel>
-        </Accordion.Row>
-        <Accordion.Row>
-          <Accordion.Button>
-            <Text size="lg" variant="neutral-subtle">
-              <Icon
-                className="m-2"
-                name="check-circle"
-                purpose="decorative"
-                size="1rem"
-              />
-              Step 1
-            </Text>
-          </Accordion.Button>
-          <Accordion.Panel>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-          </Accordion.Panel>
-        </Accordion.Row>
-        <Accordion.Row defaultOpen>
-          <Accordion.Button>
-            <Text size="lg" variant="neutral-strong">
-              <Icon
-                className="m-2"
-                name="circle"
-                purpose="decorative"
-                size="1rem"
-              />
-              Step 1
+              Step 2
             </Text>
           </Accordion.Button>
           <Accordion.Panel>
@@ -351,6 +357,44 @@ export const UsingComplexHeaders: StoryObj<Args> = {
 export const UsingNumberIconInHeaders: StoryObj<Args> = {
   parameters: {
     badges: ['1.2', 'implementationExample'],
+    docs: {
+      source: {
+        code: `<Accordion>
+  <Accordion.Row>
+    <Accordion.Button>
+      <div className="flex flex-wrap gap-1">
+        <NumberIcon aria-label="Step 1" number={1} />
+        <Text size="lg" variant="neutral-subtle">
+          Step 1
+        </Text>
+      </div>
+    </Accordion.Button>
+    <Accordion.Panel>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+    </Accordion.Panel>
+  </Accordion.Row>
+  <Accordion.Row>
+    <Accordion.Button>
+      <div className="flex flex-wrap gap-1">
+        <NumberIcon aria-label="Step 3" number={2} />
+        <Text size="lg" variant="neutral-subtle">
+          Step 2
+        </Text>
+      </div>
+    </Accordion.Button>
+    <Accordion.Panel>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+    </Accordion.Panel>
+  </Accordion.Row>
+</Accordion>`,
+      },
+    },
   },
   args: {
     children: (
@@ -377,38 +421,6 @@ export const UsingNumberIconInHeaders: StoryObj<Args> = {
               <NumberIcon aria-label="Step 3" number={2} />
               <Text size="lg" variant="neutral-subtle">
                 Step 2
-              </Text>
-            </div>
-          </Accordion.Button>
-          <Accordion.Panel>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-          </Accordion.Panel>
-        </Accordion.Row>
-        <Accordion.Row>
-          <Accordion.Button>
-            <div className="flex flex-wrap gap-1">
-              <NumberIcon aria-label="Step 3" number={3} />
-              <Text size="lg" variant="neutral-subtle">
-                Step 3
-              </Text>
-            </div>
-          </Accordion.Button>
-          <Accordion.Panel>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-          </Accordion.Panel>
-        </Accordion.Row>
-        <Accordion.Row defaultOpen>
-          <Accordion.Button>
-            <div className="flex flex-wrap gap-1">
-              <NumberIcon aria-label="Step 4" number={4} />
-              <Text size="lg" variant="neutral-subtle">
-                Step 4
               </Text>
             </div>
           </Accordion.Button>

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -2,6 +2,8 @@ import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
 import { Accordion } from './Accordion';
+import Icon from '../Icon';
+import Text from '../Text';
 
 export default {
   title: 'Components/Accordion',
@@ -254,5 +256,93 @@ export const UsingRenderProp: StoryObj<Args> = {
 </Accordion>`,
       },
     },
+  },
+};
+
+export const UsingComplexHeaders: StoryObj<Args> = {
+  parameters: {
+    badges: ['1.2', 'implementationExample'],
+  },
+  args: {
+    children: (
+      <>
+        <Accordion.Row>
+          <Accordion.Button>
+            <Text size="lg" variant="neutral-subtle">
+              <Icon
+                className="m-2"
+                name="check-circle"
+                purpose="decorative"
+                size="1rem"
+              />
+              Step 1
+            </Text>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button>
+            <Text size="lg" variant="neutral-subtle">
+              <Icon
+                className="m-2"
+                name="check-circle"
+                purpose="decorative"
+                size="1rem"
+              />
+              Step 1
+            </Text>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button>
+            <Text size="lg" variant="neutral-subtle">
+              <Icon
+                className="m-2"
+                name="check-circle"
+                purpose="decorative"
+                size="1rem"
+              />
+              Step 1
+            </Text>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen>
+          <Accordion.Button>
+            <Text size="lg" variant="neutral-strong">
+              <Icon
+                className="m-2"
+                name="circle"
+                purpose="decorative"
+                size="1rem"
+              />
+              Step 1
+            </Text>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+      </>
+    ),
   },
 };

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { Accordion } from './Accordion';
 import Icon from '../Icon';
+import NumberIcon from '../NumberIcon';
 import Text from '../Text';
 
 export default {
@@ -334,6 +335,82 @@ export const UsingComplexHeaders: StoryObj<Args> = {
               />
               Step 1
             </Text>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+      </>
+    ),
+  },
+};
+
+export const UsingNumberIconInHeaders: StoryObj<Args> = {
+  parameters: {
+    badges: ['1.2', 'implementationExample'],
+  },
+  args: {
+    children: (
+      <>
+        <Accordion.Row>
+          <Accordion.Button>
+            <div className="flex flex-wrap gap-1">
+              <NumberIcon aria-label="Step 1" number={1} />
+              <Text size="lg" variant="neutral-subtle">
+                Step 1
+              </Text>
+            </div>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button>
+            <div className="flex flex-wrap gap-1">
+              <NumberIcon aria-label="Step 3" number={2} />
+              <Text size="lg" variant="neutral-subtle">
+                Step 2
+              </Text>
+            </div>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button>
+            <div className="flex flex-wrap gap-1">
+              <NumberIcon aria-label="Step 3" number={3} />
+              <Text size="lg" variant="neutral-subtle">
+                Step 3
+              </Text>
+            </div>
+          </Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen>
+          <Accordion.Button>
+            <div className="flex flex-wrap gap-1">
+              <NumberIcon aria-label="Step 4" number={4} />
+              <Text size="lg" variant="neutral-subtle">
+                Step 4
+              </Text>
+            </div>
           </Accordion.Button>
           <Accordion.Panel>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1558,6 +1558,233 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
+<div
+  style="margin: 0.5rem;"
+>
+  <div
+    class=""
+  >
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2a:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <p
+            class="text text--lg text--neutral-subtle"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon m-2"
+              fill="currentColor"
+              height="1rem"
+              style="--icon-size: 1rem;"
+              viewBox="0 0 24 24"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22ZM10.6 16.6L17.65 9.55L16.25 8.15L10.6 13.8L7.75 10.95L6.35 12.35L10.6 16.6Z"
+              />
+            </svg>
+            Step 1
+          </p>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2c:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <p
+            class="text text--lg text--neutral-subtle"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon m-2"
+              fill="currentColor"
+              height="1rem"
+              style="--icon-size: 1rem;"
+              viewBox="0 0 24 24"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22ZM10.6 16.6L17.65 9.55L16.25 8.15L10.6 13.8L7.75 10.95L6.35 12.35L10.6 16.6Z"
+              />
+            </svg>
+            Step 1
+          </p>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2e:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <p
+            class="text text--lg text--neutral-subtle"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon m-2"
+              fill="currentColor"
+              height="1rem"
+              style="--icon-size: 1rem;"
+              viewBox="0 0 24 24"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22ZM10.6 16.6L17.65 9.55L16.25 8.15L10.6 13.8L7.75 10.95L6.35 12.35L10.6 16.6Z"
+              />
+            </svg>
+            Step 1
+          </p>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r2h:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r2g:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <p
+            class="text text--lg text--neutral-strong"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon m-2"
+              fill="currentColor"
+              height="1rem"
+              style="--icon-size: 1rem;"
+              viewBox="0 0 24 24"
+              width="1rem"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22Z"
+              />
+            </svg>
+            Step 1
+          </p>
+        </h2>
+        <svg
+          class="icon accordion-button__icon accordion-button__icon--open"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            hide content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+      <div
+        class="accordion-panel"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r2h:"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Accordion /> UsingRenderProp story renders snapshot 1`] = `
 <div
   style="margin: 0.5rem;"

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1785,6 +1785,221 @@ exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
+<div
+  style="margin: 0.5rem;"
+>
+  <div
+    class=""
+  >
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2i:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <div
+            class="flex flex-wrap gap-1"
+          >
+            <span
+              aria-label="Step 1"
+              class="text text--sm text--neutral-medium number-icon number-icon--base"
+              role="img"
+            >
+              1
+            </span>
+            <p
+              class="text text--lg text--neutral-subtle"
+            >
+              Step 1
+            </p>
+          </div>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2k:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <div
+            class="flex flex-wrap gap-1"
+          >
+            <span
+              aria-label="Step 3"
+              class="text text--sm text--neutral-medium number-icon number-icon--base"
+              role="img"
+            >
+              2
+            </span>
+            <p
+              class="text text--lg text--neutral-subtle"
+            >
+              Step 2
+            </p>
+          </div>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-expanded="false"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-:r2m:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <div
+            class="flex flex-wrap gap-1"
+          >
+            <span
+              aria-label="Step 3"
+              class="text text--sm text--neutral-medium number-icon number-icon--base"
+              role="img"
+            >
+              3
+            </span>
+            <p
+              class="text text--lg text--neutral-subtle"
+            >
+              Step 3
+            </p>
+          </div>
+        </h2>
+        <svg
+          class="icon accordion-button__icon"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r2p:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r2o:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          <div
+            class="flex flex-wrap gap-1"
+          >
+            <span
+              aria-label="Step 4"
+              class="text text--sm text--neutral-medium number-icon number-icon--base"
+              role="img"
+            >
+              4
+            </span>
+            <p
+              class="text text--lg text--neutral-subtle"
+            >
+              Step 4
+            </p>
+          </div>
+        </h2>
+        <svg
+          class="icon accordion-button__icon accordion-button__icon--open"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            hide content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+      <div
+        class="accordion-panel"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r2p:"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Accordion /> UsingRenderProp story renders snapshot 1`] = `
 <div
   style="margin: 0.5rem;"

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -1647,7 +1647,7 @@ exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
                 d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22ZM10.6 16.6L17.65 9.55L16.25 8.15L10.6 13.8L7.75 10.95L6.35 12.35L10.6 16.6Z"
               />
             </svg>
-            Step 1
+            Step 2
           </p>
         </h2>
         <svg
@@ -1668,118 +1668,6 @@ exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
           />
         </svg>
       </button>
-    </div>
-    <div
-      class="accordion-row"
-    >
-      <button
-        aria-expanded="false"
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
-        data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2e:"
-        type="button"
-      >
-        <h2
-          class="heading heading--size-h2 accordion-button__heading"
-        >
-          <p
-            class="text text--lg text--neutral-subtle"
-          >
-            <svg
-              aria-hidden="true"
-              class="icon m-2"
-              fill="currentColor"
-              height="1rem"
-              style="--icon-size: 1rem;"
-              viewBox="0 0 24 24"
-              width="1rem"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22ZM10.6 16.6L17.65 9.55L16.25 8.15L10.6 13.8L7.75 10.95L6.35 12.35L10.6 16.6Z"
-              />
-            </svg>
-            Step 1
-          </p>
-        </h2>
-        <svg
-          class="icon accordion-button__icon"
-          fill="currentColor"
-          height="1.625rem"
-          role="img"
-          style="--icon-size: 1.625rem;"
-          viewBox="0 0 24 24"
-          width="1.625rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>
-            show content
-          </title>
-          <path
-            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="accordion-row"
-    >
-      <button
-        aria-controls="headlessui-disclosure-panel-:r2h:"
-        aria-expanded="true"
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
-        data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r2g:"
-        type="button"
-      >
-        <h2
-          class="heading heading--size-h2 accordion-button__heading"
-        >
-          <p
-            class="text text--lg text--neutral-strong"
-          >
-            <svg
-              aria-hidden="true"
-              class="icon m-2"
-              fill="currentColor"
-              height="1rem"
-              style="--icon-size: 1rem;"
-              viewBox="0 0 24 24"
-              width="1rem"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M12 22C10.6167 22 9.31667 21.7373 8.1 21.212C6.88333 20.6873 5.825 19.975 4.925 19.075C4.025 18.175 3.31267 17.1167 2.788 15.9C2.26267 14.6833 2 13.3833 2 12C2 10.6167 2.26267 9.31667 2.788 8.1C3.31267 6.88333 4.025 5.825 4.925 4.925C5.825 4.025 6.88333 3.31233 8.1 2.787C9.31667 2.26233 10.6167 2 12 2C13.3833 2 14.6833 2.26233 15.9 2.787C17.1167 3.31233 18.175 4.025 19.075 4.925C19.975 5.825 20.6873 6.88333 21.212 8.1C21.7373 9.31667 22 10.6167 22 12C22 13.3833 21.7373 14.6833 21.212 15.9C20.6873 17.1167 19.975 18.175 19.075 19.075C18.175 19.975 17.1167 20.6873 15.9 21.212C14.6833 21.7373 13.3833 22 12 22Z"
-              />
-            </svg>
-            Step 1
-          </p>
-        </h2>
-        <svg
-          class="icon accordion-button__icon accordion-button__icon--open"
-          fill="currentColor"
-          height="1.625rem"
-          role="img"
-          style="--icon-size: 1.625rem;"
-          viewBox="0 0 24 24"
-          width="1.625rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>
-            hide content
-          </title>
-          <path
-            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-          />
-        </svg>
-      </button>
-      <div
-        class="accordion-panel"
-        data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r2h:"
-      >
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-      </div>
     </div>
   </div>
 </div>
@@ -1799,7 +1687,7 @@ exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2i:"
+        id="headlessui-disclosure-button-:r2e:"
         type="button"
       >
         <h2
@@ -1848,7 +1736,7 @@ exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2k:"
+        id="headlessui-disclosure-button-:r2g:"
         type="button"
       >
         <h2
@@ -1889,112 +1777,6 @@ exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
           />
         </svg>
       </button>
-    </div>
-    <div
-      class="accordion-row"
-    >
-      <button
-        aria-expanded="false"
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
-        data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2m:"
-        type="button"
-      >
-        <h2
-          class="heading heading--size-h2 accordion-button__heading"
-        >
-          <div
-            class="flex flex-wrap gap-1"
-          >
-            <span
-              aria-label="Step 3"
-              class="text text--sm text--neutral-medium number-icon number-icon--base"
-              role="img"
-            >
-              3
-            </span>
-            <p
-              class="text text--lg text--neutral-subtle"
-            >
-              Step 3
-            </p>
-          </div>
-        </h2>
-        <svg
-          class="icon accordion-button__icon"
-          fill="currentColor"
-          height="1.625rem"
-          role="img"
-          style="--icon-size: 1.625rem;"
-          viewBox="0 0 24 24"
-          width="1.625rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>
-            show content
-          </title>
-          <path
-            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-          />
-        </svg>
-      </button>
-    </div>
-    <div
-      class="accordion-row"
-    >
-      <button
-        aria-controls="headlessui-disclosure-panel-:r2p:"
-        aria-expanded="true"
-        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
-        data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r2o:"
-        type="button"
-      >
-        <h2
-          class="heading heading--size-h2 accordion-button__heading"
-        >
-          <div
-            class="flex flex-wrap gap-1"
-          >
-            <span
-              aria-label="Step 4"
-              class="text text--sm text--neutral-medium number-icon number-icon--base"
-              role="img"
-            >
-              4
-            </span>
-            <p
-              class="text text--lg text--neutral-subtle"
-            >
-              Step 4
-            </p>
-          </div>
-        </h2>
-        <svg
-          class="icon accordion-button__icon accordion-button__icon--open"
-          fill="currentColor"
-          height="1.625rem"
-          role="img"
-          style="--icon-size: 1.625rem;"
-          viewBox="0 0 24 24"
-          width="1.625rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>
-            hide content
-          </title>
-          <path
-            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-          />
-        </svg>
-      </button>
-      <div
-        class="accordion-panel"
-        data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r2p:"
-      >
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Summary:

Test and document compositions using `Accordion`, `Icon`, and `Text` to customize headers.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
