### PR TITLE
feat(Tooltip): allow formatted content to tooltip text

### DIFF
--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import React from 'react';
 
 import { Tooltip } from './Tooltip';
+import Hr from '../Hr';
+import Text from '../Text';
 
 // diminishing the threshold of this component to avoid sub-pixel jittering
 // https://www.chromatic.com/docs/threshold
@@ -49,7 +51,7 @@ export default {
     },
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
-  tags: ['autodocs', 'version:2.0'],
+  tags: ['autodocs', 'version:2.1'],
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof Tooltip>;
@@ -140,4 +142,24 @@ export const InteractiveDisabled: Story = {
       <div className="fpo p-1">Target Component</div>
     </Tooltip>
   ),
+};
+
+/**
+ * Tooltips can have formmatted content within the popover. Usage of standard HTML tags or EDS components allowed.
+ */
+export const FormattedContent: Story = {
+  args: {
+    text: (
+      <>
+        <Text as="p" preset="headline-md">
+          Formatted Tooltip
+        </Text>
+        <Hr />
+        <Text>
+          Here is a tooltip with <em>complex</em> formatting and{' '}
+          <strong>content</strong>
+        </Text>
+      </>
+    ),
+  },
 };

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -120,7 +120,7 @@ type TooltipProps = {
   /**
    * The content of the tooltip bubble.
    */
-  text?: string;
+  text?: React.ReactNode;
   /**
    * The variant treatment for tooltips
    *
@@ -147,7 +147,7 @@ export const Tooltip = ({
   className,
   duration = 200,
   placement = 'auto',
-  text,
+  text, // TODO(next-major): change prop name to `content`
   variant = 'default',
   ...rest
 }: TooltipProps) => {
@@ -188,11 +188,14 @@ export const Tooltip = ({
     );
   }
 
-  const textContent = (
-    <Text as="span" data-testid="tooltip-content" preset="body-sm">
-      {text}
-    </Text>
-  );
+  const textContent =
+    typeof text === 'string' ? (
+      <Text as="span" data-testid="tooltip-content" preset="body-sm">
+        {text}
+      </Text>
+    ) : (
+      text
+    );
 
   const tooltipClassNames = clsx(
     styles['tooltip'],

--- a/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -53,6 +53,74 @@ exports[`<Tooltip /> BottomPlacement story renders snapshot 1`] = `
 </body>
 `;
 
+exports[`<Tooltip /> FormattedContent story renders snapshot 1`] = `
+<body>
+  <div>
+    <div
+      class="p-spacing-size-4"
+    >
+      <div
+        aria-describedby="tippy-9"
+        class="fpo p-1"
+      >
+        Target Component
+      </div>
+    </div>
+  </div>
+  <div
+    data-tippy-root=""
+    id="tippy-9"
+    style="pointer-events: none; z-index: 9999; visibility: visible; min-width: 0px; position: absolute; left: 0px; top: 0px; margin: 0px; transform: translate(12px, 0px);"
+  >
+    <div
+      class="tippy-box tooltip tooltip--variant-default"
+      data-animation="fade"
+      data-escaped=""
+      data-placement="right"
+      data-reference-hidden=""
+      data-state="visible"
+      role="tooltip"
+      style="max-width: 350px; transition-duration: 0ms;"
+      tabindex="-1"
+    >
+      <div
+        class="tippy-content"
+        data-state="visible"
+        style="transition-duration: 0ms;"
+      >
+        <div>
+          <p
+            class="text text--headline-md"
+          >
+            Formatted Tooltip
+          </p>
+          <hr
+            class="hr"
+          />
+          <p
+            class="text text--body-md"
+          >
+            Here is a tooltip with 
+            <em>
+              complex
+            </em>
+             formatting and
+             
+            <strong>
+              content
+            </strong>
+          </p>
+        </div>
+      </div>
+      <div
+        class="tippy-arrow"
+        style="position: absolute; top: 0px; transform: translate(0px, 3px);"
+      />
+    </div>
+  </div>
+</body>
+`;
+
 exports[`<Tooltip /> Interactive story renders snapshot 1`] = `
 <body>
   <div>


### PR DESCRIPTION
Add in the ability to use `ReactNode` content in the tooltip's `text` prop. Include a story demonstrating this behavior

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
