### PR TITLE
fix(Select): set trigger type to button to prevent submits

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -442,6 +442,7 @@ export const SelectButtonWrapper = React.forwardRef<
           theirOnClick && theirOnClick(ev);
         }}
         ref={ref}
+        type="button"
         {...other}
       >
         {/* Wrapping span ensures that `children` and icon will be correctly pushed to


### PR DESCRIPTION
### Summary:

- when a button is in a form tag, it automatically becomes able to submit
- our wrapper doesn't include this which is usually fine
- sometimes during a slow load, the handler preventing propagation allows submit
- fixing this by adding a non-editable type

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - verify trigger buttons include type in snapshots