### PR TITLE
feat(scripts): allow import script to pull using Figma API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ storybook-components
 .env.production.local
 .cache
 .idea
+.edsrc.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/bin/_util.js
+++ b/bin/_util.js
@@ -1,3 +1,27 @@
+/* eslint-disable no-case-declarations */
+
+// TODO: Do not use directly. Extend this to support re-writing eds-import-from-figma for non-enterprise use cases
+class AbstractFigmaReader {
+  static TIER_1_MODE = '6181:0';
+  static EDS_COLLECTION_NAME = 'EDS tokens';
+
+  constructor(jsonData) {
+    this._jsonData = jsonData;
+  }
+
+  getModes(variableCollectionId) {
+    throw new Error('Cannot Use Abstract class directly');
+  }
+
+  getVariableCollections() {
+    throw new Error('Cannot Use Abstract class directly');
+  }
+
+  getVariablesByCollectionId(variableCollectionId) {
+    throw new Error('Cannot Use Abstract class directly');
+  }
+}
+
 module.exports = {
   /**
    * Fetch the EDS config from the project using the lilconfig hierarchy.
@@ -148,6 +172,8 @@ module.exports = {
    * the existing local theme. If there's a path in the local theme file, we can write there (using lodash/set
    * or similar).
    *
+   * TODO(next-major): remove this function
+   *
    * @param {object} localTheme JSON file loaded, representing the data for the local theme
    * @param {string} collectionName Name of the exported collection
    * @param {string} variableName current variable name from figma (e.g., color/text/neutral/default)
@@ -197,6 +223,8 @@ module.exports = {
    * Data Types:
    * - Type COLOR: https://www.figma.com/plugin-docs/api/RGB/
    *
+   * TODO(next-major): remove this function
+   *
    * @param {string} type Figma type for the token value (Set:)
    * @param {object} figmaResolvedValue
    * @returns {string} value using the type
@@ -232,6 +260,8 @@ module.exports = {
    * a prefix to the token name that corresponds to the prefix used for those
    * tokens.
    *
+   * TODO(next-major): remove this function
+   *
    * @param {string} collectionName The key to write to
    * @returns {string|null} a text prefix for where to write the token value or null when no prefix is found
    */
@@ -247,10 +277,200 @@ module.exports = {
   },
   /**
    * Conversion of the figma token name (e.g., some/path/to/token) to the equivalent path in a JSON object
+   *
+   * TODO(next-major): remove this function
+   *
    * @param {string} figmaTokenName The name from the figma variables panel (slash separated)
    * @returns {string} a lodash-compatible string representing the path to the token value in JSON
    */
   tokenNameToPath: function (figmaTokenName) {
     return figmaTokenName.replaceAll('/', '.').toLowerCase();
+  },
+
+  // https://www.figma.com/developers/api#get-published-variables-endpoint
+  FigmaAPIReader: class extends AbstractFigmaReader {
+    constructor(jsonData) {
+      super(jsonData.meta);
+    }
+
+    /**
+     * Get the modes associated with a specific figma collection
+     *
+     * @param {string} variableCollectionId
+     * @returns Mode[]
+     */
+    getModes(variableCollectionId) {
+      return this._jsonData.variableCollections[variableCollectionId].modes;
+    }
+
+    /**
+     * Retrieve the defined variable collections from the specific figma file data
+     * @see https://www.figma.com/plugin-docs/api/VariableCollection/
+     *
+     * @returns VariableCollection[]
+     */
+    getVariableCollections() {
+      return Object.values(this._jsonData.variableCollections).map(
+        (collection) => {
+          return {
+            id: collection.id,
+            name: collection.name,
+          };
+        },
+      );
+    }
+
+    /**
+     * Retrieve the set of variables associated with a given collection (by ID)
+     * @see https://www.figma.com/plugin-docs/api/Variable/
+     *
+     * @param {string} variableCollectionId
+     * @returns Variable[]
+     */
+    getVariablesByCollectionId(variableCollectionId) {
+      return Object.values(this._jsonData.variables).filter((variable) => {
+        return variable.variableCollectionId === variableCollectionId;
+      });
+    }
+
+    //
+    // Delegation methods: variable lookup
+    //
+
+    /**
+     * Look up a specific variable in the object, by its ID
+     * @see https://www.figma.com/plugin-docs/api/Variable/
+     *
+     * @returns Variable
+     */
+    retrieveVariable(variableId) {
+      return Object.values(this._jsonData.variables).find((variable) => {
+        return variable.id === variableId;
+      });
+    }
+  },
+
+  FigmaVariable: class {
+    constructor(json, mode, lookupDelegate) {
+      // TODO: throw if any private members are invalid
+      this._figmaVariableData = json;
+      this._mode = mode;
+      this._lookupDelegate = lookupDelegate;
+    }
+
+    /**
+     * Retrieve the normalized path for the token name. This will prefix the token based on the token type
+     * @returns string
+     */
+    getTokenPath() {
+      switch (this._figmaVariableData.resolvedType) {
+        case 'COLOR':
+          /**
+           * - when an arrow is seen, pay attention to the type of the token being read, and prefix appropriately (color, etc. => eds.theme.color, etc.)
+           */
+          return this._tokenNameToPath(
+            this._figmaVariableData.name.replace('-> ', 'eds.theme.color.'),
+          );
+        case 'FLOAT':
+          return this._tokenNameToPath(
+            'eds.theme.' + this._figmaVariableData.name,
+          );
+      }
+      return this._figmaVariableData.name;
+    }
+
+    /**
+     * Recursively find the resolved value for a given token
+     * @param {Variable} figmaVariable
+     * @param {boolean} isLookup
+     * @returns ResolvedValue object or literal representation of the stored figma variable value
+     */
+    getResovledValue(
+      figmaVariable = this._figmaVariableData,
+      isLookup = false,
+    ) {
+      // TODO: this should not fall thru when mode is missing
+      if (figmaVariable.valuesByMode[this._mode]?.type === 'VARIABLE_ALIAS') {
+        // Look up value using delegate. Take whatever value is in there regardless of mode
+        const lookupValue = this._lookupDelegate.retrieveVariable(
+          figmaVariable.valuesByMode[this._mode].id,
+        );
+
+        return this.getResovledValue(lookupValue, true);
+      } else {
+        return isLookup
+          ? figmaVariable.valuesByMode[
+              module.exports.FigmaAPIReader.TIER_1_MODE
+            ]
+          : figmaVariable.valuesByMode[this._mode];
+      }
+    }
+
+    /**
+     * Conversion of the figma token name (e.g., some/path/to/token) to the equivalent path in a JSON object
+     * @param {string} figmaTokenName The name from the figma variables panel (slash separated)
+     * @returns {string} a lodash-compatible string representing the path to the token value in JSON
+     */
+    _tokenNameToPath(figmaTokenName) {
+      // TODO: include example formats and conversions (in test)
+      return (
+        figmaTokenName
+          // Figma separates out the token name parts using '/'. convert to dots for path naming
+          .replaceAll('/', '.')
+          // Tokens also use dashes to avoid complexity in the Figma variable UI. convert to dots for path naming
+          .replaceAll('-', '.')
+      );
+    }
+
+    /**
+     * Convert the figma variable value format into a CSS-/JSON-cross-compatible format (quoted string), based on the variable type
+     * @param {ResolvedValue} figmaResolvedValue
+     * @returns string
+     */
+    parseResolvedValue(figmaResolvedValue) {
+      const varType = this._figmaVariableData.resolvedType;
+
+      /**
+       * Data Types:
+       * - Type COLOR: https://www.figma.com/plugin-docs/api/RGB/
+       */
+      switch (varType) {
+        case 'COLOR':
+          const r = Math.floor(figmaResolvedValue.r * 255);
+          const g = Math.floor(figmaResolvedValue.g * 255);
+          const b = Math.floor(figmaResolvedValue.b * 255);
+          const a = figmaResolvedValue.a;
+
+          // if we have an alpha channel, use `rgba()`
+          if (figmaResolvedValue.a > 0 && figmaResolvedValue.a < 1) {
+            return `rgba(${r}, ${g}, ${b}, ${a})`;
+          } else {
+            // print hex instead when the value has no alpha channel
+            return (
+              '#' +
+              [r, g, b]
+                .map((x) => x.toString(16))
+                .map((x) => (x.length === 1 ? '0' + x : x))
+                .join('')
+                .toUpperCase()
+            );
+          }
+        case 'FLOAT':
+          // JSON only handles strings so convert here
+          return String(figmaResolvedValue);
+        default:
+          throw new TypeError('unknown resolved varType: ' + varType, {
+            details: figmaResolvedValue,
+          });
+      }
+    }
+
+    get name() {
+      return this._figmaVariableData.name;
+    }
+
+    get value() {
+      return this.parseResolvedValue(this.getResovledValue());
+    }
   },
 };

--- a/bin/_util.test.js
+++ b/bin/_util.test.js
@@ -319,4 +319,407 @@ describe('utils', function () {
       expect(test).toThrow(TypeError);
     });
   });
+
+  describe('Reader Classes', () => {
+    const mockData = {
+      status: 200,
+      error: false,
+      meta: {
+        variableCollections: {
+          'VariableCollectionId:6181:1797': {
+            defaultModeId: '6181:0',
+            id: 'VariableCollectionId:6181:1797',
+            name: 'Collection 1',
+            remote: false,
+            modes: [
+              {
+                modeId: '6181:0',
+                name: 'Value',
+              },
+            ],
+            key: '5f66df751f45114c0d64b702b03e9ae820293768',
+            hiddenFromPublishing: false,
+            variableIds: [
+              'VariableID:6195:914',
+              'VariableID:6195:915',
+              'VariableID:6348:6248',
+            ],
+          },
+          'VariableCollectionId:6348:1793': {
+            defaultModeId: '6348:0',
+            id: 'VariableCollectionId:6348:1793',
+            name: 'Collection 2',
+            remote: false,
+            modes: [
+              {
+                modeId: '6348:0',
+                name: 'mode 1',
+              },
+              {
+                modeId: '7493:1',
+                name: 'mode 2',
+              },
+            ],
+          },
+        },
+        variables: {
+          'VariableID:6348:6248': {
+            id: 'VariableID:6348:6248',
+            name: 'Render/Neutral/Neutral-050',
+            remote: false,
+            key: '176ccd26264f7e048ae441ac585726a51fa6a819',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': {
+                r: 0.9764705896377563,
+                g: 0.9529411792755127,
+                b: 0.9450980424880981,
+                a: 1,
+              },
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:6195:915': {
+            id: 'VariableID:6195:915',
+            name: 'Render/Neutral/Neutral-025',
+            remote: false,
+            key: 'f03c13f2140f268dbedf27db0ad78660913af483',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': {
+                r: 0.9921568632125854,
+                g: 0.9764705896377563,
+                b: 0.9725490212440491,
+                a: 1,
+              },
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:6195:914': {
+            id: 'VariableID:6195:914',
+            name: 'Render/Neutral/White',
+            remote: false,
+            key: 'b2ed72ac00bfa71fbe0c0039404b125f7f5193e2',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': {
+                r: 1,
+                g: 1,
+                b: 1,
+                a: 1,
+              },
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          'VariableID:6359:7717': {
+            id: 'VariableID:6359:7717',
+            name: '-> text/utility/inverse',
+            remote: false,
+            key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+            variableCollectionId: 'VariableCollectionId:6348:1793',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: false,
+            valuesByMode: {
+              '6348:0': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:6195:914',
+              },
+              '7493:1': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:7493:9283',
+              },
+            },
+            scopes: ['TEXT_FILL'],
+            codeSyntax: {},
+          },
+          'VariableID:6370:10670': {
+            id: 'VariableID:6370:10670',
+            name: 'Border-radius/none',
+            remote: false,
+            key: '9358566cd8a6bb06f32e7682d2e8326fccf18e05',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'FLOAT',
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': 0,
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+        },
+      },
+    };
+
+    describe('FigmaAPIReader', function () {
+      it('pulls defined modes from the retrieved JSON data', () => {
+        const reader = new utils.FigmaAPIReader(mockData);
+        const modes = reader.getModes('VariableCollectionId:6348:1793');
+        expect(modes[0].name).toEqual('mode 1');
+        expect(modes[1].name).toEqual('mode 2');
+      });
+
+      it('pulls collection data from the retrieved JSON data', () => {
+        const reader = new utils.FigmaAPIReader(mockData);
+        const testCollections = reader.getVariableCollections();
+        expect(testCollections[0].name).toEqual('Collection 1');
+        expect(testCollections[1].name).toEqual('Collection 2');
+      });
+
+      it('gets variables by a given collection ID', () => {
+        const reader = new utils.FigmaAPIReader(mockData);
+        expect(
+          reader.getVariablesByCollectionId(
+            'VariableCollectionId:6348:1793',
+          )[0],
+        ).toEqual({
+          id: 'VariableID:6359:7717',
+          name: '-> text/utility/inverse',
+          remote: false,
+          key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+          variableCollectionId: 'VariableCollectionId:6348:1793',
+          resolvedType: 'COLOR',
+          description: '',
+          hiddenFromPublishing: false,
+          valuesByMode: {
+            '6348:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:6195:914',
+            },
+            '7493:1': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:7493:9283',
+            },
+          },
+          scopes: ['TEXT_FILL'],
+          codeSyntax: {},
+        });
+
+        expect(
+          reader.getVariablesByCollectionId('VariableCollectionId:6348:1793'),
+        ).toHaveLength(1);
+      });
+
+      it('allows retrieval of arbitrary variables in the retrieved JSON data', () => {
+        const reader = new utils.FigmaAPIReader(mockData);
+
+        expect(reader.retrieveVariable('VariableID:6359:7717')).toEqual({
+          id: 'VariableID:6359:7717',
+          name: '-> text/utility/inverse',
+          remote: false,
+          key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+          variableCollectionId: 'VariableCollectionId:6348:1793',
+          resolvedType: 'COLOR',
+          description: '',
+          hiddenFromPublishing: false,
+          valuesByMode: {
+            '6348:0': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:6195:914',
+            },
+            '7493:1': {
+              type: 'VARIABLE_ALIAS',
+              id: 'VariableID:7493:9283',
+            },
+          },
+          scopes: ['TEXT_FILL'],
+          codeSyntax: {},
+        });
+
+        expect(reader.retrieveVariable('VariableID:6359:7717_FAKE')).toEqual(
+          undefined,
+        );
+      });
+    });
+
+    describe('FigmaVariable', function () {
+      it('allows retrieval of token path from a variable', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6359:7717',
+            name: '-> text/utility/inverse',
+            remote: false,
+            key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+            variableCollectionId: 'VariableCollectionId:6348:1793',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: false,
+            valuesByMode: {
+              '6348:0': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:6195:914',
+              },
+              '7493:1': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:7493:9283',
+              },
+            },
+            scopes: ['TEXT_FILL'],
+            codeSyntax: {},
+          },
+          '6181:0',
+          () => {},
+        );
+
+        expect(variable.getTokenPath()).toEqual(
+          'eds.theme.color.text.utility.inverse',
+        );
+      });
+
+      it('allows deep retrieval of value from a variable, using delegate', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6359:7717',
+            name: '-> text/utility/inverse',
+            remote: false,
+            key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+            variableCollectionId: 'VariableCollectionId:6348:1793',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: false,
+            valuesByMode: {
+              '6348:0': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:6195:914',
+              },
+              '7493:1': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:7493:9283',
+              },
+            },
+            scopes: ['TEXT_FILL'],
+            codeSyntax: {},
+          },
+          '6348:0',
+          new utils.FigmaAPIReader(mockData),
+        );
+
+        expect(variable.getResovledValue()).toEqual({ r: 1, g: 1, b: 1, a: 1 });
+      });
+
+      it('handles name/value accessor methods', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6359:7717',
+            name: '-> text/utility/inverse',
+            remote: false,
+            key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+            variableCollectionId: 'VariableCollectionId:6348:1793',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: false,
+            valuesByMode: {
+              '6348:0': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:6195:914',
+              },
+              '7493:1': {
+                type: 'VARIABLE_ALIAS',
+                id: 'VariableID:7493:9283',
+              },
+            },
+            scopes: ['TEXT_FILL'],
+            codeSyntax: {},
+          },
+          '6348:0',
+          new utils.FigmaAPIReader(mockData),
+        );
+
+        expect(variable.name).toEqual('-> text/utility/inverse');
+        expect(variable.value).toEqual('#FFFFFF');
+      });
+
+      it('handles name/value accessor methods with a alpha channel', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6359:7717',
+            name: '-> text/utility/inverse',
+            remote: false,
+            key: '9f4864bc73c48fcc5a28e2320bd81e6205d4e6b5',
+            variableCollectionId: 'VariableCollectionId:6348:1793',
+            resolvedType: 'COLOR',
+            description: '',
+            hiddenFromPublishing: false,
+            valuesByMode: {
+              '6181:0': {
+                r: 1,
+                g: 1,
+                b: 1,
+                a: 0.5,
+              },
+            },
+            scopes: ['TEXT_FILL'],
+            codeSyntax: {},
+          },
+          '6181:0',
+          new utils.FigmaAPIReader(mockData),
+        );
+
+        expect(variable.name).toEqual('-> text/utility/inverse');
+        expect(variable.value).toEqual('rgba(255, 255, 255, 0.5)');
+      });
+
+      it('handles float values', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6370:10670',
+            name: 'border-radius/none',
+            remote: false,
+            key: '9358566cd8a6bb06f32e7682d2e8326fccf18e05',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'FLOAT',
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': 0,
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          '6181:0',
+        );
+
+        expect(variable.value).toEqual('0');
+        expect(variable.getTokenPath()).toEqual('eds.theme.border.radius.none');
+      });
+
+      it('throws on unparseable variable types', () => {
+        const variable = new utils.FigmaVariable(
+          {
+            id: 'VariableID:6370:10670',
+            name: 'border-radius/none',
+            remote: false,
+            key: '9358566cd8a6bb06f32e7682d2e8326fccf18e05',
+            variableCollectionId: 'VariableCollectionId:6181:1797',
+            resolvedType: 'FAKE', // no type recognized
+            description: '',
+            hiddenFromPublishing: true,
+            valuesByMode: {
+              '6181:0': 0,
+            },
+            scopes: ['ALL_SCOPES'],
+            codeSyntax: {},
+          },
+          '6181:0',
+        );
+
+        expect(() => {
+          variable.value;
+        }).toThrow(TypeError);
+      });
+    });
+  });
 });

--- a/bin/eds-import-from-figma-api.js
+++ b/bin/eds-import-from-figma-api.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+// Script shell
+(async function () {
+  const jsonfile = require('jsonfile');
+  const chalk = require('chalk');
+  const { prompt } = require('enquirer');
+  const set = require('lodash/set');
+  const at = require('lodash/at');
+  const ora = require('ora');
+
+  // eslint-disable-next-line import/extensions
+  const { hideBin } = require('yargs/helpers');
+  const yargs = require('yargs/yargs');
+
+  const { getConfig, FigmaAPIReader, FigmaVariable } = require('./_util');
+
+  // Set up the command structure to output help if the file to load is not specified
+  const args = yargs(hideBin(process.argv))
+    .command(
+      '$0 file [file_id]',
+      'Fetch the variables from Figma using the API',
+      (yargs) => {
+        yargs.positional('file_id', {
+          type: 'string',
+          describe: 'the figma file where the published variables are defined',
+        });
+      },
+    )
+    .option('token', {
+      describe: 'Figma API token',
+      type: 'string',
+    })
+    .option('verbose', {
+      describe: 'Print additional details for debugging purposes',
+      type: 'boolean',
+    })
+    .option('dry-run', {
+      describe: 'Run the script without writing any changes',
+      type: 'boolean',
+    }).argv;
+
+  // read in the config from config file, package json "eds", etc.
+  const config = await getConfig();
+  const isVerbose = args.v;
+  const canWrite = !args.dryRun;
+
+  // Get the local variables from the defined file b/c published ones won't contain the modes
+  // https://www.figma.com/developers/api#get-local-variables-endpoint
+  const figmaFileResponse = await fetch(
+    `https://api.figma.com/v1/files/${args.file_id}/variables/local`,
+    {
+      headers: {
+        'X-FIGMA-TOKEN': args.token,
+      },
+    },
+  );
+
+  if (!figmaFileResponse.ok) {
+    throw new Error('cannot access figma file: ' + figmaFileResponse.status);
+  }
+
+  const fullData = await figmaFileResponse.json();
+  const figmaApiReader = new FigmaAPIReader(fullData);
+  const edsCollection = figmaApiReader
+    .getVariableCollections()
+    .find(
+      (collection) => collection.name === FigmaAPIReader.EDS_COLLECTION_NAME,
+    );
+
+  // Determine which of the modes in the file should be used
+  let response;
+  try {
+    response = await prompt({
+      name: 'modeId',
+      message: 'Please select the Figma mode for token import',
+      type: 'select',
+      choices: figmaApiReader.getModes(edsCollection.id).map((mode) => {
+        return {
+          name: mode.modeId,
+          message: `Use the ${mode.name} figma mode`,
+          value: mode.name,
+        };
+      }),
+    });
+  } catch (e) {
+    // e.g., someone hits ESC
+    console.error(chalk.red('Aborted.'), e);
+    process.exit(-1);
+  }
+
+  const stats = {
+    skipped: [],
+    updated: [],
+    errored: [],
+    total: [],
+  };
+
+  const spinner = ora('Parsing tokens...').start();
+
+  // now, load in the local theme file. We want to look up keys in there
+  const localTheme = jsonfile.readFileSync(`${config.src}app-theme.json`);
+
+  figmaApiReader
+    .getVariablesByCollectionId(edsCollection.id)
+    .forEach((figmaVariable) => {
+      stats.total.push(figmaVariable.id);
+      const variable = new FigmaVariable(
+        figmaVariable,
+        response.modeId,
+        figmaApiReader,
+      );
+      let writePath = variable.getTokenPath();
+
+      // mesh the token path to a matching path in the local theme file
+      const found = at(localTheme, writePath).filter(
+        (entries) => typeof entries !== 'undefined',
+      );
+
+      if (found.length) {
+        // handle case where we should look for @ in the file, then pluck the value object properly
+        if (found[0]['@']?.value) {
+          // update the write path to mark the @ and value
+          writePath = writePath + '.@.value';
+        }
+
+        // handle case where it's just value
+        if (found[0]?.value) {
+          // update the write path to mark the value
+          writePath = writePath + '.value';
+        }
+      }
+
+      if (writePath) {
+        try {
+          // error when path suffix is invalid (all should end with .value)
+          if (!writePath.endsWith('value')) {
+            throw new Error(
+              `Name format violation. Name missing in local theme: ${writePath} (${figmaVariable.resolvedType})`,
+            );
+          }
+
+          canWrite && set(localTheme, writePath, variable.value);
+
+          // write the value using the calculated path and parsed value
+          if (isVerbose || !canWrite) {
+            spinner.succeed('Write: ' + variable.value + ' to ' + writePath);
+          }
+
+          spinner.text = chalk.bold(variable.name) + ': Done!';
+          stats.updated.push(variable);
+        } catch (e) {
+          // We couldn't parse the resolved value, so skip and add to errors
+          spinner.fail(chalk.bold(variable.name) + ': Error (' + e + ')');
+          stats.errored.push(variable);
+        }
+      } else {
+        spinner.text = chalk.bold(variable.name) + ': Skipped';
+
+        if (!writePath) {
+          spinner.warn(
+            chalk.bold(variable.name) +
+              ': Skipped with warning (no write path)',
+          );
+        }
+        stats.skipped.push(variable);
+      }
+    });
+
+  if (canWrite) {
+    jsonfile.writeFileSync(`${config.src}app-theme.json`, localTheme, {
+      spaces: 2,
+      finalEOL: false,
+    });
+  }
+
+  spinner.succeed(
+    `Done! updated: ${stats.updated.length}, skipped: ${stats.skipped.length}, errored: ${stats.errored.length}, total: ${stats.total.length}`,
+  );
+})();

--- a/bin/eds-import-from-figma.js
+++ b/bin/eds-import-from-figma.js
@@ -26,16 +26,6 @@
         });
       },
     )
-    .command(
-      '$0 file [file_id]',
-      'Fetch the variables from Figma using the API',
-      (yargs) => {
-        yargs.positional('file_id', {
-          type: 'string',
-          describe: 'the figma file where the published variables are defined',
-        });
-      },
-    )
     .option('verbose', {
       describe: 'Print additional details for debugging purposes',
       type: 'boolean',
@@ -48,27 +38,9 @@
   // read in the config from config file, package json "eds", etc.
   const config = await getConfig();
 
-  let figmaThemeData;
-  // Decide file source (either a downloaded JSON file or via API)
-  if (args.file) {
-    const figmaFileResponse = await fetch(
-      `https://api.figma.com/v1/files/${args.file_id}/variables/published`,
-      {
-        headers: {
-          'X-FIGMA-TOKEN': config.token,
-        },
-      },
-    );
-
-    if (!figmaFileResponse.ok) {
-      throw new Error('cannot access figma file: ' + figmaFileResponse.status);
-    }
-
-    figmaThemeData = await figmaFileResponse.json();
-  } else {
-    // Read the figma import file, and parse out the modes to select from, prompting the user to pick one,
-    figmaThemeData = jsonfile.readFileSync(args.figma_file);
-  }
+  // Read the figma import file, and parse out the modes to select from, prompting the user to pick one,
+  // and load in the local theme file. We want to look up keys in there
+  const figmaThemeData = jsonfile.readFileSync(args.figma_file);
 
   // now, load in the local theme file. We want to look up keys in there
   const localTheme = jsonfile.readFileSync(`${config.src}app-theme.json`);

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "jsonfile": "^6.1.0",
     "lilconfig": "^3.1.3",
     "lodash": "^4.17.21",
-    "ora": "^8.1.1",
+    "ora": "5.4.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-children-by-type": "^1.1.0",
     "react-focus-lock": "^2.13.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,7 +1940,7 @@ __metadata:
     lilconfig: "npm:^3.1.3"
     lint-staged: "npm:^15.4.1"
     lodash: "npm:^4.17.21"
-    ora: "npm:^8.1.1"
+    ora: "npm:5.4.1"
     plop: "npm:^4.0.1"
     postcss: "npm:^8.5.1"
     postcss-cli: "npm:^11.0.0"
@@ -15439,7 +15439,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ora@npm:^5.4.1":
+"ora@npm:5.4.1, ora@npm:^5.4.1":
   version: 5.4.1
   resolution: "ora@npm:5.4.1"
   dependencies:
@@ -15470,23 +15470,6 @@ __metadata:
     string-width: "npm:^7.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10/3d37bb3f53e965e5176004af319f82feef7323ee0b2428db5ee6f689b9b9ba939d7b1e81691d4614333c4fb9e294790eb049db9c1e990b14b9bbe150c6f09993
-  languageName: node
-  linkType: hard
-
-"ora@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "ora@npm:8.1.1"
-  dependencies:
-    chalk: "npm:^5.3.0"
-    cli-cursor: "npm:^5.0.0"
-    cli-spinners: "npm:^2.9.2"
-    is-interactive: "npm:^2.0.0"
-    is-unicode-supported: "npm:^2.0.0"
-    log-symbols: "npm:^6.0.0"
-    stdin-discarder: "npm:^0.2.2"
-    string-width: "npm:^7.2.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10/2308c0a4da83099b0778a914890f5561329e3c948f73e865e0dced9053d62327219d8bde0f9b7c79a02913a7e41458ff5667d0115032fedc54907862e2de9695
   languageName: node
   linkType: hard
 
@@ -18596,7 +18579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stdin-discarder@npm:^0.2.1, stdin-discarder@npm:^0.2.2":
+"stdin-discarder@npm:^0.2.1":
   version: 0.2.2
   resolution: "stdin-discarder@npm:0.2.2"
   checksum: 10/642ffd05bd5b100819d6b24a613d83c6e3857c6de74eb02fc51506fa61dc1b0034665163831873868157c4538d71e31762bcf319be86cea04c3aba5336470478
@@ -18700,17 +18683,6 @@ __metadata:
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
   checksum: 10/bc0de5700a2690895169fce447ec4ed44bc62de80312c2093d5606bfd48319bb88e48a99e97f269dff2bc9577448b91c26b3804c16e7d9b389699795e4655c3b
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "string-width@npm:7.2.0"
-  dependencies:
-    emoji-regex: "npm:^10.3.0"
-    get-east-asian-width: "npm:^1.0.0"
-    strip-ansi: "npm:^7.1.0"
-  checksum: 10/42f9e82f61314904a81393f6ef75b832c39f39761797250de68c041d8ba4df2ef80db49ab6cd3a292923a6f0f409b8c9980d120f7d32c820b4a8a84a2598a295
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- handle both downloaded file version and API version
- handle input and edge cases (e.g., missing config)
- separate and handle parsing of token contents into theme file
- guard against committing local edsrc config

we also flag instances of mismatches between figma and code, for later fixing (in Figma). Example:

![Screenshot 2025-02-19 at 12 47 08](https://github.com/user-attachments/assets/1f568828-87dd-4d2f-9d70-96080ea44f23)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
