### PR TITLE
fix(Popover): update component version number

### DIFF
--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['intro-1.0', 'current-2.0'],
     chromatic: {
       // These stories are very flaky, though we're not sure why.
       // We tried delaying the snapshot just in case there's a timing issue at play here, which was not successful.


### PR DESCRIPTION
Just update the component version number used in the storybook config, which should have happened in #2031 

### Test Plan:

- n/a (documentation-only change)