### PR TITLE
chore: fix ref name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push' && github.ref != 'refs/head/main'
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push' && github.ref != 'refs/heads/aholloway/x-update-commitlint-validation'
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # This workflow can also be triggered via "workflow_call".
         # Since it's a push event we have access to these properties https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
         # Filtering on just the (required) .id https://docs.github.com/en/actions/learn-github-actions/expressions#object-filters
-        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref != 'refs/heads/aholloway/x-update-commitlint-validation'
         run: |
           COMMIT_COUNT=$(echo '${{ toJSON(github.event.commits.*.id) }}' | jq length)
           echo "Number of commits in the push: $COMMIT_COUNT"


### PR DESCRIPTION
Looks like we had a typo in the config for the commitlint job. [According to this](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context), `github.ref` uses the full path, which takes the form like `refs/heads/X`, and we were missing the `s`

So, why do we want this extra line anyway, and not check `main`?

* the list of commits used in the action corresponds to what's in the release branch
* in the case of a release, the count corresponds to the commits in that branch, but then indexes that count on commits on `main`
* it looks back on `main` and will run the check on every commit to the previous merge commits, so it can be hundreds of commits being re-linted (and will fail sporadically b/c a very old commit had bad formatting)
* also, the commits will have already been linted before release :)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - [x] make sure it runs on this branch
  - [x] make sure it does NOT run if the branch name in the action is set to the PR branch name (e.g., `refs/heads/aholloway/x-update-commitlint-validation`