### PR TITLE
feat!: move from isWarning and isError to status prop

### DIFF
--- a/src/bin/migrate/migrations/alpha14-to-alpha15.test.ts
+++ b/src/bin/migrate/migrations/alpha14-to-alpha15.test.ts
@@ -1,0 +1,156 @@
+import { dedent } from 'ts-dedent';
+
+import { updateStatusProp } from './alpha14-to-alpha15';
+import { createTestSourceFile } from '../helpers';
+
+describe('alpha14-to-alpha15', () => {
+  it('updates an appropriate isWarning prop', () => {
+    const sourceFileText = dedent`
+    import {FieldNote} from '@chanzuckerberg/eds';
+
+    export default function Component() {
+      return (
+        <FieldNote isWarning />
+      )
+    }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    updateStatusProp({
+      file: sourceFile,
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {FieldNote} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <FieldNote status="warning" />
+        )
+      }
+    `);
+  });
+
+  it('updates an appropriate isError prop', () => {
+    const sourceFileText = dedent`
+    import {FieldNote} from '@chanzuckerberg/eds';
+
+    export default function Component() {
+      return (
+        <FieldNote isError />
+      )
+    }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    updateStatusProp({
+      file: sourceFile,
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {FieldNote} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <FieldNote status="critical" />
+        )
+      }
+    `);
+  });
+
+  it('does not update an isError prop on non-EDS component', () => {
+    const sourceFileText = dedent`
+    import {FieldNote} from 'somewhere';
+
+    export default function Component() {
+      return (
+        <FieldNote isError />
+      )
+    }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    updateStatusProp({
+      file: sourceFile,
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {FieldNote} from 'somewhere';
+
+      export default function Component() {
+        return (
+          <FieldNote isError />
+        )
+      }
+    `);
+  });
+
+  it('updates appropriately when both isError and isWarning prop exists', () => {
+    const sourceFileText = dedent`
+    import {FieldNote} from '@chanzuckerberg/eds';
+
+    export default function Component() {
+      return (
+        <FieldNote isWarning isError />
+      )
+    }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    updateStatusProp({
+      file: sourceFile,
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {FieldNote} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <FieldNote status="warning" status="critical" />
+        )
+      }
+    `);
+  });
+
+  it('converts on all component types', () => {
+    const sourceFileText = dedent`
+    import {FieldNote, InputField, Select, TextareaField} from '@chanzuckerberg/eds';
+
+    export default function Component() {
+      return (
+        <div>
+          <InputField isWarning />
+          <FieldNote isWarning></FieldNote>
+          <Select isError></Select>
+          <TextareaField isError isWarning></Textarea>
+        </div>
+      );
+    }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    updateStatusProp({
+      file: sourceFile,
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {FieldNote, InputField, Select, TextareaField} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <div>
+            <InputField status="warning" />
+            <FieldNote status="warning"></FieldNote>
+            <Select status="critical"></Select>
+            <TextareaField status="warning" status="critical"></Textarea>
+          </div>
+        );
+      }
+    `);
+  });
+});

--- a/src/bin/migrate/migrations/alpha14-to-alpha15.ts
+++ b/src/bin/migrate/migrations/alpha14-to-alpha15.ts
@@ -1,0 +1,98 @@
+import {
+  type JsxAttribute,
+  SyntaxKind,
+  type Project,
+  type SourceFile,
+} from 'ts-morph';
+import { isDesignSystemImport } from '../helpers';
+
+export default function migration(project: Project) {
+  const files = project.getSourceFiles();
+  const sourceFiles = files.filter((file) => !file.isDeclarationFile());
+
+  sourceFiles.forEach((sourceFile) => {
+    updateStatusProp({ file: sourceFile }); // https://github.com/chanzuckerberg/edu-design-system/pull/1973
+  });
+}
+
+type TransformOptions = {
+  file: SourceFile;
+};
+
+const statusComponents = [
+  'FieldNote',
+  'InputField',
+  'Select',
+  'TextareaField',
+].map((name) => name.toLowerCase());
+
+export function updateStatusProp({ file }: TransformOptions) {
+  // Filter down to the design-system-only imports
+  const importDeclarations = file
+    .getImportDeclarations()
+    .filter(
+      (importDeclaration) =>
+        !importDeclaration.isTypeOnly() &&
+        isDesignSystemImport(importDeclaration),
+    );
+
+  const jsxElements = file.getDescendantsOfKind(SyntaxKind.JsxOpeningElement);
+  const jsxSelfClosingElements = file.getDescendantsOfKind(
+    SyntaxKind.JsxSelfClosingElement,
+  );
+
+  // Get the component usages in the given file (which should only work on EDS imports)
+  [...jsxElements, ...jsxSelfClosingElements].forEach((element) => {
+    const tagName = element.getTagNameNode().getText();
+    const edsTags: string[] = [];
+    importDeclarations.forEach((importDeclaration) => {
+      importDeclaration.getNamedImports().forEach((namedImport) => {
+        edsTags.push(namedImport.getName());
+      });
+    });
+
+    if (
+      statusComponents.includes(tagName.toLowerCase()) &&
+      edsTags.includes(tagName)
+    ) {
+      // detect if isWarning exists (at all or with value true)
+      if (
+        isBooleanTrue(
+          element.getAttribute('isWarning')?.asKind(SyntaxKind.JsxAttribute),
+        )
+      ) {
+        element.getAttribute('isWarning')?.remove();
+        element.addAttribute({
+          name: 'status',
+          initializer: `"warning"`,
+        });
+      }
+
+      // detect if isError exists (at all or with value true)
+      if (
+        isBooleanTrue(
+          element.getAttribute('isError')?.asKind(SyntaxKind.JsxAttribute),
+        )
+      ) {
+        element.getAttribute('isError')?.remove();
+        element.addAttribute({
+          name: 'status',
+          initializer: `"critical"`,
+        });
+      }
+    }
+  });
+}
+
+/**
+ * Determine whether the attribute evaluates to being set to true
+ *
+ * @param attribute the attribute retrieved from the element node
+ * @returns whether the elements attribute evaluates to true in JSX (exists or exists AND is true)
+ */
+function isBooleanTrue(attribute: JsxAttribute | undefined): boolean {
+  return (
+    (attribute && typeof attribute?.getInitializer() === 'undefined') ||
+    attribute?.getInitializer()?.getText() === '{true}'
+  );
+}

--- a/src/components/FieldNote/FieldNote-v2.stories.tsx
+++ b/src/components/FieldNote/FieldNote-v2.stories.tsx
@@ -28,15 +28,16 @@ export const WithErrorIcon: StoryObj<Args> = {
     children: 'This is a fieldnote.',
     id: 'field-1',
     icon: 'warning-filled',
-    isError: true,
+    status: 'critical',
   },
 };
 
-export const WithIcon: StoryObj<Args> = {
+export const WithWarningIcon: StoryObj<Args> = {
   args: {
     children: 'This is a fieldnote.',
     id: 'field-1',
     icon: 'warning-filled',
+    status: 'warning',
   },
 };
 

--- a/src/components/FieldNote/FieldNote-v2.tsx
+++ b/src/components/FieldNote/FieldNote-v2.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
+import type { Status } from '../../util/variant-types';
 import { IconV2 as Icon, type IconNameV2 as IconName } from '../Icon';
 import styles from './FieldNote-v2.module.css';
 
@@ -30,13 +31,11 @@ export interface Props {
    */
   icon?: Extract<IconName, 'dangerous' | 'warning-filled'>;
   /**
-   * Whether there is an error state for the field note text (and icon)
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
    */
-  isError?: boolean;
-  /**
-   * Whether there is a warning state for the field note text (and icon)
-   */
-  isWarning?: boolean;
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
 }
 
 /**
@@ -50,36 +49,36 @@ export const FieldNote = ({
   id,
   disabled,
   icon,
-  isError,
-  isWarning,
+  status,
   ...other
 }: Props) => {
   const componentClassName = clsx(
     styles['field-note'],
     disabled && styles['field-note--disabled'],
-    isError && styles['field-note--error'],
-    isWarning && styles['field-note--warning'],
+    status === 'critical' && styles['field-note--error'],
+    status === 'warning' && styles['field-note--warning'],
     className,
   );
 
   let iconToUse = icon;
-  if (isError) {
+  let title = 'fieldnote status icon';
+  if (status === 'critical') {
     iconToUse = 'dangerous';
-  } else if (isWarning) {
+    title = 'error';
+  } else if (status === 'warning') {
     iconToUse = 'warning-filled';
-  } else if (icon) {
-    iconToUse = icon;
+    title = 'warning';
   }
 
   return (
     <div className={componentClassName} id={id} {...other}>
-      {(isError || isWarning || iconToUse) && (
+      {(status === 'critical' || status === 'warning' || iconToUse) && (
         <Icon
           className={styles['field-note__icon']}
           name={iconToUse}
           purpose="informative"
           size="1rem"
-          title={isError ? 'error' : 'warning'}
+          title={title}
         />
       )}
       {children}

--- a/src/components/Input/Input-v2.tsx
+++ b/src/components/Input/Input-v2.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler } from 'react';
 import React, { forwardRef } from 'react';
+import type { Status } from '../../util/variant-types';
 import styles from './Input-v2.module.css';
 
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
@@ -78,24 +79,22 @@ export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   defaultValue?: string | number;
   // Design API
   /**
-   * Error state of the form field
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
    */
-  isError?: boolean;
-  /**
-   * Whether there is a warning state for the field note text (and icon)
-   */
-  isWarning?: boolean;
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
 };
 
 /**
  * Input component for one line of text.
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, disabled, id, isError, isWarning, ...other }, ref) => {
+  ({ className, disabled, id, status, ...other }, ref) => {
     const componentClassName = clsx(
       styles['input'],
-      isError && styles['error'],
-      isWarning && styles['warning'],
+      status === 'critical' && styles['error'],
+      status === 'warning' && styles['warning'],
       className,
     );
 

--- a/src/components/InputField/InputField-v2.stories.tsx
+++ b/src/components/InputField/InputField-v2.stories.tsx
@@ -58,7 +58,7 @@ export const NoFieldnote: Story = {
 export const Error: Story = {
   args: {
     label: 'Error input field',
-    isError: true,
+    status: 'critical',
     fieldNote: 'This is a fieldnote with an error.',
   },
 };
@@ -69,7 +69,7 @@ export const Error: Story = {
 export const Warning: Story = {
   args: {
     label: 'Warning input field',
-    isWarning: true,
+    status: 'warning',
     fieldNote:
       'This uses the warning treatment and also applies to the field note',
   },

--- a/src/components/InputField/InputField-v2.tsx
+++ b/src/components/InputField/InputField-v2.tsx
@@ -7,6 +7,7 @@ import type {
   EitherInclusive,
   ForwardedRefComponent,
 } from '../../util/utility-types';
+import type { Status } from '../../util/variant-types';
 import FieldLabel from '../FieldLabel';
 import { FieldNoteV2 as FieldNote } from '../FieldNote';
 import { IconV2 as Icon, type IconNameV2 as IconName } from '../Icon';
@@ -95,18 +96,6 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   fieldNote?: ReactNode;
   /**
-   * Whether there is an error state for the field note text (and icon)
-   *
-   * **Default is `false`**.
-   */
-  isError?: boolean;
-  /**
-   * Whether there is a warning state for the field note text (and icon)
-   *
-   * **Default is `false`**.
-   */
-  isWarning?: boolean;
-  /**
    * An icon that prefixes the field input.
    */
   leadingIcon?: IconName;
@@ -129,6 +118,12 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    * **Default is `"false"`**.
    */
   showHint?: boolean;
+  /**
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
+   */
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
 } & EitherInclusive<
     {
       /**
@@ -168,8 +163,6 @@ export const InputField: InputFieldType = forwardRef(
       fieldNote,
       id,
       inputWithin,
-      isError,
-      isWarning,
       label,
       leadingIcon,
       maxLength,
@@ -178,6 +171,7 @@ export const InputField: InputFieldType = forwardRef(
       recommendedMaxLength,
       required,
       showHint,
+      status = 'default',
       type = 'text',
       ...other
     },
@@ -217,7 +211,7 @@ export const InputField: InputFieldType = forwardRef(
         : false;
 
     const shouldRenderError =
-      isError || textExceedsMaxLength || textExceedsRecommendedLength;
+      textExceedsMaxLength || textExceedsRecommendedLength;
 
     const generatedIdVar = useId();
     const idVar = id || generatedIdVar;
@@ -279,12 +273,10 @@ export const InputField: InputFieldType = forwardRef(
         <div className={inputBodyClassName}>
           <Input
             aria-describedby={ariaDescribedByVar}
-            aria-invalid={!!isError}
+            aria-invalid={!!(status === 'critical')}
             className={inputOverlayClassName}
             disabled={disabled}
             id={idVar}
-            isError={shouldRenderError}
-            isWarning={isWarning}
             maxLength={maxLength}
             onChange={(e) => {
               setFieldText(e.target.value);
@@ -293,6 +285,7 @@ export const InputField: InputFieldType = forwardRef(
             readOnly={readOnly}
             ref={ref}
             required={required}
+            status={shouldRenderError ? 'critical' : status}
             type={type}
             {...other}
           />
@@ -313,8 +306,7 @@ export const InputField: InputFieldType = forwardRef(
               <FieldNote
                 disabled={disabled}
                 id={ariaDescribedByVar}
-                isError={shouldRenderError}
-                isWarning={isWarning}
+                status={shouldRenderError ? 'critical' : status}
               >
                 {fieldNote}
               </FieldNote>
@@ -327,8 +319,7 @@ export const InputField: InputFieldType = forwardRef(
               <FieldNote
                 disabled={disabled}
                 id={ariaDescribedByVar}
-                isError={shouldRenderError}
-                isWarning={isWarning}
+                status={shouldRenderError ? 'critical' : status}
               >
                 {fieldNote}
               </FieldNote>

--- a/src/components/Select/Select-v2.stories.tsx
+++ b/src/components/Select/Select-v2.stories.tsx
@@ -796,7 +796,7 @@ export const Optional: StoryObj = {
 export const Error: StoryObj = {
   args: {
     ...Required.args,
-    isError: true,
+    status: 'critical',
     fieldNote: 'Some text describing error',
   },
   parameters: {
@@ -810,7 +810,7 @@ export const Error: StoryObj = {
 export const Warning: StoryObj = {
   args: {
     ...Optional.args,
-    isWarning: true,
+    status: 'warning',
     fieldNote: 'Some text describing warning',
   },
   parameters: {

--- a/src/components/TextareaField/TextareaField-v2.stories.tsx
+++ b/src/components/TextareaField/TextareaField-v2.stories.tsx
@@ -82,20 +82,40 @@ export const WhenReadOnly: Story = {
   },
 };
 
+/**
+ * The default status isn't really anything, but exists to allow a value to be set if needed. This applies
+ * the neutral styles.
+ */
+export const WhenDefaultStatus: Story = {
+  args: {
+    status: 'default',
+    fieldNote: 'Text should be at least 100 characters',
+  },
+};
+
+/**
+ * When in an error state, this is the status to use. It matches other components which have a critical status.
+ */
 export const WhenError: Story = {
   args: {
-    isError: true,
+    status: 'critical',
     fieldNote: 'Text should be at least 100 characters',
   },
 };
 
+/**
+ * You can also apply a warning status.
+ */
 export const WhenWarning: Story = {
   args: {
-    isWarning: true,
+    status: 'warning',
     fieldNote: 'Text should be at least 100 characters',
   },
 };
 
+/**
+ * Textarea components can be set as required.
+ */
 export const WhenRequired: Story = {
   args: {
     required: true,
@@ -103,6 +123,9 @@ export const WhenRequired: Story = {
   },
 };
 
+/**
+ * ... or optional.
+ */
 export const WhenOptional: Story = {
   args: {
     required: false,

--- a/src/components/TextareaField/TextareaField-v2.tsx
+++ b/src/components/TextareaField/TextareaField-v2.tsx
@@ -8,6 +8,7 @@ import type {
   ForwardedRefComponent,
 } from '../../util/utility-types';
 
+import type { Status } from '../../util/variant-types';
 import FieldLabel from '../FieldLabel';
 import { FieldNoteV2 as FieldNote } from '../FieldNote';
 import Text from '../Text';
@@ -38,16 +39,6 @@ type TextareaFieldProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   id?: string;
   // Design API
   /**
-   * Error state of the form field
-   */
-  isError?: boolean;
-  /**
-   * Whether there is a warning state for the field note text (and icon)
-   *
-   * **Default is `false`**.
-   */
-  isWarning?: boolean;
-  /**
    * Behaves similar to `maxLength` but allows the user to continue typing more text.
    * Should not be larger than `maxLength`, if present.
    */
@@ -58,6 +49,12 @@ type TextareaFieldProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
    * **Default is `"false"`**.
    */
   showHint?: boolean;
+  /**
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
+   */
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
 } & EitherInclusive<
     {
       /**
@@ -95,15 +92,11 @@ type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
    */
   disabled?: boolean;
   /**
-   * Whether the error state is active
-   */
-  isError?: boolean;
-  /**
-   * Whether there is a warning state for the field note text (and icon)
+   * Status for the field state
    *
-   * **Default is `false`**.
+   * **Default is `"default"`**.
    */
-  isWarning?: boolean;
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
 };
 
 /**
@@ -116,17 +109,16 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       children,
       disabled,
       defaultValue = '',
-      isError = false,
-      isWarning,
       readOnly,
+      status = 'default',
       ...other
     },
     ref,
   ) => {
     const componentClassName = clsx(
       styles['textarea'],
-      isError && styles['error'],
-      isWarning && styles['warning'],
+      status === 'critical' && styles['error'],
+      status === 'warning' && styles['warning'],
       disabled && styles['textarea--disabled'],
       className,
     );
@@ -163,8 +155,6 @@ export const TextareaField: TextareaFieldType = forwardRef(
       disabled,
       fieldNote,
       id,
-      isError,
-      isWarning,
       label,
       maxLength,
       onChange,
@@ -172,6 +162,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
       recommendedMaxLength,
       required,
       showHint,
+      status = 'default',
       ...other
     },
     ref,
@@ -192,7 +183,9 @@ export const TextareaField: TextareaFieldType = forwardRef(
         : false;
 
     const shouldRenderError =
-      isError || textExceedsMaxLength || textExceedsRecommendedLength;
+      status === 'critical' ||
+      textExceedsMaxLength ||
+      textExceedsRecommendedLength;
 
     const ariaDescribedByVar = fieldNote
       ? ariaDescribedBy || generatedAriaDescribedById
@@ -266,8 +259,6 @@ export const TextareaField: TextareaFieldType = forwardRef(
           defaultValue={defaultValue}
           disabled={disabled}
           id={idVar}
-          isError={shouldRenderError}
-          isWarning={isWarning}
           maxLength={maxLength}
           onChange={(e) => {
             setFieldText(e.target.value);
@@ -276,6 +267,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
           readOnly={readOnly}
           ref={ref}
           required={required}
+          status={shouldRenderError ? 'critical' : status}
           {...other}
         >
           {children}
@@ -287,8 +279,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
                 className={styles['textarea-field__field-note']}
                 disabled={disabled}
                 id={ariaDescribedByVar}
-                isError={shouldRenderError}
-                isWarning={isWarning}
+                status={shouldRenderError ? 'critical' : status}
               >
                 {fieldNote}
               </FieldNote>

--- a/src/components/TextareaField/__snapshots__/TextareaField-v2.test.tsx.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField-v2.test.tsx.snap
@@ -44,6 +44,49 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
 </div>
 `;
 
+exports[`<TextareaField /> WhenDefaultStatus story renders snapshot 1`] = `
+<div
+  class="p-8"
+>
+  <div
+    class="textarea-field w-96"
+  >
+    <div
+      class="textarea-field__overline"
+    >
+      <label
+        class="label label--lg textarea-field__label"
+        for=":ra:"
+      >
+        Textarea Field
+      </label>
+    </div>
+    <textarea
+      aria-describedby=":rb:"
+      class="textarea"
+      id=":ra:"
+      placeholder="Enter long-form text here"
+      rows="5"
+      spellcheck="false"
+    >
+      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+praesentium, commodi eligendi asperiores quis dolorum porro.
+    </textarea>
+    <div
+      class="textarea-field__footer"
+    >
+      <div
+        class="field-note textarea-field__field-note"
+        id=":rb:"
+      >
+        Text should be at least 100 characters
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
 <div
   class="p-8"
@@ -101,15 +144,15 @@ exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
     >
       <label
         class="label label--lg textarea-field__label"
-        for=":ra:"
+        for=":rc:"
       >
         Textarea Field
       </label>
     </div>
     <textarea
-      aria-describedby=":rb:"
+      aria-describedby=":rd:"
       class="textarea error"
-      id=":ra:"
+      id=":rc:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -123,7 +166,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--error textarea-field__field-note"
-        id=":rb:"
+        id=":rd:"
       >
         <svg
           class="icon field-note__icon"
@@ -189,7 +232,7 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
     >
       <label
         class="label label--lg textarea-field__label"
-        for=":rg:"
+        for=":ri:"
       >
         Textarea Field
       </label>
@@ -200,9 +243,9 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
       </span>
     </div>
     <textarea
-      aria-describedby=":rh:"
+      aria-describedby=":rj:"
       class="textarea"
-      id=":rg:"
+      id=":ri:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -216,7 +259,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rh:"
+        id=":rj:"
       >
         Longer Field description
       </div>
@@ -281,7 +324,7 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
     >
       <label
         class="label label--lg textarea-field__label"
-        for=":re:"
+        for=":rg:"
       >
         Textarea Field
       </label>
@@ -292,9 +335,9 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
       </span>
     </div>
     <textarea
-      aria-describedby=":rf:"
+      aria-describedby=":rh:"
       class="textarea"
-      id=":re:"
+      id=":rg:"
       placeholder="Enter long-form text here"
       required=""
       rows="5"
@@ -309,7 +352,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rf:"
+        id=":rh:"
       >
         Longer Field description
       </div>
@@ -373,15 +416,15 @@ exports[`<TextareaField /> WhenWarning story renders snapshot 1`] = `
     >
       <label
         class="label label--lg textarea-field__label"
-        for=":rc:"
+        for=":re:"
       >
         Textarea Field
       </label>
     </div>
     <textarea
-      aria-describedby=":rd:"
+      aria-describedby=":rf:"
       class="textarea warning"
-      id=":rc:"
+      id=":re:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -395,7 +438,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--warning textarea-field__field-note"
-        id=":rd:"
+        id=":rf:"
       >
         <svg
           class="icon field-note__icon"
@@ -433,15 +476,15 @@ exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
     >
       <label
         class="label label--lg textarea-field__label"
-        for=":ri:"
+        for=":rk:"
       >
         Textarea Field
       </label>
     </div>
     <textarea
-      aria-describedby=":rj:"
+      aria-describedby=":rl:"
       class="textarea"
-      id=":ri:"
+      id=":rk:"
       placeholder="Enter long-form text here"
       rows="10"
       spellcheck="false"
@@ -455,7 +498,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rj:"
+        id=":rl:"
       >
         Longer Field description
       </div>
@@ -465,80 +508,6 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
 `;
 
 exports[`<TextareaField /> WithAMaxLength story renders snapshot 1`] = `
-<div
-  class="p-8"
->
-  <div
-    class="textarea-field w-96"
-  >
-    <div
-      class="textarea-field__overline"
-    >
-      <label
-        class="label label--lg textarea-field__label"
-        for=":rk:"
-      >
-        Textarea Field
-      </label>
-      <div
-        class="textarea-field__character-counter"
-      >
-        <span
-          class="textarea-field--invalid-length"
-        >
-          202
-        </span>
-         
-        / 
-        144
-      </div>
-    </div>
-    <textarea
-      aria-describedby=":rl:"
-      class="textarea error"
-      id=":rk:"
-      maxlength="144"
-      placeholder="Enter long-form text here"
-      required=""
-      rows="10"
-      spellcheck="false"
-    >
-      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
-dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
-praesentium, commodi eligendi asperiores quis dolorum porro.
-    </textarea>
-    <div
-      class="textarea-field__footer"
-    >
-      <div
-        class="field-note field-note--error textarea-field__field-note"
-        id=":rl:"
-      >
-        <svg
-          class="icon field-note__icon"
-          fill="currentColor"
-          height="1rem"
-          role="img"
-          style="--icon-size: 1rem;"
-          viewBox="0 0 24 24"
-          width="1rem"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <title>
-            error
-          </title>
-          <path
-            d="M14.9,3H9.1C8.57,3,8.06,3.21,7.68,3.59l-4.1,4.1C3.21,8.06,3,8.57,3,9.1v5.8c0,0.53,0.21,1.04,0.59,1.41l4.1,4.1 C8.06,20.79,8.57,21,9.1,21h5.8c0.53,0,1.04-0.21,1.41-0.59l4.1-4.1C20.79,15.94,21,15.43,21,14.9V9.1c0-0.53-0.21-1.04-0.59-1.41 l-4.1-4.1C15.94,3.21,15.43,3,14.9,3z M15.54,15.54L15.54,15.54c-0.39,0.39-1.02,0.39-1.41,0L12,13.41l-2.12,2.12 c-0.39,0.39-1.02,0.39-1.41,0l0,0c-0.39-0.39-0.39-1.02,0-1.41L10.59,12L8.46,9.88c-0.39-0.39-0.39-1.02,0-1.41l0,0 c0.39-0.39,1.02-0.39,1.41,0L12,10.59l2.12-2.12c0.39-0.39,1.02-0.39,1.41,0l0,0c0.39,0.39,0.39,1.02,0,1.41L13.41,12l2.12,2.12 C15.93,14.51,15.93,15.15,15.54,15.54z"
-          />
-        </svg>
-        Longer Field description
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
 <div
   class="p-8"
 >
@@ -571,6 +540,7 @@ exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
       aria-describedby=":rn:"
       class="textarea error"
       id=":rm:"
+      maxlength="144"
       placeholder="Enter long-form text here"
       required=""
       rows="10"
@@ -611,7 +581,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
 </div>
 `;
 
-exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapshot 1`] = `
+exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
 <div
   class="p-8"
 >
@@ -644,7 +614,6 @@ exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapsh
       aria-describedby=":rp:"
       class="textarea error"
       id=":ro:"
-      maxlength="256"
       placeholder="Enter long-form text here"
       required=""
       rows="10"
@@ -660,6 +629,80 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
       <div
         class="field-note field-note--error textarea-field__field-note"
         id=":rp:"
+      >
+        <svg
+          class="icon field-note__icon"
+          fill="currentColor"
+          height="1rem"
+          role="img"
+          style="--icon-size: 1rem;"
+          viewBox="0 0 24 24"
+          width="1rem"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            error
+          </title>
+          <path
+            d="M14.9,3H9.1C8.57,3,8.06,3.21,7.68,3.59l-4.1,4.1C3.21,8.06,3,8.57,3,9.1v5.8c0,0.53,0.21,1.04,0.59,1.41l4.1,4.1 C8.06,20.79,8.57,21,9.1,21h5.8c0.53,0,1.04-0.21,1.41-0.59l4.1-4.1C20.79,15.94,21,15.43,21,14.9V9.1c0-0.53-0.21-1.04-0.59-1.41 l-4.1-4.1C15.94,3.21,15.43,3,14.9,3z M15.54,15.54L15.54,15.54c-0.39,0.39-1.02,0.39-1.41,0L12,13.41l-2.12,2.12 c-0.39,0.39-1.02,0.39-1.41,0l0,0c-0.39-0.39-0.39-1.02,0-1.41L10.59,12L8.46,9.88c-0.39-0.39-0.39-1.02,0-1.41l0,0 c0.39-0.39,1.02-0.39,1.41,0L12,10.59l2.12-2.12c0.39-0.39,1.02-0.39,1.41,0l0,0c0.39,0.39,0.39,1.02,0,1.41L13.41,12l2.12,2.12 C15.93,14.51,15.93,15.15,15.54,15.54z"
+          />
+        </svg>
+        Longer Field description
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapshot 1`] = `
+<div
+  class="p-8"
+>
+  <div
+    class="textarea-field w-96"
+  >
+    <div
+      class="textarea-field__overline"
+    >
+      <label
+        class="label label--lg textarea-field__label"
+        for=":rq:"
+      >
+        Textarea Field
+      </label>
+      <div
+        class="textarea-field__character-counter"
+      >
+        <span
+          class="textarea-field--invalid-length"
+        >
+          202
+        </span>
+         
+        / 
+        144
+      </div>
+    </div>
+    <textarea
+      aria-describedby=":rr:"
+      class="textarea error"
+      id=":rq:"
+      maxlength="256"
+      placeholder="Enter long-form text here"
+      required=""
+      rows="10"
+      spellcheck="false"
+    >
+      Lorem ipsum, dolor sit amet consectetur adipisicing elit. Id neque nemo
+dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
+praesentium, commodi eligendi asperiores quis dolorum porro.
+    </textarea>
+    <div
+      class="textarea-field__footer"
+    >
+      <div
+        class="field-note field-note--error textarea-field__field-note"
+        id=":rr:"
       >
         <svg
           class="icon field-note__icon"


### PR DESCRIPTION
- update all (sub-)components to use status instead of two sep. props
- refactor stories to use the new prop
- ensure snapshots do not change (not updating class names at the moment)
- add simple-case migration


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Added code mod for change
- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [ ] Manually tested my changes, and here are the details:
