### PR TITLE
fix(Checkbox): update styling for disabled checkboxes

### DIFF
--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -24,7 +24,8 @@
   display: grid;
   place-content: center;
 
-  border-radius: calc(var(--eds-theme-border-radius-objects-xs) * 1px); /* using sized radius to have an outer rounded rect and inner square */
+  border-radius: calc(var(--eds-theme-border-radius-objects-xs) * 1px);
+  /* using sized radius to have an outer rounded rect and inner square */
 
   /* preset: body-md */
   font: 400 var(--eds-typography-preset-200) var(--eds-typography-font-family-1);
@@ -84,6 +85,7 @@
 
   &.checkbox--is-disabled {
     color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+    cursor: not-allowed;
   }
 }
 
@@ -147,23 +149,23 @@
 }
 
 .checkbox__input:disabled {
-  color: light-dark(var(--eds-theme-color-background-utility-disabled-medium-emphasis), var(--eds-dark-theme-color-background-utility-disabled-medium-emphasis));
+
+  &::before {
+    color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+  }
+
+  color: light-dark(var(--eds-theme-color-icon-utility-disabled-primary), var(--eds-dark-theme-color-icon-utility-disabled-primary));
+  border-color: light-dark(var(--eds-theme-color-border-utility-disabled), var(--eds-dark-theme-color-border-utility-disabled));
 
   cursor: not-allowed;
 
   &:not(:checked) {
-    color: light-dark(var(--eds-theme-color-border-utility-disabled), var(--eds-dark-theme-color-border-utility-disabled));
-    background-color: light-dark(var(--eds-theme-color-text-utility-disabled-secondary), var(--eds-dark-theme-color-text-utility-disabled-secondary));
+    background-color: light-dark(var(--eds-theme-color-background-utility-disabled-low-emphasis), var(--eds-dark-theme-color-background-utility-disabled-low-emphasis));
   }
 
   &:checked,
   &:indeterminate {
-    background-color: light-dark(var(--eds-theme-color-background-utility-disabled-medium-emphasis), var(--eds-dark-theme-color-background-utility-disabled-medium-emphasis));
-
-    &::before {
-      color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
-
-    }
+    background-color: light-dark(var(--eds-theme-color-background-utility-disabled-low-emphasis), var(--eds-dark-theme-color-background-utility-disabled-low-emphasis));
   }
 }
 

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -12,8 +12,13 @@ const meta: Meta<typeof Checkbox> = {
   parameters: {
     layout: 'centered',
   },
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
+  },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
-  tags: ['autodocs', 'version:2.1.1'],
+  tags: ['autodocs', 'version:2.2'],
 };
 
 export default meta;


### PR DESCRIPTION
Update the styling of the disabled checkboxes to match latest designs

<img width="180" height="135" alt="Screenshot 2026-05-19 at 11 42 01" src="https://github.com/user-attachments/assets/19c82bf6-ce3f-4baf-bf3d-9e928aa175ac" />

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
