### PR TITLE
feat(config)!: use literal values in style-dictionary config

### DIFF
--- a/style-dictionary.config.js
+++ b/style-dictionary.config.js
@@ -55,6 +55,7 @@ const EDSStyleDictionary = StyleDictionary.extend({
           destination: 'lib/tokens/json/theme-base.json',
           filter: function (token) {
             // don't allow theming on legacy tokens
+            // TODO: remove filter once all legacy tokens are removed
             return token.attributes.category !== 'legacy';
           },
         },
@@ -63,13 +64,6 @@ const EDSStyleDictionary = StyleDictionary.extend({
     tailwind: {
       transforms: [...StyleDictionary.transformGroup.css, 'name/cti/kebab'],
       files: [
-        {
-          format: 'json/nested-css-variables',
-          // useful for tailwind configs in consuming apps
-          // NOTE: this will be replaced by the output utility config in a future version
-          destination: 'lib/tokens/json/css-variables-nested.json',
-          outputReferences: true,
-        },
         {
           format: 'json/tailwind-utility-config',
           // useful for tailwind configs in consuming apps
@@ -87,18 +81,6 @@ EDSStyleDictionary.registerFormat({
     const minifiedCssDictionary = minifyDictionaryUsingFormat(
       dictionary.properties,
       (obj) => `${obj.value}`,
-    );
-    formatEdsTokens(minifiedCssDictionary);
-    return JSON.stringify(minifiedCssDictionary, null, 2);
-  },
-});
-
-EDSStyleDictionary.registerFormat({
-  name: 'json/nested-css-variables',
-  formatter: function (dictionary) {
-    const minifiedCssDictionary = minifyDictionaryUsingFormat(
-      dictionary.properties,
-      (obj) => `var(--${obj.name})`,
     );
     formatEdsTokens(minifiedCssDictionary);
     return JSON.stringify(minifiedCssDictionary, null, 2);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from 'tailwindcss';
-import { eds as edsTokens } from './lib/tokens/json/css-variables-nested.json';
+import { eds as edsTokens } from './lib/tokens/json/tailwind-utility-config.json';
 
 const {
   background: backgroundColorTokens,


### PR DESCRIPTION
- remove export for old reference-based config output
- internally use the new output with value literals in the JSON

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [x] Manually tested my changes, and here are the details:
  - verify color chips and literal values appear in VSCode when using the tailwind extension
  - no changes to story snapshots
