### PR TITLE
docs(theming): document storybook setup using EDS

### DIFF
--- a/.storybook/components/Docs/Guidelines/EDSAndStorybook.mdx
+++ b/.storybook/components/Docs/Guidelines/EDSAndStorybook.mdx
@@ -1,0 +1,64 @@
+import { Canvas, Meta } from '@storybook/blocks';
+
+<Meta title="Documentation/Theming/Using EDS Theming with Storybook" />
+
+# Using EDS Theming with Storybook
+
+When using a custom EDS theme, your application will reflect the theme chosen, but you still must configure [Storybook][storybook-docs] to use the theme as well.
+
+## Telling storybook about the theme file(s)
+
+Storybook allows for customizations that affect how stories are rendered. One of the most important things to do when using EDS is to tell storybook about the same setup
+used when constructing an application.
+
+### Updating preview.(ts|js)
+
+- Make sure to add in the relevant base CSS files, placing them after any app CSS files
+
+```ts
+import type {Preview} from '@storybook/react-vite';
+
+// Style import order matters. See app/root.tsx for reference.
+import '~/app.css';
+// Load the Tailwind base first so that EDS styles take precedence.
+import '~/tailwind-base.css';
+import '@chanzuckerberg/eds/index.css';
+import '@chanzuckerberg/eds/fonts.css';
+```
+
+- When using theming, reference the initialized theme files AFTER any utility CSS files
+
+```ts
+// Load the Tailwind utility classes last so they can be used to override EDS styles.
+import '~/tailwind.css';
+import '~/components/app-theme.css';
+```
+
+### Updating preview-head.html
+
+- Load any custom font files / links here, so that they get added to the HTML template
+
+```html
+<!-- Performance optimization -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+
+<!-- Load fonts -->
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=..."
+/>
+<link
+  rel="stylesheet"
+  href="https://fonts.googleapis.com/css2?family=..."
+/>
+```
+
+**NOTE**: This should use the exact link HREF specified by Google Fonts, Adobe fonts, etc.
+
+## Using Storybook Modes
+
+Storybook supports [modes][storybook-modes]. Details on how to use this and EDS in your storybook documentation to come soon.
+
+[storybook-docs]: https://storybook.js.org/docs
+[storybook-modes]: https://www.chromatic.com/docs/modes/

--- a/.storybook/components/Docs/Guidelines/Theming.mdx
+++ b/.storybook/components/Docs/Guidelines/Theming.mdx
@@ -1,14 +1,14 @@
 import { Canvas, Meta } from '@storybook/blocks';
 
-<Meta title="Documentation/Theming" />
+<Meta title="Documentation/Theming/Using EDS Theming" />
 
-# Theming
+# Using EDS Theming
 
 Below are instructions on how to use the tooling, configs, and tokens to define custom theme values for a project.
 
 ## Using Tailwind with the Default Theme
 
-Out of the box, EDS provides a basic tailwind configuration to use in any project. The provided EDS tailwind config hooks up EDS tokens to useful utility classes and some screen sizes. To import the tailwind config into the app's tailwind config, supply the [theme](https://tailwindcss.com/docs/theme) property for use:
+Out of the box, EDS provides a basic [tailwind 3.x][tailwind-docs] configuration to use in any project. The provided EDS tailwind config hooks up EDS tokens to useful utility classes and some screen sizes. To import the tailwind config into the app's tailwind config, supply the [theme](https://tailwindcss.com/docs/theme) property for use:
 
 ```ts
 // in your tailwind.config.ts
@@ -82,6 +82,7 @@ Cons (same as above, plus):
 
 - fully detached from EDS, and harder to control or maintain.
 
+[tailwind-docs]: https://v3.tailwindcss.com/
 [tailwind-theme]: https://tailwindcss.com/docs/theme
 [eds-tailwind-config]: https://github.com/chanzuckerberg/edu-design-system/blob/main/tailwind.config.ts
 
@@ -130,6 +131,8 @@ Once run, you will have a set of theme files written to the configured `dest` pa
 - `app-tailwind-theme.config.json` (Configuration file for configuring tailwind in the application)
 
 To use, add this file to your core app root file **after** where the imported EDS's `@chanzuckerberg/eds/index.css` file is inserted.
+
+For setting up Storybook, refer to [storybook documentation](?path=/docs/documentation-theming-using-eds-theming-with-storybook--docs).
 
 ### eds-import-from-figma-api
 

--- a/.storybook/components/Docs/ReleaseChangelog.mdx
+++ b/.storybook/components/Docs/ReleaseChangelog.mdx
@@ -1,0 +1,6 @@
+import { Meta, Markdown } from '@storybook/addon-docs/blocks';
+import Readme from '../../../CHANGELOG.md?raw';
+
+<Meta title="Release Changelog" />
+
+<Markdown>{Readme}</Markdown>


### PR DESCRIPTION
Add in initial instructions for changes to make to a project's storybook instance to respect any theming setup with EDS.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
