### PR TITLE
feat(InputField): support recommendedMaxLength prop for display-only errors

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -122,8 +122,6 @@ export const IconBadgeUsingIcon: StoryObj<Args> = {
   },
 };
 
-// TODO-AH: add in test to see if error is thrown
-
 export const LargeBadgeableObject: StoryObj<Args> = {
   args: {
     children: (

--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -25,6 +25,7 @@
   color: var(--eds-theme-color-form-label);
   font: var(--eds-theme-typography-form-label);
 }
+
 .input-field__label--disabled {
   color: var(--eds-theme-color-text-disabled);
 }
@@ -33,12 +34,30 @@
   color: var(--eds-theme-color-text-neutral-subtle);
   font: var(--eds-theme-typography-body-sm);
 }
+
 .input-field__required-text--disabled {
   color: var(--eds-theme-color-text-disabled);
 }
 
+.input-field__footer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.input-field__character-counter {
+  font: var(--eds-theme-typography-body-sm);
+
+  color: var(--eds-theme-color-text-neutral-default);
+  flex: 1 0 50%;
+  text-align: right;
+}
+
 .input-field--has-fieldNote {
   margin-bottom: var(--eds-size-half);
+}
+
+.input-field--invalid-length {
+  color: var(--eds-theme-color-text-utility-error);
 }
 
 /**

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -240,6 +240,38 @@ export const RequiredVariants: Story = {
   },
 };
 
+export const WithAMaxLength: Story = {
+  args: {
+    defaultValue: 'Some initial text',
+    label: 'test label',
+    maxLength: 15,
+    required: true,
+  },
+  render: (args) => <InputField {...args} />,
+};
+
+export const WithARecommendedLength: Story = {
+  args: {
+    defaultValue: 'Some initial text',
+    label: 'test label',
+    recommendedMaxLength: 15,
+    required: true,
+  },
+  render: (args) => <InputField {...args} />,
+};
+
+export const WithBothMaxAndRecommendedLength: Story = {
+  args: {
+    label: 'test label',
+    defaultValue: 'Some initial text',
+    fieldNote: 'Longer Field Description',
+    maxLength: 20,
+    recommendedMaxLength: 15,
+    required: true,
+  },
+  render: (args) => <InputField {...args} />,
+};
+
 export const TabularInput: Story = {
   parameters: {
     badges: ['1.1', 'implementationExample'],

--- a/src/components/InputField/InputField.test.tsx
+++ b/src/components/InputField/InputField.test.tsx
@@ -33,4 +33,54 @@ describe('<InputField />', () => {
 
     expect(onChange).toHaveBeenCalledTimes(testText.length);
   });
+
+  it('will not fire when maxLength is reached', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const testText = 'typing';
+
+    render(
+      <InputField
+        aria-label="label"
+        data-testid="test-input"
+        defaultValue={testText}
+        maxLength={6}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByTestId('test-input');
+
+    input.focus();
+
+    await act(async () => {
+      await user.keyboard(testText);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('will fire when recommendedMaxLength is reached', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+    const testText = 'typing';
+
+    render(
+      <InputField
+        aria-label="label"
+        data-testid="test-input"
+        defaultValue={testText}
+        onChange={onChange}
+        recommendedMaxLength={6}
+      />,
+    );
+    const input = screen.getByTestId('test-input');
+
+    input.focus();
+
+    await act(async () => {
+      await user.keyboard(testText);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(testText.length);
+  });
 });

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
+import { getMinValue } from '../../util/getMinValue';
 import { useId } from '../../util/useId';
 import type {
   EitherInclusive,
@@ -73,6 +74,11 @@ export type Props = React.InputHTMLAttributes<HTMLInputElement> & {
    * Toggles the form control's interactivity. When `readOnly` is set to `true`, the form control is not interactive
    */
   readOnly?: boolean;
+  /**
+   * Behaves similar to `maxLength` but allows the user to continue typing more text.
+   * Should not be larger than `maxLength`, if present.
+   */
+  recommendedMaxLength?: number;
   /**
    * Indicates that field is required for form to be successfully submitted
    */
@@ -148,6 +154,9 @@ export const InputField: InputFieldType = forwardRef(
       inputWithin,
       isError,
       label,
+      maxLength,
+      onChange,
+      recommendedMaxLength,
       required,
       type = 'text',
       ...other
@@ -155,6 +164,8 @@ export const InputField: InputFieldType = forwardRef(
     ref,
   ) => {
     const shouldRenderOverline = !!(label || required);
+    const [fieldText, setFieldText] = useState(other.defaultValue);
+
     const overlineClassName = clsx(
       styles['input-field__overline'],
       !label && styles['input-field__overline--no-label'],
@@ -175,6 +186,19 @@ export const InputField: InputFieldType = forwardRef(
       fieldNote && styles['input-field--has-fieldNote'],
     );
 
+    const fieldLength = fieldText?.toString().length;
+
+    const textExceedsMaxLength =
+      maxLength !== undefined && fieldLength ? fieldLength > maxLength : false;
+
+    const textExceedsRecommendedLength =
+      recommendedMaxLength !== undefined && fieldLength
+        ? fieldLength > recommendedMaxLength
+        : false;
+
+    const shouldRenderError =
+      isError || textExceedsMaxLength || textExceedsRecommendedLength;
+
     const generatedIdVar = useId();
     const idVar = id || generatedIdVar;
 
@@ -182,6 +206,14 @@ export const InputField: InputFieldType = forwardRef(
     const ariaDescribedByVar = fieldNote
       ? ariaDescribedBy || generatedAriaDescribedById
       : undefined;
+
+    const fieldLengthCountClassName = clsx(
+      (textExceedsMaxLength || textExceedsRecommendedLength) &&
+        styles['input-field--invalid-length'],
+    );
+
+    // Pick the smallest of the lengths to set as the maximum value allowed
+    const maxLengthShown = getMinValue(maxLength, recommendedMaxLength);
 
     return (
       <div className={className}>
@@ -206,7 +238,12 @@ export const InputField: InputFieldType = forwardRef(
             aria-invalid={!!isError}
             disabled={disabled}
             id={idVar}
-            isError={isError}
+            isError={shouldRenderError}
+            maxLength={maxLength}
+            onChange={(e) => {
+              setFieldText(e.target.value);
+              onChange && onChange(e);
+            }}
             ref={ref}
             required={required}
             type={type}
@@ -218,14 +255,37 @@ export const InputField: InputFieldType = forwardRef(
             </div>
           )}
         </div>
-        {fieldNote && (
-          <FieldNote
-            disabled={disabled}
-            id={ariaDescribedByVar}
-            isError={isError}
-          >
-            {fieldNote}
-          </FieldNote>
+        {maxLengthShown ? (
+          <div className={styles['input-field__footer']}>
+            {fieldNote && (
+              <FieldNote
+                disabled={disabled}
+                id={ariaDescribedByVar}
+                isError={shouldRenderError}
+              >
+                {fieldNote}
+              </FieldNote>
+            )}
+            {maxLengthShown && (
+              <div className={styles['input-field__character-counter']}>
+                <span className={fieldLengthCountClassName}>{fieldLength}</span>{' '}
+                / {maxLengthShown}
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* maintained for seamless upgrades; can be removed on next breaking change */}
+            {fieldNote && (
+              <FieldNote
+                disabled={disabled}
+                id={ariaDescribedByVar}
+                isError={shouldRenderError}
+              >
+                {fieldNote}
+              </FieldNote>
+            )}
+          </>
         )}
       </div>
     );

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -186,7 +186,7 @@ export const InputField: InputFieldType = forwardRef(
       fieldNote && styles['input-field--has-fieldNote'],
     );
 
-    const fieldLength = fieldText?.toString().length;
+    const fieldLength = fieldText?.toString().length ?? 0;
 
     const textExceedsMaxLength =
       maxLength !== undefined && fieldLength ? fieldLength > maxLength : false;

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -1468,3 +1468,185 @@ exports[`<InputField /> TabularInput story renders snapshot 1`] = `
   </table>
 </div>
 `;
+
+exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
+<div
+  style="padding: 0.5rem; background-color: white;"
+>
+  <div>
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--lg input-field__label"
+        for=":r2m:"
+      >
+        test label
+      </label>
+      <span
+        class="text text--sm input-field__required-text"
+      >
+        Required
+      </span>
+    </div>
+    <div
+      class="input-field__body"
+    >
+      <input
+        aria-invalid="false"
+        class="input error"
+        id=":r2m:"
+        maxlength="15"
+        required=""
+        type="text"
+        value="Some initial text"
+      />
+    </div>
+    <div
+      class="input-field__footer"
+    >
+      <div
+        class="input-field__character-counter"
+      >
+        <span
+          class="input-field--invalid-length"
+        >
+          17
+        </span>
+         
+        / 
+        15
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
+<div
+  style="padding: 0.5rem; background-color: white;"
+>
+  <div>
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--lg input-field__label"
+        for=":r2o:"
+      >
+        test label
+      </label>
+      <span
+        class="text text--sm input-field__required-text"
+      >
+        Required
+      </span>
+    </div>
+    <div
+      class="input-field__body"
+    >
+      <input
+        aria-invalid="false"
+        class="input error"
+        id=":r2o:"
+        required=""
+        type="text"
+        value="Some initial text"
+      />
+    </div>
+    <div
+      class="input-field__footer"
+    >
+      <div
+        class="input-field__character-counter"
+      >
+        <span
+          class="input-field--invalid-length"
+        >
+          17
+        </span>
+         
+        / 
+        15
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1`] = `
+<div
+  style="padding: 0.5rem; background-color: white;"
+>
+  <div>
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--lg input-field__label"
+        for=":r2q:"
+      >
+        test label
+      </label>
+      <span
+        class="text text--sm input-field__required-text"
+      >
+        Required
+      </span>
+    </div>
+    <div
+      class="input-field__body input-field--has-fieldNote"
+    >
+      <input
+        aria-describedby=":r2r:"
+        aria-invalid="false"
+        class="input error"
+        id=":r2q:"
+        maxlength="20"
+        required=""
+        type="text"
+        value="Some initial text"
+      />
+    </div>
+    <div
+      class="input-field__footer"
+    >
+      <div
+        class="field-note field-note--error"
+        id=":r2r:"
+      >
+        <svg
+          class="icon field-note__icon"
+          fill="currentColor"
+          height="1rem"
+          role="img"
+          style="--icon-size: 1rem;"
+          viewBox="0 0 24 24"
+          width="1rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            error
+          </title>
+          <path
+            d="M14.9,3H9.1C8.57,3,8.06,3.21,7.68,3.59l-4.1,4.1C3.21,8.06,3,8.57,3,9.1v5.8c0,0.53,0.21,1.04,0.59,1.41l4.1,4.1 C8.06,20.79,8.57,21,9.1,21h5.8c0.53,0,1.04-0.21,1.41-0.59l4.1-4.1C20.79,15.94,21,15.43,21,14.9V9.1c0-0.53-0.21-1.04-0.59-1.41 l-4.1-4.1C15.94,3.21,15.43,3,14.9,3z M15.54,15.54L15.54,15.54c-0.39,0.39-1.02,0.39-1.41,0L12,13.41l-2.12,2.12 c-0.39,0.39-1.02,0.39-1.41,0l0,0c-0.39-0.39-0.39-1.02,0-1.41L10.59,12L8.46,9.88c-0.39-0.39-0.39-1.02,0-1.41l0,0 c0.39-0.39,1.02-0.39,1.41,0L12,10.59l2.12-2.12c0.39-0.39,1.02-0.39,1.41,0l0,0c0.39,0.39,0.39,1.02,0,1.41L13.41,12l2.12,2.12 C15.93,14.51,15.93,15.15,15.54,15.54z"
+          />
+        </svg>
+        Longer Field Description
+      </div>
+      <div
+        class="input-field__character-counter"
+      >
+        <span
+          class="input-field--invalid-length"
+        >
+          17
+        </span>
+         
+        / 
+        15
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React, { forwardRef, useState } from 'react';
+import { getMinValue } from '../../util/getMinValue';
 import { useId } from '../../util/useId';
 import type {
   EitherInclusive,
@@ -117,21 +118,6 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 );
 
 /**
- * Given two lengths that may not be defined, return the smaller of the defined lengths
- * TODO-AH: make this take a rest and can operate on any numbe of values
- * TODO-AH: move this to utilities
- */
-function getSmallest(lengthA?: number, lengthB?: number): number | undefined {
-  if (lengthA !== undefined && lengthB !== undefined) {
-    return Math.min(lengthA, lengthB);
-  } else if (lengthA && lengthB === undefined) {
-    return lengthA;
-  } else if (lengthB && lengthA === undefined) {
-    return lengthB;
-  }
-}
-
-/**
  * `import {TextareaField} from "@chanzuckerberg/eds";`
  *
  * Multi-line text input field with built-in labeling and accessory text to describe
@@ -202,7 +188,8 @@ export const TextareaField: TextareaFieldType = forwardRef(
         styles['textarea-field--invalid-length'],
     );
 
-    const maxLengthShown = getSmallest(maxLength, recommendedMaxLength);
+    // Pick the smallest of the lengths to set as the maximum value allowed
+    const maxLengthShown = getMinValue(maxLength, recommendedMaxLength);
 
     return (
       <div className={componentClassName}>

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -152,7 +152,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
 
     const idVar = id || generatedIdVar;
     const shouldRenderOverline = !!(label || required);
-    const fieldLength = fieldText?.toString().length;
+    const fieldLength = fieldText?.toString().length ?? 0;
     const textExceedsMaxLength =
       maxLength !== undefined ? fieldLength > maxLength : false;
 

--- a/src/util/getMinValue.test.ts
+++ b/src/util/getMinValue.test.ts
@@ -1,0 +1,19 @@
+import { getMinValue } from './getMinValue';
+
+describe('getMinValue', () => {
+  it.each`
+    setOfNumbers              | expectedSmallest
+    ${[1, 2, 3]}              | ${1}
+    ${[1, 2, 3]}              | ${1}
+    ${[3, 3, 3]}              | ${3}
+    ${[undefined, 2, 3]}      | ${2}
+    ${[1]}                    | ${1}
+    ${[]}                     | ${undefined}
+    ${[undefined, undefined]} | ${undefined}
+  `(
+    'returns $expectedSmallest when evaluating $setOfNumbers',
+    ({ setOfNumbers = [], expectedSmallest }) => {
+      expect(getMinValue(...setOfNumbers)).toEqual(expectedSmallest);
+    },
+  );
+});

--- a/src/util/getMinValue.ts
+++ b/src/util/getMinValue.ts
@@ -1,0 +1,16 @@
+/**
+ * Get the smallest number from a partially-defined set of numbers.
+ *
+ * @param args list of numbers, some of which may be undefined
+ * @returns the smallest number from the set, or undefined if all args are undefined
+ */
+export function getMinValue(
+  ...args: (number | undefined)[]
+): number | undefined {
+  const minValue = Math.min.apply(
+    undefined,
+    args.filter((v) => v !== undefined) as number[],
+  );
+
+  return Math.abs(minValue) === Infinity ? undefined : minValue;
+}


### PR DESCRIPTION
### Summary:

- allow handling for `maxlength` and `recommendedMaxLength` like TextareaField
- update snapshots and tests

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
