### PR TITLE
fix(AppHeader): align bottom padding to designs

### DIFF
--- a/src/components/AppHeader/AppHeader.module.css
+++ b/src/components/AppHeader/AppHeader.module.css
@@ -82,7 +82,7 @@
   &.app-header--style-floating > div {
     margin: calc(var(--eds-spacing-size-2) * 1px);
     margin-right: 0;
-    padding: calc(var(--eds-spacing-size-3) * 1px) calc(var(--eds-spacing-size-1) * 1px) calc(var(--eds-spacing-size-4) * 1px) calc(var(--eds-spacing-size-1) * 1px);
+    padding: calc(var(--eds-spacing-size-3) * 1px) calc(var(--eds-spacing-size-1) * 1px) calc(var(--eds-spacing-size-3) * 1px) calc(var(--eds-spacing-size-1) * 1px);
   }
 
   .app-header__content {


### PR DESCRIPTION
change bottom padding of vertical/floating side bars such that it matches the top padding (`spacing-size-3`)

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
