### PR TITLE
chore: update component version metadata

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -25,35 +25,35 @@ export const decorators = [
   ),
 ];
 
-function createInitialReleaseConfig(usingLabel: string) {
+function createComponentVersion(usingLabel: string) {
   return {
-    [`intro-${usingLabel}`]: {
+    [`api-${usingLabel}`]: {
       styles: {
         backgroundColor: '#ffffff',
         borderColor: '#000000',
         color: '#000000',
       },
-      title: `Introduced: ${usingLabel}`,
+      title: `Component API Version: ${usingLabel}`,
       tooltip: {
-        title: `Introduced in v${usingLabel}`,
-        desc: `This component was introduced in EDS Design version ${usingLabel}`,
+        title: `Code / API v${usingLabel}`,
+        desc: `This component's API version is at ${usingLabel}`,
       },
     },
   };
 }
 
-function createCurrentReleaseConfig(usingLabel: string) {
+function createThemeVersion(usingLabel: string) {
   return {
-    [`current-${usingLabel}`]: {
+    [`theme-${usingLabel}`]: {
       styles: {
         backgroundColor: '#ffffff',
         borderColor: '#000000',
         color: '#000000',
       },
-      title: `Current: ${usingLabel}`,
+      title: `Theme Version: ${usingLabel}`,
       tooltip: {
-        title: `Current version v${usingLabel}`,
-        desc: `This component corresponds to EDS Design version ${usingLabel}`,
+        title: `Current Theme version v${usingLabel}`,
+        desc: `This component's theme corresponds to Edu Design System Version is at ${usingLabel}`,
       },
     },
   };
@@ -79,15 +79,13 @@ export const parameters: Preview['parameters'] = {
     ],
   },
   badgesConfig: {
-    ...createInitialReleaseConfig('2.0'),
-    ...createInitialReleaseConfig('1.3'),
-    ...createInitialReleaseConfig('1.2'),
-    ...createInitialReleaseConfig('1.1'),
-    ...createInitialReleaseConfig('1.0'),
-    ...createCurrentReleaseConfig('1.0'),
-    ...createCurrentReleaseConfig('1.3'),
-    ...createCurrentReleaseConfig('2.0'),
-    ...createCurrentReleaseConfig('2.1'),
+    ...createComponentVersion('2.0'),
+    ...createComponentVersion('1.3'),
+    ...createComponentVersion('1.2'),
+    ...createComponentVersion('1.1'),
+    ...createComponentVersion('1.0'),
+    ...createThemeVersion('1.0'),
+    ...createThemeVersion('2.0'),
     implementationExample: {
       styles: {
         backgroundColor: '#ffffff',

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -12,7 +12,7 @@ export default {
   // TODO: add subcomponents like Badge has
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     controls: { sort: 'requiredFirst' },
   },
   args: {

--- a/src/components/AppNotification/AppNotification.stories.tsx
+++ b/src/components/AppNotification/AppNotification.stories.tsx
@@ -14,7 +14,7 @@ export default {
   component: AppNotification,
   parameters: {
     layout: 'centered',
-    badges: ['intro-2.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     title: 'This is an AppNotification title',

--- a/src/components/Avatar/Avatar.stories.ts
+++ b/src/components/Avatar/Avatar.stories.ts
@@ -5,7 +5,7 @@ export default {
   title: 'Components/Avatar',
   component: Avatar,
   parameters: {
-    badges: ['intro-1.3', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
     layout: 'centered',
   },
 } as Meta<typeof Avatar>;

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   argTypes: {
     children: {

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -21,7 +21,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   argTypes: {
     children: {

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -21,7 +21,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<ButtonProps>;
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -24,7 +24,7 @@ export default {
     },
   },
   parameters: {
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
 } as Meta<typeof ButtonGroup>;

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -14,7 +14,7 @@ export default {
   component: Card,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
   args: {
@@ -378,7 +378,7 @@ export const WhileDragging: Story = {
  */
 export const CancelMembership: Story = {
   parameters: {
-    badges: ['intro-1.0', 'current-2.0', 'implementationExample'],
+    badges: ['api-1.0', 'theme-2.0', 'implementationExample'],
   },
   args: {
     children: (

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Checkbox> = {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 
   decorators: [(Story) => <div className="p-8">{Story()}</div>],

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -32,7 +32,7 @@ export default {
     'DataTable.DataCell': DataTableDataCell,
   },
   parameters: {
-    badges: [BADGE.BETA, 'intro-1.0', 'current-1.0'],
+    badges: [BADGE.BETA, 'api-1.0', 'theme-2.0'],
     chromatic: {
       viewports: [
         chromaticViewports.ipadMini,

--- a/src/components/FieldLabel/FieldLabel.stories.ts
+++ b/src/components/FieldLabel/FieldLabel.stories.ts
@@ -10,7 +10,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-2.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<typeof FieldLabel>;
 

--- a/src/components/FieldNote/FieldNote.stories.tsx
+++ b/src/components/FieldNote/FieldNote.stories.tsx
@@ -10,7 +10,7 @@ export default {
   component: FieldNote,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<typeof FieldNote>;
 

--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: Fieldset,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   // TODO: fix up the sub-component documentation for Fieldset.Legend
   subcomponents: {
@@ -122,7 +122,7 @@ export const FieldsetLegendWithSubtitle: StoryObj<LegendArgs> = {
  * ```
  */
 export const WithCheckboxes: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     children: (
@@ -157,7 +157,7 @@ export const WithCheckboxes: StoryObj<Args> = {
 };
 
 export const WithDisabledCheckboxes: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     isDisabled: true,
@@ -166,7 +166,7 @@ export const WithDisabledCheckboxes: StoryObj<Args> = {
 };
 
 export const WithErrorCheckboxes: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     status: 'critical',
@@ -175,7 +175,7 @@ export const WithErrorCheckboxes: StoryObj<Args> = {
 };
 
 export const WithRadioButton: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     children: (
@@ -210,7 +210,7 @@ export const WithRadioButton: StoryObj<Args> = {
 };
 
 export const WithDisabledRadioButton: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     isDisabled: true,
@@ -219,7 +219,7 @@ export const WithDisabledRadioButton: StoryObj<Args> = {
 };
 
 export const WithErrorRadioButton: StoryObj<Args> = {
-  parameters: { badges: ['intro-1.3', 'current-2.0', 'implementationExample'] },
+  parameters: { badges: ['api-1.3', 'theme-2.0', 'implementationExample'] },
   args: {
     fieldNote: 'Attached field note to field set',
     status: 'critical',

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: Heading,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
+++ b/src/components/HorizontalStepper/HorizontalStepper.stories.tsx
@@ -14,7 +14,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
 
   decorators: [(Story) => <div className="m-4">{Story()}</div>],

--- a/src/components/Hr/Hr.stories.ts
+++ b/src/components/Hr/Hr.stories.ts
@@ -7,7 +7,7 @@ export default {
   component: Hr,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   args: {
     className: 'w-96',

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof Icon> = {
   component: Icon,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   argTypes: {
     name: {

--- a/src/components/InlineNotification/InlineNotification.stories.tsx
+++ b/src/components/InlineNotification/InlineNotification.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: InlineNotification,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     title: 'Inline notifications lorem ipsum text',

--- a/src/components/InputChip/InputChip.stories.ts
+++ b/src/components/InputChip/InputChip.stories.ts
@@ -7,7 +7,7 @@ export default {
   title: 'Components/InputChip',
   component: InputChip,
   parameters: {
-    badges: ['intro-1.0', 'current-1.0'],
+    badges: ['api-1.0', 'theme-2.0'],
   },
   argTypes: {
     onClick: {

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof InputField> = {
   component: InputField,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',
     },
@@ -345,7 +345,7 @@ export const WithBothMaxAndRecommendedLength: Story = {
  */
 export const TabularInput: Story = {
   parameters: {
-    badges: ['intro-1.1', 'implementationExample'],
+    badges: ['api-2.0', 'implementationExample'],
   },
   render: (args) => (
     <Table>

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: Label,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: Link,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     children: 'Link',

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.ts
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.ts
@@ -8,7 +8,7 @@ export default {
   component: LoadingIndicator,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -16,7 +16,7 @@ export default {
   component: Menu,
   // TODO: Add sub-components section
   parameters: {
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     layout: 'centered',
   },
   argTypes: {
@@ -224,7 +224,7 @@ export const WithCustomSecondaryButton: Story = {
  */
 export const MenuWithAvatarButton: Story = {
   parameters: {
-    badges: ['intro-1.3', 'implementationExample'],
+    badges: ['api-2.0', 'implementationExample'],
   },
   args: {
     children: (
@@ -289,7 +289,7 @@ export const MenuWithIconButton: StoryObj<MenuProps & { iconName: IconName }> =
       iconName: 'dots-vertical',
     },
     parameters: {
-      badges: ['intro-1.2', 'implementationExample'],
+      badges: ['api-2.0', 'implementationExample'],
     },
     render: ({ iconName }) => (
       <Menu>

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -15,7 +15,7 @@ export default {
     // The modal is initially closed for most of these stories,
     // which renders testing it for visual regressions unhelpful.
     chromatic: { disableSnapshot: true },
-    badges: ['intro-1.0', 'current-2.1'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   tags: ['autodocs'],
   decorators: [(Story) => <div className="p-8">{Story()}</div>],

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: NumberIcon,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     'aria-label': 'number icon example',
@@ -111,7 +111,7 @@ export const DifferentNumbers: Story = {
  */
 export const NumberIconList: Story = {
   parameters: {
-    badges: ['intro-1.0', 'current-2.0', 'implementationExample'],
+    badges: ['api-1.0', 'theme-2.0', 'implementationExample'],
   },
   render: () => (
     <div className="flex flex-wrap gap-1">

--- a/src/components/PageNotification/PageNotification.stories.tsx
+++ b/src/components/PageNotification/PageNotification.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: PageNotification,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     title: 'Alert title which communicates info to the user',

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: Popover,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     chromatic: {
       // These stories are very flaky, though we're not sure why.
       // We tried delaying the snapshot just in case there's a timing issue at play here, which was not successful.

--- a/src/components/PopoverContainer/PopoverContainer.stories.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: PopoverContainer,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   argTypes: {
     children: {

--- a/src/components/PopoverListItem/PopoverListItem.stories.ts
+++ b/src/components/PopoverListItem/PopoverListItem.stories.ts
@@ -6,7 +6,7 @@ export default {
   component: PopoverListItem,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',
     },

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: Radio,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
 } as Meta<Args>;

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -9,7 +9,7 @@ export default {
   component: SearchBar,
   parameters: {
     layout: 'centered',
-    badges: [BADGE.NEEDS_REVISION, 'intro-1.1', 'current-1.3'],
+    badges: [BADGE.NEEDS_REVISION, 'api-1.3', 'theme-2.0'],
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',
     },

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Select> = {
   component: Select,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   argTypes: {
     multiple: {
@@ -700,7 +700,7 @@ export const LongOptionList: StoryObj = {
     await expect(selectButton.getAttribute('aria-expanded')).toEqual('true');
   },
   parameters: {
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     layout: 'centered',
     chromatic: { delay: 450 },
     docs: {
@@ -907,7 +907,7 @@ export const OptionsRightAligned: StoryObj = {
 export const OpenByDefault: StoryObj = {
   ...Default,
   parameters: {
-    badges: ['intro-1.2', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     layout: 'centered',
     chromatic: { delay: 300, disableSnapshot: true },
     docs: {

--- a/src/components/SelectionChip/SelectionChip.stories.ts
+++ b/src/components/SelectionChip/SelectionChip.stories.ts
@@ -7,7 +7,7 @@ export default {
   title: 'Components/SelectionChip',
   component: SelectionChip,
   parameters: {
-    badges: ['intro-1.0', 'current-1.0'],
+    badges: ['api-1.0', 'theme-2.0'],
   },
 } as Meta<Args>;
 

--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Skeleton',
   component: Skeleton,
   parameters: {
-    badges: ['intro-1.2', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
     layout: 'centered',
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Slider> = {
   component: Slider,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.3', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   args: {
     className: 'w-96',
@@ -154,7 +154,7 @@ const moodData = [
 
 export const UsingInputDisplay: Story = {
   parameters: {
-    badges: ['intro-1.3', 'implementationExample'],
+    badges: ['api-1.3', 'implementationExample'],
     axe: {
       disabledRules: ['color-contrast'], // adding for disabled field example
     },
@@ -188,7 +188,7 @@ export const UsingInputDisplay: Story = {
 
 export const UsingControlButtons: Story = {
   parameters: {
-    badges: ['intro-1.3', 'current-1.3', 'implementationExample'],
+    badges: ['api-1.3', 'current-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 1, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -231,7 +231,7 @@ export const UsingControlButtons: Story = {
 
 export const WithHighlightedContent: Story = {
   parameters: {
-    badges: ['intro-1.3', 'implementationExample'],
+    badges: ['api-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -282,7 +282,7 @@ export const WithHighlightedContent: Story = {
 
 export const WithVisualLabel: Story = {
   parameters: {
-    badges: ['intro-1.3', 'implementationExample'],
+    badges: ['api-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -324,7 +324,7 @@ export const WithVisualLabel: Story = {
 
 export const WithMultipleVisualLabels: Story = {
   parameters: {
-    badges: ['intro-1.3', 'implementationExample'],
+    badges: ['api-1.3', 'implementationExample'],
   },
   render: ({ min = 0, max = 100, step = 25, value = 50, ...rest }) => {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/src/components/TabGroup/TabGroup.stories.tsx
+++ b/src/components/TabGroup/TabGroup.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: TabGroup,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     children: (

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -11,7 +11,7 @@ export default {
   component: Table,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.1', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   argTypes: {
     children: {
@@ -296,7 +296,7 @@ export const SortableInteractive: Story = {
 export const StackedCardsExample: Story = {
   parameters: {
     layout: 'padded',
-    badges: ['intro-1.1', 'implementationExample'],
+    badges: ['api-1.3', 'implementationExample'],
     chromatic: {
       viewports: [
         chromaticViewports.googlePixel2,

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -7,7 +7,7 @@ export default {
   component: Tag,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   args: {
     label: 'Tag text',

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -8,7 +8,7 @@ export default {
   component: Text,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-1.3', 'theme-2.0'],
   },
   argTypes: {
     children: {

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -19,7 +19,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.`,
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.3', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   decorators: [(Story) => <div className="p-8">{Story()}</div>],
 };

--- a/src/components/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/ToastNotification/ToastNotification.stories.tsx
@@ -13,7 +13,7 @@ export default {
   component: ToastNotification,
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
   },
   argTypes: {
     onDismiss: { action: 'trigger dismiss' },

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof Toggle> = {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-1.3'],
+    badges: ['api-1.3', 'theme-1.0'],
   },
   render: (args) => <InteractiveToggle {...args} />,
 };

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -42,7 +42,7 @@ export default {
   },
   parameters: {
     layout: 'centered',
-    badges: ['intro-1.0', 'current-2.0'],
+    badges: ['api-2.0', 'theme-2.0'],
     chromatic: {
       delay: 750,
       diffThreshold,


### PR DESCRIPTION
The previous version markers were mixing two ideas together, so the version numbers were ambiguous. 

Based on how design is defining the theme versions, we only have two 1.0 (SLP), and 2.0 (Render). This is mostly to normalize what versions show up for which components (there was no 1.3 theme version; that "1.3" was referring to the components API, hence the API version numbers still having the minors show up)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - validate against table api and theme versions per component (see storybook)