### PR TITLE
fix(storybook): set default foreground/background colors for story pages

### DIFF
--- a/.storybook/data/tokens.json
+++ b/.storybook/data/tokens.json
@@ -155,7 +155,6 @@
   "eds-theme-form-border-width": "1",
   "eds-theme-color-body-background": "#F4F6F8",
   "eds-theme-color-background-input": "rgb(var(--eds-color-white) / 1)",
-  "eds-theme-color-background-neutral-default-hover": "#F4F6F8",
   "eds-theme-color-background-neutral-subtle-hover": "#E7E8EA",
   "eds-theme-color-background-neutral-medium": "#E7E8EA",
   "eds-theme-color-background-brand-primary-default": "#C4C1F3",

--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -66,6 +66,7 @@
 .accordion-button__trailing-icon {
   flex: 0 0 content;
   transform: rotate(0);
+  color: var(--eds-theme-color-icon-utility-default-secondary);
 }
 
 /**

--- a/src/components/Breadcrumbs/Breadcrumbs.module.css
+++ b/src/components/Breadcrumbs/Breadcrumbs.module.css
@@ -130,7 +130,7 @@
  * Breadcrumbs Icon - a separator between breadcrumb links.
  */
 .breadcrumbs__separator {
-  color: var(--eds-theme-color-icon-neutral-subtle);
+  color: var(--eds-theme-color-text-utility-default-primary);
   margin-left: calc(var(--eds-spacing-size-1) / 16 * 1rem);
   margin-right: calc(var(--eds-spacing-size-1) / 16 * 1rem);
   cursor: default;
@@ -148,7 +148,7 @@
  * Breadcrumbs Back Icon.
  */
 .breadcrumbs__back-icon {
-  color: var(--eds-theme-color-icon-neutral-subtle);
+  color: var(--eds-theme-color-icon-utility-default-primary);
   /* Transform over height due to icon being placed inside <a>. */
   transform: scale(1.5);
   position: relative;

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -84,6 +84,8 @@
 .card__header {
   display: flex;
 
+  color: var(--eds-theme-color-text-utility-default-primary);
+
   & .header__eyebrow {
     margin-bottom: calc(var(--eds-spacing-size-1) / 16 * 1rem);
   }

--- a/src/components/Fieldset/Fieldset.module.css
+++ b/src/components/Fieldset/Fieldset.module.css
@@ -31,3 +31,7 @@
   align-items: center;
   gap: calc(var(--eds-spacing-size-half) / 16 * 1rem);
 }
+
+.fieldset-legend__hint {
+  color: var(--eds-theme-color-text-utility-default-secondary)
+}

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -178,15 +178,18 @@ const FieldsetLegend = ({
             <Text
               aria-disabled={isDisabled ?? undefined}
               as="span"
+              className={styles['fieldset-legend__hint']}
               preset="body-sm"
             >
               (Required)
             </Text>
           )}
           {!required && showHint && (
+            // TODO-AH: fix color here
             <Text
               aria-disabled={isDisabled ?? undefined}
               as="span"
+              className={styles['fieldset-legend__hint']}
               preset="body-sm"
             >
               (Optional)

--- a/src/components/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/src/components/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`<Fieldset /> FieldsetLegendOptional story renders snapshot 1`] = `
       Legend
     </label>
     <span
-      class="text text--body-sm"
+      class="text text--body-sm fieldset-legend__hint"
     >
       (Optional)
     </span>
@@ -75,7 +75,7 @@ exports[`<Fieldset /> FieldsetLegendRequired story renders snapshot 1`] = `
       Legend
     </label>
     <span
-      class="text text--body-sm"
+      class="text text--body-sm fieldset-legend__hint"
     >
       (Required)
     </span>

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -64,6 +64,9 @@
   padding: calc(var(--eds-spacing-size-3) / 16 * 1rem) calc(var(--eds-spacing-size-4) / 16 * 1rem);
 }
 
+.modal-title {
+  color: var(--eds-theme-color-text-utility-default-primary)
+}
 /**
  * The body of the modal
  */

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -206,7 +206,9 @@ export const ContentDefault: Story = {
     children: (
       <>
         <Modal.Header>
-          <Heading as="h2">Modal Title</Heading>
+          <Heading as="h2" className="text-utility-default-primary">
+            Modal Title
+          </Heading>
           <Modal.SubTitle>Modal Sub-title</Modal.SubTitle>
         </Modal.Header>
         <Modal.Body>
@@ -292,7 +294,9 @@ export const LayoutVertical: Story = {
     children: (
       <>
         <Modal.Header>
-          <Heading as="h2">Modal Title</Heading>
+          <Heading as="h2" className="text-utility-default-primary">
+            Modal Title
+          </Heading>
           <Modal.SubTitle>Modal Sub-title</Modal.SubTitle>
         </Modal.Header>
         <Modal.Body>
@@ -335,7 +339,9 @@ export const LayoutVerticalWithTertiary: Story = {
     children: (
       <>
         <Modal.Header>
-          <Heading as="h2">Modal Title</Heading>
+          <Heading as="h2" className="text-utility-default-primary">
+            Modal Title
+          </Heading>
           <Modal.SubTitle>Modal Sub-title</Modal.SubTitle>
         </Modal.Header>
         <Modal.Body>
@@ -377,7 +383,9 @@ export const WithCriticalButton: Story = {
     children: (
       <>
         <Modal.Header>
-          <Heading as="h2">Modal Title</Heading>
+          <Heading as="h2" className="text-utility-default-primary">
+            Modal Title
+          </Heading>
           <Modal.SubTitle>Modal Sub-title</Modal.SubTitle>
         </Modal.Header>
         <Modal.Body>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -412,13 +412,21 @@ const ModalTitle = ({
   className,
   preset = 'headline-md',
   ...other
-}: ModalTitleProps) => (
-  <DialogTitle as={React.Fragment}>
-    <Heading as="h2" className={className} preset={preset} {...other}>
-      {children}
-    </Heading>
-  </DialogTitle>
-);
+}: ModalTitleProps) => {
+  const componentClassName = clsx(styles['modal-title'], className);
+  return (
+    <DialogTitle as={React.Fragment}>
+      <Heading
+        as="h2"
+        className={componentClassName}
+        preset={preset}
+        {...other}
+      >
+        {children}
+      </Heading>
+    </DialogTitle>
+  );
+};
 
 const ModalSubTitle = ({
   children,

--- a/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Modal ContentDefault story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -135,7 +135,7 @@ exports[`Modal Default story renders snapshot 1`] = `
         class="modal-header"
       >
         <h2
-          class="heading heading--headline-md"
+          class="heading heading--headline-md modal-title"
           data-headlessui-state="open"
           data-open=""
           id="headlessui-dialog-title-:r8:"
@@ -241,7 +241,7 @@ exports[`Modal HighEmphasis story renders snapshot 1`] = `
         class="modal-header"
       >
         <h2
-          class="heading heading--headline-md"
+          class="heading heading--headline-md modal-title"
           data-headlessui-state="open"
           data-open=""
           id="headlessui-dialog-title-:rh:"
@@ -330,7 +330,7 @@ exports[`Modal Large story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -414,7 +414,7 @@ exports[`Modal LargeAuto story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -498,7 +498,7 @@ exports[`Modal LargeMax story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -582,7 +582,7 @@ exports[`Modal LayoutVertical story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -666,7 +666,7 @@ exports[`Modal LayoutVerticalWithTertiary story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -750,7 +750,7 @@ exports[`Modal Mobile story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -834,7 +834,7 @@ exports[`Modal MobileLandscape story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -918,7 +918,7 @@ exports[`Modal Small story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -1002,7 +1002,7 @@ exports[`Modal Tablet story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -1086,7 +1086,7 @@ exports[`Modal WithCriticalButton story renders snapshot 1`] = `
     class="modal-header"
   >
     <h2
-      class="heading heading--headline-md"
+      class="heading heading--headline-md text-utility-default-primary"
     >
       Modal Title
     </h2>
@@ -1177,7 +1177,7 @@ exports[`Modal WithLongTextScrollable story renders snapshot 1`] = `
         class="modal-header"
       >
         <h2
-          class="heading heading--headline-md"
+          class="heading heading--headline-md modal-title"
           data-headlessui-state="open"
           data-open=""
           id="headlessui-dialog-title-:rq:"

--- a/src/components/Tag/Tag.module.css
+++ b/src/components/Tag/Tag.module.css
@@ -44,7 +44,7 @@
 
 /**
  * Color variants.
- * TODO(next-major): remove these status colors
+ * TODO(next-major): remove these status colors and delete tokens
  */
 :where(.tag--neutral) {
   --tag-primary-color: var(--eds-theme-color-text-neutral-default);

--- a/src/components/TextareaField/TextareaField.module.css
+++ b/src/components/TextareaField/TextareaField.module.css
@@ -37,6 +37,10 @@
   font: var(--eds-theme-typography-form-label);
 }
 
+.textarea-field__hint {
+  color: var(--eds-theme-color-text-utility-default-secondary)
+}
+
 .textarea-field__label--disabled {
   color: var(--eds-theme-color-text-utility-disabled-primary);
 }
@@ -56,6 +60,7 @@
 
 .textarea-field__character-counter {
   font: var(--eds-theme-typography-body-sm);
+  color: var(--eds-theme-color-text-utility-default-primary);
 
   flex: 1 0 50%;
   text-align: right;

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -203,6 +203,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
     );
 
     const requiredTextClassName = clsx(
+      styles['textarea-field__hint'],
       disabled && styles['textarea-field__required-text--disabled'],
     );
     const fieldLengthCountClassName = clsx(

--- a/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
@@ -238,7 +238,7 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
         Textarea Field
       </label>
       <span
-        class="text text--body-sm"
+        class="text text--body-sm textarea-field__hint"
       >
         (Optional)
       </span>
@@ -330,7 +330,7 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
         Textarea Field
       </label>
       <span
-        class="text text--body-sm"
+        class="text text--body-sm textarea-field__hint"
       >
         (Required)
       </span>

--- a/src/design-tokens/core-tokens.json
+++ b/src/design-tokens/core-tokens.json
@@ -772,12 +772,6 @@
             "value": "rgb(var(--eds-color-white) / 1)"
           },
           "neutral": {
-            "default": {
-              "hover": {
-                "value": "#F4F6F8",
-                "group": "color"
-              }
-            },
             "subtle": {
               "hover": {
                 "value": "#E7E8EA",

--- a/src/design-tokens/css/base/body.css
+++ b/src/design-tokens/css/base/body.css
@@ -7,8 +7,8 @@ body {
   min-height: 100vh;
   padding: 0;
   margin: 0;
-  color: var(--eds-theme-color-text-neutral-default);
-  background: var(--eds-theme-color-background-neutral-default);
+  background-color: var(--eds-theme-color-background-utility-base-1);
+    color: var(--eds-theme-color-text-utility-default-primary);
 }
 
 /* Body disabled variant */
@@ -21,6 +21,6 @@ body {
 /* Body with light background on small screens */
 .body--alternate {
   @media all and (max-width: $eds-bp-lg) {
-    background: var(--eds-theme-color-background-neutral-default);
+    background: var(--eds-theme-color-background-utility-base-1);
   }
 }

--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -202,7 +202,6 @@
   --eds-theme-color-background-brand-primary-default: #C4C1F3; /* @deprecated This should not be used in code or design. It will be removed in a future version of EDS. */
   --eds-theme-color-background-neutral-medium: #E7E8EA;
   --eds-theme-color-background-neutral-subtle-hover: #E7E8EA;
-  --eds-theme-color-background-neutral-default-hover: #F4F6F8;
   --eds-theme-color-background-input: rgb(var(--eds-color-white) / 1);
   --eds-theme-color-body-background: #F4F6F8;
   --eds-theme-typography-tag: var(--eds-typography-preset-009);

--- a/src/tokens-dist/json/variables-nested.json
+++ b/src/tokens-dist/json/variables-nested.json
@@ -318,9 +318,6 @@
         "background": {
           "input": "rgb(var(--eds-color-white) / 1)",
           "neutral": {
-            "default": {
-              "hover": "#F4F6F8"
-            },
             "subtle": {
               "hover": "#E7E8EA"
             },

--- a/src/tokens-dist/ts/colors.ts
+++ b/src/tokens-dist/ts/colors.ts
@@ -1,6 +1,5 @@
 export const EdsThemeColorBodyBackground = '#F4F6F8';
 export const EdsThemeColorBackgroundInput = 'rgb(var(--eds-color-white) / 1)';
-export const EdsThemeColorBackgroundNeutralDefaultHover = '#F4F6F8';
 export const EdsThemeColorBackgroundNeutralSubtleHover = '#E7E8EA';
 export const EdsThemeColorBackgroundNeutralMedium = '#E7E8EA';
 export const EdsThemeColorBackgroundBrandPrimaryDefault = '#C4C1F3'; // @deprecated This should not be used in code or design. It will be removed in a future version of EDS.


### PR DESCRIPTION
Remove token usages for foreground/background colors in storybook CSS. Remove token which is no longer being used. Updates to a few components where the base color to use should have been specified but wasn't (we got it for free in some cases, but the component should have specified it deliberately instead of relying on storybook to do so).

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
