### PR TITLE
feat: export ClickableStyleProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,4 +63,5 @@ export { default as Tooltip } from './components/Tooltip';
 /**
  * Prop types, exported for convenience
  */
+export type { ClickableStyleProps } from './components/ClickableStyle';
 export type { IconName } from './components/Icon';


### PR DESCRIPTION
Export `ClickableStyleProps` from the top-level `index.ts`.

Usages in our Remix apps won't need to deeply import anymore (in fact, they can't with Vite due to how module resolution works)

```diff
- import type {ClickableStyleProps} from '@chanzuckerberg/eds/lib/components/ClickableStyle';
+ import type {ClickableStyleProps} from '@chanzuckerberg/eds';
```

We need the `ClickableStyleProps` [for our custom Remix Link component](https://github.com/chanzuckerberg/edu-stack/blob/6f2ad5c03485ec93c5681e5bde64cf5700f189b6/app/components/Link.tsx#L2), so we properly integrate the Remix and EDS Link components.

Re-exporting the props from the top-level index.ts is easier to work with. The deep import edu-stack uses was always a hack.