### PR TITLE
feat(Avatar): support colors on avatar based on user data

### DIFF
--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -9,6 +9,9 @@
  */
 .avatar {
   --avatar-border-radius: calc(var(--eds-border-radius-100) * 1px);
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
+  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-default-low-emphasis), var(--eds-dark-theme-color-background-utility-default-low-emphasis));
+  --avatar__border: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 
   display: flex;
   align-items: center;
@@ -17,12 +20,12 @@
   overflow: hidden;
   white-space: nowrap;
 
-  color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
-  background-color: light-dark(var(--eds-theme-color-background-utility-default-low-emphasis), var(--eds-dark-theme-color-background-utility-default-low-emphasis));
+  color: var(--avatar__fg);
+  background-color: var(--avatar__bg);
   border-radius: var(--avatar-border-radius);
   border-width: 1px;
   border-style: solid;
-  border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+  border-color: var(--avatar__border);
 
 }
 
@@ -72,4 +75,42 @@
 
 .avatar__image {
   width: 100%;
+}
+
+.avatar--color-scheme-0 {
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-warning), var(--eds-dark-theme-color-text-utility-warning));
+  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-warning-low-emphasis), var(--eds-dark-theme-color-background-utility-warning-low-emphasis));
+  --avatar__border: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
+}
+
+.avatar--color-scheme-1 {
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-critical), var(--eds-dark-theme-color-text-utility-critical));
+  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-critical-low-emphasis), var(--eds-dark-theme-color-background-utility-critical-low-emphasis));
+  --avatar__border: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+}
+
+.avatar--color-scheme-2 {
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-favorable), var(--eds-dark-theme-color-text-utility-favorable));
+  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-favorable-low-emphasis), var(--eds-dark-theme-color-background-utility-favorable-low-emphasis));
+  --avatar__border: light-dark(var(--eds-theme-color-border-utility-favorable), var(--eds-dark-theme-color-border-utility-favorable));
+}
+
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
+.avatar--color-scheme-3 {
+  --avatar__fg: light-dark(var(--eds-color-blue-650), var(--eds-color-blue-650));
+  --avatar__bg: light-dark(var(--eds-color-blue-100), var(--eds-color-blue-100));
+  --avatar__border: light-dark(var(--eds-color-blue-550), var(--eds-color-blue-550));}
+
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
+.avatar--color-scheme-4 {
+  --avatar__fg: light-dark(var(--eds-color-purple-650), var(--eds-color-purple-650));
+  --avatar__bg: light-dark(var(--eds-color-purple-100), var(--eds-color-purple-100));
+  --avatar__border: light-dark(var(--eds-color-purple-550), var(--eds-color-purple-550));
+}
+
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
+.avatar--color-scheme-5 {
+  --avatar__fg: light-dark(var(--eds-color-orange-650), var(--eds-color-orange-650));
+  --avatar__bg: light-dark(var(--eds-color-orange-100), var(--eds-color-orange-100));
+  --avatar__border: light-dark(var(--eds-color-orange-550), var(--eds-color-orange-550));
 }

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -81,40 +81,34 @@
 .avatar--color-scheme-0 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-inverse), var(--eds-dark-theme-color-text-utility-inverse));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-dark-green), var(--eds-color-brand-lc-dark-green));
-  --avatar__border: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-1 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-yellow), var(--eds-color-brand-lc-yellow));
-  /* --avatar__border: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical)); */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-2 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-light-blue), var(--eds-color-brand-lc-light-blue));
-  /* --avatar__border: light-dark(var(--eds-theme-color-border-utility-favorable), var(--eds-dark-theme-color-border-utility-favorable)); */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-3 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-pink), var(--eds-color-brand-lc-pink));
-  /* --avatar__border: light-dark(var(--eds-color-blue-550), var(--eds-color-blue-550));} */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-4 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-berry), var(--eds-color-brand-lc-berry));
-  /* --avatar__border: light-dark(var(--eds-color-purple-550), var(--eds-color-purple-550)); */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-5 {
   --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   --avatar__bg: light-dark(var(--eds-color-brand-lc-light-purple), var(--eds-color-brand-lc-light-purple));
-  /* --avatar__border: light-dark(var(--eds-color-orange-550), var(--eds-color-orange-550)); */
 }

--- a/src/components/Avatar/Avatar.module.css
+++ b/src/components/Avatar/Avatar.module.css
@@ -77,40 +77,44 @@
   width: 100%;
 }
 
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-0 {
-  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-warning), var(--eds-dark-theme-color-text-utility-warning));
-  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-warning-low-emphasis), var(--eds-dark-theme-color-background-utility-warning-low-emphasis));
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-inverse), var(--eds-dark-theme-color-text-utility-inverse));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-dark-green), var(--eds-color-brand-lc-dark-green));
   --avatar__border: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
 }
 
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-1 {
-  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-critical), var(--eds-dark-theme-color-text-utility-critical));
-  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-critical-low-emphasis), var(--eds-dark-theme-color-background-utility-critical-low-emphasis));
-  --avatar__border: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-yellow), var(--eds-color-brand-lc-yellow));
+  /* --avatar__border: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical)); */
 }
 
+/* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-2 {
-  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-favorable), var(--eds-dark-theme-color-text-utility-favorable));
-  --avatar__bg: light-dark(var(--eds-theme-color-background-utility-favorable-low-emphasis), var(--eds-dark-theme-color-background-utility-favorable-low-emphasis));
-  --avatar__border: light-dark(var(--eds-theme-color-border-utility-favorable), var(--eds-dark-theme-color-border-utility-favorable));
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-light-blue), var(--eds-color-brand-lc-light-blue));
+  /* --avatar__border: light-dark(var(--eds-theme-color-border-utility-favorable), var(--eds-dark-theme-color-border-utility-favorable)); */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-3 {
-  --avatar__fg: light-dark(var(--eds-color-blue-650), var(--eds-color-blue-650));
-  --avatar__bg: light-dark(var(--eds-color-blue-100), var(--eds-color-blue-100));
-  --avatar__border: light-dark(var(--eds-color-blue-550), var(--eds-color-blue-550));}
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-pink), var(--eds-color-brand-lc-pink));
+  /* --avatar__border: light-dark(var(--eds-color-blue-550), var(--eds-color-blue-550));} */
+}
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-4 {
-  --avatar__fg: light-dark(var(--eds-color-purple-650), var(--eds-color-purple-650));
-  --avatar__bg: light-dark(var(--eds-color-purple-100), var(--eds-color-purple-100));
-  --avatar__border: light-dark(var(--eds-color-purple-550), var(--eds-color-purple-550));
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-berry), var(--eds-color-brand-lc-berry));
+  /* --avatar__border: light-dark(var(--eds-color-purple-550), var(--eds-color-purple-550)); */
 }
 
 /* stylelint-disable-next-line eds/no-tier-1-color-variable */
 .avatar--color-scheme-5 {
-  --avatar__fg: light-dark(var(--eds-color-orange-650), var(--eds-color-orange-650));
-  --avatar__bg: light-dark(var(--eds-color-orange-100), var(--eds-color-orange-100));
-  --avatar__border: light-dark(var(--eds-color-orange-550), var(--eds-color-orange-550));
+  --avatar__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --avatar__bg: light-dark(var(--eds-color-brand-lc-light-purple), var(--eds-color-brand-lc-light-purple));
+  /* --avatar__border: light-dark(var(--eds-color-orange-550), var(--eds-color-orange-550)); */
 }

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -11,7 +11,7 @@ export default {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs', 'version:2.0.1'],
+  tags: ['autodocs', 'version:2.1'],
 } as Meta<typeof Avatar>;
 
 type Story = StoryObj<typeof Avatar>;
@@ -22,6 +22,9 @@ export const Small: Story = {
   args: {
     size: 'sm',
     variant: 'icon',
+    user: {
+      fullName: 'Douglas Adams',
+    },
   },
 };
 
@@ -29,6 +32,9 @@ export const SmallText: Story = {
   args: {
     ...Small.args,
     variant: 'text',
+    user: {
+      fullName: 'Stephen Baxter',
+    },
   },
 };
 
@@ -36,6 +42,9 @@ export const Medium: Story = {
   args: {
     size: 'md',
     variant: 'icon',
+    user: {
+      fullName: 'Ray Bradbury',
+    },
   },
 };
 
@@ -43,6 +52,9 @@ export const MediumText: Story = {
   args: {
     ...Medium.args,
     variant: 'text',
+    user: {
+      fullName: 'Robert Heinlein',
+    },
   },
 };
 
@@ -50,6 +62,9 @@ export const Large: Story = {
   args: {
     size: 'lg',
     variant: 'icon',
+    user: {
+      fullName: 'Arthur C. Clarke',
+    },
   },
 };
 
@@ -57,6 +72,9 @@ export const LargeText: Story = {
   args: {
     ...Large.args,
     variant: 'text',
+    user: {
+      fullName: 'Michael Crichton',
+    },
   },
 };
 
@@ -64,6 +82,9 @@ export const ExtraLarge: Story = {
   args: {
     size: 'xl',
     variant: 'icon',
+    user: {
+      fullName: 'Frank Herbert',
+    },
   },
 };
 
@@ -71,6 +92,9 @@ export const ExtraLargeText: Story = {
   args: {
     ...ExtraLarge.args,
     variant: 'text',
+    user: {
+      fullName: 'Edward M. Forster',
+    },
   },
 };
 
@@ -183,4 +207,16 @@ export const UsingWithTooltip: Story = {
       </span>
     </Tooltip>
   ),
+};
+
+/**
+ * When using color = `fixed` `Avatar` will use a single, static color, which doesn't change based on the user data supplied.
+ *
+ * Colors can be changed by overriding the `--avatar__fg`, `--avatar__bg`, and `--avatar__border` CSS Properties.
+ */
+export const Fixed: Story = {
+  args: {
+    ...Default.args,
+    color: 'fixed',
+  },
 };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -161,9 +161,9 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
     }
 
     const presetMap: Record<NonNullable<AvatarProps['size']>, Preset> = {
-      sm: 'title-sm',
-      md: 'title-md',
-      lg: 'title-md',
+      sm: 'label-sm',
+      md: 'label-sm',
+      lg: 'label-lg',
       xl: 'label-xl',
     };
 

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -25,7 +25,7 @@ type AvatarProps = {
   /**
    * The user associated with this avatar
    *
-   * `UserData` takes the format ([] is optional):
+   * `UserData` takes the format (`[]` key-values are optional):
    *
    * ```
    * - fullName (string)
@@ -36,6 +36,15 @@ type AvatarProps = {
    */
   user?: UserData;
   // Design API
+  /**
+   * Set the behavior of the avatar, based on the specified user data.
+   *
+   * - `default` selects a color from a set, using the user data as a "key"
+   * - `fixed` selects a static color that does not change based on the user data
+   *
+   * **Default is `"default"`**.
+   */
+  color?: 'default' | 'fixed';
   /**
    * Icon to use when an "icon" variant of the avatar. Default is "person"
    */
@@ -54,12 +63,32 @@ type AvatarProps = {
   variant?: 'icon' | 'text' | 'image';
 };
 
+const NUM_COLORS = 6; // this count should match the zero-indexed color schemes in the CSS Module
+
 /**
  * Use graphemer to take a name part, and select the first grapheme (emoji, surrogate pair, ASCII character)
  */
 function produceAbbreviation(fromName: string): string {
   const splitter = new Graphemer();
   return fromName ? splitter.splitGraphemes(fromName)[0] : '?';
+}
+
+/**
+ * Use the user's name to determine a pseudo-random color scheme/style in their avatar.
+ *
+ * @param fromName string representing a user's name, or some other string
+ * @returns offset used to determine a "random" color for the user's avatar
+ */
+function calculateColorOffset(fromName: string): number {
+  return (
+    fromName
+      .split('') // chop into individal characters
+      .filter((c) => c !== '') // strip out any spaces
+      .map((character) => character.codePointAt(0)) // convert to numbered code-points (accounting for UTF-16)
+      .filter((cp) => cp !== undefined) // remove any undefined codepoints
+      .reduce((charNumber, accumulator) => charNumber + accumulator, 0) %
+    NUM_COLORS // accumulate the values, starting with zero
+  );
 }
 
 export function getInitials(fromName: string): string {
@@ -92,6 +121,7 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
     {
       ariaLabel,
       className,
+      color = 'default',
       icon = 'person',
       isInteractive,
       size = 'md',
@@ -107,6 +137,10 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
       isInteractive && styles['avatar--is-interactive'],
       size && styles[`avatar--${size}`],
       variant && styles[`avatar--${variant}`],
+      color === 'default' &&
+        styles[
+          `avatar--color-scheme-${calculateColorOffset(user?.fullName || 'unknown')}`
+        ],
       className,
     );
 

--- a/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`<Avatar /> Default story renders snapshot 1`] = `
 <div
   aria-label="Avatar for unknown user "
-  class="avatar avatar--md avatar--text"
+  class="avatar avatar--md avatar--text avatar--color-scheme-4"
   role="img"
 >
   <span
@@ -16,8 +16,8 @@ exports[`<Avatar /> Default story renders snapshot 1`] = `
 
 exports[`<Avatar /> ExtraLarge story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--xl avatar--icon"
+  aria-label="Avatar for user Frank Herbert"
+  class="avatar avatar--xl avatar--icon avatar--color-scheme-4"
   role="img"
 >
   <svg
@@ -39,12 +39,26 @@ exports[`<Avatar /> ExtraLarge story renders snapshot 1`] = `
 
 exports[`<Avatar /> ExtraLargeText story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--xl avatar--text"
+  aria-label="Avatar for user Edward M. Forster"
+  class="avatar avatar--xl avatar--text avatar--color-scheme-3"
   role="img"
 >
   <span
     class="text text--label-xl"
+  >
+    EF
+  </span>
+</div>
+`;
+
+exports[`<Avatar /> Fixed story renders snapshot 1`] = `
+<div
+  aria-label="Avatar for unknown user "
+  class="avatar avatar--md avatar--text"
+  role="img"
+>
+  <span
+    class="text text--title-md"
   >
     ??
   </span>
@@ -53,8 +67,8 @@ exports[`<Avatar /> ExtraLargeText story renders snapshot 1`] = `
 
 exports[`<Avatar /> Large story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--lg avatar--icon"
+  aria-label="Avatar for user Arthur C. Clarke"
+  class="avatar avatar--lg avatar--icon avatar--color-scheme-3"
   role="img"
 >
   <svg
@@ -76,22 +90,22 @@ exports[`<Avatar /> Large story renders snapshot 1`] = `
 
 exports[`<Avatar /> LargeText story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--lg avatar--text"
+  aria-label="Avatar for user Michael Crichton"
+  class="avatar avatar--lg avatar--text avatar--color-scheme-1"
   role="img"
 >
   <span
     class="text text--title-md"
   >
-    ??
+    MC
   </span>
 </div>
 `;
 
 exports[`<Avatar /> Medium story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--md avatar--icon"
+  aria-label="Avatar for user Ray Bradbury"
+  class="avatar avatar--md avatar--icon avatar--color-scheme-1"
   role="img"
 >
   <svg
@@ -113,22 +127,22 @@ exports[`<Avatar /> Medium story renders snapshot 1`] = `
 
 exports[`<Avatar /> MediumText story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--md avatar--text"
+  aria-label="Avatar for user Robert Heinlein"
+  class="avatar avatar--md avatar--text avatar--color-scheme-2"
   role="img"
 >
   <span
     class="text text--title-md"
   >
-    ??
+    RH
   </span>
 </div>
 `;
 
 exports[`<Avatar /> Small story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--sm avatar--icon"
+  aria-label="Avatar for user Douglas Adams"
+  class="avatar avatar--sm avatar--icon avatar--color-scheme-1"
   role="img"
 >
   <svg
@@ -150,14 +164,14 @@ exports[`<Avatar /> Small story renders snapshot 1`] = `
 
 exports[`<Avatar /> SmallText story renders snapshot 1`] = `
 <div
-  aria-label="Avatar for unknown user "
-  class="avatar avatar--sm avatar--text"
+  aria-label="Avatar for user Stephen Baxter"
+  class="avatar avatar--sm avatar--text avatar--color-scheme-5"
   role="img"
 >
   <span
     class="text text--title-sm"
   >
-    ?
+    S
   </span>
 </div>
 `;
@@ -165,7 +179,7 @@ exports[`<Avatar /> SmallText story renders snapshot 1`] = `
 exports[`<Avatar /> UsingEmoji story renders snapshot 1`] = `
 <div
   aria-label="Avatar for user Young Yarn Lad"
-  class="avatar avatar--lg avatar--text"
+  class="avatar avatar--lg avatar--text avatar--color-scheme-5"
   role="img"
 >
   <span
@@ -179,7 +193,7 @@ exports[`<Avatar /> UsingEmoji story renders snapshot 1`] = `
 exports[`<Avatar /> UsingImage story renders snapshot 1`] = `
 <div
   aria-label="Avatar for unknown user "
-  class="avatar avatar--md avatar--image"
+  class="avatar avatar--md avatar--image avatar--color-scheme-4"
   role="img"
 >
   <img
@@ -193,7 +207,7 @@ exports[`<Avatar /> UsingImage story renders snapshot 1`] = `
 exports[`<Avatar /> UsingInitials story renders snapshot 1`] = `
 <div
   aria-label="Avatar for user John Smith"
-  class="avatar avatar--md avatar--text"
+  class="avatar avatar--md avatar--text avatar--color-scheme-0"
   role="img"
 >
   <span
@@ -207,7 +221,7 @@ exports[`<Avatar /> UsingInitials story renders snapshot 1`] = `
 exports[`<Avatar /> UsingMultibyteUnicode story renders snapshot 1`] = `
 <div
   aria-label="Avatar for user 你好世界"
-  class="avatar avatar--lg avatar--image"
+  class="avatar avatar--lg avatar--image avatar--color-scheme-1"
   role="img"
 >
   <span
@@ -222,7 +236,7 @@ exports[`<Avatar /> UsingWithTooltip story renders snapshot 1`] = `
 <span>
   <div
     aria-label="Avatar for unknown user "
-    class="avatar avatar--is-interactive avatar--md avatar--text"
+    class="avatar avatar--is-interactive avatar--md avatar--text avatar--color-scheme-4"
     role="img"
   >
     <span
@@ -237,7 +251,7 @@ exports[`<Avatar /> UsingWithTooltip story renders snapshot 1`] = `
 exports[`<Avatar /> WhenImageVariantMissingSource story renders snapshot 1`] = `
 <div
   aria-label="Avatar for user Young Yarn Lad"
-  class="avatar avatar--lg avatar--image"
+  class="avatar avatar--lg avatar--image avatar--color-scheme-5"
   role="img"
 >
   <span
@@ -251,7 +265,7 @@ exports[`<Avatar /> WhenImageVariantMissingSource story renders snapshot 1`] = `
 exports[`<Avatar /> WithCustomIcon story renders snapshot 1`] = `
 <div
   aria-label="Custom label for avatar"
-  class="avatar avatar--md avatar--icon"
+  class="avatar avatar--md avatar--icon avatar--color-scheme-4"
   role="img"
 >
   <svg

--- a/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
@@ -7,7 +7,7 @@ exports[`<Avatar /> Default story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-sm"
   >
     ??
   </span>
@@ -58,7 +58,7 @@ exports[`<Avatar /> Fixed story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-sm"
   >
     ??
   </span>
@@ -95,7 +95,7 @@ exports[`<Avatar /> LargeText story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-lg"
   >
     MC
   </span>
@@ -132,7 +132,7 @@ exports[`<Avatar /> MediumText story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-sm"
   >
     RH
   </span>
@@ -169,7 +169,7 @@ exports[`<Avatar /> SmallText story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-sm"
+    class="text text--label-sm"
   >
     S
   </span>
@@ -183,7 +183,7 @@ exports[`<Avatar /> UsingEmoji story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-lg"
   >
     🧶👦🏽
   </span>
@@ -211,7 +211,7 @@ exports[`<Avatar /> UsingInitials story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-sm"
   >
     JS
   </span>
@@ -225,7 +225,7 @@ exports[`<Avatar /> UsingMultibyteUnicode story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-lg"
   >
     你
   </span>
@@ -240,7 +240,7 @@ exports[`<Avatar /> UsingWithTooltip story renders snapshot 1`] = `
     role="img"
   >
     <span
-      class="text text--title-md"
+      class="text text--label-sm"
     >
       ??
     </span>
@@ -255,7 +255,7 @@ exports[`<Avatar /> WhenImageVariantMissingSource story renders snapshot 1`] = `
   role="img"
 >
   <span
-    class="text text--title-md"
+    class="text text--label-lg"
   >
     YL
   </span>

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`<Menu /> MenuWithAvatarButton story renders snapshot 1`] = `
       role="img"
     >
       <span
-        class="text text--title-md"
+        class="text text--label-sm"
       >
         JS
       </span>

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`<Menu /> MenuWithAvatarButton story renders snapshot 1`] = `
   >
     <div
       aria-label="Avatar for user Josie Sandberg"
-      class="avatar avatar--is-interactive avatar--md avatar--text"
+      class="avatar avatar--is-interactive avatar--md avatar--text avatar--color-scheme-0"
       role="img"
     >
       <span


### PR DESCRIPTION
Create a new default color scheme for avatar components, where the color changes and is selected based on the user's data (currently `user.fullName`). offer an option to select a fixed color if needed, and a path to override colors using CSS variables

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
