### PR TITLE
feat(Menu): allow href and onClick to co-exist on a menu item

### DIFF
--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -55,8 +55,7 @@ export const Default: StoryObj<MenuProps> = {
           >
             MDN: Menu
           </Menu.Item>
-          {/* eslint-disable-next-line no-alert */}
-          <Menu.Item onClick={() => alert('Item clicked')}>
+          <Menu.Item href="#index" onClick={() => console.log('Item clicked')}>
             Trigger Action
           </Menu.Item>
           <Menu.Item disabled href="https://example.org/" icon="warning">

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -13,6 +13,9 @@ const { Default } = composeStories(stories);
 const { Opened, ...staticStories } = stories;
 
 describe('<Menu />', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
   generateSnapshots(staticStories, {
     getElement: async () => {
       const user = userEvent.setup();
@@ -44,6 +47,27 @@ describe('<Menu />', () => {
     });
 
     expect(menuContainer.getAttribute('aria-activedescendant')).not.toBeNull();
+  });
+
+  it('handles onclick events when there is an href present', async () => {
+    // create a spy on the `log` method, and avoid calling it by setting the mock implementation to nothing
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+    const user = userEvent.setup();
+    render(<Default />);
+    const triggerButton = await screen.findByRole('button');
+    await act(async () => {
+      await user.click(triggerButton);
+    });
+
+    await act(async () => {
+      await user.keyboard('{arrowdown}{arrowdown}{arrowdown}');
+    });
+
+    await act(async () => {
+      await user.keyboard('{enter}');
+    });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should close menu on keyboard escape key', async () => {

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -42,7 +42,7 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenu.Item> & {
    */
   icon?: IconName;
   /**
-   * Configurable action for the menu item action. If both `href` and `onClick` are used, `onClick` takes precedent.
+   * Configurable action for the menu item upon click
    */
   onClick?: MouseEventHandler<HTMLAnchorElement>;
 };
@@ -189,8 +189,6 @@ const MenuItem = ({
   onClick,
   ...other
 }: MenuItemProps) => {
-  // If we have an event handler, avoid navigation by discarding the href
-  const destinationUrl = !onClick ? href : undefined;
   return (
     <HeadlessMenu.Item {...other}>
       {({ active, disabled }) => {
@@ -209,7 +207,7 @@ const MenuItem = ({
         ) : (
           <a
             className={clsx(styles['menu__item'])}
-            href={destinationUrl}
+            href={href}
             onClick={onClick}
           >
             {listItemView}


### PR DESCRIPTION
### Summary:

Remove this artificial constraint on `Menu.Item` components so that additional behavior can be attached to menu items along with an `href` with `onClick`. Like with an `<a>`, it will be up to the consumer to avoid undesired behavior.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
