### PR TITLE
feat(Badge)!: deprecate name prop on component

### DIFF
--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -100,7 +100,7 @@ export const IconBadge: StoryObj<Args> = {
         >
           Ava
         </div>
-        <Badge.Icon name="alarm" />
+        <Badge.Icon icon="alarm" />
       </>
     ),
   },

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -34,7 +34,7 @@ describe('<Badge />', () => {
           <Badge.Icon />
         </Badge>,
       );
-    }).toThrow(/Name or Icon must be passed to the Badge sub-component/);
+    }).toThrow(/Icon must be passed to the Badge sub-component/);
     consoleErrorMock.mockRestore();
   });
 });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import React from 'react';
-import type { EitherExclusive } from '../../util/utility-types';
 import Icon from '../Icon';
 import type { IconName, IconProps } from '../Icon';
 import styles from './Badge.module.css';
@@ -17,22 +16,12 @@ type BadgeProps = {
   className?: string;
 };
 
-type BadgeIconProps = Omit<IconProps, 'purpose' | 'name'> &
-  EitherExclusive<
-    {
-      /**
-       * Name of icon to render. Please use `icon` instead, which has the same behavior.
-       * @deprecated
-       */
-      name: IconName;
-    },
-    {
-      /**
-       * Name of icon to render.
-       */
-      icon: IconName;
-    }
-  >;
+type BadgeIconProps = Omit<IconProps, 'purpose' | 'name'> & {
+  /**
+   * Icon name from the defined set of EDS icons
+   */
+  icon: IconName;
+};
 
 type BadgeTextProps = {
   /**
@@ -45,17 +34,15 @@ type BadgeTextProps = {
   className?: string;
 };
 
-const BadgeIcon = ({ className, name, icon, ...other }: BadgeIconProps) => {
+const BadgeIcon = ({ className, icon, ...other }: BadgeIconProps) => {
   const componentClassName = clsx(styles['badge'], className);
   let iconName: IconName;
 
   if (icon) {
     iconName = icon;
-  } else if (name) {
-    iconName = name;
   } else {
     // both name and icon are undefined. throw an error
-    throw new Error('Name or Icon must be passed to the Badge sub-component');
+    throw new ReferenceError('Icon must be passed to the Badge sub-component');
   }
 
   return (


### PR DESCRIPTION
### Summary:

Removing this prop `name` for consistency with other components. The practice is that any component using another component in a prop should use a camelCase version of the component's name. Because both were supported, users of the now-removed `name` component can change the prop to `icon` without any issue.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)