### PR TITLE
feat(Accordion): allow empty or hidden accordion rows

### DIFF
--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -29,6 +29,10 @@
   height: 3.375rem;
 }
 
+.accordion-button--empty {
+  pointer-events: none;
+}
+
 /**
  * Small variant.
  */
@@ -103,6 +107,10 @@
 
   font: var(--eds-theme-typography-body-sm);
   color: var(--eds-theme-color-text-neutral-strong);
+}
+
+.accordion-panel--hidden {
+  padding: 0;
 }
 
 /**

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -149,6 +149,51 @@ export const DefaultOpen: StoryObj<Args> = {
   },
 };
 
+export const EmptyStackedOpen: StoryObj<Args> = {
+  args: {
+    children: (
+      <>
+        <Accordion.Row defaultOpen isExpandable={false}>
+          <Accordion.Button>Massa quam egestas massa.</Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen>
+          <Accordion.Button>Massa quam egestas massa.</Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen>
+          <Accordion.Button>Massa quam egestas massa.</Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen>
+          <Accordion.Button>Massa quam egestas massa.</Accordion.Button>
+          <Accordion.Panel>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
+            massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
+            tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
+            Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+          </Accordion.Panel>
+        </Accordion.Row>
+      </>
+    ),
+  },
+};
+
 export const SmallOpen: StoryObj<Args> = {
   args: {
     ...DefaultOpen.args,

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -95,12 +95,39 @@ describe('<Accordion />', () => {
         </Accordion.Row>
       </Accordion>,
     );
-    const accordionButton = screen.getByTestId('accordion-button');
+    const accordionButton = screen.getByRole('button');
 
     await act(async () => {
       await user.click(accordionButton);
     });
     expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should not call onOpen callback when accordion opens on an empty row', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    const onOpen = jest.fn();
+    render(
+      <Accordion headingAs="h2">
+        <Accordion.Row isExpandable={false}>
+          <Accordion.Button
+            data-testid="accordion-button"
+            onClose={onClose}
+            onOpen={onOpen}
+          >
+            Accordion Button
+          </Accordion.Button>
+          <Accordion.Panel>Accordion Panel</Accordion.Panel>
+        </Accordion.Row>
+      </Accordion>,
+    );
+    const accordionButton = screen.getByRole('button');
+
+    await act(async () => {
+      await user.click(accordionButton);
+    });
+    expect(onOpen).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -101,6 +101,166 @@ exports[`<Accordion /> DefaultOpen story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Accordion /> EmptyStackedOpen story renders snapshot 1`] = `
+<div
+  style="margin: 0.5rem;"
+>
+  <div
+    class=""
+  >
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r17:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--empty"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r16:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          Massa quam egestas massa.
+        </h2>
+      </button>
+      <div
+        class="accordion-panel accordion-panel--hidden"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r17:"
+      />
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r19:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r18:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          Massa quam egestas massa.
+        </h2>
+        <svg
+          class="icon accordion-button__icon accordion-button__icon--open"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            hide content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+      <div
+        class="accordion-panel"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r19:"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+      </div>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r1b:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r1a:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          Massa quam egestas massa.
+        </h2>
+        <svg
+          class="icon accordion-button__icon accordion-button__icon--open"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            hide content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+      <div
+        class="accordion-panel"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r1b:"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+      </div>
+    </div>
+    <div
+      class="accordion-row"
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-:r1d:"
+        aria-expanded="true"
+        class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-button-:r1c:"
+        type="button"
+      >
+        <h2
+          class="heading heading--size-h2 accordion-button__heading"
+        >
+          Massa quam egestas massa.
+        </h2>
+        <svg
+          class="icon accordion-button__icon accordion-button__icon--open"
+          fill="currentColor"
+          height="1.625rem"
+          role="img"
+          style="--icon-size: 1.625rem;"
+          viewBox="0 0 24 24"
+          width="1.625rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            hide content
+          </title>
+          <path
+            d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+          />
+        </svg>
+      </button>
+      <div
+        class="accordion-panel"
+        data-headlessui-state="open"
+        id="headlessui-disclosure-panel-:r1d:"
+      >
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Accordion /> Small story renders snapshot 1`] = `
 <div
   style="margin: 0.5rem;"
@@ -158,12 +318,12 @@ exports[`<Accordion /> SmallOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r17:"
+        aria-controls="headlessui-disclosure-panel-:r1f:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm"
         data-headlessui-state="open"
         data-testid="accordion-button"
-        id="headlessui-disclosure-button-:r16:"
+        id="headlessui-disclosure-button-:r1e:"
         type="button"
       >
         <h2
@@ -193,7 +353,7 @@ exports[`<Accordion /> SmallOpen story renders snapshot 1`] = `
         class="accordion-panel accordion-panel--sm"
         data-headlessui-state="open"
         data-testid="accordion-panel"
-        id="headlessui-disclosure-panel-:r17:"
+        id="headlessui-disclosure-panel-:r1f:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -373,11 +533,11 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r19:"
+        aria-controls="headlessui-disclosure-panel-:r1h:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r18:"
+        id="headlessui-disclosure-button-:r1g:"
         type="button"
       >
         <h2
@@ -406,7 +566,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r19:"
+        id="headlessui-disclosure-panel-:r1h:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -415,11 +575,11 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1b:"
+        aria-controls="headlessui-disclosure-panel-:r1j:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1a:"
+        id="headlessui-disclosure-button-:r1i:"
         type="button"
       >
         <h2
@@ -448,7 +608,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1b:"
+        id="headlessui-disclosure-panel-:r1j:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -457,11 +617,11 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1d:"
+        aria-controls="headlessui-disclosure-panel-:r1l:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1c:"
+        id="headlessui-disclosure-button-:r1k:"
         type="button"
       >
         <h2
@@ -490,7 +650,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1d:"
+        id="headlessui-disclosure-panel-:r1l:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -499,11 +659,11 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1f:"
+        aria-controls="headlessui-disclosure-panel-:r1n:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1e:"
+        id="headlessui-disclosure-button-:r1m:"
         type="button"
       >
         <h2
@@ -532,7 +692,7 @@ exports[`<Accordion /> StackedOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1f:"
+        id="headlessui-disclosure-panel-:r1n:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -712,11 +872,11 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1p:"
+        aria-controls="headlessui-disclosure-panel-:r21:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1o:"
+        id="headlessui-disclosure-button-:r20:"
         type="button"
       >
         <h2
@@ -745,7 +905,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1p:"
+        id="headlessui-disclosure-panel-:r21:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -754,11 +914,11 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1r:"
+        aria-controls="headlessui-disclosure-panel-:r23:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1q:"
+        id="headlessui-disclosure-button-:r22:"
         type="button"
       >
         <h2
@@ -787,7 +947,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1r:"
+        id="headlessui-disclosure-panel-:r23:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -796,11 +956,11 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1t:"
+        aria-controls="headlessui-disclosure-panel-:r25:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1s:"
+        id="headlessui-disclosure-button-:r24:"
         type="button"
       >
         <h2
@@ -829,7 +989,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1t:"
+        id="headlessui-disclosure-panel-:r25:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -838,11 +998,11 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1v:"
+        aria-controls="headlessui-disclosure-panel-:r27:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1u:"
+        id="headlessui-disclosure-button-:r26:"
         type="button"
       >
         <h2
@@ -871,7 +1031,7 @@ exports[`<Accordion /> StackedOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1v:"
+        id="headlessui-disclosure-panel-:r27:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1051,11 +1211,11 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1h:"
+        aria-controls="headlessui-disclosure-panel-:r1p:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1g:"
+        id="headlessui-disclosure-button-:r1o:"
         type="button"
       >
         <h2
@@ -1084,7 +1244,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1h:"
+        id="headlessui-disclosure-panel-:r1p:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1093,11 +1253,11 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1j:"
+        aria-controls="headlessui-disclosure-panel-:r1r:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1i:"
+        id="headlessui-disclosure-button-:r1q:"
         type="button"
       >
         <h2
@@ -1126,7 +1286,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1j:"
+        id="headlessui-disclosure-panel-:r1r:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1135,11 +1295,11 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1l:"
+        aria-controls="headlessui-disclosure-panel-:r1t:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1k:"
+        id="headlessui-disclosure-button-:r1s:"
         type="button"
       >
         <h2
@@ -1168,7 +1328,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1l:"
+        id="headlessui-disclosure-panel-:r1t:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1177,11 +1337,11 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       class="accordion-row"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r1n:"
+        aria-controls="headlessui-disclosure-panel-:r1v:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r1m:"
+        id="headlessui-disclosure-button-:r1u:"
         type="button"
       >
         <h2
@@ -1210,7 +1370,7 @@ exports[`<Accordion /> StackedSmallOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r1n:"
+        id="headlessui-disclosure-panel-:r1v:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1390,11 +1550,11 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r21:"
+        aria-controls="headlessui-disclosure-panel-:r29:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r20:"
+        id="headlessui-disclosure-button-:r28:"
         type="button"
       >
         <h2
@@ -1423,7 +1583,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r21:"
+        id="headlessui-disclosure-panel-:r29:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1432,11 +1592,11 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r23:"
+        aria-controls="headlessui-disclosure-panel-:r2b:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r22:"
+        id="headlessui-disclosure-button-:r2a:"
         type="button"
       >
         <h2
@@ -1465,7 +1625,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r23:"
+        id="headlessui-disclosure-panel-:r2b:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1474,11 +1634,11 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r25:"
+        aria-controls="headlessui-disclosure-panel-:r2d:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r24:"
+        id="headlessui-disclosure-button-:r2c:"
         type="button"
       >
         <h2
@@ -1507,7 +1667,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r25:"
+        id="headlessui-disclosure-panel-:r2d:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1516,11 +1676,11 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       class="accordion-row accordion-row--outline"
     >
       <button
-        aria-controls="headlessui-disclosure-panel-:r27:"
+        aria-controls="headlessui-disclosure-panel-:r2f:"
         aria-expanded="true"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button accordion-button--sm accordion-button--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-button-:r26:"
+        id="headlessui-disclosure-button-:r2e:"
         type="button"
       >
         <h2
@@ -1549,7 +1709,7 @@ exports[`<Accordion /> StackedSmallOutlineOpen story renders snapshot 1`] = `
       <div
         class="accordion-panel accordion-panel--sm accordion-panel--outline"
         data-headlessui-state="open"
-        id="headlessui-disclosure-panel-:r27:"
+        id="headlessui-disclosure-panel-:r2f:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet, massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At tristique et ullamcorper rhoncus amet pharetra aliquet tortor. Suscipit dui, nunc sit dui tellus massa laoreet tellus.
       </div>
@@ -1572,7 +1732,7 @@ exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2a:"
+        id="headlessui-disclosure-button-:r2i:"
         type="button"
       >
         <h2
@@ -1624,7 +1784,7 @@ exports[`<Accordion /> UsingComplexHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2c:"
+        id="headlessui-disclosure-button-:r2k:"
         type="button"
       >
         <h2
@@ -1687,7 +1847,7 @@ exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2e:"
+        id="headlessui-disclosure-button-:r2m:"
         type="button"
       >
         <h2
@@ -1736,7 +1896,7 @@ exports[`<Accordion /> UsingNumberIconInHeaders story renders snapshot 1`] = `
         aria-expanded="false"
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
-        id="headlessui-disclosure-button-:r2g:"
+        id="headlessui-disclosure-button-:r2o:"
         type="button"
       >
         <h2
@@ -1797,7 +1957,7 @@ exports[`<Accordion /> UsingRenderProp story renders snapshot 1`] = `
         class="clickable-style clickable-style--lg clickable-style--icon clickable-style--neutral clickable-style--full-width button button--icon accordion-button"
         data-headlessui-state=""
         data-testid="accordion-button"
-        id="headlessui-disclosure-button-:r28:"
+        id="headlessui-disclosure-button-:r2g:"
         type="button"
       >
         <h2


### PR DESCRIPTION
### Summary:

- adding an `isExpandable={false}` to an `AccordianRow` will hide the feature that afford clicking
- add tests to verify this behavior
- add new snapshots


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
