### PR TITLE
docs(tokens): add proper formatting to the figma/tailwind token refs 

### DIFF
--- a/.storybook/components/DesignTokens/Tier2/Colors.stories.tsx
+++ b/.storybook/components/DesignTokens/Tier2/Colors.stories.tsx
@@ -4,6 +4,8 @@ import filterTokens from '../../../util/filterTokens';
 import { ColorList } from '../../ColorList/ColorList';
 import Section from '../../Section';
 
+// TODO: remove the generation of tokens.json entirely (only used for these internal pages)?
+
 export default {
   title: 'Design Tokens/Tier 2: Usage/Colors',
   parameters: {
@@ -17,6 +19,25 @@ export default {
 const camelCaseWarning =
   'NOTE: emphasis tokens have a camelCase suffix for the emphasis (e.g., lowEmphasis)';
 
+/**
+ * Generate data for each list item row based on the contents of the tokens.json file.
+ * 
+ * Given:
+ * - row in tokens.json like "eds-theme-color-background-utility-overlay-low-emphasis": "rgba(39, 38, 37, 0.50)",
+ * - param like {
+            filterTerm: 'eds-theme-color-background-utility',
+            figmaTokenHeader: 'background',
+            tailwindClassHeader: 'bg-utility',
+          }
+ * - generate content like {
+            name: "eds-theme-color-background-utility-overlay-low-emphasis",
+            value: "rgba(39, 38, 37, 0.50)",
+            figmaToken: 'background/overlay-low-emphasis',
+            tailwindClass: "bg-utility-overlay-low-emphasis"
+          } 
+ * @param object describing the: filter to apply to tokens.json, and prefixes for figma/tailwind
+ * @returns object with information for displaying the various token formats and value
+ */
 const getListItems = ({
   filterTerm,
   figmaTokenHeader,
@@ -27,12 +48,17 @@ const getListItems = ({
   tailwindClassHeader: string;
 }) =>
   filterTokens(filterTerm).map(({ name, value }) => {
+    // trim the filter term from the full token name, along with the hyphen separator
     const specifier = name.slice(
       name.indexOf(filterTerm) + filterTerm.length + 1,
     );
+
+    // TODO-AH: tokens.json hyphen-separates camel case token name parts. make sure we "*-emphasis" => "*Emphasis"
+    // TODO-AH: this is not a problem in the emitted tailwind config since it doesn't use tokens.json
     return {
       name,
       value,
+      // apply the passed in format prefix, and the separator
       figmaToken: figmaTokenHeader + '/' + specifier,
       tailwindClass: tailwindClassHeader + '-' + specifier,
     };
@@ -82,9 +108,6 @@ export const BackgroundBrand: StoryObj = {
             filterTerm: 'eds-theme-color-background-brand',
             figmaTokenHeader: 'background',
             tailwindClassHeader: 'bg-brand',
-          }).filter((item) => {
-            // remove legacy primary tokens
-            return item.name.indexOf('primary') === -1;
           })}
         />
       </Section>
@@ -117,9 +140,6 @@ export const BorderBrand: StoryObj = {
             filterTerm: 'eds-theme-color-border-brand',
             figmaTokenHeader: 'border',
             tailwindClassHeader: 'border-brand',
-          }).filter((item) => {
-            // remove legacy primary tokens
-            return item.name.indexOf('primary') === -1;
           })}
         />
       </Section>

--- a/.storybook/components/DesignTokens/Tier2/Colors.stories.tsx
+++ b/.storybook/components/DesignTokens/Tier2/Colors.stories.tsx
@@ -16,9 +16,6 @@ export default {
   },
 };
 
-const camelCaseWarning =
-  'NOTE: emphasis tokens have a camelCase suffix for the emphasis (e.g., lowEmphasis)';
-
 /**
  * Generate data for each list item row based on the contents of the tokens.json file.
  * 
@@ -53,14 +50,22 @@ const getListItems = ({
       name.indexOf(filterTerm) + filterTerm.length + 1,
     );
 
-    // TODO-AH: tokens.json hyphen-separates camel case token name parts. make sure we "*-emphasis" => "*Emphasis"
-    // TODO-AH: this is not a problem in the emitted tailwind config since it doesn't use tokens.json
+    // tokens.json hyphen-separates camel case token name parts using the built-in "json/flat".
+    // Fxamples:
+    // - "*-emphasis" => "*Emphasis"
+    // Note that this is not a problem in the emitted tailwind config since it doesn't use tokens.json
+    const convertEmphasesToCamelCase = /([a-z]+)-emphasis*/g;
+    const updatedSpecifier = specifier.replace(
+      convertEmphasesToCamelCase,
+      '$1Emphasis',
+    );
+
     return {
       name,
       value,
       // apply the passed in format prefix, and the separator
-      figmaToken: figmaTokenHeader + '/' + specifier,
-      tailwindClass: tailwindClassHeader + '-' + specifier,
+      figmaToken: figmaTokenHeader + '/' + updatedSpecifier,
+      tailwindClass: tailwindClassHeader + '-' + updatedSpecifier,
     };
   });
 
@@ -83,10 +88,7 @@ export const TextUtility: StoryObj = {
 export const BackgroundUtility: StoryObj = {
   render: () => (
     <div>
-      <Section
-        description={camelCaseWarning}
-        title="Background Colors (utility)"
-      >
+      <Section title="Background Colors (utility)">
         <ColorList
           listItems={getListItems({
             filterTerm: 'eds-theme-color-background-utility',
@@ -102,7 +104,7 @@ export const BackgroundUtility: StoryObj = {
 export const BackgroundBrand: StoryObj = {
   render: () => (
     <div>
-      <Section description={camelCaseWarning} title="Background Colors (brand)">
+      <Section title="Background Colors (brand)">
         <ColorList
           listItems={getListItems({
             filterTerm: 'eds-theme-color-background-brand',
@@ -118,7 +120,7 @@ export const BackgroundBrand: StoryObj = {
 export const BorderUtility: StoryObj = {
   render: () => (
     <div>
-      <Section description={camelCaseWarning} title="Border Colors (utility)">
+      <Section title="Border Colors (utility)">
         <ColorList
           listItems={getListItems({
             filterTerm: 'eds-theme-color-border-utility',
@@ -134,7 +136,7 @@ export const BorderUtility: StoryObj = {
 export const BorderBrand: StoryObj = {
   render: () => (
     <div>
-      <Section description={camelCaseWarning} title="Border Colors (brand)">
+      <Section title="Border Colors (brand)">
         <ColorList
           listItems={getListItems({
             filterTerm: 'eds-theme-color-border-brand',

--- a/.storybook/components/DesignTokens/Tier3/Colors.stories.tsx
+++ b/.storybook/components/DesignTokens/Tier3/Colors.stories.tsx
@@ -14,9 +14,6 @@ export default {
   },
 };
 
-const camelCaseWarning =
-  'NOTE: table tokens have a camelCase suffix for the emphasis (e.g., tableRow)';
-
 const getListItems = ({
   filterTerm,
   figmaTokenHeader,
@@ -30,11 +27,18 @@ const getListItems = ({
     const specifier = name.slice(
       name.indexOf(filterTerm) + filterTerm.length + 1,
     );
+
+    // tokens.json hyphen-separates camel case token name parts using the built-in "json/flat".
+    // Examples:
+    // - "table-row" => "tableRow"
+    // Note that this is not a problem in the emitted tailwind config since it doesn't use tokens.json
+    const updatedSpecifier = specifier.replace('row-', 'Row-');
+
     return {
       name,
       value,
       figmaToken: figmaTokenHeader + '/' + specifier,
-      tailwindClass: tailwindClassHeader + '-' + specifier,
+      tailwindClass: tailwindClassHeader + updatedSpecifier,
     };
   });
 
@@ -57,7 +61,7 @@ export const IconUtility: StoryObj = {
 export const BackgroundTable: StoryObj = {
   render: () => (
     <div>
-      <Section description={camelCaseWarning} title="Background Colors (Table)">
+      <Section title="Background Colors (Table)">
         <ColorList
           listItems={getListItems({
             filterTerm: 'eds-theme-color-background-table',

--- a/.storybook/components/DesignTokens/Tier3/Colors.stories.tsx
+++ b/.storybook/components/DesignTokens/Tier3/Colors.stories.tsx
@@ -38,7 +38,9 @@ const getListItems = ({
       name,
       value,
       figmaToken: figmaTokenHeader + '/' + specifier,
-      tailwindClass: tailwindClassHeader + updatedSpecifier,
+      tailwindClass:
+        tailwindClassHeader +
+        (updatedSpecifier === specifier ? '-' + specifier : updatedSpecifier),
     };
   });
 


### PR DESCRIPTION
Make sure the handful of token names that are `camelCase` when used in tailwind appear as such in the documentation.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
