### PR TITLE
chore: add a bit of delay to reduce Modal test flakiness

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,4 +1,4 @@
-import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { generateSnapshots, wait } from '@chanzuckerberg/story-utils';
 import type { StoryFile } from '@storybook/testing-react';
 import { composeStories } from '@storybook/testing-react';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -28,6 +28,10 @@ describe('Modal', () => {
       });
       await user.click(openModalButton);
       const modal = await screen.findByRole('dialog');
+
+      // Give Headless UI's transition/style classes time to settle.
+      await wait(50);
+
       return modal;
     },
   });

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -142,7 +142,7 @@ exports[`Modal DefaultInteractive story renders snapshot 1`] = `
 <div
   aria-labelledby="headlessui-dialog-title-:r2:"
   aria-modal="true"
-  class="modal"
+  class="modal modal__transition--enterTo"
   data-headlessui-state="open"
   id="headlessui-dialog-:r0:"
   role="dialog"
@@ -838,7 +838,7 @@ exports[`Modal WithLongText story renders snapshot 1`] = `
 <div
   aria-labelledby="headlessui-dialog-title-:r8:"
   aria-modal="true"
-  class="modal"
+  class="modal modal__transition--enterTo"
   data-headlessui-state="open"
   id="headlessui-dialog-:r6:"
   role="dialog"
@@ -935,7 +935,7 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
 <div
   aria-labelledby="headlessui-dialog-title-:rb:"
   aria-modal="true"
-  class="modal"
+  class="modal modal__transition--enterTo"
   data-headlessui-state="open"
   id="headlessui-dialog-:r9:"
   role="dialog"
@@ -1218,7 +1218,7 @@ exports[`Modal WithoutCloseButton story renders snapshot 1`] = `
 <div
   aria-labelledby="headlessui-dialog-title-:r5:"
   aria-modal="true"
-  class="modal"
+  class="modal modal__transition--enterTo"
   data-headlessui-state="open"
   id="headlessui-dialog-:r3:"
   role="dialog"
@@ -1277,7 +1277,7 @@ exports[`Modal WithoutHeaderAndFooter story renders snapshot 1`] = `
 <div
   aria-label="The Modal Amazing Modal You've Ever Seen"
   aria-modal="true"
-  class="modal"
+  class="modal modal__transition--enterTo"
   data-headlessui-state="open"
   id="headlessui-dialog-:rc:"
   role="dialog"


### PR DESCRIPTION
Noticed [some flakiness with the Modal's interactive examples tests](https://github.com/chanzuckerberg/edu-design-system/actions/runs/6788858470/job/18454751418). Fixed here by adding a small delay.

Alternatively could try to wait for a specific class. But I don't think there's a good one. The classes in question seem to be generated, and I don't want to rely on them.