### PR TITLE
fix(AppNotification): remove children container when no children exist

### DIFF
--- a/src/components/AppNotification/AppNotification.stories.tsx
+++ b/src/components/AppNotification/AppNotification.stories.tsx
@@ -37,10 +37,13 @@ export const Default: Story = {
   args: {},
 };
 
+/**
+ * `AppNotification`s can contain children that represent actions related to the notification.
+ * These should be composed in a `ButtonGroup` component, and put the primary `Button` / CTA on the left-hand side.
+ */
 export const WithControls: Story = {
   render: (args) => (
     <AppNotification {...args}>
-      {' '}
       <ButtonGroup buttonLayout="horizontal" className="!flex-row">
         <Button
           rank="secondary"
@@ -59,6 +62,9 @@ export const WithControls: Story = {
   ),
 };
 
+/**
+ * Subtitles in `AppNotification` can be formatted and also contain links. While light formatting is allowed, contents of subTitle should remain as prose.
+ */
 export const WithLinkInSubtitle: Story = {
   args: {
     subTitle: (
@@ -73,13 +79,15 @@ export const WithLinkInSubtitle: Story = {
   },
 };
 
+/**
+ * `AppNotification` components can have an inverse variant
+ */
 export const InverseVariant: Story = {
   args: {
     variant: 'inverse',
   },
   render: (args) => (
     <AppNotification {...args}>
-      {' '}
       <ButtonGroup buttonLayout="horizontal" className="!flex-row">
         <Button
           rank="secondary"
@@ -98,6 +106,9 @@ export const InverseVariant: Story = {
   ),
 };
 
+/**
+ * When dismissed, `AppNotification` can trigger an action on dismissal.
+ */
 export const WithDismissAndControls: Story = {
   args: {
     ...WithControls.args,

--- a/src/components/AppNotification/AppNotification.stories.tsx
+++ b/src/components/AppNotification/AppNotification.stories.tsx
@@ -28,7 +28,7 @@ export default {
       control: 'text',
     },
   },
-  tags: ['autodocs', 'version:3.0'],
+  tags: ['autodocs', 'version:3.0.1'],
 } as Meta<typeof AppNotification>;
 
 type Story = StoryObj<typeof AppNotification>;

--- a/src/components/AppNotification/AppNotification.tsx
+++ b/src/components/AppNotification/AppNotification.tsx
@@ -22,7 +22,7 @@ export type AppNotificationProps = {
 
   // Component API
   /**
-   * Contents of the component below the title and sub-title (used mainly for `ButtonGroup`)
+   * Contents of the component below the title and sub-title (used mainly for `ButtonGroup` containing ranked `Buttons`)
    */
   children?: ReactNode;
   /**
@@ -73,7 +73,11 @@ export const AppNotification = ({
           >
             {subTitle}
           </Text>
-          <div className={styles['app-notification__actions']}>{children}</div>
+          {children && (
+            <div className={styles['app-notification__actions']}>
+              {children}
+            </div>
+          )}
         </section>
         {onDismiss && (
           <Button

--- a/src/components/AppNotification/__snapshots__/AppNotification.test.ts.snap
+++ b/src/components/AppNotification/__snapshots__/AppNotification.test.ts.snap
@@ -19,9 +19,6 @@ exports[`<AppNotification /> Default story renders snapshot 1`] = `
       >
         Lorem ipsum dolor sit amet consectetur. At et vitae quis amet felis mollis in vitae. Eget in neque et molestie. Luctus sed id commodo volutpat. In a eu in id molestie consectetur pellentesque.
       </span>
-      <div
-        class="app-notification__actions"
-      />
     </section>
   </div>
 </div>
@@ -49,7 +46,6 @@ exports[`<AppNotification /> InverseVariant story renders snapshot 1`] = `
       <div
         class="app-notification__actions"
       >
-         
         <div
           class="button-group button-group--horizontal !flex-row"
         >
@@ -102,7 +98,6 @@ exports[`<AppNotification /> InverseWithDismissAndControls story renders snapsho
       <div
         class="app-notification__actions"
       >
-         
         <div
           class="button-group button-group--horizontal !flex-row"
         >
@@ -179,7 +174,6 @@ exports[`<AppNotification /> WithControls story renders snapshot 1`] = `
       <div
         class="app-notification__actions"
       >
-         
         <div
           class="button-group button-group--horizontal !flex-row"
         >
@@ -232,7 +226,6 @@ exports[`<AppNotification /> WithDismissAndControls story renders snapshot 1`] =
       <div
         class="app-notification__actions"
       >
-         
         <div
           class="button-group button-group--horizontal !flex-row"
         >
@@ -319,9 +312,6 @@ exports[`<AppNotification /> WithLinkInSubtitle story renders snapshot 1`] = `
           in.
         </span>
       </span>
-      <div
-        class="app-notification__actions"
-      />
     </section>
   </div>
 </div>


### PR DESCRIPTION
When `children` is empty, do not draw the container for the buttons or actions

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
