### PR TITLE
fix(Menu): remove style overrides to Menu.Button

### DIFF
--- a/src/components/Menu/Menu.module.css
+++ b/src/components/Menu/Menu.module.css
@@ -11,19 +11,6 @@
   position: relative;
 }
 
-.menu__button {
-  font: var(--eds-theme-typography-body-md);
-
-  color: var(--eds-theme-color-text-neutral-subtle);
-  background-color: var(--eds-theme-color-form-background);
-  border-color: var(--eds-theme-color-form-border);
-  font-weight: var(--eds-font-weight-light);
-}
-
-.menu__button--with-chevron {
-  color: var(--eds-theme-color-icon-neutral-default);
-}
-
 .menu__item {
   display: block;
   text-decoration: none;


### PR DESCRIPTION
- remove style overrides left from 1.0 component
- update snapshots and re-run tests

Before:
<img width="324" alt="Screenshot 2024-08-07 at 10 01 48" src="https://github.com/user-attachments/assets/8de7c0f2-153f-4e12-9d96-17e9fb0e431c">

After:
<img width="308" alt="Screenshot 2024-08-07 at 10 01 32" src="https://github.com/user-attachments/assets/bfa23561-f22d-45be-9512-a10c8699d072">

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
