### PR TITLE
fix: direct postcss rollup plugin to emit lib/index.css always

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { codecovRollupPlugin } from '@codecov/rollup-plugin';
 import commonjs from '@rollup/plugin-commonjs';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
@@ -26,8 +27,9 @@ export default {
   plugins: [
     nodeResolve(),
     postcss({
-      extract: true,
       modules: true,
+      // When having multiple input files, the *.css can be emitted to either files' name. extract and set the path
+      extract: path.resolve('lib/index.css'),
     }),
     typescript({
       tsconfig: 'tsconfig.build.json',

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -5,13 +5,15 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import typescript from '@rollup/plugin-typescript';
 import postcss from 'rollup-plugin-postcss';
 
+const OUTPUT_DIR = 'lib';
+
 /**
  * @type {import('rollup').RollupOptions}
  */
 export default {
   input: ['src/index.ts', 'src/tokens.ts'],
   output: {
-    dir: 'lib',
+    dir: OUTPUT_DIR,
     format: 'cjs',
     preserveModules: true,
     preserveModulesRoot: 'src',
@@ -28,8 +30,8 @@ export default {
     nodeResolve(),
     postcss({
       modules: true,
-      // When having multiple input files, the *.css can be emitted to either files' name. extract and set the path
-      extract: path.resolve('lib/index.css'),
+      // When having multiple input files, the *.css can be emitted to either file's name. extract and set the path
+      extract: path.resolve(`${OUTPUT_DIR}/index.css`),
     }),
     typescript({
       tsconfig: 'tsconfig.build.json',


### PR DESCRIPTION
use `postcss()` to ALWAYS emit index.css when bundling EDS. because we have multiple inputs now (index.ts and tokens.ts), rollup would sometimes resolve to emit the css file to match either of the inputs. Almost always, it would choose `index` but on some occasions it would choose `tokens`, even tho that file does not have any imported non-JS content.

Tested this locally by first trying to change the asset file name using `assetFileNames` provided by rollup itself, then by configuring the `extract` value used by the plugin, which overrides the css content emissions.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:
  - [x] make sure bundle report doesn't show renamed css files
