### PR TITLE
docs: add clarifying back-merge instruction

### DIFF
--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -99,7 +99,8 @@ The latter will automatically post to [relevant slack channels](https://slack.gi
 #### Finishing the release
 
 11. Lastly, run the following to "back merge" release changes to `next`:
-    - `git checkout main && git pull origin main && git checkout next && git merge main && git push`
+
+```git checkout main && git pull origin main && git checkout next && git pull && git merge main && git push```
 
 #### Alpha release
 


### PR DESCRIPTION
Adding a `git pull` to grab the latest on `next` before attempting to back-merge, so that the push isn't rejected unnecessarily. Makes collaboration a little smoother :)

Without that, if any PRs land on `next` before a release is completed, it can cause some merge noise and a little off-script actions that can leave the repository in an ambiguous state.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
