### PR TITLE
fix: remove usages of deprecated border width tokens

### DIFF
--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -117,5 +117,5 @@
  * Accordion Row houses one Accordion Button subcomponent and its relevant Accordion Panel subcomponent.
  */
 .accordion-row {
-  border-bottom: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+  border-bottom: 1px solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 }

--- a/src/components/AppHeader/AppHeader.module.css
+++ b/src/components/AppHeader/AppHeader.module.css
@@ -314,7 +314,7 @@
 }
 
 .app-header__nav-item:focus-visible {
-  box-shadow: inset 0 0 0 1px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  box-shadow: inset 0 0 0 2px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
   outline: none;
 }
 

--- a/src/components/AppHeader/AppHeader.module.css
+++ b/src/components/AppHeader/AppHeader.module.css
@@ -314,7 +314,7 @@
 }
 
 .app-header__nav-item:focus-visible {
-  box-shadow: inset 0 0 0 calc(var(--eds-border-width-md) * 1px) light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  box-shadow: inset 0 0 0 1px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
   outline: none;
 }
 

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -17,7 +17,7 @@
 
   color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
   background-color: light-dark(var(--eds-theme-color-background-utility-default-low-emphasis), var(--eds-dark-theme-color-background-utility-default-low-emphasis));
-  border: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+  border: 1px solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 }
 
 /* use :has selector to put the focus ring on the container & apply the avatar's shape */

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -7,7 +7,7 @@
 .button {
   position: relative;
   border-radius: calc(var(--eds-theme-border-radius-actions) * 1px);
-  border: calc(var(--eds-border-width-sm) * 1px) solid;
+  border: 1px solid;
   overflow: hidden;
   display: flex;
 }

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -134,7 +134,7 @@
 }
 
 .card__behavior-label:has(.card__behavior-input:focus-visible) {
-  outline: calc(var(--eds-border-width-md) * 1px) solid light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  outline: 2px solid light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
   outline-offset: 4px;
   border-radius: calc(var(--eds-theme-border-radius-surfaces-lg) * 1px);
 }
@@ -165,7 +165,7 @@
   background: light-dark(var(--eds-theme-color-background-utility-container-selected), var(--eds-dark-theme-color-background-utility-container-selected));
 
   /* use an outline on top of the border to get the correct width without changing the layout */
-  outline: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-default-high-emphasis), var(--eds-dark-theme-color-border-utility-default-high-emphasis));
+  outline: 1px solid light-dark(var(--eds-theme-color-border-utility-default-high-emphasis), var(--eds-dark-theme-color-border-utility-default-high-emphasis));
   border-color: light-dark(var(--eds-theme-color-border-utility-interactive-secondary), var(--eds-dark-theme-color-border-utility-interactive-secondary));
 }
 

--- a/src/components/DataTable/DataTable.module.css
+++ b/src/components/DataTable/DataTable.module.css
@@ -58,7 +58,7 @@
 }
 
 .data-table--tableStyle-border {
-  border: calc(var(--eds-border-width-sm) * 1px) solid;
+  border: 1px solid;
 }
 
 .data-table__cell-text {
@@ -92,7 +92,7 @@
   height: 100%;
   overflow: hidden;
 
-  border-right: calc(var(--eds-border-width-sm) * 1px) solid transparent;
+  border-right: 1px solid transparent;
 
   &.data-table__cell--has-horizontal-divider {
     border-right-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
@@ -144,7 +144,7 @@
   height: 100%;
   overflow: hidden;
 
-  border-right: calc(var(--eds-border-width-sm) * 1px) solid transparent;
+  border-right: 1px solid transparent;
 
   &.data-table__cell--has-horizontal-divider {
     border-right-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
@@ -169,7 +169,7 @@
 }
 
 .data-table__header-row {
-  border-bottom: calc(var(--eds-border-width-sm) * 1px) solid;
+  border-bottom: 1px solid;
   position: sticky;
   top: -1px;
 
@@ -230,7 +230,7 @@
   }
 
   .data-table--rowStyle-lined & {
-    border-bottom: calc(var(--eds-border-width-sm) * 1px) solid;
+    border-bottom: 1px solid;
 
     &.data-table__row--is-selected {
       background-color: light-dark(var(--eds-theme-color-background-table-row-selected), var(--eds-dark-theme-color-background-table-row-selected));

--- a/src/components/Hr/Hr.module.css
+++ b/src/components/Hr/Hr.module.css
@@ -10,7 +10,7 @@
   border-top: none;
   border-right: none;
   border-left: none;
-  border-bottom-width: calc(var(--eds-border-width-sm) * 1px);
+  border-bottom-width: 1px;
   border-bottom-style: solid;
   border-bottom-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 }

--- a/src/components/NumberIcon/NumberIcon.module.css
+++ b/src/components/NumberIcon/NumberIcon.module.css
@@ -16,7 +16,7 @@
   align-items: center;
 
   /* The circle part of the icon, made with borders. */
-  border: calc(var(--eds-border-width-sm) * 1px) solid;
+  border: 1px solid;
   border-color: inherit;
   border-radius: calc(var(--eds-border-radius-full) * 1px);
 

--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -42,7 +42,7 @@
 .popover-list-item--type-separator {
   pointer-events: none;
   padding: 0;
-  border-bottom: calc(var(--eds-border-width-sm) * 1px) solid var(--eds-theme-color-border-utility-default-low-emphasis);
+  border-bottom: 1px solid var(--eds-theme-color-border-utility-default-low-emphasis);
 }
 
 .popover-list-item__icon {

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -53,7 +53,7 @@
   width: 100%;
   padding: calc(var(--eds-spacing-size-1) * 1px);
 
-  border: calc(var(--eds-border-width-sm) * 1px) solid;
+  border: 1px solid;
   border-radius: calc(var(--eds-theme-border-radius-objects-sm) * 1px);
 
   display: flex;
@@ -139,7 +139,7 @@
 
 .select-button:focus-visible {
   border-color: light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
-  outline: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  outline: 1px solid light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
 }
 
 .select-button--error {
@@ -151,7 +151,7 @@
 
   &:focus-visible {
     border-color: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
-    outline: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+    outline: 1px solid light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
   }
 }
 
@@ -164,7 +164,7 @@
 
   &:focus-visible {
     border-color: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
-    outline: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
+    outline: 1px solid light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
   }
 }
 

--- a/src/components/SelectionChip/SelectionChip.module.css
+++ b/src/components/SelectionChip/SelectionChip.module.css
@@ -16,7 +16,7 @@
   border-radius: calc(var(--eds-theme-border-radius-objects-sm) * 1px);
 
   color: light-dark(var(--eds-theme-color-text-utility-interactive-primary), var(--eds-dark-theme-color-text-utility-interactive-primary));
-  border: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+  border: 1px solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
   background-color: light-dark(var(--eds-theme-color-background-utility-interactive-no-emphasis), var(--eds-dark-theme-color-background-utility-interactive-no-emphasis));
 }
 
@@ -41,13 +41,13 @@
 
 .selection-chip:has(.selection-chip__input:focus-visible) {
   outline: none;
-  box-shadow: 0 0 0 calc(var(--eds-border-width-md) * 1px) white, 0 0 0 calc(var(--eds-border-width-lg) * 1px) light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  box-shadow: 0 0 0 2px white, 0 0 0 4px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
 }
 
 @supports not selector(:focus-visible) {
   .selection-chip:has(.selection-chip__input:focus) {
     outline: none;
-    box-shadow: 0 0 0 calc(var(--eds-border-width-md) * 1px) white, 0 0 0 calc(var(--eds-border-width-lg) * 1px) light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+    box-shadow: 0 0 0 2px white, 0 0 0 4px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
   }
 }
 
@@ -64,8 +64,8 @@
 }
 
 .selection-chip:has(.selection-chip__input:checked) {
-  border: calc(var(--eds-border-width-sm) * 1px) solid light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive));
-  box-shadow: inset 0 0 0 calc(var(--eds-border-width-sm) * 1px) light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive));
+  border: 1px solid light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive));
+  box-shadow: inset 0 0 0 1px light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive));
   background-color: light-dark(var(--eds-theme-color-background-utility-interactive-low-emphasis), var(--eds-dark-theme-color-background-utility-interactive-low-emphasis));
 }
 
@@ -81,12 +81,12 @@
 
 .selection-chip:has(.selection-chip__input:focus-visible:checked) {
   outline: none;
-  box-shadow: inset 0 0 0 calc(var(--eds-border-width-sm) * 1px) light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive)), 0 0 0 calc(var(--eds-border-width-md) * 1px) white, 0 0 0 calc(var(--eds-border-width-lg) * 1px) light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  box-shadow: inset 0 0 0 1px light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive)), 0 0 0 2px white, 0 0 0 4px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
 }
 
 @supports not selector(:focus-visible) {
   .selection-chip:has(.selection-chip__input:focus:checked) {
     outline: none;
-    box-shadow: inset 0 0 0 calc(var(--eds-border-width-sm) * 1px) light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive)), 0 0 0 calc(var(--eds-border-width-md) * 1px) white, 0 0 0 calc(var(--eds-border-width-lg) * 1px) light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+    box-shadow: inset 0 0 0 1px light-dark(var(--eds-theme-color-border-utility-interactive), var(--eds-dark-theme-color-border-utility-interactive)), 0 0 0 2px white, 0 0 0 4px light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
   }
 }

--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -4,7 +4,7 @@
 
 .tooltip {
   border-style: solid;
-  border-width: calc(var(--eds-border-width-sm) * 1px);
+  border-width: 1px;
   border-radius: calc(var(--eds-theme-border-radius-surfaces-md) * 1px);
   box-shadow: var(--eds-box-shadow-md);
   max-width: 224px;

--- a/src/design-tokens/mixins.css
+++ b/src/design-tokens/mixins.css
@@ -23,7 +23,7 @@
   -webkit-appearance: none;
   width: 100%;
 
-  border: calc(var(--eds-border-width-sm) * 1px) solid;
+  border: 1px solid;
   border-radius: calc(var(--eds-theme-border-radius-objects-sm) * 1px);
 
   outline: none;
@@ -47,7 +47,7 @@
 
   &:focus {
     border-color: var(--eds-theme-color-border-utility-focus);
-    outline: calc(var(--eds-border-width-sm) * 1px) solid var(--eds-theme-color-border-utility-focus);
+    outline: 1px solid var(--eds-theme-color-border-utility-focus);
   }
 
   &:read-only:not(:disabled) {
@@ -68,7 +68,7 @@
 
     &:focus {
       border-color: var(--eds-theme-color-border-utility-critical);
-      outline: calc(var(--eds-border-width-sm) * 1px) solid var(--eds-theme-color-border-utility-critical);
+      outline: 1px solid var(--eds-theme-color-border-utility-critical);
     }
   }
 
@@ -81,7 +81,7 @@
 
     &:focus {
       border-color: var(--eds-theme-color-border-utility-warning);
-      outline: calc(var(--eds-border-width-sm) * 1px) solid var(--eds-theme-color-border-utility-warning);
+      outline: 1px solid var(--eds-theme-color-border-utility-warning);
     }
   }
 


### PR DESCRIPTION
| old | new |
|-|-|
|`--eds-border-width-sm`|`1px`|
|`--eds-border-width-md`|`2px`|
|`--eds-border-width-lg`|`4px`|

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
