### PR TITLE
fix: sync type declarations for sublabel and fieldNote

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -16,6 +16,7 @@ type CheckboxHTMLElementProps = Omit<
   'checked' | 'id' | 'size'
 >;
 
+// TODO(next-major): rename sub-label props to be camelCase
 type CheckboxInputProps = CheckboxHTMLElementProps & {
   // Component API
   /**

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -43,7 +43,7 @@ type CheckboxInputProps = CheckboxHTMLElementProps & {
   /**
    * Additional descriptive text below the primary label, adding additional detail
    */
-  subLabel?: string;
+  subLabel?: ReactNode;
 };
 
 // id is required in CheckboxInputProps but optional in CheckboxProps, so we

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -1,6 +1,11 @@
 import { flexRender, type Table } from '@tanstack/react-table';
 import clsx from 'clsx';
-import React, { useEffect, createContext, useContext } from 'react';
+import React, {
+  useEffect,
+  createContext,
+  useContext,
+  type ReactNode,
+} from 'react';
 
 import getIconNameFromStatus from '../../util/getIconNameFromStatus';
 import type { EDSBase, Size, Status, Align } from '../../util/variant-types';
@@ -116,7 +121,7 @@ export type DataTableHeaderCellProps = EDSBase & {
    *
    * **Note**: Will warn when used in the wrong context
    */
-  sublabel?: string;
+  sublabel?: ReactNode;
   /**
    * The direction to apply to the icon (for visual treatment)
    *

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -41,7 +41,7 @@ type FieldsetProps = {
   /**
    * Text under the component used to provide a description or error message to describe the state.
    */
-  fieldNote?: string;
+  fieldNote?: ReactNode;
 } & FieldsetSharedProps &
   React.HTMLAttributes<HTMLFieldSetElement>;
 

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -127,7 +127,7 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
   /**
    * Add additional descriptive text for the field name.
    */
-  sublabel?: string;
+  sublabel?: ReactNode;
 } & EitherInclusive<
     {
       /**

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -34,7 +34,7 @@ export type PopoverListItemProps = {
   /**
    * Text below the main menu item call-to-action, briefly describing the menu item's function
    */
-  subLabel?: string;
+  subLabel?: ReactNode;
 };
 
 /**

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -5,6 +5,7 @@ import Icon, { type IconName } from '../Icon';
 import Text from '../Text';
 import styles from './PopoverListItem.module.css';
 
+// TODO(next-major): rename sub-label props to be camelCase
 export type PopoverListItemProps = {
   /**
    * Child node(s) that can be nested inside component

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -53,7 +53,7 @@ type RadioProps = RadioInputProps & {
   /**
    * Additional descriptive text below the primary label, adding additional detail
    */
-  subLabel?: string;
+  subLabel?: ReactNode;
 } & EitherInclusive<
     {
       /**

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -34,6 +34,7 @@ type RadioInputProps = RadioHTMLElementProps & {
   isError?: boolean;
 };
 
+// TODO(next-major): rename sub-label props to be camelCase
 type RadioProps = RadioInputProps & {
   // Component API
   /**

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -93,7 +93,7 @@ type SelectProps = ListboxProps<
   /**
    * Add additional descriptive text for the field name
    */
-  sublabel?: string;
+  sublabel?: ReactNode;
 };
 
 type SelectLabelProps = ExtractProps<typeof Label> & {
@@ -103,7 +103,7 @@ type SelectLabelProps = ExtractProps<typeof Label> & {
   /**
    * Add additional descriptive text for the field name
    */
-  sublabel?: string;
+  sublabel?: ReactNode;
 };
 type SelectOptionsProps = ExtractProps<typeof ListboxOptions>;
 type SelectOptionProps = ExtractProps<typeof ListboxOption> & {

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -58,7 +58,7 @@ type TextareaFieldProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   /**
    * Add additional descriptive text for the field name.
    */
-  sublabel?: string;
+  sublabel?: ReactNode;
 } & EitherInclusive<
     {
       /**

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -38,7 +38,7 @@ type ToggleButtonProps = {
 
 type ToggleProps = ToggleButtonProps & {
   children?: ReactNode;
-  sublabel?: string;
+  sublabel?: ReactNode;
 } & EitherInclusive<
     {
       /**


### PR DESCRIPTION
- use ReactNode to seamlessly allow use of null/undefined values
- verify all existing tests work

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
