### PR TITLE
fix(typography): use font-family-2 for caption presets

### DIFF
--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -246,7 +246,7 @@
 }
 
 .text--caption-md {
-  --text-font-family: var(--eds-typography-font-family-3);
+  --text-font-family: var(--eds-typography-font-family-2);
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 500;
@@ -254,7 +254,7 @@
 }
 
 .text--caption-sm {
-  --text-font-family: var(--eds-typography-font-family-3);
+  --text-font-family: var(--eds-typography-font-family-2);
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 500;


### PR DESCRIPTION
swap in `font-family-2` for `font-family-3` in `caption-*` presets

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
