### PR TITLE
chore: re-organize exports to reflect component theme major version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,8 @@ import './tokens-dist/css/variables.css';
  * 1.x component theme exports
  */
 export { default as Breadcrumbs } from './components/Breadcrumbs';
-export { default as Heading } from './components/Heading';
 export { default as Hr } from './components/Hr';
-export { default as Label } from './components/Label';
-export { default as Skeleton } from './components/Skeleton';
 export { default as Table } from './components/Table';
-export { default as Text } from './components/Text';
-export { default as Toggle } from './components/Toggle';
 
 /**
  * 2.x component theme exports
@@ -28,10 +23,12 @@ export { utils as DataTableUtils } from './components/DataTable';
 export { default as FieldLabel } from './components/FieldLabel';
 export { default as FieldNote } from './components/FieldNote';
 export { default as Fieldset } from './components/Fieldset';
+export { default as Heading } from './components/Heading';
 export { default as Icon } from './components/Icon';
 export { default as InlineNotification } from './components/InlineNotification';
 export { default as InputChip } from './components/InputChip';
 export { default as InputField } from './components/InputField';
+export { default as Label } from './components/Label';
 export { default as Link } from './components/Link';
 export { default as LoadingIndicator } from './components/LoadingIndicator';
 export { default as Menu } from './components/Menu';
@@ -45,10 +42,13 @@ export { default as PopoverListItem } from './components/PopoverListItem';
 export { default as Radio } from './components/Radio';
 export { default as Select } from './components/Select';
 export { default as SelectionChip } from './components/SelectionChip';
+export { default as Skeleton } from './components/Skeleton';
 export { default as TabGroup } from './components/TabGroup';
 export { default as Tag } from './components/Tag';
+export { default as Text } from './components/Text';
 export { default as TextareaField } from './components/TextareaField';
 export { default as ToastNotification } from './components/ToastNotification';
+export { default as Toggle } from './components/Toggle';
 export { default as Tooltip } from './components/Tooltip';
 export { UnorderedList } from './components/List';
 export { default as VisualPageIndicator } from './components/VisualPageIndicator';


### PR DESCRIPTION
### Summary

several components have recently been updated to use the new token system, but weren't grouped properly in the src/index.ts file. Clean up this cosmetic discrepancy.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
