### PR TITLE
Lodash tree shaking

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,11 +95,17 @@
     },
     {
       "files": ["src/**/*.{ts,tsx}"],
-      "excludedFiles": ["src/**/*.stories.{ts,tsx}"],
+      "excludedFiles": ["src/**/*.{stories,test,spec}.{ts,tsx}"],
       "rules": {
         "no-restricted-imports": [
           "error",
           {
+            "paths": [
+              {
+                "name": "lodash",
+                "message": "For better tree shaking, prefer deep imports from lodash (e.g. import at from 'lodash/at') instead of named (e.g. import {at} from 'lodash)"
+              }
+            ],
             "patterns": [
               {
                 "group": ["**/tokens-dist/ts/colors"],

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import React, { createContext, useContext, type ReactNode } from 'react';
 import { flattenReactChildren } from '../../util/flattenReactChildren';
 import Icon, { type IconName } from '../Icon';

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryObj, Meta } from '@storybook/react';
-import { kebabCase } from 'lodash';
+import kebabCase from 'lodash/kebabCase';
 import React from 'react';
 import { Icon, type IconProps } from './Icon';
 import icons, { type IconName } from '../../icons/spritemap';

--- a/src/components/Table/Filters.tsx
+++ b/src/components/Table/Filters.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import React, { useEffect, useState } from 'react';
 import {
   Checkbox,

--- a/src/components/Table/StackedCardsToTable.tsx
+++ b/src/components/Table/StackedCardsToTable.tsx
@@ -1,4 +1,4 @@
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import React, { useEffect, useState } from 'react';
 import { Card, Table, Text } from '../../../src';
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import React, {
   type ReactNode,
   useCallback,


### PR DESCRIPTION
This PR updates our usage of Lodash so that we replace named imports

```ts
import {at} from 'lodash';
```

with deep ones

```ts
import at from 'lodash/at';
```

This should help tree shaking work better. I don't think this is a problem in our existing Remix apps (tree shaking works properly), but I'm running into an issue when trying to use ESM modules in Remix apps.

---

Alternatives:
- Use `lodash-es` instead (which is esm). Downside of that is we'd need to have our existing Remix apps pre-bundle lodash so that it's cjs.
- Maybe there's some Vite config I'm missing to make this work