### PR TITLE
feat(Select): enable multi-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [13.11.0-alpha.0](https://github.com/chanzuckerberg/edu-design-system/compare/v13.10.0...v13.11.0-alpha.0) (2024-02-15)
+
+
+### Features
+
+* **script:** add import from figma script ([#1844](https://github.com/chanzuckerberg/edu-design-system/issues/1844)) ([9ed90e5](https://github.com/chanzuckerberg/edu-design-system/commit/9ed90e5bf1a42ce55c7c2b0f3cad1add3c71057c))
+* **Select:** enable multi-select ([ced70d5](https://github.com/chanzuckerberg/edu-design-system/commit/ced70d59b653e5132e145e9361c0bc2b358d1b48))
+
+
+### Bug Fixes
+
+* **Select:** set trigger type to button to prevent submits ([#1843](https://github.com/chanzuckerberg/edu-design-system/issues/1843)) ([d7ea037](https://github.com/chanzuckerberg/edu-design-system/commit/d7ea0370e698a09516eacb9de61af3a63e8c1432))
+
 ## [13.10.0](https://github.com/chanzuckerberg/edu-design-system/compare/v13.9.0...v13.10.0) (2024-02-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "13.10.0",
+  "version": "13.11.0-alpha.0",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",

--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -25,6 +25,8 @@
 
 .popover-list-item__icon {
   padding-right: var(--eds-size-1-and-half);
+  /* This var. matches the height set in the icon, but makes sure it is locked to only that height */
+  height: var(--eds-size-1-and-half);
 }
 
 .popover-list-item__no-icon {

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -64,6 +64,7 @@ export const PopoverListItem = React.forwardRef<HTMLDivElement, Props>(
       >
         {icon ? (
           <div className={styles['popover-list-item__icon']}>
+            {/* TODO: can link to CSS Var? var(--eds-size-1-and-half) */}
             <Icon name={icon} purpose="decorative" size="1.5rem" />
           </div>
         ) : (

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -105,6 +105,7 @@
  * The caret icon to decorate the select trigger button, animated to rotate.
  */
 .select-button__icon {
+  flex-shrink: 0;
   transform: rotate(0);
 
   transition: transform var(--eds-anim-move-medium) ease-out;
@@ -112,6 +113,12 @@
     /* Turns off animation if user prefers reduced motion. */
     transition: none;
   }
+}
+
+.select-button__text--truncated {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .select-button__icon--reversed {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -430,6 +430,41 @@ export const Multiple: StoryObj = {
 };
 
 /**
+ * The component provides some basic styles to handle long text in the provided field. Use
+ * `shouldTruncate` on `.ButtonWrapper` to truncate the text with an ellipsis.
+ */
+export const MultipleWithTruncation: StoryObj = {
+  args: {
+    ...Default.args,
+    label: 'Favorite Animal(s)',
+    multiple: true,
+    'data-testid': 'dropdown',
+    defaultValue: [exampleOptions[0]],
+    className: 'w-60',
+    name: 'standard-button',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open} shouldTruncate>
+              {value.length > 0 ? value.length : 'none'} long selected
+              description
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
+  },
+};
+
+/**
  * The field trigger width can be set with utility classes. By default, dropdown popover will exppand to match the width.
  */
 export const AdjustedWidth: StoryObj = {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -13,9 +13,7 @@ const meta: Meta<typeof Select> = {
   },
   argTypes: {
     multiple: {
-      table: {
-        disable: true,
-      },
+      description: 'Whether multiple values are allowed in this instance',
     },
     children: {
       control: {
@@ -25,22 +23,10 @@ const meta: Meta<typeof Select> = {
     value: {
       table: {
         description: 'The value of the select field (when controlled)',
-        type: {
-          summary: 'SelectOption',
-          detail:
-            'An object with at least label (as string) and any other useful key/value pairs',
-        },
       },
     },
     defaultValue: {
       description: 'The default value of the select field (when uncontrolled)',
-      table: {
-        type: {
-          summary: 'SelectOption',
-          detail:
-            'An object with at least label (as string) and any other useful key/value pairs',
-        },
-      },
     },
     onClick: {
       description:
@@ -212,7 +198,7 @@ export const WithStandardButton: StoryObj = {
  *
  * You can also add an `onClick` handler to `.ButtonWrapper` if using a render prop
  *
- * * `onClick` fires when the trigger (`.buttonWrapper`) is clicked
+ * * `onClick` fires when the trigger (`.ButtonWrapper`) is clicked
  */
 export const EventHandlingOnRenderProp: StoryObj = {
   args: {
@@ -275,7 +261,7 @@ export const EventHandlingOnRenderProp: StoryObj = {
  *
  * If not using a render prop, you can also add an `onClick` handler to `Select.Button` directly
  *
- * * `onClick` fires when the trigger (`.buttonWrapper`) is clicked
+ * * `onClick` fires when the trigger (`.ButtonWrapper`) is clicked
  *
  * **NOTE**: `onClick` has no function when using a render prop
  */
@@ -414,6 +400,10 @@ export const StyledUncontrolled: StoryObj = {
  *
  * When handling the button text, `value` represents the data for all options selected. This allows for a flexible
  * layout to fit the needs of the design.
+ *
+ * Hidden form inputs are generated for each option selected and take the following form:
+ * - `name[arrayIndex][key]`
+ * - `name[arrayIndex][value]`
  */
 export const Multiple: StoryObj = {
   args: {
@@ -422,7 +412,7 @@ export const Multiple: StoryObj = {
     multiple: true,
     'data-testid': 'dropdown',
     defaultValue: [exampleOptions[0]],
-    className: 'w-45',
+    className: 'w-60',
     name: 'standard-button',
     children: (
       <>

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -41,14 +41,8 @@ const meta: Meta<typeof Select> = {
       },
     },
     onChange: {
-      description: 'Optional change handler. Fires when a value is selected',
-      table: {
-        type: {
-          summary: 'SelectOption',
-          detail:
-            'An object with at least label (as string) and any other useful key/value pairs',
-        },
-      },
+      description:
+        'Optional change handler. Fires when a value is selected (and passes in list of selected values)',
     },
   },
 };

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -284,7 +284,9 @@ export const EventHandlingOnStandardButton: StoryObj = {
     ...Default.args,
     children: (
       <>
-        <Select.Button onClick={(args) => console.log('external click', args)}>
+        <Select.Button
+          onClick={(ev: MouseEvent) => console.log('external click')}
+        >
           - Select Option -
         </Select.Button>
         <Select.Options>
@@ -390,6 +392,44 @@ export const StyledUncontrolled: StoryObj = {
           {({ value, open, disabled }) => (
             <Select.ButtonWrapper isOpen={open}>
               {value.label}
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
+  },
+};
+
+/**
+ * You can select multiple values by passing `multiple` to the parent element. When doing this,
+ * make sure all props that use the value (e.g., `value` and `defaultValue`) should use an array instead
+ * of an object or value for the individual `Select.Option` entries.
+ *
+ * When handling the button text, `value` represents the data for all options selected. This allows for a flexible
+ * layout to fit the needs of the design.
+ */
+export const Multiple: StoryObj = {
+  args: {
+    ...Default.args,
+    label: 'Favorite Animal(s)',
+    multiple: true,
+    'data-testid': 'dropdown',
+    defaultValue: [exampleOptions[0]],
+    className: 'w-45',
+    name: 'standard-button',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open}>
+              {value.length > 0 ? value.length : 'none'} selected
             </Select.ButtonWrapper>
           )}
         </Select.Button>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -105,6 +105,10 @@ type SelectButtonWrapperProps = {
    * custom click handler for the built-in or wrapper button
    */
   onClick?: MouseEventHandler;
+  /**
+   * Whether we should truncate the text displayed in the select field
+   */
+  shouldTruncate?: boolean;
 };
 
 type SelectContextType = PopoverContext & {
@@ -399,6 +403,7 @@ export const SelectButtonWrapper = React.forwardRef<
       className,
       icon = 'expand-more',
       isOpen,
+      shouldTruncate = false,
       onClick: theirOnClick,
       ...other
     },
@@ -409,6 +414,10 @@ export const SelectButtonWrapper = React.forwardRef<
       styles['select-button__icon'],
       isOpen && styles['select-button__icon--reversed'],
     );
+    const textClassName = clsx(
+      shouldTruncate && styles['select-button__text--truncated'],
+    );
+
     return (
       <button
         className={componentClassName}
@@ -421,7 +430,7 @@ export const SelectButtonWrapper = React.forwardRef<
       >
         {/* Wrapping span ensures that `children` and icon will be correctly pushed to
             either side of the button even if `children` contains more than one element. */}
-        <span>{children}</span>
+        <span className={textClassName}>{children}</span>
         <Icon
           className={iconClassName}
           name={icon}

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`<Select /> Generated Snapshots Default story renders snapshot 1`] = `
 
 exports[`<Select /> Generated Snapshots Multiple story renders snapshot 1`] = `
 <div
-  class="select w-45"
+  class="select w-60"
   data-headlessui-state="open"
   data-testid="dropdown"
 >

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -12,19 +12,19 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r12:"
+      id="headlessui-listbox-label-:r18:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r14:"
+    aria-controls="headlessui-listbox-options-:r1a:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r12: headlessui-listbox-button-:r13:"
+    aria-labelledby="headlessui-listbox-label-:r18: headlessui-listbox-button-:r19:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r13:"
+    id="headlessui-listbox-button-:r19:"
     type="button"
   >
     <span>
@@ -96,6 +96,55 @@ exports[`<Select /> Generated Snapshots Default story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Select /> Generated Snapshots Multiple story renders snapshot 1`] = `
+<div
+  class="select w-45"
+  data-headlessui-state="open"
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:r12:"
+    >
+      Favorite Animal(s)
+    </label>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r14:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-listbox-label-:r12: headlessui-listbox-button-:r13:"
+    class="select-button"
+    data-headlessui-state="open"
+    id="headlessui-listbox-button-:r13:"
+    type="button"
+  >
+    <span>
+      1
+       selected
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`] = `
 <div
   class="select"
@@ -103,12 +152,12 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r19:"
+    aria-controls="headlessui-listbox-options-:r1f:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r18:"
+    id="headlessui-listbox-button-:r1e:"
     type="button"
   >
     <span>
@@ -196,12 +245,12 @@ exports[`<Select /> Generated Snapshots UsingFunctionProps story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1e:"
+    aria-controls="headlessui-listbox-options-:r1k:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1d:"
+    id="headlessui-listbox-button-:r1j:"
     type="button"
   >
     Select

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -12,22 +12,24 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     <label
       class="select__label"
       data-headlessui-state="open"
-      id="headlessui-listbox-label-:r18:"
+      id="headlessui-listbox-label-:r1e:"
     >
       Favorite Animal
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r1a:"
+    aria-controls="headlessui-listbox-options-:r1g:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-listbox-label-:r18: headlessui-listbox-button-:r19:"
+    aria-labelledby="headlessui-listbox-label-:r1e: headlessui-listbox-button-:r1f:"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r19:"
+    id="headlessui-listbox-button-:r1f:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Dogs
     </span>
     <svg
@@ -75,7 +77,9 @@ exports[`<Select /> Generated Snapshots Default story renders snapshot 1`] = `
     id="headlessui-listbox-button-:r1:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Dogs
     </span>
     <svg
@@ -123,9 +127,62 @@ exports[`<Select /> Generated Snapshots Multiple story renders snapshot 1`] = `
     id="headlessui-listbox-button-:r13:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       1
        selected
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="1.25rem"
+      style="--icon-size: 1.25rem;"
+      viewBox="0 0 24 24"
+      width="1.25rem"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M15.88 9.29L12 13.17 8.12 9.29c-.39-.39-1.02-.39-1.41 0-.39.39-.39 1.02 0 1.41l4.59 4.59c.39.39 1.02.39 1.41 0l4.59-4.59c.39-.39.39-1.02 0-1.41-.39-.38-1.03-.39-1.42 0z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders snapshot 1`] = `
+<div
+  class="select w-60"
+  data-headlessui-state="open"
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="select__label"
+      data-headlessui-state="open"
+      id="headlessui-listbox-label-:r18:"
+    >
+      Favorite Animal(s)
+    </label>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r1a:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-listbox-label-:r18: headlessui-listbox-button-:r19:"
+    class="select-button"
+    data-headlessui-state="open"
+    id="headlessui-listbox-button-:r19:"
+    type="button"
+  >
+    <span
+      class="select-button__text--truncated"
+    >
+      1
+       long selected description
     </span>
     <svg
       aria-hidden="true"
@@ -152,15 +209,17 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1f:"
+    aria-controls="headlessui-listbox-options-:r1l:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1e:"
+    id="headlessui-listbox-button-:r1k:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Dogs
     </span>
     <svg
@@ -196,7 +255,9 @@ exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapsho
     id="headlessui-listbox-button-:rt:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Dogs
     </span>
     <svg
@@ -245,12 +306,12 @@ exports[`<Select /> Generated Snapshots UsingFunctionProps story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r1k:"
+    aria-controls="headlessui-listbox-options-:r1q:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-headlessui-state="open"
-    id="headlessui-listbox-button-:r1j:"
+    id="headlessui-listbox-button-:r1p:"
     type="button"
   >
     Select
@@ -296,7 +357,9 @@ exports[`<Select /> Generated Snapshots WithFieldName story renders snapshot 1`]
     id="headlessui-listbox-button-:rj:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Dogs
     </span>
     <svg
@@ -344,7 +407,9 @@ exports[`<Select /> Generated Snapshots WithSelectedOption story renders snapsho
     id="headlessui-listbox-button-:rd:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       Cats
     </span>
     <svg
@@ -392,7 +457,9 @@ exports[`<Select /> Generated Snapshots WithStandardButton story renders snapsho
     id="headlessui-listbox-button-:r7:"
     type="button"
   >
-    <span>
+    <span
+      class=""
+    >
       - Select Option -
     </span>
     <svg


### PR DESCRIPTION
### Summary:

- loosen types to be based more closely match HeadlessUI
- add story for multi select
- update styles for selected and unselected items
- remove need for SelectOption

### Remaining Tasks

- [x] Update storybook doc.s to represent types showing in table (e.g., `SelectOption` is now gone)
- [x] Add details on how form fields manifest when used
- [x] Create alpha version to test this in practice with potential consumers
- [x] Fix glitch with positioning/size of selected and unselected `PopoverListItem` rows, so that when the check is added/removed, the height doesn't change slightly

### Test Plan:

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
