### PR TITLE
chore(DragDrop): mark component as deprecated

### DIFF
--- a/src/components/DragDrop/DragDrop.stories.tsx
+++ b/src/components/DragDrop/DragDrop.stories.tsx
@@ -1,3 +1,4 @@
+import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import type { ComponentProps } from 'react';
 import React, { useState } from 'react';
@@ -6,10 +7,10 @@ import { Button, Card, Heading, Icon, Text } from '../..';
 import styles from './DragDrop.stories.module.css';
 
 export default {
-  title: 'Components/Drag and Drop',
+  title: 'Components/DragDrop',
   component: DragDrop,
   parameters: {
-    badges: ['1.0'],
+    badges: ['1.0', BADGE.DEPRECATED],
   },
   argTypes: {
     children: {
@@ -18,17 +19,7 @@ export default {
       },
     },
   },
-  decorators: [
-    (Story) => (
-      <div
-        style={{
-          margin: '1rem', // Provides spacing around storybook edges
-        }}
-      >
-        {Story()}
-      </div>
-    ),
-  ],
+  decorators: [(Story) => <div className="m-4">{Story()}</div>],
 } as Meta<Args>;
 
 type Args = ComponentProps<typeof DragDrop>;

--- a/src/components/DragDrop/DragDrop.tsx
+++ b/src/components/DragDrop/DragDrop.tsx
@@ -138,6 +138,8 @@ type DragDropContainerProps = {
 
 /**
  * Container for draggable components to be dropped within the container.
+ *
+ * @deprecated
  */
 const DragDropContainer = ({
   container,
@@ -198,8 +200,9 @@ const DragDropContainer = ({
 
 /**
  * Component that contains header section for the container which consists of drag and drop components.
+ *
+ * @deprecated
  */
-
 const DragDropContainerHeader = ({
   className,
   children,
@@ -214,6 +217,8 @@ const DragDropContainerHeader = ({
 
 /**
  * Item to be dragged and dropped in containers.
+ *
+ * @deprecated
  */
 const DragDropItem = ({
   className,
@@ -270,8 +275,10 @@ const DragDropItem = ({
  * `import {DragDrop} from "@chanzuckerberg/eds"`
  *
  * A flexible Drag and Drop component that allows items to be dragged and dropped in containers.
+ *
+ * @deprecated
  */
-export const DragDrop = ({
+const DragDrop = ({
   className,
   items,
   containers,
@@ -554,3 +561,5 @@ export const DragDrop = ({
 };
 
 DragDrop.ContainerHeader = DragDropContainerHeader;
+
+export { DragDrop };

--- a/src/components/DragDrop/__snapshots__/DragDrop.test.ts.snap
+++ b/src/components/DragDrop/__snapshots__/DragDrop.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`<DragDrop /> Default story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <section
     class="drag-drop drag-drop--unstyled eds-is-overflow-right"
@@ -276,7 +276,7 @@ exports[`<DragDrop /> Default story renders snapshot 1`] = `
 
 exports[`<DragDrop /> HoveredHandle story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <section
     class="drag-drop drag-drop--unstyled eds-is-overflow-right"
@@ -550,7 +550,7 @@ exports[`<DragDrop /> HoveredHandle story renders snapshot 1`] = `
 
 exports[`<DragDrop /> Interactive story renders snapshot 1`] = `
 <div
-  style="margin: 1rem;"
+  class="m-4"
 >
   <section
     class="drag-drop drag-drop--unstyled eds-is-overflow-right"


### PR DESCRIPTION
### Summary:

- in its current form, it is far too application-specific to be generally usable
- also, the underlying library is now deprecated and no longer supported
- marking this as not recommended for current use, to move on to another codebase

### Test Plan:

- n/a (component metadata change)
