### PR TITLE
fix(InputChip): add padding to inside left edge to match design

### DIFF
--- a/src/components/InputChip/InputChip.module.css
+++ b/src/components/InputChip/InputChip.module.css
@@ -14,6 +14,7 @@
   display: inline-flex;
   padding: calc(var(--eds-spacing-size-1) * 1px);
   padding-right: 0;
+  padding-left: calc(var(--eds-spacing-size-1-and-half) * 1px);
   gap: calc(var(--eds-spacing-size-1) * 1px);
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Add left padding equivalent to 12px to the inside of `InputChip` components to match design

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
