### PR TITLE
fix(Button): change overflow on small buttons to show descenders

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -27,6 +27,7 @@
   .button--sm & {
     /* Offset to better align text in small button */
     transform: translateY(-1px);
+    overflow: visible;
     gap: calc(var(--eds-spacing-size-half) * 1px);
   }
 

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -300,7 +300,7 @@ export const InputWithin: Story = {
     <InputField
       inputWithin={
         <Button rank="secondary" size="sm">
-          Button
+          Copy
         </Button>
       }
       label="Input field with button inside"

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -252,7 +252,7 @@ exports[`<InputField /> InputWithin story renders snapshot 1`] = `
           <span
             class="text text--label-sm button__text"
           >
-            Button
+            Copy
           </span>
         </button>
       </div>


### PR DESCRIPTION
allow text in small buttons to overflow, so that typographical descenders are still visible. Modify the story where this is demonstrated.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
