### PR TITLE
feat(Label): mark optional as deprecated

### DIFF
--- a/src/components/Label/Label.stories.ts
+++ b/src/components/Label/Label.stories.ts
@@ -19,10 +19,3 @@ export const Default: StoryObj<Args> = {
     required: true,
   },
 };
-
-export const Optional: StoryObj<Args> = {
-  args: {
-    text: 'Label',
-    required: false,
-  },
-};

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -25,11 +25,16 @@ export interface Props {
    */
   labelAfter?: ReactNode;
   /**
-   * String for the optional label. By default it is '(optional)'
+   * String for the optional label.
+   *
+   * **Default is `"(optional)"`**
+   *
+   * **Deprecated**. This will be removed in the next major version.
+   * @deprecated
    */
   optionalLabel?: string;
   /**
-   * Indicates that field is required for form to be successfully submitted. Non-required fields will display a text "(optional)" beside the label text
+   * Indicates that field is required for form to be successfully submitted.
    */
   required?: boolean;
   /**

--- a/src/components/Label/__snapshots__/Label.test.ts.snap
+++ b/src/components/Label/__snapshots__/Label.test.ts.snap
@@ -8,17 +8,3 @@ exports[`<Label /> Default story renders snapshot 1`] = `
    
 </label>
 `;
-
-exports[`<Label /> Optional story renders snapshot 1`] = `
-<label
-  class="label"
->
-  Label
-   
-  <span
-    class="label__flag"
-  >
-    (optional)
-  </span>
-</label>
-`;


### PR DESCRIPTION
### Summary:

- optional text should not appear next to the label
- remove any stories or docs demonstrating this behavior

### Test Plan:

- n/a (documentation-only change)