### PR TITLE
fix(PopoverListItem): align sizing for leading and trailing content slots

### DIFF
--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -55,8 +55,8 @@
   display: flex;
   align-items: center;
 
-  /* if an icon container is adjacent to a container with a sub-label, don't use flex */
-  &:has(+ div > .popover-list-item__sub-label) {
+  /* if an content container is adjacent to a container with a sub-label, don't use flex */
+  &:has(~ div > .popover-list-item__sub-label) {
     display: revert;
   }
 }
@@ -66,8 +66,14 @@
 }
 
 .popover-list-item__trailing-content {
+  display: flex;
+  align-items: center;
   color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
-  align-self: flex-end;
+
+  /* if the predecessor has a sub label, don't use flex */
+  .popover-list-item--has-sub-label ~ & {
+    display: revert;
+  }
 }
 
 .popover-list-item__no-icon {

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -44,6 +44,17 @@ export const Default: Story = {
   },
 };
 
+export const DefaultWithTrailingContent: Story = {
+  args: {
+    children: 'Favorite',
+    leadingContent: (
+      <Icon name={'heart-filled'} purpose="decorative" size="24px" />
+    ),
+    trailingContent: '5',
+    subLabel: 'Save posts for later',
+  },
+};
+
 /**
  * Note: using `__type` list item b/c there is no icon to display. Other types preserve icon space for checkboxes.
  */
@@ -102,6 +113,19 @@ export const WithLeadingAndTrailingContent: Story = {
       <Icon name="document-blank" purpose="decorative" size="24px" />
     ),
     trailingContent: '5',
+  },
+};
+
+/**
+ * List items can also have trailing content. By default this is plain text, but can also function as a flexible slot.
+ */
+export const WithLeadingAndTrailingIcons: Story = {
+  args: {
+    children: 'Add comment',
+    leadingContent: (
+      <Icon name="document-blank" purpose="decorative" size="24px" />
+    ),
+    trailingContent: <Icon name="check" purpose="decorative" size="24px" />,
   },
 };
 

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -109,7 +109,12 @@ export const PopoverListItem = React.forwardRef<
         ) : (
           <div className={styles['popover-list-item__no-icon']}></div>
         )}
-        <div className={styles['popover-list-item__menu-labels']}>
+        <div
+          className={clsx(
+            styles['popover-list-item__menu-labels'],
+            subLabel && styles['popover-list-item--has-sub-label'],
+          )}
+        >
           {__type === 'label' ? (
             <Text
               as="div"


### PR DESCRIPTION
The leading and trailing content areas in popovers were not using the same exact layout ergonomics. In particular, `trailingContent` was not using flexbox while `leadingContent` was. Change this, and also fix how trailing content aligns when sub labels are in use.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
