### PR TITLE
fix: remove duplicate addon-docs loading

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,13 +25,6 @@ const config: StorybookConfig = {
     '@storybook/addon-interactions',
     '@geometricpanda/storybook-addon-badges',
     {
-      name: '@storybook/addon-docs',
-      options: {
-        configureJSX: true,
-        transcludeMarkdown: true,
-      },
-    },
-    {
       name: '@storybook/addon-styling',
       options: {
         postCss: true,

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "@rollup/plugin-typescript": "^11.1.5",
     "@size-limit/file": "^8.2.6",
     "@storybook/addon-a11y": "^7.6.3",
-    "@storybook/addon-docs": "^7.6.3",
     "@storybook/addon-essentials": "^7.6.3",
     "@storybook/addon-interactions": "^7.6.3",
     "@storybook/addon-links": "^7.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,7 +1729,6 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^11.1.5"
     "@size-limit/file": "npm:^8.2.6"
     "@storybook/addon-a11y": "npm:^7.6.3"
-    "@storybook/addon-docs": "npm:^7.6.3"
     "@storybook/addon-essentials": "npm:^7.6.3"
     "@storybook/addon-interactions": "npm:^7.6.3"
     "@storybook/addon-links": "npm:^7.6.3"
@@ -3900,7 +3899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/addon-docs@npm:7.6.3, @storybook/addon-docs@npm:^7.6.3":
+"@storybook/addon-docs@npm:7.6.3":
   version: 7.6.3
   resolution: "@storybook/addon-docs@npm:7.6.3"
   dependencies:


### PR DESCRIPTION
### Summary:

The docs addon comes pre-installed with storybook 7.x, so we don't need to install it or configure it directly. This clears up that duplicate install and use (which also cleans up some small output from the console when starting storybook. Slightly quicker now.

As it's now pre-installed, we also don't have to worry about keeping it up to date anymore.

![Screenshot 2023-12-05 at 16 12 06](https://github.com/chanzuckerberg/edu-design-system/assets/3056447/ff8958fb-ede6-4449-9227-63abde714363)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - verify the "Docs" tab works normally on build in CI