### PR TITLE
fix: add .displayName to components

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -282,22 +282,6 @@ export const UsingRenderProp: StoryObj<Args> = {
   ),
   parameters: {
     chromatic: { disableSnapshot: true },
-    docs: {
-      source: {
-        code: `<Accordion headingAs="h2">
-  <Accordion.Row>
-    {({ open }) => (
-      <>
-        <Accordion.Button data-testid="accordion-button">
-          Accordion Button {(open && 'open') || 'closed'}
-        </Accordion.Button>
-        <Accordion.Panel>Accordion Panel</Accordion.Panel>
-      </>
-    )}
-  </Accordion.Row>
-</Accordion>`,
-      },
-    },
   },
 };
 
@@ -332,50 +316,6 @@ export const WithLargeHeader: StoryObj<Args> = {
 export const UsingComplexHeaders: StoryObj<Args> = {
   parameters: {
     badges: ['1.2', 'implementationExample'],
-    docs: {
-      source: {
-        code: `<Accordion>
-  <Accordion.Row>
-    <Accordion.Button>
-      <Text size="lg" variant="neutral-subtle">
-        <Icon
-          className="m-2"
-          name="check-circle"
-          purpose="decorative"
-          size="1rem"
-        />
-        Step 1
-      </Text>
-    </Accordion.Button>
-    <Accordion.Panel>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-    </Accordion.Panel>
-  </Accordion.Row>
-  <Accordion.Row>
-    <Accordion.Button>
-      <Text size="lg" variant="neutral-subtle">
-        <Icon
-          className="m-2"
-          name="check-circle"
-          purpose="decorative"
-          size="1rem"
-        />
-        Step 2
-      </Text>
-    </Accordion.Button>
-    <Accordion.Panel>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-    </Accordion.Panel>
-  </Accordion.Row>
-</Accordion>`,
-      },
-    },
   },
   args: {
     children: (
@@ -426,44 +366,6 @@ export const UsingComplexHeaders: StoryObj<Args> = {
 export const UsingNumberIconInHeaders: StoryObj<Args> = {
   parameters: {
     badges: ['1.2', 'implementationExample'],
-    docs: {
-      source: {
-        code: `<Accordion>
-  <Accordion.Row>
-    <Accordion.Button>
-      <div className="flex flex-wrap gap-1">
-        <NumberIcon aria-label="Step 1" number={1} />
-        <Text size="lg" variant="neutral-subtle">
-          Step 1
-        </Text>
-      </div>
-    </Accordion.Button>
-    <Accordion.Panel>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-    </Accordion.Panel>
-  </Accordion.Row>
-  <Accordion.Row>
-    <Accordion.Button>
-      <div className="flex flex-wrap gap-1">
-        <NumberIcon aria-label="Step 3" number={2} />
-        <Text size="lg" variant="neutral-subtle">
-          Step 2
-        </Text>
-      </div>
-    </Accordion.Button>
-    <Accordion.Panel>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla amet,
-      massa ultricies iaculis. Quam lacus maecenas nibh malesuada. At
-      tristique et ullamcorper rhoncus amet pharetra aliquet tortor.
-      Suscipit dui, nunc sit dui tellus massa laoreet tellus.
-    </Accordion.Panel>
-  </Accordion.Row>
-</Accordion>`,
-      },
-    },
   },
   args: {
     children: (

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -264,6 +264,11 @@ const AccordionRow = ({
   );
 };
 
+Accordion.displayName = 'Accordion';
+AccordionButton.displayName = 'Accordion.Button';
+AccordionPanel.displayName = 'Accordion.Panel';
+AccordionRow.displayName = 'Accordion.Row';
+
 Accordion.Button = AccordionButton;
 Accordion.Panel = AccordionPanel;
 Accordion.Row = AccordionRow;

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -139,3 +139,5 @@ export const Avatar = ({
     </div>
   );
 };
+
+Avatar.displayName = 'Avatar';

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -125,6 +125,10 @@ export const Badge = ({ children, className, ...other }: BadgeProps) => {
   );
 };
 
+BadgeDot.displayName = 'Badge.Dot';
+BadgeIcon.displayName = 'Badge.Icon';
+BadgeText.displayName = 'Badge.Text';
+
 Badge.Dot = BadgeDot;
 Badge.Icon = BadgeIcon;
 Badge.Text = BadgeText;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -291,4 +291,7 @@ export const BreadcrumbsItem = ({
   );
 };
 
+Breadcrumbs.displayName = 'Breadcrumbs';
+CustomSeparatorBreadcrumbsItem.displayName = 'Breadcrumbs.Item';
+
 Breadcrumbs.Item = CustomSeparatorBreadcrumbsItem;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -101,4 +101,5 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     );
   },
 );
+
 Button.displayName = 'Button';

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -72,8 +72,6 @@ export const Card = ({
   );
 };
 
-Card.displayName = 'Card';
-
 /**
  * Body of the Card component.
  */
@@ -85,8 +83,6 @@ const CardBody = ({ children, className, ...other }: CardSubComponentProps) => {
     </div>
   );
 };
-
-CardBody.displayName = 'CardBody';
 
 /**
  * Footer of the Card component.
@@ -104,8 +100,6 @@ const CardFooter = ({
   );
 };
 
-CardFooter.displayName = 'CardFooter';
-
 /**
  * Header of the Card component.
  */
@@ -122,7 +116,10 @@ const CardHeader = ({
   );
 };
 
-CardHeader.displayName = 'CardHeader';
+Card.displayName = 'Card';
+CardBody.displayName = 'Card.Body';
+CardFooter.displayName = 'Card.Footer';
+CardHeader.displayName = 'Card.Header';
 
 Card.Body = CardBody;
 Card.Footer = CardFooter;

--- a/src/components/ClickableStyle/ClickableStyle.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.tsx
@@ -137,4 +137,5 @@ export const ClickableStyle = React.forwardRef(
     return <Component className={componentClassName} ref={ref} {...other} />;
   },
 );
+
 ClickableStyle.displayName = 'ClickableStyle';

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -66,3 +66,5 @@ export const FieldNote = ({
     </div>
   );
 };
+
+FieldNote.displayName = 'FieldNote';

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -103,5 +103,9 @@ const FieldsetLegend = ({
   );
 };
 
+Fieldset.displayName = 'Fieldset';
+FieldsetItems.displayName = 'Fieldset.Items';
+FieldsetLegend.displayName = 'Fieldset.Legend';
+
 Fieldset.Items = FieldsetItems;
 Fieldset.Legend = FieldsetLegend;

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -124,4 +124,4 @@ export const Heading = forwardRef(
   },
 );
 
-Heading.displayName = 'Heading'; // Satisfy eslint.
+Heading.displayName = 'Heading';

--- a/src/components/HorizontalStepper/HorizontalStepper.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.tsx
@@ -202,4 +202,7 @@ export const HorizontalStep = ({
   );
 };
 
+HorizontalStepper.displayName = 'HorizontalStepper';
+HorizontalStep.displayName = 'HorizontalStepper.Step';
+
 HorizontalStepper.Step = HorizontalStep;

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -34,3 +34,5 @@ export const Hr = ({ className, size, variant, ...other }: Props) => {
 
   return <hr className={componentClassName} {...other} />;
 };
+
+Hr.displayName = 'Hr';

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -153,3 +153,5 @@ export const Icon = (props: IconProps) => {
     );
   }
 };
+
+Icon.displayName = 'Icon';

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -125,3 +125,5 @@ export const InlineNotification = ({
     </div>
   );
 };
+
+InlineNotification.displayName = 'InlineNotification';

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -104,4 +104,5 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     );
   },
 );
+
 Input.displayName = 'Input';

--- a/src/components/InputLabel/InputLabel.tsx
+++ b/src/components/InputLabel/InputLabel.tsx
@@ -52,3 +52,5 @@ export const InputLabel = ({
     </label>
   );
 };
+
+InputLabel.displayName = 'InputLabel';

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -80,3 +80,5 @@ export const Label = ({
     </label>
   );
 };
+
+Label.displayName = 'Label';

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -61,4 +61,5 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
     );
   },
 );
+
 Link.displayName = 'Link';

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -116,3 +116,5 @@ export const LoadingIndicator = ({
     </div>
   );
 };
+
+LoadingIndicator.displayName = 'LoadingIndicator';

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -218,6 +218,12 @@ const MenuItem = ({
   );
 };
 
+Menu.displayName = 'Menu';
+MenuButton.displayName = 'Menu.Button';
+MenuPlainButton.displayName = 'Menu.PlainButton';
+MenuItems.displayName = 'Menu.Items';
+MenuItem.displayName = 'Menu.Item';
+
 Menu.Button = MenuButton;
 Menu.PlainButton = MenuPlainButton;
 Menu.Items = MenuItems;

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -483,6 +483,13 @@ const StickyModalFooter = (props: ModalFooterProps) => {
   return <ModalFooter isSticky={isScrollable} {...props} />;
 };
 
+Modal.displayName = 'Modal';
+VariantModalHeader.displayName = 'Modal.Header';
+ModalTitle.displayName = 'Modal.Title';
+FocusableModalBody.displayName = 'Modal.Body';
+StickyModalFooter.displayName = 'Modal.Footer';
+ModalStepper.displayName = 'Modal.Stepper';
+
 Modal.Header = VariantModalHeader;
 Modal.Title = ModalTitle;
 Modal.Body = FocusableModalBody;

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -104,3 +104,5 @@ export const NumberIcon = ({
     </Text>
   );
 };
+
+NumberIcon.displayName = 'NumberIcon';

--- a/src/components/PageLevelBanner/PageLevelBanner.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.tsx
@@ -148,4 +148,5 @@ export const PageLevelBanner = ({
     </aside>
   );
 };
+
 PageLevelBanner.displayName = 'PageLevelBanner';

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -154,6 +154,12 @@ const PopoverContent = ({
   return null;
 };
 
+Popover.displayName = 'Popover';
+PopoverButton.displayName = 'Popover.Group';
+PopoverContent.displayName = 'Popover.Content';
+PopoverOverlay.displayName = 'Popover.Overlay';
+PopoverGroup.displayName = 'Popover.Group';
+
 /**
  * A button that when clicked, can show or hide the Popover Menu
  * (Product teams can decide how a Popover will close, if it is on click, release, hover, etc.)

--- a/src/components/PopoverContainer/PopoverContainer.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.tsx
@@ -107,3 +107,5 @@ export const PopoverContainer = React.forwardRef<HTMLDivElement, Props>(
     );
   },
 );
+
+PopoverContainer.displayName = 'PopoverContainer';

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -74,3 +74,5 @@ export const PopoverListItem = React.forwardRef<HTMLDivElement, Props>(
     );
   },
 );
+
+PopoverListItem.displayName = 'PopoverListItem';

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -98,3 +98,5 @@ export const ProgressBar = ({
     </div>
   );
 };
+
+ProgressBar.displayName = 'ProgressBar';

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -142,5 +142,9 @@ export const Radio = ({
   );
 };
 
+Radio.displayName = 'Radio';
+RadioInput.displayName = 'Radio.Input';
+RadioLabel.displayName = 'Radio.Label';
+
 Radio.Input = RadioInput;
 Radio.Label = RadioLabel;

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -97,5 +97,9 @@ export const SearchBar = ({ children, className }: SearchBarProps) => {
   return <div className={componentClassName}>{children}</div>;
 };
 
+SearchBar.displayName = 'SearchBar';
+SearchField.displayName = 'Searchbar.Field';
+SearchButton.displayName = 'SearchBar.Button';
+
 SearchBar.Field = SearchField;
 SearchBar.Button = SearchButton;

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -210,14 +210,67 @@ function InteractiveExampleUsingChildren(props: Props) {
   ),
 };
 
-export const Disabled: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: '// refer to "Default" story code',
-      },
-    },
+/**
+ * You can implement a `Select.Button` with a render prop. This exposes several useful values to
+ * control the appearance of the rendered button. The render prop case is "Headless", in that it has
+ * no styling by default.
+ */
+export const UncontrolledHeadless: StoryObj = {
+  args: {
+    'aria-label': 'some label',
+    'data-testid': 'dropdown',
+    defaultValue: exampleOptions[0],
+    name: 'select',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <button className="fpo">{value.label} </button>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
   },
+};
+
+/**
+ * You can use `Select.ButtonWrapper` to borrow the existing style used for controlled `Select` components.
+ */
+export const StyledUncontrolled: StoryObj = {
+  args: {
+    'aria-label': 'some label',
+    'data-testid': 'dropdown',
+    defaultValue: exampleOptions[0],
+    name: 'select',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open}>
+              {value.label}
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
+  },
+};
+
+export const Disabled: StoryObj = {
   render: () => (
     <InteractiveExampleUsingChildren aria-label="Favorite Animal" disabled />
   ),
@@ -435,63 +488,5 @@ export const WithSelectedOption: StoryObj<typeof Select> = {
       labelComponent={<Select.Label>Favorite Animal</Select.Label>}
       value={exampleOptions[0]}
     />
-  ),
-};
-
-/**
- * You can implement a `Select.Button` with a render prop. This exposes several useful values to
- * control the appearance of the rendered button. The render prop case is "Headless", in that it has
- * no styling by default.
- */
-export const UncontrolledHeadless: StoryObj = {
-  render: () => (
-    <Select
-      aria-label="some label"
-      data-testid="dropdown"
-      defaultValue={exampleOptions[0]}
-      name="select"
-    >
-      <Select.Button>
-        {({ value, open, disabled }) => (
-          <button className="fpo">{value.label} </button>
-        )}
-      </Select.Button>
-      <Select.Options>
-        {exampleOptions.map((option) => (
-          <Select.Option key={option.key} value={option}>
-            {option.label}
-          </Select.Option>
-        ))}
-      </Select.Options>
-    </Select>
-  ),
-};
-
-/**
- * You can use `Select.ButtonWrapper` to borrow the existing style used for controlled `Select` components.
- */
-export const StyledUncontrolled: StoryObj = {
-  render: () => (
-    <Select
-      aria-label="some label"
-      data-testid="dropdown"
-      defaultValue={exampleOptions[0]}
-      name="select"
-    >
-      <Select.Button>
-        {({ value, open, disabled }) => (
-          <Select.ButtonWrapper isOpen={open}>
-            {value.label}
-          </Select.ButtonWrapper>
-        )}
-      </Select.Button>
-      <Select.Options>
-        {exampleOptions.map((option) => (
-          <Select.Option key={option.key} value={option}>
-            {option.label}
-          </Select.Option>
-        ))}
-      </Select.Options>
-    </Select>
   ),
 };

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -382,6 +382,13 @@ export const SelectButtonWrapper = React.forwardRef<
   );
 });
 
+Select.displayName = 'Select';
+SelectButton.displayName = 'Select.Button';
+SelectButtonWrapper.displayName = 'Select.ButtonWrapper';
+SelectLabel.displayName = 'Select.Label';
+SelectOption.displayName = 'Select.Option';
+SelectOptions.displayName = 'Select.Options';
+
 Select.Button = SelectButton;
 Select.ButtonWrapper = SelectButtonWrapper;
 Select.Label = SelectLabel;

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -7,12 +7,12 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:rc:"
+    aria-controls="headlessui-listbox-options-:rm:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button select-button--compact"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rb:"
+    id="headlessui-listbox-button-:rl:"
     type="button"
   >
     <span>
@@ -84,19 +84,19 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r5:"
+      id="headlessui-listbox-label-:rf:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r7:"
+    aria-controls="headlessui-listbox-options-:rh:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r5: headlessui-listbox-button-:r6:"
+    aria-labelledby="headlessui-listbox-label-:rf: headlessui-listbox-button-:rg:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r6:"
+    id="headlessui-listbox-button-:rg:"
     type="button"
   >
     <span>
@@ -127,12 +127,12 @@ exports[`<Select /> NoVisibleLabel story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:rh:"
+    aria-controls="headlessui-listbox-options-:rr:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rg:"
+    id="headlessui-listbox-button-:rq:"
     type="button"
   >
     <span>
@@ -163,12 +163,12 @@ exports[`<Select /> StyledUncontrolled story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1c:"
+    aria-controls="headlessui-listbox-options-:rb:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1b:"
+    id="headlessui-listbox-button-:ra:"
     type="button"
   >
     <span>
@@ -199,12 +199,12 @@ exports[`<Select /> UncontrolledHeadless story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r17:"
+    aria-controls="headlessui-listbox-options-:r6:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r16:"
+    id="headlessui-listbox-button-:r5:"
     type="button"
   >
     Dogs
@@ -225,19 +225,19 @@ exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:rl:"
+      id="headlessui-listbox-label-:rv:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:rn:"
+    aria-controls="headlessui-listbox-options-:r11:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:rl: headlessui-listbox-button-:rm:"
+    aria-labelledby="headlessui-listbox-label-:rv: headlessui-listbox-button-:r10:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rm:"
+    id="headlessui-listbox-button-:r10:"
     type="button"
   >
     <span>
@@ -269,12 +269,12 @@ exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:rs:"
+    aria-controls="headlessui-listbox-options-:r16:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rr:"
+    id="headlessui-listbox-button-:r15:"
     type="button"
   >
     Select
@@ -305,19 +305,19 @@ exports[`<Select /> WithSelectedOption story renders snapshot 1`] = `
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r10:"
+      id="headlessui-listbox-label-:r1a:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r12:"
+    aria-controls="headlessui-listbox-options-:r1c:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r10: headlessui-listbox-button-:r11:"
+    aria-labelledby="headlessui-listbox-label-:r1a: headlessui-listbox-button-:r1b:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r11:"
+    id="headlessui-listbox-button-:r1b:"
     type="button"
   >
     <span>

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -106,6 +106,10 @@ const CircleSkeleton = ({
   );
 };
 
+Skeleton.displayName = 'Skeleton';
+TextSkeleton.displayName = 'Skeleton.Text';
+CircleSkeleton.displayName = 'Skeleton.Circle';
+
 Skeleton.Text = TextSkeleton;
 /** @deprecated Use `Skeleton` instead */
 Skeleton.Rect = Skeleton;

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -219,3 +219,5 @@ export const Slider = ({
     </div>
   );
 };
+
+Slider.displayName = 'Slider';

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -74,6 +74,9 @@ const TabButton = (props: TabButtonProps) => {
   return <div />;
 };
 
+Tab.displayName = 'Tab';
+TabButton.displayName = 'Tab.Button';
+
 /**
  * Allows for control of the Tab Title contents, for custom tab handling
  *

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -299,6 +299,15 @@ export const Table = ({ children, className, ...other }: TableProps) => {
   );
 };
 
+Table.displayName = 'Table';
+TableBody.displayName = 'Table.Body';
+TableCell.displayName = 'Table.Cell';
+TableFooter.displayName = 'Table.Footer';
+TableHeader.displayName = 'Table.Header';
+TableHeaderCell.displayName = 'Table.HeaderCell';
+TableRow.displayName = 'Table.Row';
+TableCaption.displayName = 'Table.Caption';
+
 Table.Body = TableBody;
 Table.Cell = TableCell;
 Table.Footer = TableFooter;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -275,3 +275,5 @@ function usePrevious<T>(prop: T) {
   });
   return ref.current;
 }
+
+Tabs.displayName = 'Tabs';

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -104,4 +104,4 @@ export const Text = forwardRef(
   },
 );
 
-Text.displayName = 'Text'; // Satisfy eslint
+Text.displayName = 'Text';

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -252,5 +252,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
 );
 
 TextareaField.displayName = 'TextareaField';
+TextArea.displayName = 'TextareaField.Textarea';
+
 TextareaField.TextArea = TextArea;
 TextareaField.Label = InputLabel;

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -113,6 +113,12 @@ export const Toggle = ({ label, ...other }: ToggleProps) => {
     <ToggleButton {...other} />
   );
 };
+
+Toggle.displayName = 'Toggle';
+ToggleLabel.displayName = 'Toggle.Label';
+ToggleButton.displayName = 'Toggle.Button';
+ToggleWrapper.displayName = 'Toggle.Wrapper';
+
 Toggle.Label = ToggleLabel;
 Toggle.Button = ToggleButton;
 Toggle.Wrapper = ToggleWrapper;

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -175,3 +175,5 @@ export const Tooltip = ({
     </Tippy>
   );
 };
+
+Tooltip.displayName = 'Tooltip';


### PR DESCRIPTION
### Summary:

- this fixes a documentation issue where published docs would only show `No Display Name`

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Validate manually that the requested display name appears on components locally (localhost), and on the built storybook
