### PR TITLE
chore: update github config

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,9 @@
 ### Test Plan:
 
 <!--
-  How did you validate that your changes were implemented correctly?
+  How did you validate that your changes were implemented correctly? If manually test, how?
 -->
 
-- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
+- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
 - [ ] CI tests / new tests are not applicable
-- [ ] Manually tested my changes, but I want to keep the details secret
-- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
 - [ ] Manually tested my changes, and here are the details:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref != 'refs/head/main'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push' && github.ref != 'refs/head/main'
+        if: github.event_name == 'push' && github.ref == 'refs/head/main'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push' && github.ref == 'refs/head/main'
+        if: github.event_name == 'push' && github.ref != 'refs/head/main'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"


### PR DESCRIPTION
When doing a release, the commits have already been pre-validated, and the current check will sometimes look back thru old commits which 1-2 have longer titles/text than the lint check allows, yielding failed builds on `main`.

Only run checks for release that can involve actual build-breaking checks by running on any branch but `main`.

Also update the commit template to be more concise

- simplify commit template
- don't do commitlint checks when merging into main


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly?
-->

- [ ] Wrote [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, but I want to keep the details secret
- [ ] Created and used an [alpha publish](https://github.com/chanzuckerberg/edu-design-system/blob/main/docs/PUBLISHING.md#alpha-release)
- [x] Manually tested my changes, and here are the details:
  - added change to build config to see if the commit lint would be skipped