### PR TITLE
chore: set dependabot target-branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     # dependabot does not work with yarn v2, disabling for now
     open-pull-requests-limit: 0
+    target-branch: "next"
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
Dependabot opens PRs against `main` which gets in the way of our git flow process. have it instead scan against `main` like usual, but issue PRs against `next` so that they can apply to the next release.

This should also address the issue of rebasing the PRs it opens, since any fixes to help dependabot won't cause it to rebase against the correct branch

See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependabot-prs#targeting-pull-requests-against-a-non-default-branch

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
