### PR TITLE
fix(scripts): add locality check to value pre-validation

### DIFF
--- a/bin/eds-import-from-figma-api.js
+++ b/bin/eds-import-from-figma-api.js
@@ -167,10 +167,11 @@ const { identity } = require('lodash');
 
           if (
             FigmaVariable.isAliased(figmaVariable, response.modeId) &&
+            args.local &&
             !at(localTheme, variable.valueRef).some(identity)
           ) {
             throw new Error(
-              `Value violation. Trying to write a reference value path not in local theme: ${writePath} => {${variable.valueRef}}`,
+              `Value violation. Trying to write a local reference value path not in local theme: ${writePath} => {${variable.valueRef}}`,
             );
           }
 


### PR DESCRIPTION
The script should only attempt to write reference values when used with `--local`. Instead, when used in a consuming app that needed a non-default theme, it would try to write reference values to the custom theme, which would be missing from EDS.

This updates the check to only throw a validation error when run in local mode, AND when the reference value to write is missing (the intention).

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: **tested against an export to a sample project with a custom theme**
