### PR TITLE
fix(Table): allow nodes in header cells

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -163,6 +163,48 @@ export const TableWithCaption: Story = {
 };
 
 /**
+ * Headers can be more than text.
+ */
+export const TableWithStyledHeader: Story = {
+  args: {
+    children: (
+      <>
+        <Table.Caption>
+          Optional caption for the table. Must be first descendant of Table if
+          used.
+        </Table.Caption>
+
+        <Table.Header>
+          <Table.Row variant="header">
+            {tableColumns.map((item) => {
+              return (
+                <Table.HeaderCell key={'table-header-row-' + item.title}>
+                  <em>{item.title}</em>
+                </Table.HeaderCell>
+              );
+            })}
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          {tableRows.map((item) => {
+            return (
+              <Table.Row key={item.value1.slice(0, 11)}>
+                <Table.Cell>{item.value1}</Table.Cell>
+                <Table.Cell>{item.value2}</Table.Cell>
+                <Table.Cell>{item.value3}</Table.Cell>
+                <Table.Cell>{item.value4}</Table.Cell>
+                <Table.Cell>{item.value5}</Table.Cell>
+              </Table.Row>
+            );
+          })}
+        </Table.Body>
+      </>
+    ),
+  },
+};
+
+/**
  * This implementation example shows how one might implement sort. Sort can be implemented to work based
  * on the current content (if the full table is already rendered), or using request results from the server
  * if the table needs to contain any additional logic to sort (e.g., sorting needs to fetch different search

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -79,7 +79,7 @@ type TableHeaderCellProps = React.HTMLAttributes<HTMLTableCellElement> & {
   /**
    * Child node(s) that can be nested inside component
    */
-  children?: string;
+  children?: ReactNode;
   /**
    * CSS class names that can be appended to the component.
    */
@@ -253,9 +253,7 @@ const TableHeaderCell = ({
               rank="tertiary"
               size="sm"
               title={iconTitle}
-            >
-              {children}
-            </Button>
+            ></Button>
           </>
         ) : (
           children

--- a/src/components/Table/__snapshots__/Table.test.ts.snap
+++ b/src/components/Table/__snapshots__/Table.test.ts.snap
@@ -736,3 +736,192 @@ exports[`<Table /> TableWithCaption story renders snapshot 1`] = `
   </tbody>
 </table>
 `;
+
+exports[`<Table /> TableWithStyledHeader story renders snapshot 1`] = `
+<table
+  class="table"
+>
+  <caption>
+    Optional caption for the table. Must be first descendant of Table if used.
+  </caption>
+  <thead>
+    <tr
+      class="table-row table-row--header"
+    >
+      <th
+        class="table-header-cell"
+      >
+        <div
+          class="table-header-cell__container"
+        >
+          <em>
+            Name
+          </em>
+        </div>
+      </th>
+      <th
+        class="table-header-cell"
+      >
+        <div
+          class="table-header-cell__container"
+        >
+          <em>
+            Status
+          </em>
+        </div>
+      </th>
+      <th
+        class="table-header-cell"
+      >
+        <div
+          class="table-header-cell__container"
+        >
+          <em>
+            Chart
+          </em>
+        </div>
+      </th>
+      <th
+        class="table-header-cell"
+      >
+        <div
+          class="table-header-cell__container"
+        >
+          <em>
+            Window
+          </em>
+        </div>
+      </th>
+      <th
+        class="table-header-cell"
+      >
+        <div
+          class="table-header-cell__container"
+        >
+          <em>
+            Last Update
+          </em>
+        </div>
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr
+      class="table-row"
+    >
+      <td
+        class="table-cell"
+      >
+        Table Row 1, Table Cell 1
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 1, Table Cell 2
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 1, Table Cell 3
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 1, Table Cell 4
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 1, Table Cell 5
+      </td>
+    </tr>
+    <tr
+      class="table-row"
+    >
+      <td
+        class="table-cell"
+      >
+        Table Row 2, Table Cell 1
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 2, Table Cell 2
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 2, Table Cell 3
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 2, Table Cell 4
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 2, Table Cell 5
+      </td>
+    </tr>
+    <tr
+      class="table-row"
+    >
+      <td
+        class="table-cell"
+      >
+        Table Row 3, Table Cell 1
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 3, Table Cell 2
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 3, Table Cell 3
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 3, Table Cell 4
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 3, Table Cell 5
+      </td>
+    </tr>
+    <tr
+      class="table-row"
+    >
+      <td
+        class="table-cell"
+      >
+        Table Row 4, Table Cell 1
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 4, Table Cell 2
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 4, Table Cell 3
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 4, Table Cell 4
+      </td>
+      <td
+        class="table-cell"
+      >
+        Table Row 4, Table Cell 5
+      </td>
+    </tr>
+  </tbody>
+</table>
+`;


### PR DESCRIPTION
### Test Plan:

Expand type usages that are allowed in `.HeaderCell` instances. This will allow for some flexibility needed.

- [x] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [ ] Manually tested my changes, and here are the details:
