### PR TITLE
feat(tailwind): emit EDS shadow tokens in default configuration

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -107,6 +107,9 @@ export function applyTailwindConfig(
   };
 
   return {
+    boxShadow: {
+      ...tokenConfig['box-shadow'],
+    },
     colors: {
       ...colorTokens,
     },


### PR DESCRIPTION
Add in the EDS tokens to override the default shadow utility classes in the default tailwind configuration.

This will replace the [default values][tailwind-defaults] with the [EDS equivalents][eds-defaults]. This will also remove the rows that don't have an equivalent in EDS, to avoid technical / design debt:

* `shadow`
* `shadow-inner`
* `shadow-2xl`

**For consumers**, this means that if you are using the built-in util. classes by name, you won't have to change any code; the new usages will match the EDS equivalents. If you have any [inlined][inline-tailwind-syntax], those will still work but should be updated in design/code.

[tailwind-defaults]: https://v3.tailwindcss.com/docs/box-shadow
[eds-defaults]: https://github.com/chanzuckerberg/edu-design-system/blob/main/src/tokens-dist/css/variables.css#L80-L83
[inline-tailwind-syntax]: https://v3.tailwindcss.com/docs/box-shadow#arbitrary-values

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
