### PR TITLE
fix(Modal): adjust handling of borders for modal content

### DIFF
--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -51,7 +51,8 @@
   * background colors but makes borders 100% opacity black. Without this, the
   * modal would have no clear boundary. 
   */
-  border: var(--eds-theme-form-border-width) transparent var(--eds-theme-color-background-utility-container);
+  border: calc(var(--eds-theme-form-border-width) * 1px) transparent var(--eds-theme-color-background-utility-container);
+  border-radius: calc(var(--eds-theme-border-radius-surfaces-lg) * 1px);
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
- add calc() to get units for border token
- add in token usage for content radius

When the value of the `surfaces-lg` token change, it will now propagate to the token border radius as expected. This is used when applying themes.

https://github.com/user-attachments/assets/40c15112-a956-47a9-bb52-2ece65346558


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
  - [x] See above demo (apply new value to `surfaces-lg` to make sure it applies and properly wraps around close trigger button
