### PR TITLE
chore: test commit lint change (1/n)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         if: github.event_name == 'push'
         run: |
-          COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits) }}' | jq length)
+          COMMIT_COUNT=${{github.event.size}}
           echo "Number of commits in the push: $COMMIT_COUNT"
 
           yarn commitlint --from HEAD~$COMMIT_COUNT --to HEAD --verbose


### PR DESCRIPTION
### Summary:

Testing out alternatives to how we determine the number of commit message titles to verify

- [x] using `github.event.size`
- [ ] using `github.event.distinct_size`
- [ ] using bash HereDoc ... somehow
- [ ] changing quote escaping

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [x] Manually tested my changes, and here are the details:
  - verify build runs on github UI