### PR TITLE
fix(Checkbox): specify a font size for the checked glyph

### DIFF
--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -25,8 +25,7 @@
   place-content: center;
 
   border-radius: calc(var(--eds-theme-border-radius-objects-sm) * 1px);
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  
+  font: var(--eds-theme-typography-body-md);
 }
 
 .checkbox__input:checked::before {
@@ -38,6 +37,9 @@
   one. In other words, the height/width here need to match the expected viewbox for the path. */
   height: calc(var(--eds-size-3) / 16 * 1rem);
   width: calc(var(--eds-size-3) / 16 * 1rem);
+
+  /* use the platform's font face, which defines the checkbox glyph to use */
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
 
 .checkbox__input:checked {

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -27,6 +27,9 @@ export const WithSublabel: Story = {
   args: { subLabel: 'Additional descriptive text' },
 };
 
+/**
+ * Checkboxes can have an error state
+ */
 export const Error: Story = {
   args: {
     isError: true,
@@ -34,6 +37,9 @@ export const Error: Story = {
   },
 };
 
+/**
+ * Checkboxes can, of course, can be checked
+ */
 export const Checked: Story = {
   ...Default,
   args: {
@@ -41,6 +47,20 @@ export const Checked: Story = {
   },
 };
 
+/**
+ * The checkbox glyph is not affected by any wrapping of font resizing
+ */
+export const GlyphIsConsistent: Story = {
+  ...Default,
+  args: {
+    defaultChecked: true,
+  },
+  decorators: [(Story) => <div style={{ fontSize: '10px' }}>{Story()}</div>],
+};
+
+/**
+ * Checkboxes can be in an indeterminate state, marking a partially checked state
+ */
 export const Indeterminate: Story = {
   args: {
     indeterminate: true,

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -66,28 +66,6 @@ exports[`<Checkbox /> Disabled story renders snapshot 1`] = `
       <input
         class="checkbox__input"
         disabled=""
-        id=":r5:"
-        type="checkbox"
-      />
-      <div
-        class="checkbox__labels"
-      >
-        <label
-          aria-disabled="true"
-          class="label label--lg label--disabled"
-          for=":r5:"
-        >
-          Disabled
-        </label>
-      </div>
-    </div>
-    <div
-      class="checkbox"
-    >
-      <input
-        checked=""
-        class="checkbox__input"
-        disabled=""
         id=":r6:"
         type="checkbox"
       />
@@ -107,6 +85,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 1`] = `
       class="checkbox"
     >
       <input
+        checked=""
         class="checkbox__input"
         disabled=""
         id=":r7:"
@@ -124,6 +103,27 @@ exports[`<Checkbox /> Disabled story renders snapshot 1`] = `
         </label>
       </div>
     </div>
+    <div
+      class="checkbox"
+    >
+      <input
+        class="checkbox__input"
+        disabled=""
+        id=":r8:"
+        type="checkbox"
+      />
+      <div
+        class="checkbox__labels"
+      >
+        <label
+          aria-disabled="true"
+          class="label label--lg label--disabled"
+          for=":r8:"
+        >
+          Disabled
+        </label>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -135,7 +135,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 2`] = `
   <input
     class="checkbox__input"
     disabled=""
-    id=":ra:"
+    id=":rb:"
     type="checkbox"
   />
   <div
@@ -144,7 +144,7 @@ exports[`<Checkbox /> Disabled story renders snapshot 2`] = `
     <label
       aria-disabled="true"
       class="label label--lg label--disabled"
-      for=":ra:"
+      for=":rb:"
     >
       Disabled
     </label>
@@ -178,6 +178,37 @@ exports[`<Checkbox /> Error story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Checkbox /> GlyphIsConsistent story renders snapshot 1`] = `
+<div
+  class="p-8"
+>
+  <div
+    style="font-size: 10px;"
+  >
+    <div
+      class="checkbox"
+    >
+      <input
+        checked=""
+        class="checkbox__input"
+        id=":r4:"
+        type="checkbox"
+      />
+      <div
+        class="checkbox__labels"
+      >
+        <label
+          class="label label--lg"
+          for=":r4:"
+        >
+          Checkbox
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Checkbox /> Indeterminate story renders snapshot 1`] = `
 <div
   class="p-8"
@@ -187,7 +218,7 @@ exports[`<Checkbox /> Indeterminate story renders snapshot 1`] = `
   >
     <input
       class="checkbox__input"
-      id=":r4:"
+      id=":r5:"
       type="checkbox"
     />
     <div
@@ -195,7 +226,7 @@ exports[`<Checkbox /> Indeterminate story renders snapshot 1`] = `
     >
       <label
         class="label label--lg"
-        for=":r4:"
+        for=":r5:"
       >
         Checkbox
       </label>
@@ -213,7 +244,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
   >
     <input
       class="checkbox__input"
-      id=":r9:"
+      id=":ra:"
       type="checkbox"
     />
     <div
@@ -221,7 +252,7 @@ exports[`<Checkbox /> LongLabels story renders snapshot 1`] = `
     >
       <label
         class="label label--lg"
-        for=":r9:"
+        for=":ra:"
       >
         Lorem ipsum dolor sit amet, consectetur adipiscing elit
       </label>
@@ -271,7 +302,7 @@ exports[`<Checkbox /> WithoutVisibleLabel story renders snapshot 1`] = `
     <input
       aria-label="a checkbox has no name"
       class="checkbox__input"
-      id=":r8:"
+      id=":r9:"
       type="checkbox"
     />
     <div


### PR DESCRIPTION
Specify a font-size for the glyph in the checkbox so that wrapping adjacent text doesn't change the size of the glyph when `:checked`

### Test Plan:

Before:
<img width="170" alt="Screenshot 2024-08-08 at 17 16 24" src="https://github.com/user-attachments/assets/e1b9392c-fd5e-49c4-ac7e-4600a0754b69">

After:
<img width="149" alt="Screenshot 2024-08-08 at 17 16 29" src="https://github.com/user-attachments/assets/69847711-f7ec-4dbd-bbde-3ca59ec1721d">


<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
