### PR TITLE
chore: upgrade testing-library/react to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "@storybook/testing-library": "^0.2.0",
     "@storybook/testing-react": "^2.0.1",
     "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.1",
     "@types/jest": "^29.5.5",
     "@types/node": "^18.18.5",

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -1,7 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Accordion } from './Accordion';
@@ -18,14 +18,10 @@ describe('<Accordion />', () => {
     expect(screen.queryByTestId('accordion-panel')).not.toBeInTheDocument();
     const accordionButton = screen.getByTestId('accordion-button');
 
-    await act(async () => {
-      await user.click(accordionButton);
-    });
+    await user.click(accordionButton);
     expect(screen.getByTestId('accordion-panel')).toBeInTheDocument();
 
-    await act(async () => {
-      await user.click(accordionButton);
-    });
+    await user.click(accordionButton);
     expect(screen.queryByTestId('accordion-panel')).not.toBeInTheDocument();
   });
 
@@ -35,24 +31,16 @@ describe('<Accordion />', () => {
     const accordionButton = screen.getByTestId('accordion-button');
     accordionButton.focus();
 
-    await act(async () => {
-      await user.keyboard(' ');
-    });
+    await user.keyboard(' ');
     expect(screen.getByTestId('accordion-panel')).toBeInTheDocument();
 
-    await act(async () => {
-      await user.keyboard(' ');
-    });
+    await user.keyboard(' ');
     expect(screen.queryByTestId('accordion-panel')).not.toBeInTheDocument();
 
-    await act(async () => {
-      await user.keyboard('{enter}');
-    });
+    await user.keyboard('{enter}');
     expect(screen.getByTestId('accordion-panel')).toBeInTheDocument();
 
-    await act(async () => {
-      await user.keyboard('{enter}');
-    });
+    await user.keyboard('{enter}');
     expect(screen.queryByTestId('accordion-panel')).not.toBeInTheDocument();
   });
 
@@ -71,9 +59,7 @@ describe('<Accordion />', () => {
     );
     const accordionButton = screen.getByTestId('accordion-button');
 
-    await act(async () => {
-      await user.click(accordionButton);
-    });
+    await user.click(accordionButton);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -97,9 +83,7 @@ describe('<Accordion />', () => {
     );
     const accordionButton = screen.getByRole('button');
 
-    await act(async () => {
-      await user.click(accordionButton);
-    });
+    await user.click(accordionButton);
     expect(onOpen).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
   });
@@ -124,9 +108,7 @@ describe('<Accordion />', () => {
     );
     const accordionButton = screen.getByRole('button');
 
-    await act(async () => {
-      await user.click(accordionButton);
-    });
+    await user.click(accordionButton);
     expect(onOpen).not.toHaveBeenCalled();
     expect(onClose).not.toHaveBeenCalled();
   });

--- a/src/components/DataBar/DataBar.test.tsx
+++ b/src/components/DataBar/DataBar.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { DataBar } from './DataBar';
@@ -25,19 +25,13 @@ describe('<DataBar />', () => {
     );
     screen.getByTestId('databar-test').focus();
 
-    await act(async () => {
-      await user.tab();
-    });
+    await user.tab();
     expect(screen.getByLabelText('Segment 1')).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowright}');
-    });
+    await user.keyboard('{arrowright}');
     expect(screen.getByLabelText('Segment 2')).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowleft}');
-    });
+    await user.keyboard('{arrowleft}');
     expect(screen.getByLabelText('Segment 1')).toHaveFocus();
   });
 });

--- a/src/components/Drawer/Drawer.test.tsx
+++ b/src/components/Drawer/Drawer.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './Drawer.stories';
@@ -21,9 +21,7 @@ describe('<Drawer />', () => {
       name: 'Open Drawer',
     });
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-    await act(async () => {
-      await user.click(openDrawerButton);
-    });
+    await user.click(openDrawerButton);
     expect(screen.getByRole('dialog')).toBeTruthy();
   });
 });

--- a/src/components/FiltersDrawer/FiltersDrawer.test.tsx
+++ b/src/components/FiltersDrawer/FiltersDrawer.test.tsx
@@ -1,7 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './FiltersDrawer.stories';
@@ -17,9 +17,7 @@ describe('<Filters />', () => {
         name: 'Filters',
       });
       if (toggleFiltersButton) {
-        await act(async () => {
-          await user.click(toggleFiltersButton);
-        });
+        await user.click(toggleFiltersButton);
       }
       const filters = await screen.findByRole('dialog');
       return filters.parentElement; // eslint-disable-line testing-library/no-node-access

--- a/src/components/FiltersPopover/FiltersPopover.test.tsx
+++ b/src/components/FiltersPopover/FiltersPopover.test.tsx
@@ -1,7 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './FiltersPopover.stories';
@@ -16,11 +16,9 @@ describe('<Filters />', () => {
         name: 'Filters',
       });
 
-      await act(async () => {
-        if (toggleFiltersButton) {
-          await user.click(toggleFiltersButton);
-        }
-      });
+      if (toggleFiltersButton) {
+        await user.click(toggleFiltersButton);
+      }
 
       return toggleFiltersButton.parentElement; // eslint-disable-line testing-library/no-node-access
     },
@@ -32,42 +30,31 @@ describe('<Filters />', () => {
     const openFiltersButton = screen.getByRole('button', {
       name: 'Filters',
     });
-    await act(async () => {
-      await user.click(openFiltersButton);
-    });
+    await user.click(openFiltersButton);
 
     const checkboxes = screen.getAllByRole('checkbox');
-    await act(async () => {
-      await user.click(checkboxes[0]);
-      await user.click(checkboxes[4]);
-      await user.click(checkboxes[9]);
-    });
+
+    await user.click(checkboxes[0]);
+    await user.click(checkboxes[4]);
+    await user.click(checkboxes[9]);
+
     const applyFiltersButton = screen.getByRole('button', {
       name: 'Apply',
     });
-    await act(async () => {
-      await user.click(applyFiltersButton);
-    });
+
+    await user.click(applyFiltersButton);
     expect(openFiltersButton).toHaveAccessibleName('Filters (3)');
 
-    await act(async () => {
-      await user.click(openFiltersButton);
-    });
-    await act(async () => {
-      await user.keyboard('{Escape}');
-    });
+    await user.click(openFiltersButton);
+    await user.keyboard('{Escape}');
     expect(openFiltersButton).toHaveAccessibleName('Filters (3)');
 
-    await act(async () => {
-      await user.click(openFiltersButton);
-    });
+    await user.click(openFiltersButton);
     const clearAllFiltersButton = screen.getByRole('button', {
       name: 'Clear All',
     });
 
-    await act(async () => {
-      await user.click(clearAllFiltersButton);
-    });
+    await user.click(clearAllFiltersButton);
     expect(openFiltersButton).toHaveAccessibleName('Filters');
   });
 });

--- a/src/components/InputField/InputField.test.tsx
+++ b/src/components/InputField/InputField.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -27,9 +27,7 @@ describe('<InputField />', () => {
 
     input.focus();
 
-    await act(async () => {
-      await user.keyboard(testText);
-    });
+    await user.keyboard(testText);
 
     expect(onChange).toHaveBeenCalledTimes(testText.length);
   });
@@ -51,10 +49,7 @@ describe('<InputField />', () => {
     const input = screen.getByTestId('test-input');
 
     input.focus();
-
-    await act(async () => {
-      await user.keyboard(testText);
-    });
+    await user.keyboard(testText);
 
     expect(onChange).toHaveBeenCalledTimes(0);
   });
@@ -76,10 +71,7 @@ describe('<InputField />', () => {
     const input = screen.getByTestId('test-input');
 
     input.focus();
-
-    await act(async () => {
-      await user.keyboard(testText);
-    });
+    await user.keyboard(testText);
 
     expect(onChange).toHaveBeenCalledTimes(testText.length);
   });

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import React from 'react';
@@ -20,9 +20,7 @@ describe('<Menu />', () => {
     getElement: async () => {
       const user = userEvent.setup();
       const triggerButton = await screen.findByRole('button');
-      await act(async () => {
-        await user.click(triggerButton);
-      });
+      await user.click(triggerButton);
       return triggerButton.parentElement; // eslint-disable-line testing-library/no-node-access
     },
   });
@@ -31,9 +29,7 @@ describe('<Menu />', () => {
     const user = userEvent.setup();
     render(<Default />);
     const triggerButton = await screen.findByRole('button');
-    await act(async () => {
-      await user.click(triggerButton);
-    });
+    await user.click(triggerButton);
     const menuContainer = await screen.findByRole('menu');
 
     // a11y requires attaching the control dynamically, so confirm
@@ -42,9 +38,7 @@ describe('<Menu />', () => {
     );
 
     expect(menuContainer.getAttribute('aria-activedescendant')).toBeNull();
-    await act(async () => {
-      await user.keyboard('{arrowdown}');
-    });
+    await user.keyboard('{arrowdown}');
 
     expect(menuContainer.getAttribute('aria-activedescendant')).not.toBeNull();
   });
@@ -55,17 +49,10 @@ describe('<Menu />', () => {
     const user = userEvent.setup();
     render(<Default />);
     const triggerButton = await screen.findByRole('button');
-    await act(async () => {
-      await user.click(triggerButton);
-    });
 
-    await act(async () => {
-      await user.keyboard('{arrowdown}{arrowdown}{arrowdown}');
-    });
-
-    await act(async () => {
-      await user.keyboard('{enter}');
-    });
+    await user.click(triggerButton);
+    await user.keyboard('{arrowdown}{arrowdown}{arrowdown}');
+    await user.keyboard('{enter}');
 
     expect(consoleSpy).toHaveBeenCalledTimes(1);
   });
@@ -74,9 +61,7 @@ describe('<Menu />', () => {
     const user = userEvent.setup();
     render(<Default />);
     const triggerButton = await screen.findByRole('button');
-    await act(async () => {
-      await user.click(triggerButton);
-    });
+    await user.click(triggerButton);
     const menuContainer = await screen.findByRole('menu');
 
     // a11y attaches the control dynamically, so confirm
@@ -84,9 +69,7 @@ describe('<Menu />', () => {
       menuContainer.getAttribute('id'),
     );
 
-    await act(async () => {
-      await user.keyboard('{Escape}');
-    });
+    await user.keyboard('{Escape}');
     expect(screen.queryByTestId('menu-content')).not.toBeInTheDocument();
   });
 
@@ -107,9 +90,7 @@ describe('<Menu />', () => {
     );
     const triggerButton = await screen.findByRole('button');
     expect(triggerButton).toHaveAccessibleName('closed');
-    await act(async () => {
-      await user.click(triggerButton);
-    });
+    await user.click(triggerButton);
     expect(triggerButton).toHaveAccessibleName('open');
   });
 });

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,7 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Modal } from './Modal';
@@ -26,9 +26,7 @@ describe('Modal', () => {
       const openModalButton = await screen.findByRole('button', {
         name: 'Open the modal',
       });
-      await act(async () => {
-        await user.click(openModalButton);
-      });
+      await user.click(openModalButton);
       const modal = await screen.findByRole('dialog');
       return modal;
     },
@@ -45,9 +43,7 @@ describe('Modal', () => {
     const openModalButton = await screen.findByRole('button', {
       name: 'Open the modal',
     });
-    await act(async () => {
-      await user.click(openModalButton);
-    });
+    await user.click(openModalButton);
     const modal = await screen.findByRole('dialog');
     expect(modal).toBeTruthy();
   });
@@ -58,15 +54,11 @@ describe('Modal', () => {
     const openModalButton = await screen.findByRole('button', {
       name: 'Open the modal',
     });
-    await act(async () => {
-      await user.click(openModalButton);
-    });
+    await user.click(openModalButton);
     const closeButton = await screen.findByRole('button', {
       name: 'close modal',
     });
-    await act(async () => {
-      await user.click(closeButton);
-    });
+    await user.click(closeButton);
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).toBeFalsy();
     });
@@ -78,12 +70,8 @@ describe('Modal', () => {
     const openModalButton = await screen.findByRole('button', {
       name: 'Open the modal',
     });
-    await act(async () => {
-      await user.click(openModalButton);
-    });
-    await act(async () => {
-      await user.keyboard('{Escape}');
-    });
+    await user.click(openModalButton);
+    await user.keyboard('{Escape}');
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).toBeFalsy();
     });

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './Popover.stories';
@@ -13,9 +13,7 @@ describe('<Popover />', () => {
       const user = userEvent.setup();
       const triggerButton = await screen.findByRole('button');
 
-      await act(async () => {
-        await user.click(triggerButton);
-      });
+      await user.click(triggerButton);
       return triggerButton.parentElement; // eslint-disable-line testing-library/no-node-access
     },
   });
@@ -24,12 +22,8 @@ describe('<Popover />', () => {
     const user = userEvent.setup();
     render(<Default />);
     const triggerButton = screen.getByTestId('popover-trigger-button');
-    await act(async () => {
-      await user.click(triggerButton);
-    });
-    await act(async () => {
-      await user.keyboard('{Escape}');
-    });
+    await user.click(triggerButton);
+    await user.keyboard('{Escape}');
     expect(screen.queryByTestId('popover-content')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Radio/Radio.test.tsx
+++ b/src/components/Radio/Radio.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Radio } from './Radio';
@@ -33,9 +33,7 @@ describe('<Radio />', () => {
     const radio = screen.getByRole('radio');
     radio.focus();
 
-    await act(async () => {
-      await user.keyboard(' ');
-    });
+    await user.keyboard(' ');
 
     expect(radio).toBeChecked();
     expect(onChange).toHaveBeenCalledTimes(1);

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStory } from '@storybook/testing-react';
-import { screen, render, act } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Select } from './Select';
@@ -37,9 +37,7 @@ describe('<Select />', () => {
     getElement: async () => {
       const user = userEvent.setup();
       const openButton = await screen.findByRole('button');
-      await act(async () => {
-        await user.click(openButton);
-      });
+      await user.click(openButton);
       await screen.findAllByRole('option');
       return screen.getByTestId('dropdown');
     },
@@ -51,9 +49,7 @@ describe('<Select />', () => {
 
     const openTrigger = await screen.findByRole('button');
 
-    await act(async () => {
-      await user.click(openTrigger);
-    });
+    await user.click(openTrigger);
 
     // see if there are any options, which there should not be
     expect(screen.queryByRole('option')).not.toBeInTheDocument();

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,6 +1,6 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import { composeStories } from '@storybook/testing-react';
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import * as stories from './Tabs.stories';
@@ -18,35 +18,21 @@ describe('<Tabs />', () => {
     const secondTab = screen.getByRole('tab', { name: 'Tab Title 2' });
     firstTab.focus();
 
-    await act(async () => {
-      await user.keyboard('{arrowright}');
-    });
+    await user.keyboard('{arrowright}');
     expect(secondTab).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowleft}');
-    });
+    await user.keyboard('{arrowleft}');
     expect(firstTab).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowdown}');
-    });
+    await user.keyboard('{arrowdown}');
     expect(secondTab).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowup}');
-    });
+    await user.keyboard('{arrowup}');
     expect(firstTab).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('{arrowdown}');
-    });
-    await act(async () => {
-      await user.keyboard('{arrowright}');
-    });
-    await act(async () => {
-      await user.keyboard('{enter}');
-    });
+    await user.keyboard('{arrowdown}');
+    await user.keyboard('{arrowright}');
+    await user.keyboard('{enter}');
     expect(screen.getByRole('tab', { name: 'Tab Title 3' })).toHaveAttribute(
       'aria-selected',
       'true',

--- a/src/components/TextareaField/TextareaField.test.tsx
+++ b/src/components/TextareaField/TextareaField.test.tsx
@@ -1,7 +1,7 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import React from 'react';
@@ -96,9 +96,7 @@ describe('<TextareaField />', () => {
 
     expect(field).toHaveFocus();
 
-    await act(async () => {
-      await user.keyboard('abc');
-    });
+    await user.keyboard('abc');
 
     expect(onChangeFn).toHaveBeenCalled();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2553,7 +2553,7 @@ __metadata:
     "@storybook/testing-library": ^0.2.0
     "@storybook/testing-react": ^2.0.1
     "@testing-library/jest-dom": ^5.17.0
-    "@testing-library/react": ^13.4.0
+    "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.5.1
     "@tippyjs/react": ^4.2.6
     "@types/jest": ^29.5.5
@@ -6188,22 +6188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.5.0":
-  version: 8.20.0
-  resolution: "@testing-library/dom@npm:8.20.0"
-  dependencies:
-    "@babel/code-frame": ^7.10.4
-    "@babel/runtime": ^7.12.5
-    "@types/aria-query": ^5.0.1
-    aria-query: ^5.0.0
-    chalk: ^4.1.0
-    dom-accessibility-api: ^0.5.9
-    lz-string: ^1.4.4
-    pretty-format: ^27.0.2
-  checksum: 1e599129a2fe91959ce80900a0a4897232b89e2a8e22c1f5950c36d39c97629ea86b4986b60b173b5525a05de33fde1e35836ea597b03de78cc51b122835c6f0
-  languageName: node
-  linkType: hard
-
 "@testing-library/dom@npm:^9.0.0":
   version: 9.3.1
   resolution: "@testing-library/dom@npm:9.3.1"
@@ -6237,17 +6221,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^13.4.0":
-  version: 13.4.0
-  resolution: "@testing-library/react@npm:13.4.0"
+"@testing-library/react@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "@testing-library/react@npm:14.0.0"
   dependencies:
     "@babel/runtime": ^7.12.5
-    "@testing-library/dom": ^8.5.0
+    "@testing-library/dom": ^9.0.0
     "@types/react-dom": ^18.0.0
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
-  checksum: 51ec548c1fdb1271089a5c63e0908f0166f2c7fcd9cacd3108ebbe0ce64cb4351812d885892020dc37608418cfb15698514856502b3cab0e5cc58d6cc1bd4a3e
+  checksum: 4a54c8f56cc4a39b50803205f84f06280bb76521d6d5d4b3b36651d760c7c7752ef142d857d52aaf4fad4848ed7a8be49afc793a5dda105955d2f8bef24901ac
   languageName: node
   linkType: hard
 
@@ -15347,15 +15331,6 @@ __metadata:
   version: 10.0.1
   resolution: "lru-cache@npm:10.0.1"
   checksum: 06f8d0e1ceabd76bb6f644a26dbb0b4c471b79c7b514c13c6856113879b3bf369eb7b497dad4ff2b7e2636db202412394865b33c332100876d838ad1372f0181
-  languageName: node
-  linkType: hard
-
-"lz-string@npm:^1.4.4":
-  version: 1.4.4
-  resolution: "lz-string@npm:1.4.4"
-  bin:
-    lz-string: bin/bin.js
-  checksum: 54e31238a61a84d8f664d9860a9fba7310c5b97a52c444f80543069bc084815eff40b8d4474ae1d93992fdf6c252dca37cf27f6adbeb4dbc3df2f3ac773d0e61
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Summary:

re: https://github.com/testing-library/user-event/issues/1104#issuecomment-1759110918 update version of testing-library for react to latest major v14.

After validating stable tests, try removing/reducing calls to `act()` that might now be superfluous.

### Test Plan:


- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - validate build with existing `act()` tests
  - validate build after removing some superfluous `act()` calls in test