### PR TITLE
Add sublabel prop for input fields (Select, InputField, TextareaField)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -80,6 +80,7 @@ export const parameters: Preview['parameters'] = {
     ],
   },
   badgesConfig: {
+    ...createComponentVersion('3.1'),
     ...createComponentVersion('3.0'),
     ...createComponentVersion('2.1'),
     ...createComponentVersion('2.0'),

--- a/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
@@ -10589,11 +10589,12 @@ exports[`<DataTable /> WithLongCaption story renders snapshot 1`] = `
           class="input-field__body"
         >
           <input
+            aria-describedby=""
             aria-invalid="false"
             aria-label="search"
             class="input input-field__input--leading-icon"
             disabled=""
-            id=":r16:"
+            id=":r19:"
             placeholder="Search..."
             type="search"
           />
@@ -10760,6 +10761,7 @@ exports[`<DataTable /> WithSearch story renders snapshot 1`] = `
           class="input-field__body"
         >
           <input
+            aria-describedby=""
             aria-invalid="false"
             aria-label="search"
             class="input input-field__input--leading-icon"
@@ -10835,11 +10837,12 @@ exports[`<DataTable /> WithSearchAndActions story renders snapshot 1`] = `
           class="input-field__body"
         >
           <input
+            aria-describedby=""
             aria-invalid="false"
             aria-label="search"
             class="input input-field__input--leading-icon"
             disabled=""
-            id=":rs:"
+            id=":rt:"
             placeholder="Search..."
             type="search"
           />
@@ -10947,11 +10950,12 @@ exports[`<DataTable /> WithSearchAndCustomActions story renders snapshot 1`] = `
           class="input-field__body"
         >
           <input
+            aria-describedby=""
             aria-invalid="false"
             aria-label="search"
             class="input input-field__input--leading-icon"
             disabled=""
-            id=":ru:"
+            id=":r10:"
             placeholder="Search..."
             type="search"
           />
@@ -11040,7 +11044,7 @@ exports[`<DataTable /> WithSearchAndCustomActions story renders snapshot 1`] = `
             aria-label="show more actions"
             class="button button--layout-icon-only button--secondary button--lg button--size-lg button--variant-default"
             data-headlessui-state=""
-            id="headlessui-menu-button-:r12:"
+            id="headlessui-menu-button-:r15:"
             type="button"
           >
             <span

--- a/src/components/FieldLabel/FieldLabel.tsx
+++ b/src/components/FieldLabel/FieldLabel.tsx
@@ -41,8 +41,7 @@ export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(
   ({ children, className, htmlFor, size = 'lg', disabled, ...other }, ref) => {
     const componentClassName = clsx(
       styles['label'],
-      size === 'md' && styles['label--md'],
-      size === 'lg' && styles['label--lg'],
+      size && styles[`label--${size}`],
       disabled && styles['label--disabled'],
       className,
     );

--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -7,6 +7,7 @@
  */
 .input-field__overline {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   margin-bottom: calc(var(--eds-spacing-size-half) * 1px);
   gap: calc(var(--eds-spacing-size-half) * 1px);
@@ -14,6 +15,11 @@
 
 .input-field__overline--no-label {
   justify-content: flex-start;
+}
+
+.input-field__sublabel {
+  color: var(--eds-theme-color-text-utility-default-secondary);
+  flex: 1 0 100%;
 }
 
 /**

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -10,13 +10,14 @@ const meta: Meta<typeof InputField> = {
   component: InputField,
   parameters: {
     layout: 'centered',
-    badges: ['api-2.0', 'theme-2.0'],
+    badges: ['api-2.1', 'theme-2.0'],
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',
     },
   },
   args: {
     className: 'w-[384px]',
+    sublabel: 'Additional descriptive text for the field',
   },
   argTypes: {
     type: {

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof InputField> = {
   },
   args: {
     className: 'w-[384px]',
-    sublabel: 'Additional descriptive text for the field',
+    sublabel: 'Additional descriptive text for the field.',
   },
   argTypes: {
     type: {
@@ -47,7 +47,18 @@ type Story = StoryObj<typeof InputField>;
 export const Default: Story = {
   args: {
     label: 'Default input field',
-    fieldNote: 'This is a fieldnote.',
+    sublabel: '',
+  },
+};
+
+/**
+ * An input field can have both a footnote (describing how the field is validated), and a sublabel
+ * (a longer description to elaborate on the label)
+ */
+export const WithFullDescription: Story = {
+  args: {
+    label: 'Default input field',
+    fieldNote: 'Field validation description.',
   },
 };
 

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -116,6 +116,12 @@ export const Disabled: Story = {
     fieldNote: 'This InputField is disabled',
     defaultValue: 'Text in disabled field',
   },
+  parameters: {
+    axe: {
+      // Disabled input does not need to meet color contrast
+      disabledRules: ['color-contrast'],
+    },
+  },
 };
 
 /**
@@ -151,6 +157,12 @@ export const RequiredDisabled: Story = {
     required: true,
     disabled: true,
     fieldNote: 'This is a fieldnote for a required input field.',
+  },
+  parameters: {
+    axe: {
+      // Disabled input does not need to meet color contrast
+      disabledRules: ['color-contrast'],
+    },
   },
 };
 

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -92,7 +92,7 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
   value?: string | number;
   // Design API
   /**
-   * Text under the text input used to provide a description or error message to describe the input.
+   * Text under the textarea used to provide validation hints or error message to describe the input error.
    */
   fieldNote?: ReactNode;
   /**
@@ -124,6 +124,10 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    * **Default is `"default"`**.
    */
   status?: 'default' | Extract<Status, 'warning' | 'critical'>;
+  /**
+   * Add additional descriptive text for the field name.
+   */
+  sublabel?: string;
 } & EitherInclusive<
     {
       /**
@@ -172,6 +176,7 @@ export const InputField: InputFieldType = forwardRef(
       required,
       showHint,
       status = 'default',
+      sublabel,
       type = 'text',
       ...other
     },
@@ -191,6 +196,11 @@ export const InputField: InputFieldType = forwardRef(
 
     const labelClassName = clsx(
       styles['input-field__label'],
+      disabled && styles['input-field__label--disabled'],
+    );
+
+    const subLabelClassName = clsx(
+      styles['input-field__sublabel'],
       disabled && styles['input-field__label--disabled'],
     );
 
@@ -281,6 +291,13 @@ export const InputField: InputFieldType = forwardRef(
                 <span className={fieldLengthCountClassName}>{fieldLength}</span>{' '}
                 / {maxLengthShown}
               </Text>
+            )}
+            {label && sublabel && (
+              <div className={subLabelClassName}>
+                <Text as="span" preset="body-sm">
+                  {sublabel}
+                </Text>
+              </div>
             )}
           </div>
         )}

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -200,7 +200,7 @@ export const InputField: InputFieldType = forwardRef(
       disabled && styles['input-field__label--disabled'],
     );
 
-    const subLabelClassName = clsx(
+    const sublabelClassName = clsx(
       styles['input-field__sublabel'],
       disabled && styles['input-field__label--disabled'],
     );
@@ -303,7 +303,7 @@ export const InputField: InputFieldType = forwardRef(
               </Text>
             )}
             {label && sublabel && (
-              <div className={subLabelClassName}>
+              <div className={sublabelClassName}>
                 <Text as="span" id={generatedSubLabelId} preset="body-sm">
                   {sublabel}
                 </Text>

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<InputField /> DateHandling story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":rm:"
+        for=":r14:"
       >
         <span
           class="text text--label-md"
@@ -20,40 +20,17 @@ exports[`<InputField /> DateHandling story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
-      <div
-        class="input-field__sublabel"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          Additional descriptive text for the field
-        </span>
-      </div>
     </div>
     <div
-      class="input-field__body input-field--has-fieldNote"
+      class="input-field__body"
     >
       <input
-        aria-describedby=":rn:"
+        aria-describedby=""
         aria-invalid="false"
         class="input"
-        id=":rm:"
+        id=":r14:"
         type="date"
       />
-    </div>
-    <div
-      class="input-field__footer"
-    >
-      <div
-        class="field-note"
-        id=":rn:"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          This is a fieldnote.
-        </span>
-      </div>
     </div>
   </div>
 </div>
@@ -79,40 +56,17 @@ exports[`<InputField /> Default story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
-      <div
-        class="input-field__sublabel"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          Additional descriptive text for the field
-        </span>
-      </div>
     </div>
     <div
-      class="input-field__body input-field--has-fieldNote"
+      class="input-field__body"
     >
       <input
-        aria-describedby=":r1:"
+        aria-describedby=""
         aria-invalid="false"
         class="input"
         id=":r0:"
         type="text"
       />
-    </div>
-    <div
-      class="input-field__footer"
-    >
-      <div
-        class="field-note"
-        id=":r1:"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          This is a fieldnote.
-        </span>
-      </div>
     </div>
   </div>
 </div>
@@ -131,7 +85,7 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
       <label
         aria-disabled="true"
         class="label label--md label--disabled input-field__label input-field__label--disabled"
-        for=":rc:"
+        for=":rl:"
       >
         <span
           class="text text--label-md"
@@ -144,8 +98,9 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rn:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -153,11 +108,11 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":rd:"
+        aria-describedby=":rn: :rm:"
         aria-invalid="false"
         class="input"
         disabled=""
-        id=":rc:"
+        id=":rl:"
         type="text"
         value="Text in disabled field"
       />
@@ -168,7 +123,7 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
       <div
         aria-disabled="true"
         class="field-note field-note--disabled"
-        id=":rd:"
+        id=":rm:"
       >
         <span
           class="text text--body-sm"
@@ -193,7 +148,7 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r6:"
+        for=":rc:"
       >
         <span
           class="text text--label-md"
@@ -206,8 +161,9 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":re:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -215,10 +171,10 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":r7:"
+        aria-describedby=":re: :rd:"
         aria-invalid="true"
         class="input error"
-        id=":r6:"
+        id=":rc:"
         type="text"
       />
     </div>
@@ -227,7 +183,7 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
     >
       <div
         class="field-note field-note--error"
-        id=":r7:"
+        id=":rd:"
       >
         <svg
           class="icon field-note__icon"
@@ -267,7 +223,7 @@ exports[`<InputField /> InputWithin story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":rs:"
+        for=":r1d:"
       >
         <span
           class="text text--label-md"
@@ -280,9 +236,10 @@ exports[`<InputField /> InputWithin story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=""
         aria-invalid="false"
         class="input input-field__input--input-within"
-        id=":rs:"
+        id=":r1d:"
         type="text"
       />
       <div
@@ -315,10 +272,11 @@ exports[`<InputField /> LeadingIcon story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=":rq:"
         aria-invalid="false"
         aria-label="search field"
         class="input input-field__input--leading-icon"
-        id=":re:"
+        id=":ro:"
         placeholder="Search..."
         type="text"
       />
@@ -355,7 +313,7 @@ exports[`<InputField /> LongInputWithin story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":ru:"
+        for=":r1g:"
       >
         <span
           class="text text--label-md"
@@ -368,9 +326,10 @@ exports[`<InputField /> LongInputWithin story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=""
         aria-invalid="false"
         class="input input-field__input--input-within"
-        id=":ru:"
+        id=":r1g:"
         type="text"
       />
       <div
@@ -418,7 +377,7 @@ exports[`<InputField /> NoFieldnote story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r4:"
+        for=":r9:"
       >
         <span
           class="text text--label-md"
@@ -431,8 +390,9 @@ exports[`<InputField /> NoFieldnote story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rb:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -440,9 +400,10 @@ exports[`<InputField /> NoFieldnote story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=":rb:"
         aria-invalid="false"
         class="input"
-        id=":r4:"
+        id=":r9:"
         type="text"
       />
     </div>
@@ -464,11 +425,11 @@ exports[`<InputField /> NoVisibleLabel story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":rl:"
+        aria-describedby=":r13: :r12:"
         aria-invalid="false"
         aria-label="Input for no visible label"
         class="input"
-        id=":rk:"
+        id=":r11:"
         required=""
         type="text"
       />
@@ -478,7 +439,7 @@ exports[`<InputField /> NoVisibleLabel story renders snapshot 1`] = `
     >
       <div
         class="field-note"
-        id=":rl:"
+        id=":r12:"
       >
         <span
           class="text text--body-sm"
@@ -503,7 +464,7 @@ exports[`<InputField /> ReadOnly story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":ra:"
+        for=":ri:"
       >
         <span
           class="text text--label-md"
@@ -516,8 +477,9 @@ exports[`<InputField /> ReadOnly story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rk:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -525,10 +487,10 @@ exports[`<InputField /> ReadOnly story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":rb:"
+        aria-describedby=":rk: :rj:"
         aria-invalid="false"
         class="input"
-        id=":ra:"
+        id=":ri:"
         readonly=""
         type="text"
         value="some read-only information"
@@ -539,7 +501,7 @@ exports[`<InputField /> ReadOnly story renders snapshot 1`] = `
     >
       <div
         class="field-note"
-        id=":rb:"
+        id=":rj:"
       >
         <span
           class="text text--body-sm"
@@ -564,7 +526,7 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":rg:"
+        for=":rr:"
       >
         <span
           class="text text--label-md"
@@ -582,8 +544,9 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rt:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -591,10 +554,10 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":rh:"
+        aria-describedby=":rt: :rs:"
         aria-invalid="false"
         class="input"
-        id=":rg:"
+        id=":rr:"
         required=""
         type="text"
       />
@@ -604,7 +567,7 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
     >
       <div
         class="field-note"
-        id=":rh:"
+        id=":rs:"
       >
         <span
           class="text text--body-sm"
@@ -630,7 +593,7 @@ exports[`<InputField /> RequiredDisabled story renders snapshot 1`] = `
       <label
         aria-disabled="true"
         class="label label--md label--disabled input-field__label input-field__label--disabled"
-        for=":ri:"
+        for=":ru:"
       >
         <span
           class="text text--label-md"
@@ -649,8 +612,9 @@ exports[`<InputField /> RequiredDisabled story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r10:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -658,11 +622,11 @@ exports[`<InputField /> RequiredDisabled story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":rj:"
+        aria-describedby=":r10: :rv:"
         aria-invalid="false"
         class="input"
         disabled=""
-        id=":ri:"
+        id=":ru:"
         required=""
         type="text"
       />
@@ -673,7 +637,7 @@ exports[`<InputField /> RequiredDisabled story renders snapshot 1`] = `
       <div
         aria-disabled="true"
         class="field-note field-note--disabled"
-        id=":rj:"
+        id=":rv:"
       >
         <span
           class="text text--body-sm"
@@ -698,7 +662,7 @@ exports[`<InputField /> ShowHint story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":rq:"
+        for=":r1a:"
       >
         <span
           class="text text--label-md"
@@ -716,8 +680,9 @@ exports[`<InputField /> ShowHint story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r1c:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -725,9 +690,10 @@ exports[`<InputField /> ShowHint story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=":r1c:"
         aria-invalid="false"
         class="input"
-        id=":rq:"
+        id=":r1a:"
         type="text"
       />
     </div>
@@ -747,7 +713,7 @@ exports[`<InputField /> TimeHandling story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":ro:"
+        for=":r17:"
       >
         <span
           class="text text--label-md"
@@ -755,40 +721,17 @@ exports[`<InputField /> TimeHandling story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
-      <div
-        class="input-field__sublabel"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          Additional descriptive text for the field
-        </span>
-      </div>
     </div>
     <div
-      class="input-field__body input-field--has-fieldNote"
+      class="input-field__body"
     >
       <input
-        aria-describedby=":rp:"
+        aria-describedby=""
         aria-invalid="false"
         class="input"
-        id=":ro:"
+        id=":r17:"
         type="time"
       />
-    </div>
-    <div
-      class="input-field__footer"
-    >
-      <div
-        class="field-note"
-        id=":rp:"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          This is a fieldnote.
-        </span>
-      </div>
     </div>
   </div>
 </div>
@@ -806,7 +749,7 @@ exports[`<InputField /> Warning story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r8:"
+        for=":rf:"
       >
         <span
           class="text text--label-md"
@@ -819,8 +762,9 @@ exports[`<InputField /> Warning story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rh:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -828,10 +772,10 @@ exports[`<InputField /> Warning story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":r9:"
+        aria-describedby=":rh: :rg:"
         aria-invalid="false"
         class="input warning"
-        id=":r8:"
+        id=":rf:"
         type="text"
       />
     </div>
@@ -840,7 +784,7 @@ exports[`<InputField /> Warning story renders snapshot 1`] = `
     >
       <div
         class="field-note field-note--warning"
-        id=":r9:"
+        id=":rg:"
       >
         <svg
           class="icon field-note__icon"
@@ -882,7 +826,7 @@ exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r10:"
+        for=":r1j:"
       >
         <span
           class="text text--label-md"
@@ -907,8 +851,9 @@ exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r1l:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -916,9 +861,10 @@ exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=":r1l:"
         aria-invalid="false"
         class="input error"
-        id=":r10:"
+        id=":r1j:"
         maxlength="15"
         required=""
         type="text"
@@ -941,7 +887,7 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r12:"
+        for=":r1m:"
       >
         <span
           class="text text--label-md"
@@ -966,8 +912,9 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r1o:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -975,9 +922,10 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
+        aria-describedby=":r1o:"
         aria-invalid="false"
         class="input error"
-        id=":r12:"
+        id=":r1m:"
         required=""
         type="text"
         value="Some initial text"
@@ -999,7 +947,7 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
     >
       <label
         class="label label--md input-field__label"
-        for=":r14:"
+        for=":r1p:"
       >
         <span
           class="text text--label-md"
@@ -1024,8 +972,9 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
       >
         <span
           class="text text--body-sm"
+          id=":r1r:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -1033,10 +982,10 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":r15:"
+        aria-describedby=":r1r: :r1q:"
         aria-invalid="false"
         class="input error"
-        id=":r14:"
+        id=":r1p:"
         maxlength="20"
         required=""
         type="text"
@@ -1048,7 +997,7 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
     >
       <div
         class="field-note field-note--error"
-        id=":r15:"
+        id=":r1q:"
       >
         <svg
           class="icon field-note__icon"
@@ -1078,7 +1027,7 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
 </div>
 `;
 
-exports[`<InputField /> WithText story renders snapshot 1`] = `
+exports[`<InputField /> WithFullDescription story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"
 >
@@ -1090,7 +1039,7 @@ exports[`<InputField /> WithText story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r2:"
+        for=":r3:"
       >
         <span
           class="text text--label-md"
@@ -1103,8 +1052,9 @@ exports[`<InputField /> WithText story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r5:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
@@ -1112,10 +1062,70 @@ exports[`<InputField /> WithText story renders snapshot 1`] = `
       class="input-field__body input-field--has-fieldNote"
     >
       <input
-        aria-describedby=":r3:"
+        aria-describedby=":r5: :r4:"
         aria-invalid="false"
         class="input"
-        id=":r2:"
+        id=":r3:"
+        type="text"
+      />
+    </div>
+    <div
+      class="input-field__footer"
+    >
+      <div
+        class="field-note"
+        id=":r4:"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Field validation description.
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InputField /> WithText story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="w-[384px]"
+  >
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--md input-field__label"
+        for=":r6:"
+      >
+        <span
+          class="text text--label-md"
+        >
+          Default input field
+        </span>
+      </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+          id=":r8:"
+        >
+          Additional descriptive text for the field.
+        </span>
+      </div>
+    </div>
+    <div
+      class="input-field__body input-field--has-fieldNote"
+    >
+      <input
+        aria-describedby=":r8: :r7:"
+        aria-invalid="false"
+        class="input"
+        id=":r6:"
         type="text"
         value="Text value"
       />
@@ -1125,7 +1135,7 @@ exports[`<InputField /> WithText story renders snapshot 1`] = `
     >
       <div
         class="field-note"
-        id=":r3:"
+        id=":r7:"
       >
         <span
           class="text text--body-sm"

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -20,6 +20,15 @@ exports[`<InputField /> DateHandling story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -70,6 +79,15 @@ exports[`<InputField /> Default story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -121,6 +139,15 @@ exports[`<InputField /> Disabled story renders snapshot 1`] = `
           Disabled input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel input-field__label--disabled"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -174,6 +201,15 @@ exports[`<InputField /> Error story renders snapshot 1`] = `
           Error input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -390,6 +426,15 @@ exports[`<InputField /> NoFieldnote story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body"
@@ -466,6 +511,15 @@ exports[`<InputField /> ReadOnly story renders snapshot 1`] = `
           Read-only field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -523,6 +577,15 @@ exports[`<InputField /> Required story renders snapshot 1`] = `
       >
         (Required)
       </span>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -581,6 +644,15 @@ exports[`<InputField /> RequiredDisabled story renders snapshot 1`] = `
       >
         (Required)
       </span>
+      <div
+        class="input-field__sublabel input-field__label--disabled"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -639,6 +711,15 @@ exports[`<InputField /> ShowHint story renders snapshot 1`] = `
       >
         (Optional)
       </span>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body"
@@ -674,6 +755,15 @@ exports[`<InputField /> TimeHandling story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -724,6 +814,15 @@ exports[`<InputField /> Warning story renders snapshot 1`] = `
           Warning input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"
@@ -803,6 +902,15 @@ exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
         / 
         15
       </div>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body"
@@ -853,6 +961,15 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
         / 
         15
       </div>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body"
@@ -901,6 +1018,15 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
          
         / 
         15
+      </div>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
       </div>
     </div>
     <div
@@ -972,6 +1098,15 @@ exports[`<InputField /> WithText story renders snapshot 1`] = `
           Default input field
         </span>
       </label>
+      <div
+        class="input-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <div
       class="input-field__body input-field--has-fieldNote"

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -16,6 +16,7 @@
  */
 .select__overline {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   margin-bottom: calc(var(--eds-spacing-size-half) * 1px);
   gap: calc(var(--eds-spacing-size-half) * 1px);
@@ -105,6 +106,11 @@
  */
 .select__label {
   color: var(--eds-theme-color-text-utility-default-primary);
+}
+
+.select__sublabel {
+  color: var(--eds-theme-color-text-utility-default-secondary);
+  flex: 1 0 100%;
 }
 
 .select__label--disabled {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof Select> = {
   component: Select,
   parameters: {
     layout: 'centered',
-    badges: ['api-3.0', 'theme-2.0'],
+    badges: ['api-3.1', 'theme-2.0'],
   },
   argTypes: {
     multiple: {
@@ -337,6 +337,7 @@ export const WithSelectedBy: StoryObj<typeof Select> = {
 export const WithFieldName: StoryObj = {
   args: {
     ...Default.args,
+    sublabel: 'Additional descriptive text',
     children: (
       <>
         <Select.Button>
@@ -770,6 +771,7 @@ export const SeparateButtonAndMenuWidth: StoryObj = {
 export const Disabled: StoryObj = {
   args: {
     ...Default.args,
+    sublabel: 'Some descriptive text',
     disabled: true,
   },
   parameters: {
@@ -788,6 +790,7 @@ export const Required: StoryObj = {
     required: true,
     showHint: true,
     className: 'w-[384px]',
+    sublabel: 'Some descriptive text',
   },
   parameters: {
     ...Default.parameters,
@@ -802,6 +805,7 @@ export const Optional: StoryObj = {
     ...Default.args,
     required: false,
     showHint: true,
+    sublabel: 'Some descriptive text',
     className: 'w-[384px]',
   },
   parameters: {
@@ -950,7 +954,7 @@ export const OptionsRightAligned: StoryObj = {
 export const OpenByDefault: StoryObj = {
   ...Default,
   parameters: {
-    badges: ['api-2.0', 'theme-2.0'],
+    badges: ['api-2.1', 'theme-2.0'],
     layout: 'centered',
     chromatic: { delay: 300, disableSnapshot: true },
     docs: {

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -775,6 +775,10 @@ export const Disabled: StoryObj = {
     disabled: true,
   },
   parameters: {
+    axe: {
+      // Disabled input does not need to meet color contrast
+      disabledRules: ['color-contrast'],
+    },
     docs: {
       ...Default.parameters?.docs,
     },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -337,6 +337,7 @@ const SelectLabel = ({
       )}
       {label && sublabel && (
         <div className={subLabelClassName}>
+          {/* TODO: is there a way to coerce HeadlessUI into using aria-describedby like InputField/TextareaField */}
           <Text as="span" preset="body-sm">
             {sublabel}
           </Text>

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -300,7 +300,7 @@ const SelectLabel = ({
     !label && styles['select__overline--no-label'],
   );
 
-  const subLabelClassName = clsx(
+  const sublabelClassName = clsx(
     styles['select__sublabel'],
     disabled && styles['select__label--disabled'],
   );
@@ -336,7 +336,7 @@ const SelectLabel = ({
         </Text>
       )}
       {label && sublabel && (
-        <div className={subLabelClassName}>
+        <div className={sublabelClassName}>
           {/* TODO: is there a way to coerce HeadlessUI into using aria-describedby like InputField/TextareaField */}
           <Text as="span" preset="body-sm">
             {sublabel}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -65,7 +65,7 @@ type SelectProps = ListboxProps<
   required?: boolean;
   // Design API
   /**
-   * Text under the text input used to provide a description or error message to describe the input.
+   * Text under the textarea used to provide validation hints or error message to describe the input error.
    */
   fieldNote?: ReactNode;
   /**
@@ -90,12 +90,20 @@ type SelectProps = ListboxProps<
    * **Default is `"default"`**.
    */
   status?: 'default' | Extract<Status, 'warning' | 'critical'>;
+  /**
+   * Add additional descriptive text for the field name
+   */
+  sublabel?: string;
 };
 
 type SelectLabelProps = ExtractProps<typeof Label> & {
   disabled?: boolean;
   required?: boolean;
   showHint?: boolean;
+  /**
+   * Add additional descriptive text for the field name
+   */
+  sublabel?: string;
 };
 type SelectOptionsProps = ExtractProps<typeof ListboxOptions>;
 type SelectOptionProps = ExtractProps<typeof ListboxOption> & {
@@ -180,6 +188,7 @@ export function Select({
   showHint,
   status,
   onChange: theirOnChange,
+  sublabel,
   ...other
 }: SelectProps) {
   if (process.env.NODE_ENV !== 'production') {
@@ -249,6 +258,7 @@ export function Select({
             disabled={disabled}
             required={required}
             showHint={showHint}
+            sublabel={sublabel}
           >
             {label}
           </Select.Label>
@@ -272,6 +282,7 @@ const SelectLabel = ({
   className,
   disabled,
   showHint,
+  sublabel,
 }: SelectLabelProps) => {
   const componentClassName = clsx(
     styles['select__label'],
@@ -287,6 +298,11 @@ const SelectLabel = ({
   const overlineClassName = clsx(
     styles['select__overline'],
     !label && styles['select__overline--no-label'],
+  );
+
+  const subLabelClassName = clsx(
+    styles['select__sublabel'],
+    disabled && styles['select__label--disabled'],
   );
 
   return (
@@ -318,6 +334,13 @@ const SelectLabel = ({
         >
           (Optional)
         </Text>
+      )}
+      {label && sublabel && (
+        <div className={subLabelClassName}>
+          <Text as="span" preset="body-sm">
+            {sublabel}
+          </Text>
+        </div>
       )}
     </div>
   );

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -146,6 +146,15 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
     >
       (Required)
     </span>
+    <div
+      class="select__sublabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
   </div>
   <button
     aria-controls="headlessui-listbox-options-:r44:"
@@ -427,6 +436,15 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
     >
       (Optional)
     </span>
+    <div
+      class="select__sublabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
   </div>
   <button
     aria-controls="headlessui-listbox-options-:r3q:"
@@ -491,6 +509,15 @@ exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
     >
       (Required)
     </span>
+    <div
+      class="select__sublabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
   </div>
   <button
     aria-controls="headlessui-listbox-options-:r3g:"
@@ -619,6 +646,15 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
     >
       (Optional)
     </span>
+    <div
+      class="select__sublabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
   </div>
   <button
     aria-controls="headlessui-listbox-options-:r4e:"
@@ -678,6 +714,15 @@ exports[`<Select /> Generated Snapshots WithFieldName story renders snapshot 1`]
         Favorite Animal
       </span>
     </label>
+    <div
+      class="select__sublabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Additional descriptive text
+      </span>
+    </div>
   </div>
   <button
     aria-controls="headlessui-listbox-options-:r1m:"

--- a/src/components/TextareaField/TextareaField.module.css
+++ b/src/components/TextareaField/TextareaField.module.css
@@ -22,6 +22,7 @@
  */
 .textarea-field__overline {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   margin-bottom: calc(var(--eds-spacing-size-half) * 1px);
   gap: calc(var(--eds-spacing-size-half) * 1px);
@@ -33,10 +34,6 @@
 
 .textarea-field__hint {
   color: var(--eds-theme-color-text-utility-default-secondary)
-}
-
-.textarea-field__label--disabled {
-  color: var(--eds-theme-color-text-utility-disabled-primary);
 }
 
 .textarea-field--invalid-length {
@@ -57,4 +54,13 @@
 
   flex: 1 0 50%;
   text-align: right;
+}
+
+.textarea-field__sublabel {
+  color: var(--eds-theme-color-text-utility-default-secondary);
+  flex: 1 0 100%;
+}
+
+.textarea-field__label--disabled {
+  color: var(--eds-theme-color-text-utility-disabled-primary);
 }

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -13,13 +13,14 @@ const meta: Meta<typeof TextareaField> = {
 dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
 praesentium, commodi eligendi asperiores quis dolorum porro.`,
     label: 'Textarea Field',
+    sublabel: 'Additional descriptive text for the field',
     rows: 5,
-    fieldNote: 'Longer Field description',
+    fieldNote: 'Validation information or error details about the input',
     spellCheck: false,
   },
   parameters: {
     layout: 'centered',
-    badges: ['api-2.0', 'theme-2.0'],
+    badges: ['api-2.1', 'theme-2.0'],
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
 };

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -13,9 +13,9 @@ const meta: Meta<typeof TextareaField> = {
 dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
 praesentium, commodi eligendi asperiores quis dolorum porro.`,
     label: 'Textarea Field',
-    sublabel: 'Additional descriptive text for the field',
+    sublabel: 'Additional descriptive text for the field.',
     rows: 5,
-    fieldNote: 'Validation information or error details about the input',
+    fieldNote: 'Validation information or error details about the input.',
     spellCheck: false,
   },
   parameters: {
@@ -29,9 +29,10 @@ export default meta;
 type Story = StoryObj<typeof TextareaField>;
 
 export const Default: Story = {
-  render: (args) => (
-    <TextareaField aria-label="Text Label" {...args}></TextareaField>
-  ),
+  args: {
+    sublabel: '',
+    fieldNote: '',
+  },
 };
 
 /**

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -173,10 +173,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
     ref,
   ) => {
     const [fieldText, setFieldText] = useState(defaultValue);
-    const generatedIdVar = useId();
-    const generatedAriaDescribedById = useId();
 
-    const idVar = id || generatedIdVar;
     const shouldRenderOverline = !!(label || required);
     const fieldLength = fieldText?.toString().length ?? 0;
     const textExceedsMaxLength =
@@ -191,10 +188,6 @@ export const TextareaField: TextareaFieldType = forwardRef(
       status === 'critical' ||
       textExceedsMaxLength ||
       textExceedsRecommendedLength;
-
-    const ariaDescribedByVar = fieldNote
-      ? ariaDescribedBy || generatedAriaDescribedById
-      : undefined;
 
     const componentClassName = clsx(styles['textarea-field'], className);
     const overlineClassName = clsx(
@@ -224,6 +217,20 @@ export const TextareaField: TextareaFieldType = forwardRef(
     const textareaClassName = clsx(
       readOnly && styles['textarea-field__textarea--read-only'],
     );
+
+    // Accessibility: attach the IDs of fieldnote and/or sublabel to the input
+    const generatedIdVar = useId();
+    const idVar = id || generatedIdVar;
+    const generatedFieldNoteId = useId();
+    const generatedSubLabelId = useId();
+
+    // set up the aria-describedby based on the following rules:
+    // - describedby is blank if sublabel and fieldnote are not defined
+    // - for each sublabel/fieldnote, append the space-separated, generated IDs to aria-describedby
+    // - if the user has given a aria-describedby prop, override the calculation
+    const completeDescribedByVar = ariaDescribedBy
+      ? ariaDescribedBy
+      : `${sublabel ? generatedSubLabelId : ''}${fieldNote ? ' ' + generatedFieldNoteId : ''}`;
 
     // Pick the smallest of the lengths to set as the maximum value allowed
     const maxLengthShown = getMinValue(maxLength, recommendedMaxLength);
@@ -266,7 +273,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
             )}
             {label && sublabel && (
               <div className={subLabelClassName}>
-                <Text as="span" preset="body-sm">
+                <Text as="span" id={generatedSubLabelId} preset="body-sm">
                   {sublabel}
                 </Text>
               </div>
@@ -274,7 +281,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
           </div>
         )}
         <TextArea
-          aria-describedby={ariaDescribedByVar}
+          aria-describedby={completeDescribedByVar ?? undefined}
           aria-disabled={disabled}
           className={textareaClassName}
           defaultValue={defaultValue}
@@ -299,7 +306,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
               <FieldNote
                 className={styles['textarea-field__field-note']}
                 disabled={disabled}
-                id={ariaDescribedByVar}
+                id={generatedFieldNoteId}
                 status={shouldRenderError ? 'critical' : status}
               >
                 {fieldNote}

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -200,7 +200,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
       disabled && styles['textarea-field__label--disabled'],
     );
 
-    const subLabelClassName = clsx(
+    const sublabelClassName = clsx(
       styles['textarea-field__sublabel'],
       disabled && styles['textarea-field__label--disabled'],
     );
@@ -272,7 +272,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
               </Text>
             )}
             {label && sublabel && (
-              <div className={subLabelClassName}>
+              <div className={sublabelClassName}>
                 <Text as="span" id={generatedSubLabelId} preset="body-sm">
                   {sublabel}
                 </Text>

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -30,7 +30,7 @@ type TextareaFieldProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
    */
   disabled?: boolean;
   /**
-   * Text under the textarea used to provide a description or error message to describe the input.
+   * Text under the textarea used to provide validation hints or error message to describe the input error.
    */
   fieldNote?: ReactNode;
   /**
@@ -55,6 +55,10 @@ type TextareaFieldProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
    * **Default is `"default"`**.
    */
   status?: 'default' | Extract<Status, 'warning' | 'critical'>;
+  /**
+   * Add additional descriptive text for the field name.
+   */
+  sublabel?: string;
 } & EitherInclusive<
     {
       /**
@@ -163,6 +167,7 @@ export const TextareaField: TextareaFieldType = forwardRef(
       required,
       showHint,
       status = 'default',
+      sublabel,
       ...other
     },
     ref,
@@ -197,7 +202,13 @@ export const TextareaField: TextareaFieldType = forwardRef(
       !label && styles['textarea-field__overline--no-label'],
       disabled && styles['textarea-field__overline--disabled'],
     );
+
     const labelClassName = clsx(
+      disabled && styles['textarea-field__label--disabled'],
+    );
+
+    const subLabelClassName = clsx(
+      styles['textarea-field__sublabel'],
       disabled && styles['textarea-field__label--disabled'],
     );
 
@@ -252,6 +263,13 @@ export const TextareaField: TextareaFieldType = forwardRef(
                 <span className={fieldLengthCountClassName}>{fieldLength}</span>{' '}
                 / {maxLengthShown}
               </Text>
+            )}
+            {label && sublabel && (
+              <div className={subLabelClassName}>
+                <Text as="span" preset="body-sm">
+                  {sublabel}
+                </Text>
+              </div>
             )}
           </div>
         )}

--- a/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
@@ -20,6 +20,15 @@ exports[`<TextareaField /> Default story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":r1:"
@@ -44,7 +53,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -72,6 +81,15 @@ exports[`<TextareaField /> WhenDefaultStatus story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rb:"
@@ -123,6 +141,15 @@ exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel textarea-field__label--disabled"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":r7:"
@@ -149,7 +176,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -177,6 +204,15 @@ exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rd:"
@@ -245,6 +281,15 @@ exports[`<TextareaField /> WhenNoDefaultValue story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       class="textarea"
@@ -282,6 +327,15 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
       >
         (Optional)
       </span>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rj:"
@@ -305,7 +359,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -333,6 +387,15 @@ exports[`<TextareaField /> WhenReadOnly story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":r9:"
@@ -357,7 +420,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -390,6 +453,15 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
       >
         (Required)
       </span>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rh:"
@@ -414,7 +486,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -442,6 +514,15 @@ exports[`<TextareaField /> WhenUsingChildren story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":r3:"
@@ -465,7 +546,7 @@ exports[`<TextareaField /> WhenUsingChildren story renders snapshot 1`] = `
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -493,6 +574,15 @@ exports[`<TextareaField /> WhenWarning story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rf:"
@@ -561,6 +651,15 @@ exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rl:"
@@ -584,7 +683,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -624,6 +723,15 @@ exports[`<TextareaField /> WithAMaxLength story renders snapshot 1`] = `
         / 
         144
       </p>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rn:"
@@ -666,7 +774,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -706,6 +814,15 @@ exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
         / 
         144
       </p>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rp:"
@@ -747,7 +864,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>
@@ -787,6 +904,15 @@ exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapsh
         / 
         144
       </p>
+      <div
+        class="textarea-field__sublabel"
+      >
+        <span
+          class="text text--body-sm"
+        >
+          Additional descriptive text for the field
+        </span>
+      </div>
     </div>
     <textarea
       aria-describedby=":rr:"
@@ -829,7 +955,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Longer Field description
+          Validation information or error details about the input
         </span>
       </div>
     </div>

--- a/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
+++ b/src/components/TextareaField/__snapshots__/TextareaField.test.tsx.snap
@@ -20,19 +20,9 @@ exports[`<TextareaField /> Default story renders snapshot 1`] = `
           Textarea Field
         </span>
       </label>
-      <div
-        class="textarea-field__sublabel"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          Additional descriptive text for the field
-        </span>
-      </div>
     </div>
     <textarea
-      aria-describedby=":r1:"
-      aria-label="Text Label"
+      aria-describedby=""
       class="textarea"
       id=":r0:"
       placeholder="Enter long-form text here"
@@ -43,20 +33,6 @@ exports[`<TextareaField /> Default story renders snapshot 1`] = `
 dicta rerum commodi et fugiat quo optio veniam! Ea odio corporis nemo
 praesentium, commodi eligendi asperiores quis dolorum porro.
     </textarea>
-    <div
-      class="textarea-field__footer"
-    >
-      <div
-        class="field-note textarea-field__field-note"
-        id=":r1:"
-      >
-        <span
-          class="text text--body-sm"
-        >
-          Validation information or error details about the input
-        </span>
-      </div>
-    </div>
   </div>
 </div>
 `;
@@ -73,7 +49,7 @@ exports[`<TextareaField /> WhenDefaultStatus story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":ra:"
+        for=":rf:"
       >
         <span
           class="text text--label-md"
@@ -86,15 +62,16 @@ exports[`<TextareaField /> WhenDefaultStatus story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rh:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rb:"
+      aria-describedby=":rh: :rg:"
       class="textarea"
-      id=":ra:"
+      id=":rf:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -108,7 +85,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rb:"
+        id=":rg:"
       >
         <span
           class="text text--body-sm"
@@ -133,7 +110,7 @@ exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
     >
       <label
         class="label label--md textarea-field__label--disabled"
-        for=":r6:"
+        for=":r9:"
       >
         <span
           class="text text--label-md"
@@ -146,17 +123,18 @@ exports[`<TextareaField /> WhenDisabled story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rb:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":r7:"
+      aria-describedby=":rb: :ra:"
       aria-disabled="true"
       class="textarea textarea--disabled"
       disabled=""
-      id=":r6:"
+      id=":r9:"
       placeholder="Enter long-form text here"
       rows="2"
       spellcheck="false"
@@ -171,12 +149,12 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
       <div
         aria-disabled="true"
         class="field-note field-note--disabled textarea-field__field-note"
-        id=":r7:"
+        id=":ra:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -196,7 +174,7 @@ exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":rc:"
+        for=":ri:"
       >
         <span
           class="text text--label-md"
@@ -209,15 +187,16 @@ exports[`<TextareaField /> WhenError story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rk:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rd:"
+      aria-describedby=":rk: :rj:"
       class="textarea error"
-      id=":rc:"
+      id=":ri:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -231,7 +210,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--error textarea-field__field-note"
-        id=":rd:"
+        id=":rj:"
       >
         <svg
           class="icon field-note__icon"
@@ -273,7 +252,7 @@ exports[`<TextareaField /> WhenNoDefaultValue story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":r4:"
+        for=":r6:"
       >
         <span
           class="text text--label-md"
@@ -286,14 +265,16 @@ exports[`<TextareaField /> WhenNoDefaultValue story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r8:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
+      aria-describedby=":r8:"
       class="textarea"
-      id=":r4:"
+      id=":r6:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -314,7 +295,7 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":ri:"
+        for=":rr:"
       >
         <span
           class="text text--label-md"
@@ -332,15 +313,16 @@ exports[`<TextareaField /> WhenOptional story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rt:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rj:"
+      aria-describedby=":rt: :rs:"
       class="textarea"
-      id=":ri:"
+      id=":rr:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -354,12 +336,12 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rj:"
+        id=":rs:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -379,7 +361,7 @@ exports[`<TextareaField /> WhenReadOnly story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":r8:"
+        for=":rc:"
       >
         <span
           class="text text--label-md"
@@ -392,15 +374,16 @@ exports[`<TextareaField /> WhenReadOnly story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":re:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":r9:"
+      aria-describedby=":re: :rd:"
       class="textarea textarea-field__textarea--read-only"
-      id=":r8:"
+      id=":rc:"
       placeholder="Enter long-form text here"
       readonly=""
       rows="2"
@@ -415,12 +398,12 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":r9:"
+        id=":rd:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -440,7 +423,7 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":rg:"
+        for=":ro:"
       >
         <span
           class="text text--label-md"
@@ -458,15 +441,16 @@ exports[`<TextareaField /> WhenRequired story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rq:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rh:"
+      aria-describedby=":rq: :rp:"
       class="textarea"
-      id=":rg:"
+      id=":ro:"
       placeholder="Enter long-form text here"
       required=""
       rows="5"
@@ -481,12 +465,12 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rh:"
+        id=":rp:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -506,7 +490,7 @@ exports[`<TextareaField /> WhenUsingChildren story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":r2:"
+        for=":r3:"
       >
         <span
           class="text text--label-md"
@@ -519,15 +503,16 @@ exports[`<TextareaField /> WhenUsingChildren story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r5:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":r3:"
+      aria-describedby=":r5: :r4:"
       class="textarea"
-      id=":r2:"
+      id=":r3:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -541,12 +526,12 @@ exports[`<TextareaField /> WhenUsingChildren story renders snapshot 1`] = `
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":r3:"
+        id=":r4:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -566,7 +551,7 @@ exports[`<TextareaField /> WhenWarning story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":re:"
+        for=":rl:"
       >
         <span
           class="text text--label-md"
@@ -579,15 +564,16 @@ exports[`<TextareaField /> WhenWarning story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":rn:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rf:"
+      aria-describedby=":rn: :rm:"
       class="textarea warning"
-      id=":re:"
+      id=":rl:"
       placeholder="Enter long-form text here"
       rows="5"
       spellcheck="false"
@@ -601,7 +587,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--warning textarea-field__field-note"
-        id=":rf:"
+        id=":rm:"
       >
         <svg
           class="icon field-note__icon"
@@ -643,7 +629,7 @@ exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":rk:"
+        for=":ru:"
       >
         <span
           class="text text--label-md"
@@ -656,15 +642,16 @@ exports[`<TextareaField /> WithADifferentSize story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r10:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rl:"
+      aria-describedby=":r10: :rv:"
       class="textarea"
-      id=":rk:"
+      id=":ru:"
       placeholder="Enter long-form text here"
       rows="10"
       spellcheck="false"
@@ -678,12 +665,12 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note textarea-field__field-note"
-        id=":rl:"
+        id=":rv:"
       >
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -703,7 +690,7 @@ exports[`<TextareaField /> WithAMaxLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":rm:"
+        for=":r11:"
       >
         <span
           class="text text--label-md"
@@ -728,15 +715,16 @@ exports[`<TextareaField /> WithAMaxLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r13:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rn:"
+      aria-describedby=":r13: :r12:"
       class="textarea error"
-      id=":rm:"
+      id=":r11:"
       maxlength="144"
       placeholder="Enter long-form text here"
       required=""
@@ -752,7 +740,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--error textarea-field__field-note"
-        id=":rn:"
+        id=":r12:"
       >
         <svg
           class="icon field-note__icon"
@@ -774,7 +762,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -794,7 +782,7 @@ exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md"
-        for=":ro:"
+        for=":r14:"
       >
         <span
           class="text text--label-md"
@@ -819,15 +807,16 @@ exports[`<TextareaField /> WithARecommendedLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
+          id=":r16:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rp:"
+      aria-describedby=":r16: :r15:"
       class="textarea error"
-      id=":ro:"
+      id=":r14:"
       placeholder="Enter long-form text here"
       required=""
       rows="10"
@@ -842,7 +831,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--error textarea-field__field-note"
-        id=":rp:"
+        id=":r15:"
       >
         <svg
           class="icon field-note__icon"
@@ -864,7 +853,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>
@@ -884,7 +873,7 @@ exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapsh
     >
       <label
         class="label label--md"
-        for=":rq:"
+        for=":r17:"
       >
         <span
           class="text text--label-md"
@@ -909,15 +898,16 @@ exports[`<TextareaField /> WithBothRecommendedAndMaxLengths story renders snapsh
       >
         <span
           class="text text--body-sm"
+          id=":r19:"
         >
-          Additional descriptive text for the field
+          Additional descriptive text for the field.
         </span>
       </div>
     </div>
     <textarea
-      aria-describedby=":rr:"
+      aria-describedby=":r19: :r18:"
       class="textarea error"
-      id=":rq:"
+      id=":r17:"
       maxlength="256"
       placeholder="Enter long-form text here"
       required=""
@@ -933,7 +923,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
     >
       <div
         class="field-note field-note--error textarea-field__field-note"
-        id=":rr:"
+        id=":r18:"
       >
         <svg
           class="icon field-note__icon"
@@ -955,7 +945,7 @@ praesentium, commodi eligendi asperiores quis dolorum porro.
         <span
           class="text text--body-sm"
         >
-          Validation information or error details about the input
+          Validation information or error details about the input.
         </span>
       </div>
     </div>


### PR DESCRIPTION
* Add `sublabel` for each of the listed components
* Update snapshots and test descriptions

### TODO
- [ ] update aria-label handling for each component so that (sub-)label is part of each labeled field

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
