### PR TITLE
feat: allow programmatic close on Menus and AppHeader

### DIFF
--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -21,7 +21,7 @@ export default {
     },
   },
 
-  tags: ['autodocs', 'version:1.5.1'],
+  tags: ['autodocs', 'version:1.6.0'],
 } as Meta<typeof AppHeader>;
 
 type Story = StoryObj<typeof AppHeader>;
@@ -239,11 +239,13 @@ export const DefaultWithNavMenus: Story = {
                 name: 'Lorem Ipsum, Inc.',
                 user: { fullName: 'Lorem Ipsum' },
                 trailingContent: 'check',
+                shouldClose: false,
               },
               {
                 type: 'button',
                 leadingContent: 'avatar',
                 name: 'Unknown Organization',
+                shouldClose: false,
               },
               {
                 type: 'button',
@@ -253,6 +255,10 @@ export const DefaultWithNavMenus: Story = {
               {
                 type: 'separator',
                 name: 'line-0',
+              },
+              {
+                type: 'label',
+                name: 'test',
               },
               {
                 type: 'button',

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -257,10 +257,6 @@ export const DefaultWithNavMenus: Story = {
                 name: 'line-0',
               },
               {
-                type: 'label',
-                name: 'test',
-              },
-              {
                 type: 'button',
                 name: 'Settings',
               },

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -36,11 +36,6 @@ export type AppHeaderEventHandler = (
   navItem: NavItem,
 ) => void;
 
-/**
- * - swap `icon` for leading/trailing content on navitems
- * - add in avatar item type
- */
-
 export type AppHeaderProps = {
   // Component API
   /**
@@ -201,6 +196,7 @@ function NavMenuItemLeadingContent(props: {
 
   return leadingContent;
 }
+
 function NavMenuItemTrailingContent(props: {
   navItem: NavMenuButton | NavMenuLink;
 }): ReactNode {
@@ -214,6 +210,22 @@ function NavMenuItemTrailingContent(props: {
 
   return trailingContent;
 }
+
+/**
+ * Handler for whether a click on the associated NavItem should close the `Menu`
+ * @param navItem NavItem associated with the nav menu (NavMenuLink or NavMenuButton)
+ * @param close function provided to trigger close on a clicked menu item
+ */
+function handleShouldClose(
+  ev: React.MouseEvent,
+  navItem: NavMenuButton | NavMenuLink,
+  close: () => void,
+) {
+  if (typeof navItem.shouldClose !== 'undefined') {
+    navItem.shouldClose ? close() : ev.preventDefault();
+  }
+}
+
 /**
  * `import {AppHeader} from "@chanzuckerberg/eds";`
  *
@@ -447,91 +459,105 @@ const AppHeaderNavGroup = ({
               )}
               {(navItem.type === 'menu' || navItem.type === 'tree') && (
                 <Menu>
-                  <Menu.PlainButton as={React.Fragment}>
-                    <AppHeaderButton
-                      icon={navItem.icon}
-                      iconLayout={navItem.iconLayout}
-                      name={navItem.name}
-                      type="button"
-                    >
-                      {navItem.name}
-                    </AppHeaderButton>
-                  </Menu.PlainButton>
-                  <Menu.Items
-                    anchor={{ to: 'bottom end', gap: 12 }}
-                    className={styles['app-header__nav-items']}
-                  >
-                    {navItem.navItems?.map((navItem) => {
-                      switch (navItem.type) {
-                        case 'link':
-                          return (
-                            <Menu.Item
-                              href={navItem.href}
-                              key={navItem.name}
-                              leadingContent={
-                                <NavMenuItemLeadingContent navItem={navItem} />
-                              }
-                              onClick={(ev) => {
-                                onLinkClick && onLinkClick(ev, navItem);
-                              }}
-                              target={navItem.isExternal ? '_blank' : undefined}
-                              trailingContent={
-                                <NavMenuItemTrailingContent navItem={navItem} />
-                              }
-                            >
-                              {navItem.name}
-                            </Menu.Item>
-                          );
-                        case 'button':
-                          return (
-                            <Menu.Item
-                              key={navItem.name}
-                              leadingContent={
-                                <NavMenuItemLeadingContent navItem={navItem} />
-                              }
-                              onClick={(ev) => {
-                                onButtonClick && onButtonClick(ev, navItem);
-                              }}
-                              trailingContent={
-                                <NavMenuItemTrailingContent navItem={navItem} />
-                              }
-                            >
-                              {navItem.name}
-                            </Menu.Item>
-                          );
-                        case 'label':
-                          return (
-                            <Menu.Item __type="label" key={navItem.name}>
-                              {navItem.name}
-                            </Menu.Item>
-                          );
-                        case 'caption':
-                          return (
-                            <Menu.Item __type="caption" key={navItem.name}>
-                              {navItem.name}
-                            </Menu.Item>
-                          );
-                        case 'separator':
-                          return (
-                            <Menu.Item __type="separator" key={navItem.name} />
-                          );
-                        default:
-                          // This should not be reachable as types guard against it
-                          // however, in cases where data sent in is dynamic, this
-                          // protects the UI.
-                          assertEdsUsage(
-                            [typeof navItem === 'undefined'],
-                            `Problem with navItem data: ${navItem}`,
-                            'error',
-                          );
-                          return (
-                            <Menu.Item key="error-unknown-nav-item-type">
-                              N/A
-                            </Menu.Item>
-                          );
-                      }
-                    })}
-                  </Menu.Items>
+                  {({ close }) => (
+                    <>
+                      <Menu.PlainButton as={React.Fragment}>
+                        <AppHeaderButton
+                          icon={navItem.icon}
+                          iconLayout={navItem.iconLayout}
+                          name={navItem.name}
+                          type="button"
+                        >
+                          {navItem.name}
+                        </AppHeaderButton>
+                      </Menu.PlainButton>
+                      <Menu.Items
+                        anchor={{ to: 'bottom end', gap: 12 }}
+                        className={styles['app-header__nav-items']}
+                      >
+                        {navItem.navItems?.map((navItem) => {
+                          switch (navItem.type) {
+                            case 'link':
+                              return (
+                                <Menu.Item
+                                  href={navItem.href}
+                                  key={navItem.name}
+                                  leadingContent={
+                                    <NavMenuItemLeadingContent
+                                      navItem={navItem}
+                                    />
+                                  }
+                                  onClick={(ev) => {
+                                    onLinkClick && onLinkClick(ev, navItem);
+                                    handleShouldClose(ev, navItem, close);
+                                  }}
+                                  target={
+                                    navItem.isExternal ? '_blank' : undefined
+                                  }
+                                  trailingContent={
+                                    <NavMenuItemTrailingContent
+                                      navItem={navItem}
+                                    />
+                                  }
+                                >
+                                  {navItem.name}
+                                </Menu.Item>
+                              );
+                            case 'button':
+                              return (
+                                <Menu.Item
+                                  key={navItem.name}
+                                  leadingContent={
+                                    <NavMenuItemLeadingContent
+                                      navItem={navItem}
+                                    />
+                                  }
+                                  onClick={(ev) => {
+                                    onButtonClick && onButtonClick(ev, navItem);
+                                    handleShouldClose(ev, navItem, close);
+                                  }}
+                                  trailingContent={
+                                    <NavMenuItemTrailingContent
+                                      navItem={navItem}
+                                    />
+                                  }
+                                >
+                                  {navItem.name}
+                                </Menu.Item>
+                              );
+                            case 'label':
+                              return (
+                                <Menu.Item __type="label" key={navItem.name}>
+                                  {navItem.name}
+                                </Menu.Item>
+                              );
+                            case 'caption':
+                              return (
+                                <Menu.Item __type="caption" key={navItem.name}>
+                                  {navItem.name}
+                                </Menu.Item>
+                              );
+                            case 'separator':
+                              return <Menu.Separator key={navItem.name} />;
+                            default:
+                              // This should not be reachable as types guard against it
+                              // however, in cases where data sent in is dynamic, this
+                              // protects the UI.
+                              assertEdsUsage(
+                                [typeof navItem === 'undefined'],
+                                `Problem with navItem data: ${navItem}`,
+                                'error',
+                              );
+                              return (
+                                <Menu.Item key="error-unknown-nav-item-type">
+                                  N/A
+                                </Menu.Item>
+                              );
+                          }
+                        })}
+                      </Menu.Items>
+                    </>
+                  )}
                 </Menu>
               )}
               {/* In horizontal layouts, we never render the horizontal rule */}
@@ -791,143 +817,131 @@ const AppHeaderDrawerContent = ({
                 )}
                 {navItem.type === 'menu' && (
                   <Menu>
-                    <Menu.PlainButton as={React.Fragment}>
-                      <AppHeaderButton
-                        className={styles['app-header__menu-trigger']}
-                        icon={navItem.icon}
-                        iconLayout={navItem.iconLayout}
-                        isVertical
-                        name={navItem.name}
-                        type="button"
-                      >
-                        {navItem.name}
-                        {navItem.type === 'menu' && navItem.subLabel && (
-                          <Text as="div" preset="body-xs">
-                            {navItem.subLabel}
-                          </Text>
-                        )}
-                      </AppHeaderButton>
-                    </Menu.PlainButton>
-                    <HeadlessMenuItems
-                      anchor={
-                        mode === 'default'
-                          ? { to: 'right end', gap: 24 }
-                          : undefined
-                      }
-                      as={PopoverContainer}
-                      className={clsx(
-                        styles['app-header__nav-items'],
-                        mode === 'drawer' &&
-                          styles['app-header__nav-items--absolute'],
-                      )}
-                      modal={false}
-                    >
-                      {navItem.navItems?.map((navItem) => {
-                        switch (navItem.type) {
-                          case 'link':
-                            return (
-                              <Menu.Item
-                                href={navItem.href}
-                                key={navItem.name}
-                                leadingContent={
-                                  <NavMenuItemLeadingContent
-                                    navItem={navItem}
-                                  />
-                                }
-                                onClick={(ev) => {
-                                  mode === 'drawer' &&
-                                    document
-                                      .getElementById('popover')
-                                      ?.hidePopover();
-                                  onLinkClick && onLinkClick(ev, navItem);
-                                }}
-                                target={
-                                  navItem.isExternal ? '_blank' : undefined
-                                }
-                                trailingContent={
-                                  <NavMenuItemTrailingContent
-                                    navItem={navItem}
-                                  />
-                                }
-                              >
-                                {navItem.name}
-                              </Menu.Item>
-                            );
-                          case 'button': {
-                            return (
-                              <Menu.Item
-                                key={navItem.name}
-                                leadingContent={
-                                  <NavMenuItemLeadingContent
-                                    navItem={navItem}
-                                  />
-                                }
-                                onClick={(ev) => {
-                                  mode === 'drawer' &&
-                                    document
-                                      .getElementById('popover')
-                                      ?.hidePopover();
-                                  onButtonClick && onButtonClick(ev, navItem);
-                                }}
-                                trailingContent={
-                                  <NavMenuItemTrailingContent
-                                    navItem={navItem}
-                                  />
-                                }
-                              >
-                                {navItem.name}
-                              </Menu.Item>
-                            );
+                    {({ close }) => (
+                      <>
+                        <Menu.PlainButton as={React.Fragment}>
+                          <AppHeaderButton
+                            className={styles['app-header__menu-trigger']}
+                            icon={navItem.icon}
+                            iconLayout={navItem.iconLayout}
+                            isVertical
+                            name={navItem.name}
+                            type="button"
+                          >
+                            {navItem.name}
+                            {navItem.type === 'menu' && navItem.subLabel && (
+                              <Text as="div" preset="body-xs">
+                                {navItem.subLabel}
+                              </Text>
+                            )}
+                          </AppHeaderButton>
+                        </Menu.PlainButton>
+                        <HeadlessMenuItems
+                          anchor={
+                            mode === 'default'
+                              ? { to: 'right end', gap: 24 }
+                              : undefined
                           }
-                          case 'caption':
-                            return (
-                              <Menu.Item
-                                __type="caption"
-                                key={navItem.name}
-                                onClick={(ev) => {
-                                  mode === 'drawer' &&
-                                    document
-                                      .getElementById('popover')
-                                      ?.hidePopover();
-                                }}
-                              >
-                                {navItem.name}
-                              </Menu.Item>
-                            );
-                          case 'label':
-                            return (
-                              <Menu.Item
-                                __type="label"
-                                key={navItem.name}
-                                onClick={(ev) => {
-                                  mode === 'drawer' &&
-                                    document
-                                      .getElementById('popover')
-                                      ?.hidePopover();
-                                }}
-                              >
-                                {navItem.name}
-                              </Menu.Item>
-                            );
-                          case 'separator':
-                            return (
-                              <Menu.Item
-                                __type="separator"
-                                key={navItem.name}
-                              />
-                            );
-                          default:
-                            // This should not be reachable as types guard against it
-                            // however, in cases where data sent in is dynamic, this
-                            // protects the UI.
-                            return (
-                              <Menu.Item key="error-unknown-nav-item-type">
-                                N/A
-                              </Menu.Item>
-                            );
-                        }
-                      })}
-                    </HeadlessMenuItems>
+                          as={PopoverContainer}
+                          className={clsx(
+                            styles['app-header__nav-items'],
+                            mode === 'drawer' &&
+                              styles['app-header__nav-items--absolute'],
+                          )}
+                          modal={false}
+                        >
+                          {navItem.navItems?.map((navItem) => {
+                            switch (navItem.type) {
+                              case 'link':
+                                return (
+                                  <Menu.Item
+                                    href={navItem.href}
+                                    key={navItem.name}
+                                    leadingContent={
+                                      <NavMenuItemLeadingContent
+                                        navItem={navItem}
+                                      />
+                                    }
+                                    onClick={(ev) => {
+                                      mode === 'drawer' &&
+                                        document
+                                          .getElementById('popover')
+                                          ?.hidePopover();
+                                      onLinkClick && onLinkClick(ev, navItem);
+                                      handleShouldClose(ev, navItem, close);
+                                    }}
+                                    target={
+                                      navItem.isExternal ? '_blank' : undefined
+                                    }
+                                    trailingContent={
+                                      <NavMenuItemTrailingContent
+                                        navItem={navItem}
+                                      />
+                                    }
+                                  >
+                                    {navItem.name}
+                                  </Menu.Item>
+                                );
+                              case 'button': {
+                                return (
+                                  <Menu.Item
+                                    key={navItem.name}
+                                    leadingContent={
+                                      <NavMenuItemLeadingContent
+                                        navItem={navItem}
+                                      />
+                                    }
+                                    onClick={(ev) => {
+                                      mode === 'drawer' &&
+                                        document
+                                          .getElementById('popover')
+                                          ?.hidePopover();
+                                      onButtonClick &&
+                                        onButtonClick(ev, navItem);
+                                      handleShouldClose(ev, navItem, close);
+                                    }}
+                                    trailingContent={
+                                      <NavMenuItemTrailingContent
+                                        navItem={navItem}
+                                      />
+                                    }
+                                  >
+                                    {navItem.name}
+                                  </Menu.Item>
+                                );
+                              }
+                              case 'caption':
+                                return (
+                                  <Menu.Item
+                                    __type="caption"
+                                    key={navItem.name}
+                                  >
+                                    {navItem.name}
+                                  </Menu.Item>
+                                );
+                              case 'label':
+                                // TODO: change to Menu.Heading once Menu.Sections are used
+                                return (
+                                  <Menu.Item __type="label" key={navItem.name}>
+                                    {navItem.name}
+                                  </Menu.Item>
+                                );
+                              case 'separator':
+                                return <Menu.Separator key={navItem.name} />;
+                              default:
+                                // This should not be reachable as types guard against it
+                                // however, in cases where data sent in is dynamic, this
+                                // protects the UI.
+                                return (
+                                  <Menu.Item key="error-unknown-nav-item-type">
+                                    N/A
+                                  </Menu.Item>
+                                );
+                            }
+                          })}
+                        </HeadlessMenuItems>
+                      </>
+                    )}
                   </Menu>
                 )}
               </li>

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -39,52 +39,62 @@ export default {
       </div>
     ),
   ],
-  tags: ['autodocs', 'version:3.2.0'],
+  tags: ['autodocs', 'version:3.3.0'],
 } as Meta<MenuProps>;
 
 type Story = StoryObj<MenuProps>;
 
 const menuItems = (
   <Menu.Items data-testid="menu-content">
-    <Menu.Item
-      leadingContent={
-        <Icon name="heart-filled" purpose="decorative" size="24px" />
-      }
-      trailingContent="5"
-    >
-      Favorite
-    </Menu.Item>
-    <Menu.Item
-      leadingContent={<Icon name="ballot" purpose="decorative" size="24px" />}
-      subLabel="Everyone can see comments"
-    >
-      Add comment
-    </Menu.Item>
-    <Menu.Item
-      leadingContent={<Icon name="lock" purpose="decorative" size="24px" />}
-    >
-      Protect with password
-    </Menu.Item>
-    <Menu.Item __type="separator" />
-    <Menu.Item
-      leadingContent={<Icon name="print" purpose="decorative" size="24px" />}
-    >
-      Print
-    </Menu.Item>
-    <Menu.Item
-      isDestructiveAction
-      leadingContent={<Icon name="trash" purpose="decorative" size="24px" />}
-    >
-      Destructive
-    </Menu.Item>
-    <Menu.Item __type="separator" />
-    <Menu.Item __type="label">Account</Menu.Item>
-    <Menu.Item leadingContent={<Avatar size="sm" />}>Switch account</Menu.Item>
-    <Menu.Item
-      leadingContent={<Icon name="settings" purpose="decorative" size="24px" />}
-    >
-      Settings
-    </Menu.Item>
+    <Menu.Section>
+      <Menu.Item
+        leadingContent={
+          <Icon name="heart-filled" purpose="decorative" size="24px" />
+        }
+        trailingContent="5"
+      >
+        Favorite
+      </Menu.Item>
+      <Menu.Item
+        leadingContent={<Icon name="ballot" purpose="decorative" size="24px" />}
+        subLabel="Everyone can see comments"
+      >
+        Add comment
+      </Menu.Item>
+      <Menu.Item
+        leadingContent={<Icon name="lock" purpose="decorative" size="24px" />}
+      >
+        Protect with password
+      </Menu.Item>
+    </Menu.Section>
+    <Menu.Separator />
+    <Menu.Section>
+      <Menu.Item
+        leadingContent={<Icon name="print" purpose="decorative" size="24px" />}
+      >
+        Print
+      </Menu.Item>
+      <Menu.Item
+        isDestructiveAction
+        leadingContent={<Icon name="trash" purpose="decorative" size="24px" />}
+      >
+        Destructive
+      </Menu.Item>
+    </Menu.Section>
+    <Menu.Separator />
+    <Menu.Section>
+      <Menu.Heading>Account</Menu.Heading>
+      <Menu.Item leadingContent={<Avatar size="sm" />}>
+        Switch account
+      </Menu.Item>
+      <Menu.Item
+        leadingContent={
+          <Icon name="settings" purpose="decorative" size="24px" />
+        }
+      >
+        Settings
+      </Menu.Item>
+    </Menu.Section>
     <Menu.Item __type="caption">© 2026 Your Company Here, Inc.</Menu.Item>
   </Menu.Items>
 );

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,8 +1,11 @@
 import {
   Menu as HeadlessMenu,
-  MenuButton as HeadlessMenuButton,
   MenuItem as HeadlessMenuItem,
   MenuItems as HeadlessMenuItems,
+  MenuButton as HeadlessMenuButton,
+  MenuSection as HeadlessMenuSection,
+  MenuHeading as HeadlessMenuHeading,
+  MenuSeparator as HeadlessMenuSeparator,
 } from '@headlessui/react';
 import type { AnchorProps } from '@headlessui/react/dist/internal/floating';
 
@@ -46,11 +49,13 @@ export type MenuButtonProps = {
   /**
    * Icon override for component. Default is 'chevron-down'
    */
-  icon?: Extract<IconName, 'chevron-down'>;
+  icon?: Extract<IconName, 'chevron-down'>; // TODO(next-major): change to `leadingContent`
 };
 
+export type MenuSeparatorProps = ExtractProps<typeof HeadlessMenuSeparator>;
 export type MenuPlainButtonProps = ExtractProps<typeof HeadlessMenuButton>;
-
+export type MenuHeadingProps = ExtractProps<typeof HeadlessMenuHeading>;
+export type MenuSectionProps = ExtractProps<typeof HeadlessMenuSection>;
 export type MenuItemsProps = ExtractProps<typeof HeadlessMenuItems>;
 
 export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
@@ -77,8 +82,6 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
     target?: HTMLAttributeAnchorTarget;
   };
 
-// TODO: how to handle type for separator w/o using private API `__type`
-
 /**
  * `import {Menu} from "@chanzuckerberg/eds";`
  *
@@ -91,6 +94,7 @@ export const Menu = ({ className, ...other }: MenuProps) => {
 
 /**
  * A styled button that when clicked, shows or hides the Options.
+ *
  * @see https://headlessui.com/react/menu#menu-button
  */
 const MenuButton = ({
@@ -117,10 +121,41 @@ const MenuButton = ({
 
 /**
  * A minimally styled button that when clicked, shows or hides the Options.
+ *
+ * @see https://headlessui.com/react/menu#menu-button
  */
-const MenuPlainButton = ({ className, ...other }: MenuPlainButtonProps) => {
-  return <HeadlessMenuButton className={className} {...other} />;
-};
+const MenuPlainButton = ({ className, ...other }: MenuPlainButtonProps) => (
+  <HeadlessMenuButton className={className} {...other} />
+);
+
+/**
+ * Divides a list of `Menu.Item` components into sections with proper accessibility semantics.
+ *
+ * @see https://headlessui.com/react/menu#menu-section
+ */
+const MenuSection = (props: MenuSectionProps) => (
+  <HeadlessMenuSection {...props} />
+);
+
+/**
+ * Separates two `Menu.Section` components, with proper accessibility semantics.
+ *
+ * @see https://headlessui.com/react/menu#menu-separator
+ */
+const MenuSeparator = (props: MenuSeparatorProps) => (
+  <HeadlessMenuSeparator __type="separator" as={PopoverListItem} />
+);
+
+/**
+ * Adds an accessible label to a `MenuSection`.
+ *
+ * @see https://headlessui.com/react/menu#menu-heading
+ */
+const MenuHeading = (props: MenuHeadingProps) => (
+  <HeadlessMenuHeading __type="label" as={PopoverListItem}>
+    {props.children as ReactNode}
+  </HeadlessMenuHeading>
+);
 
 /**
  * A list of actions that are revealed in the menu
@@ -216,13 +251,19 @@ const MenuItem = ({
   );
 };
 
-Menu.displayName = 'Menu';
-MenuButton.displayName = 'Menu.Button';
 MenuPlainButton.displayName = 'Menu.PlainButton';
+MenuSeparator.displayName = 'Menu.Separator';
+MenuSection.displayName = 'Menu.Section';
+MenuHeading.displayName = 'Menu.Heading';
+MenuButton.displayName = 'Menu.Button';
 MenuItems.displayName = 'Menu.Items';
 MenuItem.displayName = 'Menu.Item';
+Menu.displayName = 'Menu';
 
-Menu.Button = MenuButton;
 Menu.PlainButton = MenuPlainButton;
+Menu.Separator = MenuSeparator;
+Menu.Heading = MenuHeading;
+Menu.Section = MenuSection;
+Menu.Button = MenuButton;
 Menu.Items = MenuItems;
 Menu.Item = MenuItem;

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -143,7 +143,7 @@ const MenuSection = (props: MenuSectionProps) => (
  * @see https://headlessui.com/react/menu#menu-separator
  */
 const MenuSeparator = (props: MenuSeparatorProps) => (
-  <HeadlessMenuSeparator __type="separator" as={PopoverListItem} />
+  <HeadlessMenuSeparator {...props} __type="separator" as={PopoverListItem} />
 );
 
 /**
@@ -152,9 +152,7 @@ const MenuSeparator = (props: MenuSeparatorProps) => (
  * @see https://headlessui.com/react/menu#menu-heading
  */
 const MenuHeading = (props: MenuHeadingProps) => (
-  <HeadlessMenuHeading __type="label" as={PopoverListItem}>
-    {props.children as ReactNode}
-  </HeadlessMenuHeading>
+  <HeadlessMenuHeading {...props} __type="label" as={PopoverListItem} />
 );
 
 /**

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -47,13 +47,13 @@ exports[`<Menu /> MenuWithAvatarButton story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:r1t:"
+    aria-controls="headlessui-menu-items-:r20:"
     aria-expanded="true"
     aria-haspopup="menu"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:r1s:"
+    id="headlessui-menu-button-:r1v:"
     type="button"
   >
     <div
@@ -78,13 +78,13 @@ exports[`<Menu /> MenuWithIconButton story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:r2a:"
+    aria-controls="headlessui-menu-items-:r2e:"
     aria-expanded="true"
     aria-haspopup="menu"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:r29:"
+    id="headlessui-menu-button-:r2d:"
     type="button"
   >
     <svg
@@ -115,13 +115,13 @@ exports[`<Menu /> WithCustomButton story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:r13:"
+    aria-controls="headlessui-menu-items-:r14:"
     aria-expanded="true"
     aria-haspopup="menu"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:r12:"
+    id="headlessui-menu-button-:r13:"
     type="button"
   >
     <div
@@ -140,14 +140,14 @@ exports[`<Menu /> WithCustomSecondaryButton story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:r1g:"
+    aria-controls="headlessui-menu-items-:r1i:"
     aria-expanded="true"
     aria-haspopup="menu"
     class="button button--layout-none button--secondary button--lg button--size-lg button--variant-default"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:r1f:"
+    id="headlessui-menu-button-:r1h:"
     type="button"
   >
     <span
@@ -166,14 +166,14 @@ exports[`<Menu /> WithLongButtonText story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:rg:"
+    aria-controls="headlessui-menu-items-:rh:"
     aria-expanded="true"
     aria-haspopup="menu"
     class="button button--layout-right button--primary button--lg button--size-lg button--variant-default menu__button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:rf:"
+    id="headlessui-menu-button-:rg:"
     type="button"
   >
     <span
@@ -206,14 +206,14 @@ exports[`<Menu /> WithShortButtonText story renders snapshot 1`] = `
   data-open=""
 >
   <button
-    aria-controls="headlessui-menu-items-:rq:"
+    aria-controls="headlessui-menu-items-:rr:"
     aria-expanded="true"
     aria-haspopup="menu"
     class="button button--layout-right button--primary button--lg button--size-lg button--variant-default menu__button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-menu-button-:rp:"
+    id="headlessui-menu-button-:rq:"
     type="button"
   >
     <span

--- a/src/util/utility-types.ts
+++ b/src/util/utility-types.ts
@@ -207,6 +207,7 @@ export type NavMenuButton = NavButton & {
   leadingContent?: IconName | 'avatar';
   trailingContent?: IconName;
   user?: UserData;
+  shouldClose?: boolean;
 };
 
 /**
@@ -216,4 +217,5 @@ export type NavMenuLink = NavLink & {
   leadingContent?: IconName | 'avatar';
   trailingContent?: IconName;
   user?: UserData;
+  shouldClose?: boolean;
 };


### PR DESCRIPTION
Support changes to the component interface to address a few functionalities:

* `Menu` now exposes the rest of the API from HeadlessUI's Dropdown Menu, including all the sub-components
* Each of these is mapped to the corresponding EDS component (e.g., `PopoverListItem`)
* Allow usage of render prop for `Menu` body as well, which includes ability to trigger `close()`
* Hook up `AppHeader` to use this functionality thru a `shouldClose` value on relevant `NavItem` entries
* Default behavior still exists (without specifying `shouldClose` all sub nav items of a navItem type `"menu"` will have an optional prop to set

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
