### PR TITLE
feat(Select): add support for label prop

### DIFF
--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -13,10 +13,12 @@
 
 /**
  * Compact variant.
+ * TODO: remove treatment for compact, as it only adjusts the component width, not its overall padding
  */
 .select--compact {
   width: min-content;
 }
+
 .select-button--compact {
   padding: var(--eds-size-half);
 }
@@ -27,6 +29,10 @@
 .select__label {
   font: var(--eds-theme-typography-form-label);
   display: inline-block;
+}
+
+.select__label--disabled {
+  color: var(--eds-theme-color-text-disabled);
 }
 
 /**

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,8 +1,6 @@
 import type { StoryObj, Meta } from '@storybook/react';
 import { userEvent, within } from '@storybook/testing-library';
-import clsx from 'clsx';
-import React from 'react';
-import type { OptionsAlignType, VariantType } from './Select';
+import React, { type SyntheticEvent } from 'react';
 import { Select } from './Select';
 import Icon from '../Icon';
 
@@ -17,6 +15,11 @@ const meta: Meta<typeof Select> = {
     multiple: {
       table: {
         disable: true,
+      },
+    },
+    children: {
+      control: {
+        type: null,
       },
     },
     value: {
@@ -39,20 +42,32 @@ const meta: Meta<typeof Select> = {
         },
       },
     },
+    onClick: {
+      description:
+        'Optional click handler. Fires after `onChange`, when a value in the dropdown popover is picked',
+      table: {
+        type: {
+          summary: 'SyntheticEvent',
+          detail:
+            'See: https://react.dev/reference/react-dom/components/common#react-event-object',
+        },
+        default: 'void',
+      },
+    },
+    onChange: {
+      description: 'Optional change handler. Fires when a value is selected',
+      table: {
+        type: {
+          summary: 'SelectOption',
+          detail:
+            'An object with at least label (as string) and any other useful key/value pairs',
+        },
+      },
+    },
   },
 };
 
 export default meta;
-
-type Props = {
-  'aria-label'?: string;
-  labelComponent?: React.ReactNode;
-  optionsAlign?: OptionsAlignType;
-  optionsClassName?: string;
-  variant?: VariantType;
-  disabled?: boolean;
-  value?: SelectOption;
-};
 
 type SelectOption = {
   key: string;
@@ -73,91 +88,6 @@ const exampleOptions: SelectOption[] = [
     label: 'Birds',
   },
 ];
-
-function InteractiveExampleUsingChildren(props: Props) {
-  const { variant, optionsAlign, optionsClassName, disabled, value } = props;
-  const compact = variant === 'compact';
-
-  const [selectedOption, setSelectedOption] = React.useState<
-    SelectOption | undefined
-  >(value);
-
-  return (
-    <div className="mb-10 p-8">
-      <Select
-        aria-label={props['aria-label']}
-        className={clsx(!compact && 'w-60')}
-        data-testid="dropdown"
-        disabled={disabled}
-        name="interactive-select"
-        onChange={setSelectedOption}
-        optionsAlign={optionsAlign}
-        optionsClassName={optionsClassName}
-        value={selectedOption}
-        variant={variant}
-      >
-        {props.labelComponent}
-        <Select.Button>{selectedOption?.label || 'Select'}</Select.Button>
-        <Select.Options>
-          {exampleOptions.map((option) => (
-            <Select.Option key={option.key} value={option}>
-              {option.label}
-            </Select.Option>
-          ))}
-        </Select.Options>
-      </Select>
-    </div>
-  );
-}
-
-// This story just tests the case where a function in passed in that wraps the children.
-function InteractiveExampleUsingFunctionChildren() {
-  const [selectedOption, setSelectedOption] =
-    React.useState<(typeof exampleOptions)[0]>();
-
-  return (
-    <div className="mb-10 p-8">
-      <Select
-        aria-label="Favorite Animal"
-        as="div"
-        className="w-60"
-        data-testid="dropdown"
-        name="interactive-with-children"
-        onChange={setSelectedOption}
-        value={selectedOption}
-      >
-        {({ open }) => (
-          <>
-            <Select.Button
-              // Because we're using a render prop to completely control the styling and icon of the
-              // button, we need to configure this component to render as a Fragment. Otherwise we'd
-              // render two, nested buttons.
-              as={React.Fragment}
-            >
-              {() => (
-                <button aria-expanded={open} className="fpo">
-                  {selectedOption?.label || 'Select'}
-                  <Icon
-                    className="ml-4"
-                    name="filter-list"
-                    purpose="decorative"
-                  />
-                </button>
-              )}
-            </Select.Button>
-            <Select.Options>
-              {exampleOptions.map((option) => (
-                <Select.Option key={option.key} value={option}>
-                  {option.label}
-                </Select.Option>
-              ))}
-            </Select.Options>
-          </>
-        )}
-      </Select>
-    </div>
-  );
-}
 
 /**
  * Play function to open a menu item
@@ -191,35 +121,28 @@ const selectCat: StoryObj['play'] = async (playOptions) => {
   await userEvent.click(selectButton);
 };
 
+/**
+ * The simplest and default case, using the options, button, and button wrapper.
+ * This shows how to reflect the value in the button upon selection, and how to generate
+ * a set of options from a list.
+ *
+ * **NOTE**: for select value data types, `{label: string}` is required, but any other key/value pairs are allowed.
+ */
 export const Default: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: `
-// props: {aria-label: 'Favorite Animal'}
-function InteractiveExampleUsingChildren(props: Props) {
-  const { variant, optionsAlign, optionsClassName, disabled, value } = props;
-  const compact = variant === 'compact';
-
-  const [selectedOption, setSelectedOption] = React.useState<
-    SelectOption | undefined
-  >(value);
-
-  return (
-    <div className="mb-10 p-8">
-      <Select
-        aria-label={props['aria-label']}
-        className={clsx(!compact && 'w-60')}
-        data-testid="dropdown"
-        disabled={disabled}
-        onChange={setSelectedOption}
-        optionsAlign={optionsAlign}
-        optionsClassName={optionsClassName}
-        value={selectedOption}
-        variant={variant}
-      >
-        {props.labelComponent}
-        <Select.Button>{selectedOption?.label || 'Select'}</Select.Button>
+  args: {
+    label: 'Favorite Animal',
+    'data-testid': 'dropdown',
+    defaultValue: exampleOptions[0],
+    name: 'select',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open}>
+              {value.label}
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
         <Select.Options>
           {exampleOptions.map((option) => (
             <Select.Option key={option.key} value={option}>
@@ -227,16 +150,34 @@ function InteractiveExampleUsingChildren(props: Props) {
             </Select.Option>
           ))}
         </Select.Options>
-      </Select>
-    </div>
-  );
-}`,
-      },
-    },
+      </>
+    ),
   },
-  render: () => (
-    <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
-  ),
+};
+
+/**
+ * You can select a different option on render.
+ */
+export const WithSelectedOption: StoryObj<typeof Select> = {
+  args: {
+    ...Default.args,
+    'aria-label': 'Favorite Animal',
+    defaultValue: exampleOptions[1],
+  },
+};
+
+/**
+ * `Select` allows for event handlers to be added to the component.
+ *
+ * * `onChange` fires when a value is selected (with value of type `SelectOption`)
+ * * `onClick` fires after onChange, when a value in the dropdown popover is picked
+ */
+export const EventHandling: StoryObj = {
+  args: {
+    ...Default.args,
+    onClick: (args: SelectOption) => console.log('test', args),
+    onChange: (args: SyntheticEvent) => console.log('test 2', args),
+  },
 };
 
 /**
@@ -248,14 +189,10 @@ function InteractiveExampleUsingChildren(props: Props) {
  * * `interactive-select[label]`
  * * `interactive-select[key]`
  *
- * **NOTE**: for select value data types, `{label: string}` is required, but any other key/value pairs are allowed.
  */
 export const WithFieldName: StoryObj = {
   args: {
-    'aria-label': 'some label',
-    'data-testid': 'dropdown',
-    defaultValue: exampleOptions[0],
-    name: 'select',
+    ...Default.args,
     children: (
       <>
         <Select.Button>
@@ -305,36 +242,6 @@ export const UncontrolledHeadless: StoryObj = {
       </>
     ),
   },
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<Select
-  name="select"
-  defaultValue={exampleOptions[0]}
-  data-testid="dropdown"
-  aria-label="some label"
->
-  <Select.Button>
-  {({ value, open, disabled }) => (
-    <button className="fpo">{value.label} </button>
-  )}
-  </Select.Button>
-  <Select.Options>
-    {exampleOptions.map((option) => (
-      <Select.Option key={option.key} value={option}>
-        {option.label}
-      </Select.Option>
-    ))}
-  </Select.Options>
-</Select>
-<!--
-Hidden fields named "select[key]" and "select[label]" because the datatype used is {key: value, label: value}
--->
-        `,
-      },
-    },
-  },
 };
 
 /**
@@ -365,188 +272,99 @@ export const StyledUncontrolled: StoryObj = {
       </>
     ),
   },
-  parameters: {
-    docs: {
-      source: {
-        code: `
-<Select
-  name="select"
-  defaultValue={exampleOptions[0]}
-  data-testid="dropdown"
-  aria-label="some label"
->
-  <Select.Button>
-    {({ value, open, disabled }) => (
-      <Select.ButtonWrapper isOpen={open}>
-        {value.label}
-      </Select.ButtonWrapper>
-    )}
-  </Select.Button>
-  <Select.Options>
-    {exampleOptions.map((option) => (
-      <Select.Option key={option.key} value={option}>
-        {option.label}
-      </Select.Option>
-    ))}
-  </Select.Options>
-</Select>
-<!--
-Hidden fields named "select[key]" and "select[label]" because the datatype used is {key: value, label: value}
--->
-        `,
-      },
-    },
+};
+
+/**
+ * The field trigger width can be set with utility classes. By default, dropdown popover will exppand to match the width.
+ */
+export const AdjustedWidth: StoryObj = {
+  args: {
+    ...Default.args,
+    className: 'w-60',
   },
 };
 
-export const Disabled: StoryObj = {
-  render: () => (
-    <InteractiveExampleUsingChildren aria-label="Favorite Animal" disabled />
-  ),
-};
-
-export const DefaultWithVisibleLabel: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: `
-// refer to "Default" story code with:
-// props: {aria-label: 'Favorite Animal', labelComponent: <Select.Label>Favorite Animal</Select.Label>}`,
-      },
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      labelComponent={<Select.Label>Favorite Animal</Select.Label>}
-    />
-  ),
-};
-
-export const Compact: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: '// refer to "Default" story code',
-      },
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      variant="compact"
-    />
-  ),
-};
-
-export const NoVisibleLabel: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: '// refer to "Default" story code',
-      },
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren aria-label="Favorite Animal" />
-  ),
-};
-
-export const OptionsRightAligned: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: '// refer to "Default" story code',
-      },
-    },
-    chromatic: {
-      delay: 300,
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      optionsAlign="right"
-      optionsClassName="w-96"
-    />
-  ),
-  play: openMenu,
-};
-
-export const OptionsLeftAligned: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: '// refer to "Default" story code',
-      },
-    },
-    chromatic: {
-      delay: 300,
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      optionsAlign="left"
-      optionsClassName="w-96"
-    />
-  ),
-  play: openMenu,
-};
-
+/**
+ * If you want a different width for the trigger and the dropdown popover, you can control them separately.
+ */
 export const SeparateButtonAndMenuWidth: StoryObj = {
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      optionsClassName="w-96"
-      variant="compact"
-    />
-  ),
+  args: {
+    ...Default.args,
+    className: 'w-40',
+    optionsClassName: 'w-96',
+  },
   play: selectCat,
   parameters: {
     chromatic: {
       diffIncludeAntiAliasing: false,
       diffThreshold: 0.72,
-      docs: {
-        source: {
-          code: '// refer to "Default" story code',
-        },
-      },
     },
+  },
+  decorators: [(Story) => <div className="p-8">{Story()}</div>],
+};
+
+/**
+ * Each Select can be marked as disabled. This will update the visual treatment to indicate the field cannot be changed (but by default
+ * will show the selected value).
+ */
+export const Disabled: StoryObj = {
+  args: {
+    ...Default.args,
+    disabled: true,
   },
 };
 
-export const UsingChildrenProp: StoryObj = {
+/**
+ * Having a visible label is not necessary. In those cases, use `aria-label` to set a accessible label for the field
+ */
+export const NoVisibleLabel: StoryObj = {
+  args: {
+    ...Default.args,
+    label: undefined,
+    'aria-label': 'hidden label',
+  },
+};
+
+/**
+ * Options for each `Select` can be aligned on different sides of the target button. Options for `placement` defined by
+ * PopperJS.
+ *
+ * More information: https://popper.js.org/docs/v2/constructors/#options
+ */
+export const OptionsRightAligned: StoryObj = {
   parameters: {
-    docs: {
-      source: {
-        code: '// refer to "DefaultWithVisibleLabel" story code',
-      },
+    chromatic: {
+      delay: 300,
     },
   },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      labelComponent={<Select.Label>Favorite Animal</Select.Label>}
-    />
-  ),
+  args: {
+    ...Default.args,
+    className: 'w-60',
+    optionsClassName: 'w-96',
+    placement: 'bottom-end',
+  },
+  play: openMenu,
+  decorators: [(Story) => <div className="p-8">{Story()}</div>],
 };
 
+/**
+ * As an alternative rendering method, you can apply fine-grained control to the button rendering, AND the rendering of the
+ * list itself. Here, we use a render prop to control the contents of `Select`
+ *
+ * For more information on `Select` render props, review: https://headlessui.com/react/listbox#using-render-props
+ */
 export const UsingFunctionChildrenProp: StoryObj = {
-  parameters: {
-    docs: {
-      source: {
-        code: `
-function InteractiveExampleUsingFunctionChildren() {
-  const [selectedOption, setSelectedOption] =
-    React.useState<(typeof exampleOptions)[0]>();
+  render: () => {
+    const [selectedOption, setSelectedOption] =
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      React.useState<(typeof exampleOptions)[0]>();
 
-  return (
-    <div className="mb-10 p-8">
+    return (
       <Select
         aria-label="Favorite Animal"
         as="div"
-        className="w-60"
         data-testid="dropdown"
+        name="interactive-with-children"
         onChange={setSelectedOption}
         value={selectedOption}
       >
@@ -559,10 +377,7 @@ function InteractiveExampleUsingFunctionChildren() {
               as={React.Fragment}
             >
               {() => (
-                <button
-                  aria-expanded={open}
-                  className={styles['function-children__button']}
-                >
+                <button aria-expanded={open} className="fpo">
                   {selectedOption?.label || 'Select'}
                   <Icon
                     className="ml-4"
@@ -582,15 +397,13 @@ function InteractiveExampleUsingFunctionChildren() {
           </>
         )}
       </Select>
-    </div>
-  );
-}`,
-      },
-    },
+    );
   },
-  render: () => <InteractiveExampleUsingFunctionChildren />,
 };
 
+/**
+ * This shows the contents of `Select` upon render. Mostly to demonstrate it is possible, to capture a snapshot of the appearance.
+ */
 export const OpenByDefault: StoryObj = {
   ...Default,
   parameters: {
@@ -599,23 +412,4 @@ export const OpenByDefault: StoryObj = {
     chromatic: { delay: 300, disableSnapshot: true },
   },
   play: selectCat,
-};
-
-export const WithSelectedOption: StoryObj<typeof Select> = {
-  parameters: {
-    docs: {
-      source: {
-        code: `
-// refer to "Default" story code with:
-// props: {aria-label: 'Favorite Animal', labelComponent: <Select.Label>Favorite Animal</Select.Label>, value}`,
-      },
-    },
-  },
-  render: () => (
-    <InteractiveExampleUsingChildren
-      aria-label="Favorite Animal"
-      labelComponent={<Select.Label>Favorite Animal</Select.Label>}
-      value={exampleOptions[0]}
-    />
-  ),
 };

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -9,7 +9,6 @@ import * as stories from './Select.stories';
 const {
   OpenByDefault,
   Disabled,
-  OptionsLeftAligned,
   OptionsRightAligned,
   SeparateButtonAndMenuWidth,
   ...closedStories

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -62,8 +62,15 @@ type SelectProps = ExtractProps<typeof Listbox> &
      * The style of the select.
      *
      * Compact renders select trigger button that is only as wide as the content.
+     *
+     * This is **deprecated**. Please use utility classes to adjust the component width.
+     * @deprecated
      */
     variant?: VariantType;
+    /**
+     * Visible text label for the component.
+     */
+    label?: string;
   };
 
 type SelectOption = {
@@ -145,6 +152,7 @@ export function Select(props: SelectProps) {
     'aria-label': ariaLabel,
     children,
     className,
+    label,
     modifiers = defaultPopoverModifiers,
     name,
     onFirstUpdate,
@@ -185,7 +193,7 @@ export function Select(props: SelectProps) {
   if (process.env.NODE_ENV !== 'production') {
     const childrenHaveLabel =
       children && childrenHaveLabelComponent(children as ReactNode);
-    if (!props['aria-label'] && !childrenHaveLabel) {
+    if (!props['aria-label'] && !props.label && !childrenHaveLabel) {
       throw new Error('You must provide a visible label or `aria-label`.');
     }
   }
@@ -233,15 +241,28 @@ export function Select(props: SelectProps) {
 
   return (
     <SelectContext.Provider value={contextValue}>
-      <Listbox {...sharedProps}>{children}</Listbox>
+      <Listbox {...sharedProps}>
+        {label && (
+          <Select.Label disabled={props.disabled}>{label}</Select.Label>
+        )}
+        {children}
+      </Listbox>
     </SelectContext.Provider>
   );
 }
 
-const SelectLabel = (props: { className?: string; children: ReactNode }) => {
-  const { children, className } = props;
+const SelectLabel = (props: {
+  className?: string;
+  children: ReactNode;
+  disabled?: boolean;
+}) => {
+  const { children, className, disabled } = props;
 
-  const componentClassName = clsx(styles['select__label'], className);
+  const componentClassName = clsx(
+    styles['select__label'],
+    disabled && clsx(styles['select__label--disabled']),
+    className,
+  );
   const overlineClassName = clsx(styles['select__overline']);
   return (
     <div className={overlineClassName}>

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -1,22 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Select /> Compact story renders snapshot 1`] = `
+exports[`<Select /> AdjustedWidth story renders snapshot 1`] = `
 <div
-  class="select select--compact"
+  class="select w-60"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:r12:"
+    >
+      Favorite Animal
+    </label>
+  </div>
   <button
-    aria-controls="headlessui-listbox-options-:rr:"
+    aria-controls="headlessui-listbox-options-:r14:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    class="select-button select-button--compact"
+    aria-labelledby="headlessui-listbox-label-:r12: headlessui-listbox-button-:r13:"
+    class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rq:"
+    id="headlessui-listbox-button-:r13:"
     type="button"
   >
     <span>
-      Select
+      Dogs
     </span>
     <svg
       aria-hidden="true"
@@ -38,21 +50,33 @@ exports[`<Select /> Compact story renders snapshot 1`] = `
 
 exports[`<Select /> Default story renders snapshot 1`] = `
 <div
-  class="select w-60"
+  class="select"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:r0:"
+    >
+      Favorite Animal
+    </label>
+  </div>
   <button
-    aria-controls="headlessui-listbox-options-:r1:"
+    aria-controls="headlessui-listbox-options-:r2:"
     aria-expanded="true"
     aria-haspopup="listbox"
+    aria-labelledby="headlessui-listbox-label-:r0: headlessui-listbox-button-:r1:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r0:"
+    id="headlessui-listbox-button-:r1:"
     type="button"
   >
     <span>
-      Select
+      Dogs
     </span>
     <svg
       aria-hidden="true"
@@ -72,9 +96,9 @@ exports[`<Select /> Default story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
+exports[`<Select /> EventHandling story renders snapshot 1`] = `
 <div
-  class="select w-60"
+  class="select"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
@@ -84,23 +108,23 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:rk:"
+      id="headlessui-listbox-label-:rc:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:rm:"
+    aria-controls="headlessui-listbox-options-:re:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:rk: headlessui-listbox-button-:rl:"
+    aria-labelledby="headlessui-listbox-label-:rc: headlessui-listbox-button-:rd:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rl:"
+    id="headlessui-listbox-button-:rd:"
     type="button"
   >
     <span>
-      Select
+      Dogs
     </span>
     <svg
       aria-hidden="true"
@@ -122,21 +146,21 @@ exports[`<Select /> DefaultWithVisibleLabel story renders snapshot 1`] = `
 
 exports[`<Select /> NoVisibleLabel story renders snapshot 1`] = `
 <div
-  class="select w-60"
+  class="select"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r10:"
+    aria-controls="headlessui-listbox-options-:r19:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rv:"
+    id="headlessui-listbox-button-:r18:"
     type="button"
   >
     <span>
-      Select
+      Dogs
     </span>
     <svg
       aria-hidden="true"
@@ -163,12 +187,12 @@ exports[`<Select /> StyledUncontrolled story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:rg:"
+    aria-controls="headlessui-listbox-options-:ru:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:rf:"
+    id="headlessui-listbox-button-:rt:"
     type="button"
   >
     <span>
@@ -199,12 +223,12 @@ exports[`<Select /> UncontrolledHeadless story renders snapshot 1`] = `
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:rb:"
+    aria-controls="headlessui-listbox-options-:rp:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:ra:"
+    id="headlessui-listbox-button-:ro:"
     type="button"
   >
     Dogs
@@ -213,68 +237,20 @@ exports[`<Select /> UncontrolledHeadless story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<Select /> UsingChildrenProp story renders snapshot 1`] = `
-<div
-  class="select w-60"
-  data-headlessui-state="open"
-  data-testid="dropdown"
->
-  <div
-    class="select__overline"
-  >
-    <label
-      class="select__label"
-      data-headlessui-state="open"
-      id="headlessui-listbox-label-:r14:"
-    >
-      Favorite Animal
-    </label>
-  </div>
-  <button
-    aria-controls="headlessui-listbox-options-:r16:"
-    aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r14: headlessui-listbox-button-:r15:"
-    class="select-button"
-    data-headlessui-state="open"
-    id="headlessui-listbox-button-:r15:"
-    type="button"
-  >
-    <span>
-      Select
-    </span>
-    <svg
-      aria-hidden="true"
-      class="icon select-button__icon select-button__icon--reversed"
-      fill="currentColor"
-      height="1.25rem"
-      style="--icon-size: 1.25rem;"
-      viewBox="0 0 24 24"
-      width="1.25rem"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
-      />
-    </svg>
-  </button>
-</div>
-`;
-
 exports[`<Select /> UsingFunctionChildrenProp story renders snapshot 1`] = `
 <div
   aria-label="Favorite Animal"
-  class="select w-60"
+  class="select"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1b:"
+    aria-controls="headlessui-listbox-options-:r1e:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1a:"
+    id="headlessui-listbox-button-:r1d:"
     type="button"
   >
     Select
@@ -299,13 +275,25 @@ exports[`<Select /> WithFieldName story renders snapshot 1`] = `
   data-headlessui-state="open"
   data-testid="dropdown"
 >
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:ri:"
+    >
+      Favorite Animal
+    </label>
+  </div>
   <button
-    aria-controls="headlessui-listbox-options-:r6:"
+    aria-controls="headlessui-listbox-options-:rk:"
     aria-expanded="true"
     aria-haspopup="listbox"
+    aria-labelledby="headlessui-listbox-label-:ri: headlessui-listbox-button-:rj:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r5:"
+    id="headlessui-listbox-button-:rj:"
     type="button"
   >
     <span>
@@ -331,7 +319,7 @@ exports[`<Select /> WithFieldName story renders snapshot 1`] = `
 
 exports[`<Select /> WithSelectedOption story renders snapshot 1`] = `
 <div
-  class="select w-60"
+  class="select"
   data-headlessui-state="open"
   data-testid="dropdown"
 >
@@ -341,23 +329,23 @@ exports[`<Select /> WithSelectedOption story renders snapshot 1`] = `
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r1f:"
+      id="headlessui-listbox-label-:r6:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r1h:"
+    aria-controls="headlessui-listbox-options-:r8:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r1f: headlessui-listbox-button-:r1g:"
+    aria-labelledby="headlessui-listbox-label-:r6: headlessui-listbox-button-:r7:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1g:"
+    id="headlessui-listbox-button-:r7:"
     type="button"
   >
     <span>
-      Dogs
+      Cats
     </span>
     <svg
       aria-hidden="true"


### PR DESCRIPTION
### Summary:

- provide a cleaner API for implementing the label similar to other form fields
- add disabled prop should a user want to still detach and use Select.Label
- update styles to support this
- docs: clean up all Select stories and API table in storybook
- docs: greatly simplify the presentation of Select documentation
- update relevant snapshots

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details: