### PR TITLE
feat(Link)!: remove and reset deprecated props

### DIFF
--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -525,11 +525,3 @@ button:where(.link--link) {
   padding: 0 var(--eds-size-2);
 }
 
-/**
- * Full-width link style
- * A block link that fills 100% of the width of its container
- * @deprecated ?
- */
- .link--full-width {
-  width: 100%;
-}

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -14,7 +14,6 @@ export default {
     children: 'Link',
     variant: 'link',
     status: 'brand',
-    fullWidth: false,
     size: 'lg',
     href: 'https://go.czi.team/eds',
     // stop link from navigating to another page so we can click the link for testing
@@ -34,12 +33,6 @@ export default {
       options: ['brand', 'neutral'],
     },
     size: {
-      table: {
-        disable: true,
-      },
-    },
-    fullWidth: {
-      control: 'boolean',
       table: {
         disable: true,
       },

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -15,17 +15,9 @@ export type LinkProps = LinkHTMLElementProps & {
    * The link contents or label.
    */
   children: ReactNode;
-  /**
-   * Toggles link that fills the full width of its container
-   * @deprecated
-   */
-  fullWidth?: boolean;
   'data-testid'?: string;
   /**
    * Link size inherits from the surrounding text.
-   *
-   * **Deprecated**. This will be removed in the next major version.
-   * @deprecated
    */
   size?: Extract<Size, 'sm' | 'md' | 'lg'>;
 } & VariantStatus;
@@ -48,7 +40,6 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       variant = 'link',
       status = 'brand',
       size = 'lg',
-      fullWidth,
       ...rest
     },
     ref,
@@ -73,8 +64,6 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
       status === 'success' && styles['link--success'],
       status === 'warning' && styles['link--warning'],
       status === 'error' && styles['link--error'],
-      // Other options
-      fullWidth && styles['link--full-width'],
       className,
     );
 


### PR DESCRIPTION
### Summary:

- restore `size` to available

This is used sparingly, but will be used more effectively in the future.

- remove `fullWidth` from component

This is a holdover from linkages to `Button`, so removing now that link is its own component. Use utility classes to alter layout.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Manually tested my changes, and here are the details:
  - Create an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release) and try out in `edu-stack` or `traject` as a sanity check if changes affect build or deploy, or are breaking, such as token changes, widely used component updates, hooks changes, and major dependency upgrades.
