### PR TITLE
test(Modal): add backdrop content for modal snapshots

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -34,10 +34,19 @@ function InteractiveExample(args: InteractiveArgs) {
 
   return (
     <>
-      <Button onClick={() => setOpen(true)} rank="primary">
-        Open the modal
-      </Button>
+      <div className="fpo mb-spacing-size-3">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Rerum ipsa,
+        quis iure eligendi voluptates delectus earum suscipit porro
+        exercitationem asperiores voluptatibus repellat saepe neque nisi quidem
+        repellendus temporibus accusamus ea officiis illo unde illum mollitia
+        eos consectetur. Possimus, eaque nihil?
+      </div>
 
+      <div className="flex justify-center">
+        <Button onClick={() => setOpen(true)} rank="primary">
+          Open the modal
+        </Button>
+      </div>
       <Modal {...args} onClose={() => setOpen(false)} open={open} />
     </>
   );


### PR DESCRIPTION
In order to validate future changes to backdrop handling, show content behind expanded modals in the snapshots

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
