### PR TITLE
feat(Select): support showing subLabels on options

### DIFF
--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -48,7 +48,7 @@ const meta: Meta<typeof Select> = {
         'Optional change handler. Fires when a value is selected (and passes in list of selected values)',
     },
   },
-  tags: ['autodocs', 'version:3.1.1'],
+  tags: ['autodocs', 'version:3.2.0'],
 };
 
 export default meta;
@@ -56,20 +56,24 @@ export default meta;
 type SelectOption = {
   key: string;
   label: string;
+  subLabel?: string;
 };
 
 const exampleOptions: SelectOption[] = [
   {
     key: '1',
     label: 'Dogs',
+    subLabel: "Who's a good boy?",
   },
   {
     key: '2',
     label: 'Cats',
+    subLabel: 'Super independent.',
   },
   {
     key: '3',
     label: 'Birds',
+    subLabel: 'Living relics',
   },
 ];
 
@@ -349,6 +353,41 @@ export const WithFieldNote: StoryObj = {
         <Select.Options>
           {exampleOptions.map((option) => (
             <Select.Option key={option.key} value={option}>
+              {option.label}
+            </Select.Option>
+          ))}
+        </Select.Options>
+      </>
+    ),
+  },
+  parameters: {
+    ...Default.parameters,
+  },
+};
+
+/**
+ * This demonstrates how select items can also have an optional subLabel attached to give more details about the option.
+ */
+export const WithSubLabels: StoryObj = {
+  args: {
+    ...Default.args,
+    fieldNote: 'Choose your beast',
+    children: (
+      <>
+        <Select.Button>
+          {({ value, open, disabled }) => (
+            <Select.ButtonWrapper isOpen={open}>
+              {value.label}
+            </Select.ButtonWrapper>
+          )}
+        </Select.Button>
+        <Select.Options>
+          {exampleOptions.map((option) => (
+            <Select.Option
+              key={option.key}
+              subLabel={option.subLabel}
+              value={option}
+            >
               {option.label}
             </Select.Option>
           ))}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -73,7 +73,7 @@ const exampleOptions: SelectOption[] = [
   {
     key: '3',
     label: 'Birds',
-    subLabel: 'Living relics',
+    subLabel: 'Living relics!',
   },
 ];
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -372,6 +372,7 @@ export const WithSubLabels: StoryObj = {
   args: {
     ...Default.args,
     fieldNote: 'Choose your beast',
+    optionsClassName: 'w-[384px]',
     children: (
       <>
         <Select.Button>
@@ -381,7 +382,7 @@ export const WithSubLabels: StoryObj = {
             </Select.ButtonWrapper>
           )}
         </Select.Button>
-        <Select.Options>
+        <Select.Options anchor={{ to: 'bottom end', gap: 12 }}>
           {exampleOptions.map((option) => (
             <Select.Option
               key={option.key}
@@ -397,7 +398,11 @@ export const WithSubLabels: StoryObj = {
   },
   parameters: {
     ...Default.parameters,
+    snapshot: {
+      skip: true,
+    },
   },
+  play: openMenu,
 };
 
 /**
@@ -508,6 +513,11 @@ export const Multiple: StoryObj = {
       </>
     ),
   },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
 };
 
 /**
@@ -599,6 +609,9 @@ export const LongOptionList: StoryObj = {
   parameters: {
     layout: 'centered',
     chromatic: { delay: 450 },
+    snapshot: {
+      skip: true,
+    },
   },
   decorators: [
     (Story) => (
@@ -624,6 +637,9 @@ export const SeparateButtonAndMenuWidth: StoryObj = {
     },
     docs: {
       ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
     },
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
@@ -653,6 +669,9 @@ export const Disabled: StoryObj = {
     },
     docs: {
       ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
     },
   },
 };
@@ -762,6 +781,9 @@ export const DisabledRequired: StoryObj = {
     docs: {
       ...Default.parameters?.docs,
     },
+    snapshot: {
+      skip: true,
+    },
   },
 };
 
@@ -799,6 +821,11 @@ export const OptionsRightAligned: StoryObj = {
       <div className="p-spacing-size-4 pb-spacing-size-8">{Story()}</div>
     ),
   ],
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
 };
 
 /**
@@ -811,6 +838,9 @@ export const OpenByDefault: StoryObj = {
     chromatic: { delay: 300, disableSnapshot: true },
     docs: {
       ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
     },
   },
   play: selectCat,

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -11,19 +11,12 @@ import type { StoryFile } from '../../../.storybook/utility-types';
 mockResizeObserver();
 
 const {
-  OpenByDefault,
-  LongOptionList,
-  Disabled,
-  DisabledRequired,
-  OptionsRightAligned,
-  SeparateButtonAndMenuWidth,
   EventHandlingOnRenderProp,
   EventHandlingOnStandardButton,
-  Multiple,
   ...closedStories
 } = stories;
 
-const DisabledComponent = composeStory(Disabled, stories.default);
+const DisabledComponent = composeStory(closedStories.Disabled, stories.default);
 
 const exampleOptions = [
   {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -24,6 +24,7 @@ import Icon, { type IconName } from '../Icon';
 
 import PopoverContainer from '../PopoverContainer';
 import PopoverListItem from '../PopoverListItem';
+import type { PopoverListItemProps } from '../PopoverListItem/PopoverListItem';
 import Text from '../Text';
 
 import styles from './Select.module.css';
@@ -105,10 +106,14 @@ type SelectLabelProps = ExtractProps<typeof Label> & {
    */
   subLabel?: ReactNode;
 };
+
 type SelectOptionsProps = ExtractProps<typeof ListboxOptions>;
-type SelectOptionProps = ExtractProps<typeof ListboxOption> & {
-  optionClassName?: string;
-};
+
+type SelectOptionProps = ExtractProps<typeof ListboxOption> &
+  Pick<PopoverListItemProps, 'subLabel'> & {
+    optionClassName?: string;
+  };
+
 type SelectButtonProps = ExtractProps<typeof ListboxButton> & {
   // Design API
   /**
@@ -415,7 +420,13 @@ const SelectOptions = function (props: SelectOptionsProps) {
  * Represents one of the available options for selection
  */
 const SelectOption = function (props: SelectOptionProps) {
-  const { children, className, optionClassName, ...other } = props;
+  const {
+    children,
+    className,
+    optionClassName,
+    subLabel: optionSubLabel,
+    ...other
+  } = props;
 
   const optionItemClassName = clsx(optionClassName, styles['select__option']);
 
@@ -437,6 +448,7 @@ const SelectOption = function (props: SelectOptionProps) {
                 icon={selected ? 'check' : undefined}
                 isDisabled={disabled}
                 isFocused={focus}
+                subLabel={optionSubLabel}
               >
                 <span className={styles['select__option-text']}>
                   {children}

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r3f:"
-      id="headlessui-label-:r3e:"
+      for="headlessui-listbox-button-:r35:"
+      id="headlessui-label-:r34:"
     >
       <span
         class="text text--label-md"
@@ -25,15 +25,15 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r3g:"
+    aria-controls="headlessui-listbox-options-:r36:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r3e: headlessui-listbox-button-:r3f:"
+    aria-labelledby="headlessui-label-:r34: headlessui-listbox-button-:r35:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r3f:"
+    id="headlessui-listbox-button-:r35:"
     type="button"
   >
     <span
@@ -132,8 +132,8 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r4d:"
-      id="headlessui-label-:r4c:"
+      for="headlessui-listbox-button-:r43:"
+      id="headlessui-label-:r42:"
     >
       <span
         class="text text--label-md"
@@ -157,15 +157,15 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r4e:"
+    aria-controls="headlessui-listbox-options-:r44:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4c: headlessui-listbox-button-:r4d:"
+    aria-labelledby="headlessui-label-:r42: headlessui-listbox-button-:r43:"
     class="select-button select-button--error"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4d:"
+    id="headlessui-listbox-button-:r43:"
     type="button"
   >
     <span
@@ -264,8 +264,8 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r35:"
-      id="headlessui-label-:r34:"
+      for="headlessui-listbox-button-:r2r:"
+      id="headlessui-label-:r2q:"
     >
       <span
         class="text text--label-md"
@@ -275,15 +275,15 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r36:"
+    aria-controls="headlessui-listbox-options-:r2s:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r34: headlessui-listbox-button-:r35:"
+    aria-labelledby="headlessui-label-:r2q: headlessui-listbox-button-:r2r:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r35:"
+    id="headlessui-listbox-button-:r2r:"
     type="button"
   >
     <span
@@ -318,14 +318,14 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r51:"
+    aria-controls="headlessui-listbox-options-:r4n:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r50:"
+    id="headlessui-listbox-button-:r4m:"
     type="button"
   >
     <span
@@ -365,8 +365,8 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r5a:"
-      id="headlessui-label-:r59:"
+      for="headlessui-listbox-button-:r50:"
+      id="headlessui-label-:r4v:"
     >
       <span
         class="text text--label-md"
@@ -374,15 +374,15 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r5b:"
+    aria-controls="headlessui-listbox-options-:r51:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r59: headlessui-listbox-button-:r5a:"
+    aria-labelledby="headlessui-label-:r4v: headlessui-listbox-button-:r50:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r5a:"
+    id="headlessui-listbox-button-:r50:"
     type="button"
   >
     <span
@@ -422,79 +422,6 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r43:"
-      id="headlessui-label-:r42:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
-    <span
-      class="text text--body-sm select__required-text"
-    >
-      (Optional)
-    </span>
-    <div
-      class="select__subLabel"
-    >
-      <span
-        class="text text--body-sm"
-      >
-        Some descriptive text
-      </span>
-    </div>
-  </div>
-  <button
-    aria-controls="headlessui-listbox-options-:r44:"
-    aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r42: headlessui-listbox-button-:r43:"
-    class="select-button"
-    data-active=""
-    data-headlessui-state="open active"
-    data-open=""
-    id="headlessui-listbox-button-:r43:"
-    type="button"
-  >
-    <span
-      class="text text--input"
-    >
-      Dogs
-    </span>
-    <svg
-      aria-hidden="true"
-      class="icon select-button__icon select-button__icon--reversed"
-      fill="currentColor"
-      height="24px"
-      style="--icon-size: 24px;"
-      viewBox="0 0 24 24"
-      width="24px"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
-      />
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
-<div
-  class="select select--label-layout-vertical w-[384px]"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="dropdown"
->
-  <div
-    class="select__overline"
-  >
-    <label
-      class="label label--md select__label"
-      data-headlessui-state="open"
-      data-open=""
       for="headlessui-listbox-button-:r3p:"
       id="headlessui-label-:r3o:"
     >
@@ -507,7 +434,7 @@ exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
     <span
       class="text text--body-sm select__required-text"
     >
-      (Required)
+      (Optional)
     </span>
     <div
       class="select__subLabel"
@@ -554,6 +481,79 @@ exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
+<div
+  class="select select--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="label label--md select__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-listbox-button-:r3f:"
+      id="headlessui-label-:r3e:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm select__required-text"
+    >
+      (Required)
+    </span>
+    <div
+      class="select__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r3g:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-label-:r3e: headlessui-listbox-button-:r3f:"
+    class="select-button"
+    data-active=""
+    data-headlessui-state="open active"
+    data-open=""
+    id="headlessui-listbox-button-:r3f:"
+    type="button"
+  >
+    <span
+      class="text text--input"
+    >
+      Dogs
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="24px"
+      style="--icon-size: 24px;"
+      viewBox="0 0 24 24"
+      width="24px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapshot 1`] = `
 <div
   class="select select--label-layout-vertical"
@@ -562,14 +562,14 @@ exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r2s:"
+    aria-controls="headlessui-listbox-options-:r2i:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2r:"
+    id="headlessui-listbox-button-:r2h:"
     type="button"
   >
     <span
@@ -603,14 +603,14 @@ exports[`<Select /> Generated Snapshots UncontrolledHeadless story renders snaps
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r2j:"
+    aria-controls="headlessui-listbox-options-:r29:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2i:"
+    id="headlessui-listbox-button-:r28:"
     type="button"
   >
     🐶🐕🐩
@@ -632,8 +632,8 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r4n:"
-      id="headlessui-label-:r4m:"
+      for="headlessui-listbox-button-:r4d:"
+      id="headlessui-label-:r4c:"
     >
       <span
         class="text text--label-md"
@@ -657,15 +657,15 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r4o:"
+    aria-controls="headlessui-listbox-options-:r4e:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4m: headlessui-listbox-button-:r4n:"
+    aria-labelledby="headlessui-label-:r4c: headlessui-listbox-button-:r4d:"
     class="select-button select-button--warning"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4n:"
+    id="headlessui-listbox-button-:r4d:"
     type="button"
   >
     <span
@@ -976,65 +976,6 @@ exports[`<Select /> Generated Snapshots WithStandardButton story renders snapsho
       class="text text--input"
     >
       - Select Option -
-    </span>
-    <svg
-      aria-hidden="true"
-      class="icon select-button__icon select-button__icon--reversed"
-      fill="currentColor"
-      height="24px"
-      style="--icon-size: 24px;"
-      viewBox="0 0 24 24"
-      width="24px"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
-      />
-    </svg>
-  </button>
-</div>
-`;
-
-exports[`<Select /> Generated Snapshots WithSubLabels story renders snapshot 1`] = `
-<div
-  class="select select--has-fieldNote select--label-layout-vertical w-60"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="dropdown"
->
-  <div
-    class="select__overline"
-  >
-    <label
-      class="label label--md select__label"
-      data-headlessui-state="open"
-      data-open=""
-      for="headlessui-listbox-button-:r29:"
-      id="headlessui-label-:r28:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
-  </div>
-  <button
-    aria-controls="headlessui-listbox-options-:r2a:"
-    aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r28: headlessui-listbox-button-:r29:"
-    class="select-button"
-    data-active=""
-    data-headlessui-state="open active"
-    data-open=""
-    id="headlessui-listbox-button-:r29:"
-    type="button"
-  >
-    <span
-      class="text text--input"
-    >
-      Dogs
     </span>
     <svg
       aria-hidden="true"

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r35:"
-      id="headlessui-label-:r34:"
+      for="headlessui-listbox-button-:r3f:"
+      id="headlessui-label-:r3e:"
     >
       <span
         class="text text--label-md"
@@ -25,15 +25,15 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r36:"
+    aria-controls="headlessui-listbox-options-:r3g:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r34: headlessui-listbox-button-:r35:"
+    aria-labelledby="headlessui-label-:r3e: headlessui-listbox-button-:r3f:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r35:"
+    id="headlessui-listbox-button-:r3f:"
     type="button"
   >
     <span
@@ -132,8 +132,8 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r43:"
-      id="headlessui-label-:r42:"
+      for="headlessui-listbox-button-:r4d:"
+      id="headlessui-label-:r4c:"
     >
       <span
         class="text text--label-md"
@@ -157,15 +157,15 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r44:"
+    aria-controls="headlessui-listbox-options-:r4e:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r42: headlessui-listbox-button-:r43:"
+    aria-labelledby="headlessui-label-:r4c: headlessui-listbox-button-:r4d:"
     class="select-button select-button--error"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r43:"
+    id="headlessui-listbox-button-:r4d:"
     type="button"
   >
     <span
@@ -264,8 +264,8 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r2r:"
-      id="headlessui-label-:r2q:"
+      for="headlessui-listbox-button-:r35:"
+      id="headlessui-label-:r34:"
     >
       <span
         class="text text--label-md"
@@ -275,15 +275,15 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r2s:"
+    aria-controls="headlessui-listbox-options-:r36:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r2q: headlessui-listbox-button-:r2r:"
+    aria-labelledby="headlessui-label-:r34: headlessui-listbox-button-:r35:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2r:"
+    id="headlessui-listbox-button-:r35:"
     type="button"
   >
     <span
@@ -318,14 +318,14 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r4n:"
+    aria-controls="headlessui-listbox-options-:r51:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4m:"
+    id="headlessui-listbox-button-:r50:"
     type="button"
   >
     <span
@@ -365,8 +365,8 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r50:"
-      id="headlessui-label-:r4v:"
+      for="headlessui-listbox-button-:r5a:"
+      id="headlessui-label-:r59:"
     >
       <span
         class="text text--label-md"
@@ -374,15 +374,15 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r51:"
+    aria-controls="headlessui-listbox-options-:r5b:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4v: headlessui-listbox-button-:r50:"
+    aria-labelledby="headlessui-label-:r59: headlessui-listbox-button-:r5a:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r50:"
+    id="headlessui-listbox-button-:r5a:"
     type="button"
   >
     <span
@@ -422,6 +422,79 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
+      for="headlessui-listbox-button-:r43:"
+      id="headlessui-label-:r42:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm select__required-text"
+    >
+      (Optional)
+    </span>
+    <div
+      class="select__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r44:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-label-:r42: headlessui-listbox-button-:r43:"
+    class="select-button"
+    data-active=""
+    data-headlessui-state="open active"
+    data-open=""
+    id="headlessui-listbox-button-:r43:"
+    type="button"
+  >
+    <span
+      class="text text--input"
+    >
+      Dogs
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="24px"
+      style="--icon-size: 24px;"
+      viewBox="0 0 24 24"
+      width="24px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
+<div
+  class="select select--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="label label--md select__label"
+      data-headlessui-state="open"
+      data-open=""
       for="headlessui-listbox-button-:r3p:"
       id="headlessui-label-:r3o:"
     >
@@ -434,7 +507,7 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
     <span
       class="text text--body-sm select__required-text"
     >
-      (Optional)
+      (Required)
     </span>
     <div
       class="select__subLabel"
@@ -481,79 +554,6 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
-<div
-  class="select select--label-layout-vertical w-[384px]"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="dropdown"
->
-  <div
-    class="select__overline"
-  >
-    <label
-      class="label label--md select__label"
-      data-headlessui-state="open"
-      data-open=""
-      for="headlessui-listbox-button-:r3f:"
-      id="headlessui-label-:r3e:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
-    <span
-      class="text text--body-sm select__required-text"
-    >
-      (Required)
-    </span>
-    <div
-      class="select__subLabel"
-    >
-      <span
-        class="text text--body-sm"
-      >
-        Some descriptive text
-      </span>
-    </div>
-  </div>
-  <button
-    aria-controls="headlessui-listbox-options-:r3g:"
-    aria-expanded="true"
-    aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r3e: headlessui-listbox-button-:r3f:"
-    class="select-button"
-    data-active=""
-    data-headlessui-state="open active"
-    data-open=""
-    id="headlessui-listbox-button-:r3f:"
-    type="button"
-  >
-    <span
-      class="text text--input"
-    >
-      Dogs
-    </span>
-    <svg
-      aria-hidden="true"
-      class="icon select-button__icon select-button__icon--reversed"
-      fill="currentColor"
-      height="24px"
-      style="--icon-size: 24px;"
-      viewBox="0 0 24 24"
-      width="24px"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
-      />
-    </svg>
-  </button>
-</div>
-`;
-
 exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapshot 1`] = `
 <div
   class="select select--label-layout-vertical"
@@ -562,14 +562,14 @@ exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r2i:"
+    aria-controls="headlessui-listbox-options-:r2s:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2h:"
+    id="headlessui-listbox-button-:r2r:"
     type="button"
   >
     <span
@@ -603,14 +603,14 @@ exports[`<Select /> Generated Snapshots UncontrolledHeadless story renders snaps
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r29:"
+    aria-controls="headlessui-listbox-options-:r2j:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r28:"
+    id="headlessui-listbox-button-:r2i:"
     type="button"
   >
     🐶🐕🐩
@@ -632,8 +632,8 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r4d:"
-      id="headlessui-label-:r4c:"
+      for="headlessui-listbox-button-:r4n:"
+      id="headlessui-label-:r4m:"
     >
       <span
         class="text text--label-md"
@@ -657,15 +657,15 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r4e:"
+    aria-controls="headlessui-listbox-options-:r4o:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4c: headlessui-listbox-button-:r4d:"
+    aria-labelledby="headlessui-label-:r4m: headlessui-listbox-button-:r4n:"
     class="select-button select-button--warning"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4d:"
+    id="headlessui-listbox-button-:r4n:"
     type="button"
   >
     <span
@@ -976,6 +976,65 @@ exports[`<Select /> Generated Snapshots WithStandardButton story renders snapsho
       class="text text--input"
     >
       - Select Option -
+    </span>
+    <svg
+      aria-hidden="true"
+      class="icon select-button__icon select-button__icon--reversed"
+      fill="currentColor"
+      height="24px"
+      style="--icon-size: 24px;"
+      viewBox="0 0 24 24"
+      width="24px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M11.9999 14.379C11.8923 14.379 11.7929 14.3614 11.7019 14.3262C11.6109 14.2909 11.5218 14.2296 11.4344 14.1425L7.04619 9.75397C6.95252 9.66047 6.90252 9.54572 6.89619 9.40972C6.88969 9.27388 6.93969 9.1528 7.04619 9.04647C7.15252 8.93997 7.27044 8.88672 7.39994 8.88672C7.52944 8.88672 7.64736 8.93997 7.75369 9.04647L11.9999 13.2925L16.2462 9.04647C16.3397 8.9528 16.4544 8.9028 16.5904 8.89647C16.7263 8.88997 16.8474 8.93997 16.9537 9.04647C17.0602 9.1528 17.1134 9.27072 17.1134 9.40022C17.1134 9.52972 17.0602 9.64764 16.9537 9.75397L12.5654 14.1425C12.4781 14.2296 12.3889 14.2909 12.2979 14.3262C12.2069 14.3614 12.1076 14.379 11.9999 14.379Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`<Select /> Generated Snapshots WithSubLabels story renders snapshot 1`] = `
+<div
+  class="select select--has-fieldNote select--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="dropdown"
+>
+  <div
+    class="select__overline"
+  >
+    <label
+      class="label label--md select__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-listbox-button-:r29:"
+      id="headlessui-label-:r28:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <button
+    aria-controls="headlessui-listbox-options-:r2a:"
+    aria-expanded="true"
+    aria-haspopup="listbox"
+    aria-labelledby="headlessui-label-:r28: headlessui-listbox-button-:r29:"
+    class="select-button"
+    data-active=""
+    data-headlessui-state="open active"
+    data-open=""
+    id="headlessui-listbox-button-:r29:"
+    type="button"
+  >
+    <span
+      class="text text--input"
+    >
+      Dogs
     </span>
     <svg
       aria-hidden="true"


### PR DESCRIPTION
Make sure to pass the subLabel down to the `Select.Option` component so that it can be shown adjacent to the main label content. Also add a story to verify this.

<img width="292" height="329" alt="Screenshot 2026-04-03 at 3 49 36 PM" src="https://github.com/user-attachments/assets/d373476f-ad47-49fc-adb3-cc3bdc06f96c" />

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
