### PR TITLE
feat(Skeleton)!: deprecate .Rect subcomponent mapping

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,4 +1,3 @@
-import { BADGE } from '@geometricpanda/storybook-addon-badges';
 import type { StoryObj, Meta } from '@storybook/react';
 import React from 'react';
 
@@ -7,11 +6,6 @@ import { Skeleton } from './Skeleton';
 export default {
   title: 'Components/Skeleton',
   component: Skeleton,
-  subcomponents: {
-    'Skeleton.Circle': Skeleton.Circle,
-    'Skeleton.Rect': Skeleton.Rect,
-    'Skeleton.Text': Skeleton.Text,
-  },
   parameters: {
     badges: ['1.2'],
     layout: 'centered',
@@ -23,6 +17,9 @@ export default {
 
 type Args = React.ComponentProps<typeof Skeleton>;
 
+/**
+ * The default shape for a skeleton is a Rounded rectangle with an optional animation.
+ */
 export const Default: StoryObj<Args> = {
   args: {
     width: 100,
@@ -30,19 +27,9 @@ export const Default: StoryObj<Args> = {
   },
 };
 
-export const Rect: StoryObj<Args> = {
-  args: {
-    width: 50,
-    height: 50,
-  },
-  parameters: {
-    badges: [BADGE.DEPRECATED],
-  },
-  render: (args) => {
-    return <Skeleton.Rect {...args} />;
-  },
-};
-
+/**
+ * It's also possible to use a fully-rounded circle for components like `Avatar`. Only `width` is defined for `.Circle`.
+ */
 export const Circle: StoryObj<React.ComponentProps<typeof Skeleton.Circle>> = {
   args: {
     width: 100,
@@ -52,6 +39,10 @@ export const Circle: StoryObj<React.ComponentProps<typeof Skeleton.Circle>> = {
   },
 };
 
+/**
+ * You can also use a specific variant for handling text. It is recommended to use charactor spacing units,
+ * representing the length in a way that mimics expected/maximum character length.
+ */
 export const Text: StoryObj<React.ComponentProps<typeof Skeleton.Text>> = {
   args: {
     width: '30ch',

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -23,14 +23,6 @@ type SkeletonProps = BaseProps & {
  * `import {Skeleton} from "@chanzuckerberg/eds";`
  *
  * Skeleton states inform users about the wait time, reason, and status of ongoing processes, showing the expected layout
- *
- * Examples:
- *
- * For text, Use `Skeleton.Text` and specify the height and the width (for example in 'ch' units).
- *
- * For circular objects, use `Skeleton.Circle` and specify the width (which is the same as the height).
- *
- * For rectangular objects, just use `Skeleton` and specify the width and height.
  */
 export const Skeleton = ({
   className,

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -111,6 +111,4 @@ TextSkeleton.displayName = 'Skeleton.Text';
 CircleSkeleton.displayName = 'Skeleton.Circle';
 
 Skeleton.Text = TextSkeleton;
-/** @deprecated Use `Skeleton` instead */
-Skeleton.Rect = Skeleton;
 Skeleton.Circle = CircleSkeleton;

--- a/src/components/Skeleton/__snapshots__/Skeleton.test.ts.snap
+++ b/src/components/Skeleton/__snapshots__/Skeleton.test.ts.snap
@@ -16,14 +16,6 @@ exports[`<Skeleton /> Default story renders snapshot 1`] = `
 />
 `;
 
-exports[`<Skeleton /> Rect story renders snapshot 1`] = `
-<div
-  aria-hidden="true"
-  class="skeleton skeleton--is-animating"
-  style="width: 50px; height: 50px;"
-/>
-`;
-
 exports[`<Skeleton /> Text story renders snapshot 1`] = `
 <div
   aria-hidden="true"


### PR DESCRIPTION
- `Skeleton` provides the same functionality as `.Rect` so simplify by removing this abstraction.

In each case, `Skeleton.Rect` can be replaced with `Skeleton` and retain the same functionality.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)