### PR TITLE
fix(AppHeader): do not show menu when there are no nav groups

### DIFF
--- a/src/components/AppHeader/AppHeader.module.css
+++ b/src/components/AppHeader/AppHeader.module.css
@@ -56,6 +56,7 @@
 
   .app-header__content {
     flex-direction: row;
+    min-height: 40px;
     max-width: 1320px;
     /* add in a bit of left/right padding to prevent outline from being cut off */
     padding: 0 2px;

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -21,7 +21,7 @@ export default {
     },
   },
 
-  tags: ['autodocs', 'version:1.4.0'],
+  tags: ['autodocs', 'version:1.4.1'],
 } as Meta<typeof AppHeader>;
 
 type Story = StoryObj<typeof AppHeader>;
@@ -346,6 +346,22 @@ export const MobileFloatingVerticalOrientation: Story = {
   args: {
     ...FloatingVerticalOrientation.args,
     orientation: 'vertical',
+  },
+  globals: {
+    viewport: {
+      value: 'googlePixel2',
+      isRotated: false,
+    },
+  },
+};
+
+/**
+ * When empty, we do not render the menu button (there is nothing to show).
+ */
+export const MobileFloatingVerticalEmpty: Story = {
+  args: {
+    ...MobileFloatingVerticalOrientation.args,
+    navGroups: [],
   },
   globals: {
     viewport: {

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -277,18 +277,20 @@ export const AppHeader = ({
                     />
                   ))}
                 </div>
-                <div className={styles['app-header__menu']}>
-                  <AppHeaderButton
-                    aria-label="Show Menu"
-                    icon="menu"
-                    iconLayout="icon-only"
-                    name="hamburger-menu"
-                    onClick={() => {
-                      document.getElementById('popover')?.showPopover();
-                    }}
-                    type="button"
-                  />
-                </div>
+                {navGroups?.length && (
+                  <div className={styles['app-header__menu']}>
+                    <AppHeaderButton
+                      aria-label="Show Menu"
+                      icon="menu"
+                      iconLayout="icon-only"
+                      name="hamburger-menu"
+                      onClick={() => {
+                        document.getElementById('popover')?.showPopover();
+                      }}
+                      type="button"
+                    />
+                  </div>
+                )}
               </>
             )}
             {headerOrientation === 'vertical' && (
@@ -301,7 +303,7 @@ export const AppHeader = ({
           </div>
         </div>
       </header>
-      {headerOrientation === 'horizontal'
+      {headerOrientation === 'horizontal' && navGroups?.length
         ? createPortal(
             <div
               className={drawerComponentClassName}

--- a/src/components/AppHeader/__snapshots__/AppHeader.test.tsx.snap
+++ b/src/components/AppHeader/__snapshots__/AppHeader.test.tsx.snap
@@ -1082,6 +1082,44 @@ exports[`<AppHeader /> FloatingVerticalOrientation story renders snapshot 1`] = 
 </header>
 `;
 
+exports[`<AppHeader /> MobileFloatingVerticalEmpty story renders snapshot 1`] = `
+<header
+  class="app-header app-header--orientation-vertical app-header--style-floating"
+>
+  <div>
+    <div
+      class="app-header__content"
+    >
+      <div
+        class="app-header-title"
+      >
+        <div
+          class="app-header-title__title"
+        >
+          <span
+            class="text text--headline-sm"
+          >
+            Bodies of water
+          </span>
+        </div>
+        <div
+          class="app-header-title__sub-title"
+        >
+          <span
+            class="text text--body-md"
+          >
+            They're cool!
+          </span>
+        </div>
+      </div>
+      <div
+        class="drawer-content"
+      />
+    </div>
+  </div>
+</header>
+`;
+
 exports[`<AppHeader /> MobileFloatingVerticalOrientation story renders snapshot 1`] = `
 <header
   class="app-header app-header--orientation-vertical app-header--style-floating"


### PR DESCRIPTION
Use the existence / length of `navGroup` to determine if we need to handle the hamburger menu behavior.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
