### PR TITLE
fix(InputField): mark unused prop as deprecated

### DIFF
--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -78,7 +78,10 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   required?: boolean;
   /**
-   * String for the required label to add additional information if needed.
+   * String for the required label to add additional information if needed. Currently not being used.
+   *
+   * **Deprecated**. This will be removed in the next major version.
+   * @deprecated
    */
   requiredLabel?: string;
   /**

--- a/src/components/InputLabel/InputLabel.stories.ts
+++ b/src/components/InputLabel/InputLabel.stories.ts
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import type { ComponentProps } from 'react';
 
@@ -11,7 +10,7 @@ export default {
     children: 'Label',
   },
   parameters: {
-    badges: ['1.0', BADGE.BETA],
+    badges: ['1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -34,6 +34,9 @@ export interface Props {
   required?: boolean;
   /**
    * String for the required label to add additional information if needed.
+   *
+   * **Deprecated**. This will be removed in the next major version.
+   * @deprecated
    */
   requiredLabel?: string;
   /**


### PR DESCRIPTION
### Summary:

- this was leftover from some previous factoring
- this behavior is not available in design, so marking to remove

### Test Plan:

- n/a (documentation-only change)