### PR TITLE
fix(tailwind): adjust config creation to avoid TypeScript issues

### DIFF
--- a/src/tokens-dist/css/variables.css
+++ b/src/tokens-dist/css/variables.css
@@ -49,7 +49,7 @@
   --eds-spacing-size-1-and-half: 12; /* Pixels (px) - can convert to Relative EMs (rem) */
   --eds-spacing-size-quarter: 2; /* Pixels (px) - can convert to Relative EMs (rem) */
   --eds-spacing-size-half: 4; /* Pixels (px) - can convert to Relative EMs (rem) */
-  --eds-spacing-size-7-and-half: 60; /* Pixels (px) - can convert to Relative EMs (rem) */
+  --eds-spacing-size-7-and-half: 60; /* Pixels (px) - can convert to Relative EMs (rem) @deprecated This should not be used in code or design. It will be removed in a future version of EDS. */
   --eds-spacing-size-4-and-half: 36; /* Pixels (px) - can convert to Relative EMs (rem) */
   --eds-spacing-size-48: 384; /* Pixels (px) - can convert to Relative EMs (rem) */
   --eds-spacing-size-40: 320; /* Pixels (px) - can convert to Relative EMs (rem) */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,19 +2,6 @@ import type { Config } from 'tailwindcss';
 import { eds as edsTokens } from './lib/tokens/json/tailwind-utility-config.json';
 
 /**
- * Convert a series of objects with one key-value pair into a combined object
- *
- * @param accumulate object each key/value pair is being written to
- * @param current current entry that is being put into the object
- * @returns object-ized version of the sequence of key value pairs
- */
-function objArrayToObject(accumulate, current) {
-  const entry = Object.entries(current)[0];
-  accumulate[entry[0]] = entry[1];
-  return accumulate;
-}
-
-/**
  * Convert the token config values into a tailwind 3.x compatible format
  *
  * @param tokenConfig EDS-compatible JSON config, mapping the structure of the known tokens
@@ -49,7 +36,9 @@ export function applyTailwindConfig(
       .map((movement) => {
         return { [movement]: `${movements[movement]}s` };
       })
-      .reduce(objArrayToObject, {}),
+      .reduce((acc, cur) => {
+        return Object.assign(acc, cur);
+      }, {}),
   };
 
   const spacingTokens = {
@@ -57,7 +46,9 @@ export function applyTailwindConfig(
       .map((spacing) => {
         return { [`spacing-size-${spacing}`]: `${spacings[spacing]}px` };
       })
-      .reduce(objArrayToObject, {}),
+      .reduce((acc, cur) => {
+        return Object.assign(acc, cur);
+      }, {}),
   };
 
   return {


### PR DESCRIPTION
Previously we created a utility method to DRY up the code. However this required typing which, after thinking a bit, wasn't worth the effort to make accurate (this is not exported). Further, it's possible to use built-in things to achieve the same result. Use `Object.assign` instead of a custom piece of code that does the same.

A further improvement could involve breaking this down such that we can use `.apply` and reduce the lines of code for conversion. BUT, since there are only two of these, can come back to that. Example:

```js
Object.assign.apply(null, [{}, ...entries]); // where `entries` is the list of converted key-value pairs after the .map
```

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - [x] added some console logging to make sure the output types map to the documented format for tailwind
