### PR TITLE
feat(Tag): mark yield color variant as deprecated

### DIFF
--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -4,6 +4,8 @@ import { Tag, VARIANTS } from './Tag';
 import Icon from '../Icon';
 import styles from './Tag.stories.module.css';
 
+const supportedVariants = VARIANTS.filter((variant) => variant !== 'yield');
+
 export default {
   title: 'Components/Tag',
   component: Tag,
@@ -35,7 +37,7 @@ export const Default: Story = {};
 export const Variants: Story = {
   render: (args) => (
     <div className={styles.tagList}>
-      {VARIANTS.map((variant) => {
+      {supportedVariants.map((variant) => {
         return (
           <Tag
             data-testid="test"
@@ -56,7 +58,7 @@ export const Variants: Story = {
 export const OutlineVariants: Story = {
   render: (args) => (
     <div className={styles.tagList}>
-      {VARIANTS.map((variant) => {
+      {supportedVariants.map((variant) => {
         return (
           <Tag
             key={variant}
@@ -81,7 +83,7 @@ export const WithIcon: Story = {
   },
   render: (args) => (
     <div className={styles.tagList}>
-      {VARIANTS.map((variant) => {
+      {supportedVariants.map((variant) => {
         return (
           <Tag
             key={variant}
@@ -107,7 +109,7 @@ export const WithLongTextAndIcon: Story = {
   },
   render: (args) => (
     <div className={styles.tagList}>
-      {VARIANTS.map((variant) => {
+      {supportedVariants.map((variant) => {
         return <Tag key={variant} {...args} hasOutline variant={variant} />;
       })}
     </div>

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -8,6 +8,7 @@ export const VARIANTS = [
   'error',
   'success',
   'warning',
+  /** @deprecated */
   'yield',
   'brand',
 ] as const;
@@ -17,6 +18,8 @@ export type Variant = (typeof VARIANTS)[number];
 type Props = {
   /**
    * The color variant of the tag. It will update the content colors, background color, and border (when `hasOutline` is set to `true`).
+   *
+   * **NOTE**: `yield` variant is deprecated and will be removed in a future release.
    *
    * **Default is `"neutral"`**.
    */

--- a/src/components/Tag/__snapshots__/Tag.test.ts.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.ts.snap
@@ -53,15 +53,6 @@ exports[`<Tag /> OutlineVariants story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="text text--sm text--bold-weight tag tag--yield tag--outline"
-  >
-    <span
-      class="tag__body"
-    >
-      yield
-    </span>
-  </span>
-  <span
     class="text text--sm text--bold-weight tag tag--brand tag--outline"
   >
     <span
@@ -115,16 +106,6 @@ exports[`<Tag /> Variants story renders snapshot 1`] = `
       class="tag__body"
     >
       warning
-    </span>
-  </span>
-  <span
-    class="text text--sm text--bold-weight tag tag--yield"
-    data-testid="test"
-  >
-    <span
-      class="tag__body"
-    >
-      yield
     </span>
   </span>
   <span
@@ -225,26 +206,6 @@ exports[`<Tag /> WithIcon story renders snapshot 1`] = `
     </span>
   </span>
   <span
-    class="text text--sm text--bold-weight tag tag--yield tag--outline"
-  >
-    <svg
-      aria-hidden="true"
-      class="icon"
-      fill="currentColor"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M10.65 19.8004L8.925 18.2254C7.15833 16.6087 5.5625 15.0046 4.1375 13.4129C2.7125 11.8212 2 10.0671 2 8.15039C2 6.58372 2.525 5.27539 3.575 4.22539C4.625 3.17539 5.93333 2.65039 7.5 2.65039C8.38333 2.65039 9.21667 2.83789 10 3.21289C10.7833 3.58789 11.45 4.10039 12 4.75039C12.55 4.10039 13.2167 3.58789 14 3.21289C14.7833 2.83789 15.6167 2.65039 16.5 2.65039C18.0667 2.65039 19.375 3.17539 20.425 4.22539C21.475 5.27539 22 6.58372 22 8.15039C22 10.0671 21.2917 11.8254 19.875 13.4254C18.4583 15.0254 16.85 16.6337 15.05 18.2504L13.35 19.8004C12.9667 20.1504 12.5167 20.3254 12 20.3254C11.4833 20.3254 11.0333 20.1504 10.65 19.8004Z"
-      />
-    </svg>
-    <span
-      class="tag__body"
-    >
-      yield
-    </span>
-  </span>
-  <span
     class="text text--sm text--bold-weight tag tag--brand tag--outline"
   >
     <svg
@@ -333,26 +294,6 @@ exports[`<Tag /> WithLongTextAndIcon story renders snapshot 1`] = `
   </span>
   <span
     class="text text--sm text--bold-weight tag tag--warning tag--outline"
-  >
-    <svg
-      aria-hidden="true"
-      class="icon"
-      fill="currentColor"
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="m12 17.27 4.15 2.51c.76.46 1.69-.22 1.49-1.08l-1.1-4.72 3.67-3.18c.67-.58.31-1.68-.57-1.75l-4.83-.41-1.89-4.46c-.34-.81-1.5-.81-1.84 0L9.19 8.63l-4.83.41c-.88.07-1.24 1.17-.57 1.75l3.67 3.18-1.1 4.72c-.2.86.73 1.54 1.49 1.08l4.15-2.5z"
-      />
-    </svg>
-    <span
-      class="tag__body"
-    >
-      This tag has a really long text message
-    </span>
-  </span>
-  <span
-    class="text text--sm text--bold-weight tag tag--yield tag--outline"
   >
     <svg
       aria-hidden="true"


### PR DESCRIPTION
### Summary:

- After syncing with design, will remove this variant from the component, and lean toward `warning` instead
- update corresponding snapshots

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details: