### PR TITLE
ci: replace commitlint action with our own implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,13 +119,12 @@ jobs:
           cache: 'yarn'
       - name: Install Dependencies 🧶
         run: yarn install --immutable
-
       - name: Validate commits commitlint
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         if: github.event_name == 'push'
         run: |
-          COMMIT_COUNT=$(echo '${{ toJson(github.event.commits) }}' | jq length)
+          COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"
 
           yarn commitlint --from HEAD~$COMMIT_COUNT --to HEAD --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,30 @@ jobs:
       - name: Build design tokens 🛠️
         run: yarn build:tokens
 
-      - name: Lint Commit Messages 👕
-        uses: wagoid/commitlint-github-action@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Lint Javascript + SCSS 👕
         run: yarn run lint --max-warnings=0
+
+  commitlint:
+    name: Lint Commit Messages 👕
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Setup node 😻
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.node-version'
+          cache: 'yarn'
+      - name: Install Dependencies 🧶
+        run: yarn install --immutable
+
+      - name: Validate commits commitlint
+        # This workflow can also be triggered via "workflow_call".
+        # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
+        if: github.event_name == 'push'
+        run: |
+          COMMIT_COUNT=$(echo '${{ toJson(github.event.commits) }}' | jq length)
+          echo "Number of commits in the push: $COMMIT_COUNT"
+
+          yarn commitlint --from HEAD~$COMMIT_COUNT --to HEAD --verbose


### PR DESCRIPTION
### Summary:

Our usage of `wagoid/commitlint-github-action@v5` is causing upgrade to commitlint 18.6.0 to fail (source: https://github.com/chanzuckerberg/edu-design-system/actions/runs/7847650438/job/21417042874?pr=1841). I'm updating the workflow to use own implementation that way we aren't held back from updating libraries.

https://czi-tech.atlassian.net/browse/EFI-1617

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Workflow lints 1 commit when only 1 commit is pushed.
- [x] Workflow lints >1 commits when >1 commits are pushed.
