### PR TITLE
refactor(config): export and document tailwind config utility method

### DIFF
--- a/.storybook/components/Docs/Guidelines/Theming.mdx
+++ b/.storybook/components/Docs/Guidelines/Theming.mdx
@@ -153,45 +153,24 @@ npx eds-import-from-figma-api file <file_id> --token <personal_access_token>
 
 When you have your own custom theme, you can use the tokens provided in `app-tailwind-theme.config.json` to do advanced tailwind configuration. This file contains all the tokens in JSON format, mapped to the literal values in your local theme.
 
-You can use similar import values to what is in `@chanzuckerberg/eds/tailwind.config.ts` in your local tailwind configuration file:
+EDS provides a utility method to pull in the theme config and generate the proper tailwind 3.x config object.
+
+**NOTE**: Tailwind 4.x support to come in a future release of EDS.
 
 ```ts
 // in your tailwind.config.ts file
 import type { Config } from 'tailwindcss';
-import baseConfig from '@chanzuckerberg/eds/tailwind.config';
+import {applyTailwindConfig} from '@chanzuckerberg/eds/tailwind.config';
 import {eds as customTokens} from "./<edsrc.json:dest>/app-tailwind-theme.config.json"; // where <edsrc.json:dest> is the path configured in .edsrc.json
-
-const {
-  background: backgroundColorTokens,
-  border: borderColorTokens,
-  text: textColorTokens,
-  ...colorTokens
-} = customTokens.theme.color;
 
 // export the following
 export default {
-  ... // your local content export
+  // your project's `content` array
+  content: ['./app/**/*.{ts,tsx,jsx,js}'],
   theme: {
-    colors: {
-      ...colorTokens,
-    },
-    extend: {
-      ...baseConfig.theme.extend,
-      backgroundColor: {
-        ...backgroundColorTokens,
-      },
-      borderColor: {
-        ...borderColorTokens,
-      },
-      textColor: {
-        ...textColorTokens,
-      },
-    },
-    screens: {
-      ...baseConfig.theme.screens, // you can mix in any base config values into the local theme
-    }
-    ... // any local theme settings
-  }
+    ...applyTailwindConfig(customTokens)
+    // ...any local theme overrides and additions...
+  },
 } satisfies Config
 
 ```

--- a/src/design-tokens/css/base/reset.css
+++ b/src/design-tokens/css/base/reset.css
@@ -4,14 +4,13 @@
   box-sizing: border-box;
 }
 
-/* TODO-AH: figure out what these tokens should be */
 ::-moz-selection {
   /* Code for Firefox */
   color: var(--eds-theme-color-text-highlight-foreground);
-  background: var(--eds-theme-color-text-highlight-background);
+  background: var(--eds-theme-color-background-utility-default-low-emphasis);
 }
 
 ::selection {
   color: var(--eds-theme-color-text-highlight-foreground);
-  background: var(--eds-theme-color-text-highlight-background);
+  background: var(--eds-theme-color-background-utility-default-low-emphasis);
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,54 +1,66 @@
 import type { Config } from 'tailwindcss';
 import { eds as edsTokens } from './lib/tokens/json/tailwind-utility-config.json';
 
-const {
-  background: backgroundColorTokens,
-  border: borderColorTokens,
-  text: textColorTokens,
-  ...colorTokens
-} = edsTokens.theme.color;
+/**
+ * Convert a series of objects with one key-value pair into a combined object
+ *
+ * @param accumulate object each key/value pair is being written to
+ * @param current current entry that is being put into the object
+ * @returns object-ized version of the sequence of key value pairs
+ */
+function objArrayToObject(accumulate, current) {
+  const entry = Object.entries(current)[0];
+  accumulate[entry[0]] = entry[1];
+  return accumulate;
+}
 
-// Add a type to the tokens to avoid literals for keys
-const movements: { [x: string]: string } = edsTokens.anim.move;
-const spacings: { [x: string]: string } = edsTokens.spacing.size;
+/**
+ * Convert the token config values into a tailwind 3.x compatible format
+ *
+ * @param tokenConfig EDS-compatible JSON config, mapping the structure of the known tokens
+ * @returns Tailwind-compatible mapping of the keys and values to the right part of the tailwind config structure
+ */
+export function applyTailwindConfig(
+  tokenConfig: typeof edsTokens,
+): Config['theme'] {
+  const {
+    background: backgroundColorTokens,
+    border: borderColorTokens,
+    text: textColorTokens,
+    ...colorTokens
+  } = tokenConfig.theme.color;
 
-const movementTokens = {
-  ...Object.keys(movements)
-    .map((movement) => {
-      return { [movement]: `${movements[movement]}s` };
-    })
-    .reduce((accumulate, current) => {
-      const entry = Object.entries(current)[0];
-      accumulate[entry[0]] = entry[1];
-      return accumulate;
-    }, {}),
-};
+  const movements: { [x: string]: string } = tokenConfig.anim.move;
+  const spacings: { [x: string]: string } = tokenConfig.spacing.size;
 
-const spacingTokens = {
-  ...Object.keys(spacings)
-    .map((spacing) => {
-      return { [`spacing-size-${spacing}`]: `${spacings[spacing]}px` };
-    })
-    .reduce((accumulate, current) => {
-      const entry = Object.entries(current)[0];
-      accumulate[entry[0]] = entry[1];
-      return accumulate;
-    }, {}),
-};
-
-export default {
   /**
-   * The main value in TW utility classes is for Storybook stories, etc..
-   * We avoid using them in component styles to reduce chance of conflict with other libraries.
-   * Please configure downstream Tailwind config purge to include app files if necessary.
+   * Take each set of unitless key/value pairs, and convert them so they become unit-ized equivalents.
+   *
+   * Adjust two degrees of freedom:
+   * - resulting key name
+   * - unit to add to each value
+   *
+   * To modify each one using map/reduce, convert into an array, modify, then convert back into an object.
+   *
+   * Tailwind needs units on these so that the right CSS gets applied.
    */
-  content: [
-    './src/components/**/*.stories.{ts,tsx}',
-    './src/components/**/*Example.tsx',
-    './.storybook/**/*.{js,jsx,ts,tsx}',
-    './src/components/Table/StackedCardsToTable.tsx',
-  ],
-  theme: {
+  const movementTokens = {
+    ...Object.keys(movements)
+      .map((movement) => {
+        return { [movement]: `${movements[movement]}s` };
+      })
+      .reduce(objArrayToObject, {}),
+  };
+
+  const spacingTokens = {
+    ...Object.keys(spacings)
+      .map((spacing) => {
+        return { [`spacing-size-${spacing}`]: `${spacings[spacing]}px` };
+      })
+      .reduce(objArrayToObject, {}),
+  };
+
+  return {
     colors: {
       ...colorTokens,
     },
@@ -88,5 +100,20 @@ export default {
       lg: '1040px',
       xl: '1440px',
     },
-  },
+  };
+}
+
+export default {
+  /**
+   * The main value in TW utility classes is for Storybook stories, etc..
+   * We avoid using them in component styles to reduce chance of conflict with other libraries.
+   * Please configure downstream Tailwind config purge to include app files if necessary.
+   */
+  content: [
+    './src/components/**/*.stories.{ts,tsx}',
+    './src/components/**/*Example.tsx',
+    './.storybook/**/*.{js,jsx,ts,tsx}',
+    './src/components/Table/StackedCardsToTable.tsx',
+  ],
+  theme: { ...applyTailwindConfig(edsTokens) },
 } satisfies Config;


### PR DESCRIPTION
Before, anyone using the theming tools would have to occasionally combine keys and values very similar to what comes with EDS, in order to get the same config results using their theme file. Inconvenient!

Instead, move this creation logic into an exported method AND use the method to generate the default config. This way we re-use the logic internally, and provide a simpler interface for using the old method (duplicate logic seen in EDS in your project directly).

Update the documentation to reflect this improvement 

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - [x] use the function in the built-in storybook to confirm no snapshots change unexpectedly
