### PR TITLE
feat: re-export HeadlessUI's Transition component

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,3 +65,9 @@ export type { AppNotificationProps } from './components/AppNotification';
 // TODO(next-major): Remove the below types at the next major release
 export type { PageNotificationProps as PageNotificationV2Props } from './components/PageNotification';
 export type { AppNotificationProps as AppNotificationV2Props } from './components/AppNotification';
+
+/**
+ * Utilities re-exported from dependent libraries
+ */
+// https://headlessui.com/v1/react/transition
+export { Transition } from '@headlessui/react';


### PR DESCRIPTION
Provide the transition component from HeadlessUI to consumers, since there is no bound UI or design for this helper component, and would otherwise take time to implement separately.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
