### PR TITLE
ESM support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chanzuckerberg/eds",
-  "version": "13.11.0",
+  "version": "13.11.1-alpha.1",
   "description": "The React-powered design system library for Chan Zuckerberg Initiative education web applications",
   "author": "CZI <edu-frontend-infra@chanzuckerberg.com>",
   "homepage": "https://github.com/chanzuckerberg/edu-design-system",

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
     "eds-init-theme": "bin/eds-init.js"
   },
   "scripts": {
-    "build": "yarn build:clean && yarn build:tokens && yarn build:declarations && yarn build:js && yarn copy-fonts-to-lib",
+    "build": "yarn build:clean && yarn build:tokens && yarn build:js && yarn copy-fonts-to-lib",
     "build:clean": "rm -rf lib/",
-    "build:declarations": "tsc --emitDeclarationOnly --project tsconfig.build.json",
     "build:tokens": "rm -rf src/tokens-dist/ && node ./style-dictionary.config.js && yarn prettier-tokens-dist",
     "build:js": "rollup --config",
     "build:storybook": "storybook build -o storybook-static -s src/design-tokens/tier-1-definitions/fonts",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,14 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "import": "./lib/index.js",
-      "require": "./lib/index.cjs"
+      "import": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.js"
+      },
+      "require": {
+        "types": "./lib/index.d.ts",
+        "default": "./lib/index.cjs"
+      }
     },
     "./index.css": "./lib/index.css",
     "./fonts.css": "./lib/tokens/fonts.css",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ".": {
       "import": {
         "types": "./lib/index.d.ts",
-        "default": "./lib/index.js"
+        "default": "./lib/index.mjs"
       },
       "require": {
         "types": "./lib/index.d.ts",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -10,6 +10,7 @@ export default {
   output: [
     {
       dir: 'lib',
+      entryFileNames: '[name].mjs',
       format: 'es',
       preserveModules: true,
       preserveModulesRoot: 'src',


### PR DESCRIPTION
This PR fixes the ESM build so that it works with Vite, which Remix will use by default in v3.

(Alternatively we could have Vite process the CJS build. My first choice is to make the ESM build work, though).

Testing:
- [x] Along 
   <img width="921" alt="along eds icon cjs" src="https://github.com/chanzuckerberg/edu-design-system/assets/2503289/068d662a-acc5-493a-8687-d548af278ed6">
- [x] CJS build in a Remix app
   <img width="849" alt="edu-stack eds cjs" src="https://github.com/chanzuckerberg/edu-design-system/assets/2503289/2972c411-413b-490b-a950-2c0126039423">
- [ ] ~~ESM build in a Remix app~~ (didn't work because of Lodash. The EDS types worked, though, which is a good sign.