### PR TITLE
fix(Button): add token usage for primary default button on hover

### DIFF
--- a/.storybook/data/tokens.json
+++ b/.storybook/data/tokens.json
@@ -156,7 +156,7 @@
   "eds-theme-border-radius-objects-xs": "0",
   "eds-theme-border-radius-tab-underline": "50",
   "eds-theme-border-radius-tab-underline-default": "9999",
-  "eds-theme-border-radius-tab-underline-sticky": "50",
+  "eds-theme-border-radius-tab-underline-sticky": "9999",
   "eds-theme-border-width": "1",
   "eds-theme-box-button-border-radius": "4",
   "eds-theme-box-focus-ring-outline-width": "1",

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -337,6 +337,13 @@
   border-color: var(--eds-theme-color-border-utility-interactive-hover);
 }
 
+.button--primary.button--variant-default:hover {
+  color: var(--eds-theme-color-text-utility-inverse);
+
+  border-color: var(--eds-theme-color-background-utility-interactive-high-emphasis-hover);
+  background-color: var(--eds-theme-color-background-utility-interactive-high-emphasis-hover);
+}
+
 .button--secondary.button--variant-default:hover,
 .button--tertiary.button--variant-default:hover {
   color: var(--eds-theme-color-text-utility-interactive-primary-hover);

--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -849,7 +849,7 @@
   --eds-theme-box-focus-ring-outline-width: var(--eds-outline-width-sm);
   --eds-theme-box-button-border-radius: var(--eds-border-radius-md);
   --eds-theme-border-width: var(--eds-border-width-sm);
-  --eds-theme-border-radius-tab-underline-sticky: var(--eds-border-radius-round);
+  --eds-theme-border-radius-tab-underline-sticky: var(--eds-border-radius-full);
   --eds-theme-border-radius-tab-underline-default: var(--eds-border-radius-full);
   --eds-theme-border-radius-tab-underline: var(--eds-border-radius-round);
   --eds-theme-border-radius-objects-xs: var(--eds-border-radius-none);

--- a/src/tokens-dist/json/variables-nested.json
+++ b/src/tokens-dist/json/variables-nested.json
@@ -307,7 +307,7 @@
           "tabUnderline": {
             "@": "50",
             "default": "9999",
-            "sticky": "50"
+            "sticky": "9999"
           }
         },
         "width": "1"


### PR DESCRIPTION
Saw that the treatment for the following button styles were missing

* variant=default
* rank=primary
* state=hover

Add in the color styles for this case, and update snapshots as needed

### Test Plan:

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
