### PR TITLE
test(Menu): add delay to menu open user event trigger

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -210,7 +210,7 @@ export const Opened: StoryObj<MenuProps> = {
   },
   play: () => {
     userEvent.tab();
-    userEvent.keyboard(' ');
+    userEvent.keyboard(' ', { delay: 300 });
   },
 };
 


### PR DESCRIPTION
### Summary:

Attempt nr. 2 at making the open menu test less flaky. Add a delay to the user event that triggers the open menu. 

Trying this, as the snapshot likely happens right after the event completes, when the positioning library is calculating the final location and width of the popover. 

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] ~Wrote~ modified [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
