### PR TITLE
docs: add version tracking to storybook components

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -24,18 +24,35 @@ export const decorators = [
   ),
 ];
 
-function createPaperReleaseConfig(usingLabel: string) {
+function createInitialReleaseConfig(usingLabel: string) {
   return {
-    [usingLabel]: {
+    [`intro-${usingLabel}`]: {
       styles: {
         backgroundColor: '#ffffff',
         borderColor: '#000000',
         color: '#000000',
       },
-      title: `${usingLabel}+`,
+      title: `Introduced: ${usingLabel}`,
       tooltip: {
-        title: `Introduced in /paper ${usingLabel}`,
-        desc: `This component was introduced in /paper ${usingLabel}`,
+        title: `Introduced in v${usingLabel}`,
+        desc: `This component was introduced in EDS Design version ${usingLabel}`,
+      },
+    },
+  };
+}
+
+function createCurrentReleaseConfig(usingLabel: string) {
+  return {
+    [`current-${usingLabel}`]: {
+      styles: {
+        backgroundColor: '#ffffff',
+        borderColor: '#000000',
+        color: '#000000',
+      },
+      title: `Current: ${usingLabel}`,
+      tooltip: {
+        title: `Current version v${usingLabel}`,
+        desc: `This component corresponds to EDS Design version ${usingLabel}`,
       },
     },
   };
@@ -62,10 +79,11 @@ export const parameters = {
     ],
   },
   badgesConfig: {
-    ...createPaperReleaseConfig('1.3'),
-    ...createPaperReleaseConfig('1.2'),
-    ...createPaperReleaseConfig('1.1'),
-    ...createPaperReleaseConfig('1.0'),
+    ...createInitialReleaseConfig('1.3'),
+    ...createInitialReleaseConfig('1.2'),
+    ...createInitialReleaseConfig('1.1'),
+    ...createInitialReleaseConfig('1.0'),
+    ...createCurrentReleaseConfig('2.0'),
     implementationExample: {
       styles: {
         backgroundColor: '#ffffff',

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -13,7 +13,7 @@ export default {
   title: 'Components/Accordion',
   component: Accordion,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
   },
   args: {
     headingAs: 'h2',
@@ -309,7 +309,7 @@ export const WithLargeHeader: Story = {
  */
 export const UsingComplexHeaders: Story = {
   parameters: {
-    badges: ['1.2', 'implementationExample'],
+    badges: ['intro-1.2', 'implementationExample'],
   },
   args: {
     children: (
@@ -364,7 +364,7 @@ export const UsingComplexHeaders: Story = {
  */
 export const UsingNumberIconInHeaders: Story = {
   parameters: {
-    badges: ['1.2', 'implementationExample'],
+    badges: ['intro-1.2', 'implementationExample'],
   },
   args: {
     children: (

--- a/src/components/Avatar/Avatar.stories.ts
+++ b/src/components/Avatar/Avatar.stories.ts
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Avatar',
   component: Avatar,
   parameters: {
-    badges: ['1.3'],
+    badges: ['intro-1.3'],
     layout: 'centered',
   },
 } as Meta<Args>;

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
   },
   argTypes: {
     children: {

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -26,7 +26,7 @@ export default {
     },
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   decorators: [(Story) => <div style={{ margin: '0.5rem' }}>{Story()}</div>],
 } as Meta<Args>;

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -43,7 +43,7 @@ export default {
     },
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -24,7 +24,7 @@ export default {
     },
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -17,7 +17,7 @@ export default {
     CardFooter: Card.Footer,
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
   args: {
@@ -91,7 +91,7 @@ export const LoadingProfileCard: StoryObj<Args> = {
     isLoading: true,
   },
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   render: ({ isLoading, ...cardProps }) => {
     return (

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Checkbox> = {
     label: 'Checkbox',
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 
   decorators: [(Story) => <div className="m-1">{Story()}</div>],

--- a/src/components/ClickableStyle/ClickableStyle.stories.tsx
+++ b/src/components/ClickableStyle/ClickableStyle.stories.tsx
@@ -15,7 +15,7 @@ export default {
     children: 'example text',
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
     layout: 'centered',
     controls: { expand: true },
   },

--- a/src/components/FieldNote/FieldNote.stories.tsx
+++ b/src/components/FieldNote/FieldNote.stories.tsx
@@ -9,7 +9,7 @@ export default {
   title: 'Components/FieldNote',
   component: FieldNote,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Fieldset',
   component: Fieldset,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   subcomponents: {
     FieldsetLegend: Fieldset.Legend,

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -38,7 +38,7 @@ export default {
     },
   },
   parameters: {
-    badges: ['1.0', BADGE.DEPRECATED],
+    badges: ['intro-1.0', BADGE.DEPRECATED],
   },
   component: Grid,
   subcomponents: { GridItem: Grid.Item },

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Heading',
   component: Heading,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
@@ -14,7 +14,7 @@ export default {
     steps: ['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5'],
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 
   decorators: [

--- a/src/components/Hr/Hr.stories.ts
+++ b/src/components/Hr/Hr.stories.ts
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Hr',
   component: Hr,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Icon> = {
   title: 'Components/Icon',
   component: Icon,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   argTypes: {
     name: {

--- a/src/components/InlineNotification/InlineNotification.stories.tsx
+++ b/src/components/InlineNotification/InlineNotification.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Components/InlineNotification',
   component: InlineNotification,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   args: {
     text: 'Inline notifications lorem ipsum text',

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof InputField> = {
   title: 'Components/InputField',
   component: InputField,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
     backgrounds: {
       default: 'eds-color-neutral-white',
     },
@@ -151,7 +151,7 @@ export const WithBothMaxAndRecommendedLength: Story = {
  */
 export const TabularInput: Story = {
   parameters: {
-    badges: ['1.1', 'implementationExample'],
+    badges: ['intro-1.1', 'implementationExample'],
   },
   render: (args) => (
     <Table>

--- a/src/components/InputLabel/InputLabel.stories.ts
+++ b/src/components/InputLabel/InputLabel.stories.ts
@@ -10,7 +10,7 @@ export default {
     children: 'Label',
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Label',
   component: Label,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/Link',
   component: Link,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   args: {
     children: 'Link',

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.ts
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.ts
@@ -8,7 +8,7 @@ export default {
   component: LoadingIndicator,
   parameters: {
     layout: 'centered',
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
   },
 } as Meta<Args>;
 

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -18,7 +18,7 @@ export default {
     'Menu.Item': Menu.Item,
   },
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     layout: 'centered',
   },
   argTypes: {
@@ -166,7 +166,7 @@ export const WithCustomButton: StoryObj<MenuProps> = {
 
 export const MenuWithAvatarButton: StoryObj<MenuProps> = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   args: {
     children: (
@@ -225,7 +225,7 @@ export const MenuWithIconButton: StoryObj<MenuProps & { iconName: IconName }> =
       iconName: 'dots-vertical',
     },
     parameters: {
-      badges: ['1.2', 'implementationExample'],
+      badges: ['intro-1.2', 'implementationExample'],
     },
     render: ({ iconName }) => (
       <Menu>

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -14,7 +14,7 @@ export default {
     // The modal is initially closed for most of these stories,
     // which renders testing it for visual regressions unhelpful.
     chromatic: { disableSnapshot: true },
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/NumberIcon',
   component: NumberIcon,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   args: {
     'aria-label': 'Step 1',
@@ -96,7 +96,7 @@ export const DifferentNumbers: Story = {
  */
 export const NumberIconList: Story = {
   parameters: {
-    badges: ['1.0', 'implementationExample'],
+    badges: ['intro-1.0', 'implementationExample'],
   },
   render: () => (
     <div className="flex flex-wrap gap-1">

--- a/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
+++ b/src/components/PageLevelBanner/PageLevelBanner.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/PageLevelBanner',
   component: PageLevelBanner,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   args: {
     title:

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
     chromatic: {
       // These stories are very flaky, though we're not sure why.
       // We tried delaying the snapshot just in case there's a timing issue at play here, which was not successful.

--- a/src/components/PopoverContainer/PopoverContainer.stories.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/PopoverContainer',
   component: PopoverContainer,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
 } as Meta<Args>;

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/PopoverListItem',
   component: PopoverListItem,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
   },
 } as Meta<Args>;
 

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -11,7 +11,7 @@ export default {
     maxValue: 100,
   },
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     backgrounds: {
       default: 'eds-color-neutral-white',
     },

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Radio> = {
     checked: false,
   },
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   decorators: [(Story) => <div style={{ margin: '0.25rem' }}>{Story()}</div>],
 };

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -8,7 +8,7 @@ export default {
   title: 'Components/SearchBar',
   component: SearchBar,
   parameters: {
-    badges: ['1.1', BADGE.NEEDS_REVISION],
+    badges: ['intro-1.1', BADGE.NEEDS_REVISION],
   },
   decorators: [
     (Story) => (

--- a/src/components/Section/Section.stories.tsx
+++ b/src/components/Section/Section.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: 'Components/Section',
   component: Section,
   parameters: {
-    badges: ['1.0', BADGE.DEPRECATED],
+    badges: ['intro-1.0', BADGE.DEPRECATED],
   },
   args: {
     children:

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Select> = {
   title: 'Components/Select',
   component: Select,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     layout: 'centered',
   },
   argTypes: {
@@ -517,7 +517,7 @@ export const LongOptionList: StoryObj = {
     await expect(selectButton.getAttribute('aria-expanded')).toEqual('true');
   },
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     layout: 'centered',
     chromatic: { delay: 450 },
   },
@@ -684,7 +684,7 @@ export const UsingFunctionProps: StoryObj = {
 export const OpenByDefault: StoryObj = {
   ...Default,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     layout: 'centered',
     chromatic: { delay: 300, disableSnapshot: true },
   },

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Skeleton',
   component: Skeleton,
   parameters: {
-    badges: ['1.2'],
+    badges: ['intro-1.2'],
     layout: 'centered',
     backgrounds: {
       default: 'eds-color-neutral-white',

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Slider> = {
   title: 'Components/Slider',
   component: Slider,
   parameters: {
-    badges: ['1.3'],
+    badges: ['intro-1.3'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
   argTypes: {
@@ -192,7 +192,7 @@ const moodData = [
 
 export const UsingInputDisplay: Story = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
     axe: {
       disabledRules: ['color-contrast'], // adding for disabled field example
     },
@@ -228,7 +228,7 @@ export const UsingInputDisplay: Story = {
 
 export const UsingControlButtons: Story = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 1, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -274,7 +274,7 @@ export const UsingControlButtons: Story = {
 
 export const WithHighlightedContent: Story = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -326,7 +326,7 @@ export const WithHighlightedContent: Story = {
 
 export const WithVisualLabel: Story = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -369,7 +369,7 @@ export const WithVisualLabel: Story = {
 
 export const WithMultipleVisualLabels: Story = {
   parameters: {
-    badges: ['1.3', 'implementationExample'],
+    badges: ['intro-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -10,7 +10,7 @@ export default {
   title: 'Components/Table',
   component: Table,
   parameters: {
-    badges: ['1.1'],
+    badges: ['intro-1.1'],
   },
   argTypes: {
     children: {
@@ -253,7 +253,7 @@ export const SortableInteractive: Story = {
  */
 export const StackedCardsExample: Story = {
   parameters: {
-    badges: ['1.1', 'implementationExample'],
+    badges: ['intro-1.1', 'implementationExample'],
     chromatic: {
       viewports: [
         chromaticViewports.googlePixel2,

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -12,7 +12,7 @@ export default {
   title: 'Components/Tabs',
   component: Tabs,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   args: {
     children: (

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Tag',
   component: Tag,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   argTypes: {
     variant: {

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Text',
   component: Text,
   parameters: {
-    badges: ['1.0'],
+    badges: ['intro-1.0'],
   },
   argTypes: {
     children: {

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -17,7 +17,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.`,
     spellCheck: false,
   },
   parameters: {
-    badges: ['1.3'],
+    badges: ['intro-1.3'],
   },
 };
 

--- a/src/components/Toast/Toast.stories.ts
+++ b/src/components/Toast/Toast.stories.ts
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Toast',
   component: Toast,
   parameters: {
-    badges: ['1.0', BADGE.DEPRECATED],
+    badges: ['intro-1.0', BADGE.DEPRECATED],
   },
   argTypes: { onDismiss: { action: 'dismissed' } },
   args: {

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof Toggle> = {
   },
   parameters: {
     layout: 'centered',
-    badges: ['1.0', BADGE.BETA],
+    badges: ['intro-1.0', BADGE.BETA],
   },
   render: (args) => <InteractiveToggle {...args} />,
 };

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -45,7 +45,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['1.0', BADGE.NEEDS_REVISION],
+    badges: ['intro-1.0', BADGE.NEEDS_REVISION],
     chromatic: {
       diffThreshold,
       diffIncludeAntiAliasing: false,


### PR DESCRIPTION
this updates how we badge components so we can keep the existing introduction badges, and add new "current" version badges. This will be used to track the versions of individual components between design and code.

![Screenshot 2024-03-07 at 17 32 05](https://github.com/chanzuckerberg/edu-design-system/assets/3056447/6c6fb84e-f8ed-46f2-be06-332a0cac48fd)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [ ] Manually tested my changes, and here are the details:
