### PR TITLE
fix(Select): pull z-index of select options to top

### DIFF
--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -32,7 +32,7 @@
  */
 .select__options {
   max-height: 25vh;
-  z-index: 100;
+  z-index: var(--eds-z-index-top);
 }
 
 .select--label-layout-vertical {


### PR DESCRIPTION
Give the select field the highest token value for z-index so that it will appear above modal containers (both portal to the top edge of the DOM, so z-index and sequencing can cause `Select.Options` to appear beneath the modal container). Modals currently use z-index of 1050 and are set manually to that level, so this will go above that.

No stacking context changes are needed.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
