### PR TITLE
docs(InputField): add in description for handling error states on fields

### DIFF
--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -154,7 +154,12 @@ export const LeadingIcon: Story = {
 };
 
 /**
- * Fields can be marked as required.
+ * Fields can be marked as required. When required, consumers should implement error state handling on the associated `<form>` element. This should
+ * make use of the `status="critical"` and `fieldNote` properties to signal that the field requirement is unmet.
+ *
+ * Consumers must implement this to avoid the fallback tooltip which can show up in some browsers upon submit.
+ *
+ * See <https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/noValidate> for a possible method of suppressing this behavior.
  */
 export const Required: Story = {
   args: {

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -108,7 +108,7 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   recommendedMaxLength?: number;
   /**
-   * Indicates that field is required for form to be successfully submitted
+   * Indicates that field is required for form to be successfully submitted. Consumers must implement handling for error states using `status="critical"`
    */
   required?: boolean;
   /**
@@ -118,7 +118,7 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   showHint?: boolean;
   /**
-   * Status for the field state
+   * Status for the field state. Use `"critical"` for an error state.
    *
    * **Default is `"default"`**.
    */


### PR DESCRIPTION
Add in clearer documentation on how to handle input validation errors on required fields. This should be done in order to prevent `<form>` examples from rendering the built-in UI for required fields remaining empty.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
