### PR TITLE
fix: remove lingering usages of depecated animation token

### DIFF
--- a/.storybook/components/Docs/Guidelines/CodeGuidelines.mdx
+++ b/.storybook/components/Docs/Guidelines/CodeGuidelines.mdx
@@ -194,7 +194,7 @@ Examples:
 ```css
 .dropdown-button__icon {
   transition: transform calc(var(--eds-anim-move-medium) * 1s)
-    var(--eds-anim-ease);
+    ease-in-out;
 
   @media (prefers-reduced-motion) {
     transition: none;

--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -75,7 +75,7 @@
  * Animates the icon rotation when opening and closing.
  */
 .accordion-button>.accordion-button__trailing-icon {
-  transition: transform calc(var(--eds-anim-move-medium) * 1s) var(--eds-anim-ease);
+  transition: transform calc(var(--eds-anim-move-medium) * 1s) ease-in-out;
 
   @media screen and (prefers-reduced-motion) {
     transition: none;

--- a/src/components/Modal/Modal.module.css
+++ b/src/components/Modal/Modal.module.css
@@ -103,7 +103,7 @@
  * Modal transition animations.
  */
 .modal__transition--enter {
-  transition: opacity calc(var(--eds-anim-fade-long) * 1s) var(--eds-anim-ease);
+  transition: opacity calc(var(--eds-anim-fade-long) * 1s) ease-in-out;
 
   @media (prefers-reduced-motion) {
     transition: none;
@@ -119,7 +119,7 @@
 }
 
 .modal__transition--leave {
-  transition: opacity calc(var(--eds-anim-fade-long) * 1s) var(--eds-anim-ease);
+  transition: opacity calc(var(--eds-anim-fade-long) * 1s) ease-in-out;
 
   @media (prefers-reduced-motion) {
     transition: none;

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -26,8 +26,8 @@
   padding: calc(var(--eds-spacing-size-1) * 1px);
   margin: 0;
 
-  transition: box-shadow calc(var(--eds-anim-fade-quick) * 1s) var(--eds-anim-ease),
-  border-color calc(var(--eds-anim-fade-quick) * 1s) var(--eds-anim-ease);
+  transition: box-shadow calc(var(--eds-anim-fade-quick) * 1s) ease-in-out,
+  border-color calc(var(--eds-anim-fade-quick) * 1s) ease-in-out;
   
   @media screen and (prefers-reduced-motion) {
     transition: none;


### PR DESCRIPTION
The token was removed, and this cleans up the few lingering usages of that token that were missed.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - [x] see attached media
