### PR TITLE
feat(Tailwind): add config to expose primary and secondary fonts

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -100,6 +100,15 @@ export const Callout: StoryObj<Args> = {
   },
 };
 
+export const OverridingFontFamily: StoryObj<Args> = {
+  args: {
+    size: 'md',
+    children:
+      'You can use tailwind to override the font family used for a given size',
+    className: '!font-secondary',
+  },
+};
+
 /**
  * Used mainly for visual regression testing and to show the different color options available.
  */

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -108,6 +108,18 @@ exports[`<Text /> Overline story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Text /> OverridingFontFamily story renders snapshot 1`] = `
+<div
+  style="margin: 0.25rem;"
+>
+  <p
+    class="text text--md !font-secondary"
+  >
+    You can use tailwind to override the font family used for a given size
+  </p>
+</div>
+`;
+
 exports[`<Text /> TextVariantInherit story renders snapshot 1`] = `
 <div
   style="margin: 0.25rem;"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -53,6 +53,13 @@ export default {
       medium: edsTokens['font-weight'].medium,
       bold: edsTokens['font-weight'].bold,
     },
+    fontFamily: {
+      // provide values for the configured font family tokens
+      // Useful when your app imports '@chanzuckerberg/eds/fonts.css' or
+      // if you have custom token values for primary and secondary fonts
+      primary: edsTokens['font-family'].primary,
+      secondary: edsTokens['font-family'].secondary,
+    },
     // sync with src/design-tokens/tier-1-definitions/breakpoints.js
     screens: {
       xs: '375px',


### PR DESCRIPTION
### Summary:

expose more tokens used in EDS to tailwind, to allow for utility classes for the preconfigured font families, or for any custom font families added by consumers. Can be used in isolation like `font-primary` or `font-secondary`, or as an occasional override to any typography components like `Heading` or `Text`.

- add the example config to tailwind.config.js with brief documentation
- add example to Text component
- update snapshots

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
