### PR TITLE
feat(Select): enable multi-select

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -284,7 +284,9 @@ export const EventHandlingOnStandardButton: StoryObj = {
     ...Default.args,
     children: (
       <>
-        <Select.Button onClick={(args) => console.log('external click', args)}>
+        <Select.Button
+          onClick={(ev: MouseEvent) => console.log('external click')}
+        >
           - Select Option -
         </Select.Button>
         <Select.Options>
@@ -390,6 +392,44 @@ export const StyledUncontrolled: StoryObj = {
           {({ value, open, disabled }) => (
             <Select.ButtonWrapper isOpen={open}>
               {value.label}
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
+  },
+};
+
+/**
+ * You can select multiple values by passing `multiple` to the parent element. When doing this,
+ * make sure all props that use the value (e.g., `value` and `defaultValue`) should use an array instead
+ * of an object or value for the individual `Select.Option` entries.
+ *
+ * When handling the button text, `value` represents the data for all options selected. This allows for a flexible
+ * layout to fit the needs of the design.
+ */
+export const Multiple: StoryObj = {
+  args: {
+    ...Default.args,
+    label: 'Favorite Animal(s)',
+    multiple: true,
+    'data-testid': 'dropdown',
+    defaultValue: [exampleOptions[0]],
+    className: 'w-45',
+    name: 'standard-button',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open}>
+              {value.length > 0 ? value.length : 'none'} selected
             </Select.ButtonWrapper>
           )}
         </Select.Button>

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -12,19 +12,19 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r12:"
+      id="headlessui-listbox-label-:r18:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r14:"
+    aria-controls="headlessui-listbox-options-:r1a:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r12: headlessui-listbox-button-:r13:"
+    aria-labelledby="headlessui-listbox-label-:r18: headlessui-listbox-button-:r19:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r13:"
+    id="headlessui-listbox-button-:r19:"
     type="button"
   >
     <span>
@@ -96,6 +96,55 @@ exports[`<Select /> Generated Snapshots Default story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Select /> Generated Snapshots Multiple story renders snapshot 1`] = `
+<div
+  class="select w-45"
+  data-headlessui-state="open"
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:r12:"
+    >
+      Favorite Animal(s)
+    </label>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r14:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-listbox-label-:r12: headlessui-listbox-button-:r13:"
+    class="select-button"
+    data-headlessui-state="open"
+    id="headlessui-listbox-button-:r13:"
+    type="button"
+  >
+    <span>
+      1
+       selected
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`] = `
 <div
   class="select"
@@ -103,12 +152,12 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r19:"
+    aria-controls="headlessui-listbox-options-:r1f:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r18:"
+    id="headlessui-listbox-button-:r1e:"
     type="button"
   >
     <span>
@@ -196,12 +245,12 @@ exports[`<Select /> Generated Snapshots UsingFunctionProps story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1e:"
+    aria-controls="headlessui-listbox-options-:r1k:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1d:"
+    id="headlessui-listbox-button-:r1j:"
     type="button"
   >
     Select


### PR DESCRIPTION
### Summary:

- loosen types to be based more closely match HeadlessUI
- add story for multi select
- update styles for selected and unselected items
- remove need for SelectOption

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
