### PR TITLE
fix(Accordion): address QA updates from design

### DIFF
--- a/src/components/Accordion/Accordion-v2.module.css
+++ b/src/components/Accordion/Accordion-v2.module.css
@@ -103,7 +103,12 @@
 }
 
 .accordion-button__leading-icon {
-  color: var(--eds-theme-color-icon-utility-default-primary);
+  color: var(--eds-theme-color-icon-utility-default-secondary);
+
+  /* Targeting NumberIcons and other images used in this specific context */
+  & [role='img'] {
+    display: inline-flex;
+  }
 }
 
 .accordion-button__title {

--- a/src/components/Accordion/Accordion-v2.tsx
+++ b/src/components/Accordion/Accordion-v2.tsx
@@ -109,7 +109,7 @@ type AccordionRowProps = {
    */
   isExpandable?: boolean;
   /**
-   *
+   * Whether the row has a leading icon on the row's trigger
    */
   hasLeadingIcon?: boolean;
 };


### PR DESCRIPTION
- better positioning of `NumberIcon` when used with `Accordion`
- fixes to color token when using `Icon` instances

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [ ] Manually tested my changes, and here are the details:
