### PR TITLE
chore: use CHROMATIC_PROJECT_TOKEN as environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,13 +79,14 @@ jobs:
       - name: Publish to Chromatic 🦄
         run: |
           yarn run chromatic \
-            --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} \
             --storybook-build-dir storybook-static \
             --exit-zero-on-changes \
             --exit-once-uploaded \
             --auto-accept-changes '{main,next}' \
             --only-changed \
             --skip 'dependabot/**'
+        env:
+            CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       - name: Build and Run Accessibility Tests 💛
         run: yarn run storybook:axe
 


### PR DESCRIPTION
See [docs](https://www.chromatic.com/docs/cli/#continuous-integration)

It looks like the previous config was using an unsupported (?) `=` syntax for the value, which may be tripping things up with the latest version of the `chromatic` dependency. Switch to using the environment variable approach.

Result: https://github.com/chanzuckerberg/edu-design-system/actions/runs/17445020400/job/49537232470?pr=2264#step:6:3

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
