### PR TITLE
fix(Button): update button padding to match design

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -66,7 +66,7 @@
 .button--lg {
   align-items: center;
 
-  padding: calc(var(--eds-size-1) / 16 * 1rem) 1.25rem;
+  padding: calc(var(--eds-size-1) / 16 * 1rem) calc(var(--eds-size-2-and-half) / 16 * 1rem);
   font: var(--eds-theme-typography-button-lg);
 
   min-width:calc(var(--eds-size-9) / 16 * 1rem);
@@ -86,11 +86,11 @@
 }
 
 .button--sm {
-  padding: calc(var(--eds-size-half) / 16 * 1rem) 1.33333333rem;
+  padding: calc(var(--eds-size-half) / 16 * 1rem) calc(var(--eds-size-1-and-half) / 16 * 1rem);
   font: var(--eds-theme-typography-button-sm);
 
   min-width: calc(var(--eds-size-6) / 16 * 1rem);
-  max-width: calc(var(--eds-size-24) / 16 * 1rem);;
+  max-width: calc(var(--eds-size-24) / 16 * 1rem);
   max-height: calc(var(--eds-size-3) / 16 * 1rem);
 }
 


### PR DESCRIPTION
Update the padding for `Button`, fixing some glitches in the layout.

<img width="1017" alt="Screenshot 2024-08-02 at 17 12 46" src="https://github.com/user-attachments/assets/8e778ccd-b384-49ea-b9a4-f584cc487af9">
<img width="342" alt="Screenshot 2024-08-02 at 17 13 12" src="https://github.com/user-attachments/assets/3c69f450-9061-4392-aae4-34f9e9b78263">


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
