### PR TITLE
fix(PageNotification): handle default aria-label on <aside>

### DIFF
--- a/src/components/PageNotification/PageNotification.stories.tsx
+++ b/src/components/PageNotification/PageNotification.stories.tsx
@@ -41,14 +41,14 @@ const dismissMethod = () => {
 
 export const Default: StoryObj<Args> = {
   args: {
-    title: 'Default alert title',
+    'aria-label': 'Default alert title',
   },
 };
 
 export const Warning: StoryObj<Args> = {
   args: {
     status: 'warning',
-    title: 'Warning title which communicates info to the user',
+    'aria-label': 'Warning title which communicates info to the user',
   },
 };
 
@@ -56,7 +56,8 @@ export const WarningWithSubtitle: StoryObj<Args> = {
   args: {
     status: 'warning',
     subTitle: <span>Subtitle text</span>,
-    title: 'Warning title and subtitle which communicates info to the user',
+    'aria-label':
+      'Warning title and subtitle which communicates info to the user',
   },
 };
 
@@ -71,7 +72,7 @@ export const Critical: StoryObj<Args> = {
       </Button>
     ),
     status: 'critical',
-    title: 'Critical title which communicates info to the user',
+    'aria-label': 'Critical title which communicates info to the user',
   },
 };
 
@@ -84,21 +85,21 @@ export const CriticalHorizontal: StoryObj<Args> = {
       </Button>
     ),
     status: 'critical',
-    title: 'Critical title with horizontal buttons',
+    'aria-label': 'Critical title with horizontal buttons',
   },
 };
 
 export const Favorable: StoryObj<Args> = {
   args: {
     status: 'favorable',
-    title: 'Favorable title which communicates info to the user',
+    'aria-label': 'Favorable title which communicates info to the user',
   },
 };
 
 export const Dismissable: StoryObj<Args> = {
   args: {
     onDismiss: dismissMethod,
-    title: 'Dismissable title which communicates info to the user',
+    'aria-label': 'Dismissable title which communicates info to the user',
   },
 };
 
@@ -106,21 +107,26 @@ export const HorizontalDismissable: StoryObj<Args> = {
   args: {
     ...Dismissable.args,
     ...CriticalHorizontal.args,
-    title: 'Dismissable Horizontal Critical title',
+    'aria-label': 'Dismissable Horizontal Critical title',
   },
 };
 
+/**
+ * When having multiple notifications on screen at once, make sure they are labeled uniquely, so that assisstive technologies can tell them apart.
+ */
 export const MultipleNotifications: StoryObj<Args> = {
   render: (args) => (
     <>
       <PageNotification
         {...args}
+        aria-label="Notification 1 of 2"
         status="critical"
         subTitle="Test SubTitle"
         title="Test Critical Title"
       />
       <PageNotification
         {...args}
+        aria-label="Notification 2 of 2"
         status="favorable"
         subTitle="Test SubTitle"
         title="Test Favorable Title"

--- a/src/components/PageNotification/PageNotification.tsx
+++ b/src/components/PageNotification/PageNotification.tsx
@@ -69,7 +69,7 @@ export const PageNotification = ({
   );
 
   return (
-    <aside aria-label={title} className={componentClassName} {...other}>
+    <aside className={componentClassName} {...other}>
       <Icon
         className={styles['page-notification__icon']}
         name={getIconNameFromStatus(status)}

--- a/src/components/PageNotification/__snapshots__/PageNotification.test.ts.snap
+++ b/src/components/PageNotification/__snapshots__/PageNotification.test.ts.snap
@@ -28,7 +28,7 @@ exports[`<PageNotification /> Critical story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Critical title which communicates info to the user
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -82,7 +82,7 @@ exports[`<PageNotification /> CriticalHorizontal story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Critical title with horizontal buttons
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -136,7 +136,7 @@ exports[`<PageNotification /> Default story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Default alert title
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -190,7 +190,7 @@ exports[`<PageNotification /> Dismissable story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Dismissable title which communicates info to the user
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -268,7 +268,7 @@ exports[`<PageNotification /> Favorable story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Favorable title which communicates info to the user
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -322,7 +322,7 @@ exports[`<PageNotification /> HorizontalDismissable story renders snapshot 1`] =
       <h3
         class="heading heading--title-md"
       >
-        Dismissable Horizontal Critical title
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -374,7 +374,7 @@ exports[`<PageNotification /> HorizontalDismissable story renders snapshot 1`] =
 
 exports[`<PageNotification /> MultipleNotifications story renders snapshot 1`] = `
 <aside
-  aria-label="Test Critical Title"
+  aria-label="Notification 1 of 2"
   class="page-notification page-notification--status-critical w-[384px]"
 >
   <svg
@@ -454,7 +454,7 @@ exports[`<PageNotification /> Warning story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Warning title which communicates info to the user
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"
@@ -508,7 +508,7 @@ exports[`<PageNotification /> WarningWithSubtitle story renders snapshot 1`] = `
       <h3
         class="heading heading--title-md"
       >
-        Warning title and subtitle which communicates info to the user
+        Alert title which communicates info to the user
       </h3>
       <p
         class="text text--body-sm page-notification__sub-title"


### PR DESCRIPTION
Use the following pattern to apply an `aria-label` to each `PageNotification` either by defaulting to use the `title` value, or take in any props applicable to an `<aside>` element.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
