### PR TITLE
fix(Select): ensure name prop gets to Listbox

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -214,6 +214,8 @@ function InteractiveExampleUsingChildren(props: Props) {
  * You can implement a `Select.Button` with a render prop. This exposes several useful values to
  * control the appearance of the rendered button. The render prop case is "Headless", in that it has
  * no styling by default.
+ *
+ * Remember to include a `name` so that a hidden field is generated in this case
  */
 export const UncontrolledHeadless: StoryObj = {
   args: {
@@ -238,10 +240,42 @@ export const UncontrolledHeadless: StoryObj = {
       </>
     ),
   },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<Select
+  name="select"
+  defaultValue={exampleOptions[0]}
+  data-testid="dropdown"
+  aria-label="some label"
+>
+  <Select.Button>
+  {({ value, open, disabled }) => (
+    <button className="fpo">{value.label} </button>
+  )}
+  </Select.Button>
+  <Select.Options>
+    {exampleOptions.map((option) => (
+      <Select.Option key={option.key} value={option}>
+        {option.label}
+      </Select.Option>
+    ))}
+  </Select.Options>
+</Select>
+<!--
+Hidden fields named "select[key]" and "select[label]" because the datatype used is {key: value, label: value}
+-->
+        `,
+      },
+    },
+  },
 };
 
 /**
  * You can use `Select.ButtonWrapper` to borrow the existing style used for controlled `Select` components.
+ *
+ * Remember to include a `name` so that a hidden field is generated in this case
  */
 export const StyledUncontrolled: StoryObj = {
   args: {
@@ -267,6 +301,38 @@ export const StyledUncontrolled: StoryObj = {
         </Select.Options>
       </>
     ),
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<Select
+  name="select"
+  defaultValue={exampleOptions[0]}
+  data-testid="dropdown"
+  aria-label="some label"
+>
+  <Select.Button>
+    {({ value, open, disabled }) => (
+      <Select.ButtonWrapper isOpen={open}>
+        {value.label}
+      </Select.ButtonWrapper>
+    )}
+  </Select.Button>
+  <Select.Options>
+    {exampleOptions.map((option) => (
+      <Select.Option key={option.key} value={option}>
+        {option.label}
+      </Select.Option>
+    ))}
+  </Select.Options>
+</Select>
+<!--
+Hidden fields named "select[key]" and "select[label]" because the datatype used is {key: value, label: value}
+-->
+        `,
+      },
+    },
   },
 };
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -109,4 +109,31 @@ describe('<Select />', () => {
 
     expect(renderMethod).not.toThrow(Error);
   });
+
+  it('[GROUP-112] generates a hidden field when used in uncontrolled mode', () => {
+    const dropdownWithChildrenAndLabelText = (
+      <Select
+        aria-label="test"
+        data-testid="dropdown"
+        name="uncontrolled-select"
+        onChange={() => undefined}
+        value={exampleOptions[0]}
+      >
+        <Select.Button>Select</Select.Button>
+
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </Select>
+    );
+
+    const { container } = render(dropdownWithChildrenAndLabelText);
+
+    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+    expect(container.querySelector(`input`)).toBeInTheDocument();
+  });
 });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -200,6 +200,7 @@ export function Select(props: SelectProps) {
     // passed directly to this component have a corresponding DOM element to receive them.
     // Otherwise we get an error.
     as: 'div' as const,
+    name,
     ...other,
   };
 


### PR DESCRIPTION
### Summary:

- add in `name` prop to sharedProps
- add test to ensure prop causes hidden input to be generated
- improvements to documentation in uncontrolled components

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
