### PR TITLE
fix: move parabolica-text offsets to Text component

### DIFF
--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -29,16 +29,12 @@
   width: 100%;
 
   .button--sm & {
-    /* Offset to better align text in button */
-    transform: translateY(-1px);
     overflow: visible;
     gap: calc(var(--eds-spacing-size-half) * 1px);
   }
 
   .button--md &,
   .button--lg & {
-    /* Offset to better align text in button */
-    transform: translateY(-1px);
     gap: calc(var(--eds-spacing-size-1) * 1px);
   }
 

--- a/src/components/Link/Link.module.css
+++ b/src/components/Link/Link.module.css
@@ -45,6 +45,9 @@
   --link-font-family: var(--eds-typography-font-family-1);
   --link-letter-spacing: var(--eds-typography-letter-spacing-normal);
 
+  /* shift up by one pixel b/c of the baseline of the font for font-family-1 */
+  transform: translateY(-1px);
+
   letter-spacing: var(--link-letter-spacing);
   font: var(--link-font-weight) var(--link-size-line-height) var(--link-font-family);
 

--- a/src/components/Select/Select.module.css
+++ b/src/components/Select/Select.module.css
@@ -65,11 +65,6 @@
 
   color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
   background-color: light-dark(var(--eds-theme-color-background-input), var(--eds-dark-theme-color-background-input));
-
-  & > span {
-    /* add additional alignment space toward top for the current fonts in use */
-    transform: translateY(-1px);
-  }
 }
 
 /**

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -132,6 +132,8 @@
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 500;
   --text-letter-spacing: 2%;
+
+  transform: translateY(-1px);
 }
 
 .text--body-xl {
@@ -186,12 +188,16 @@
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--body-xs-bold {
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 700;
+
+  transform: translateY(-1px);
 }
 
 .text--label-xl {
@@ -216,6 +222,8 @@
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--overline-lg {
@@ -291,12 +299,16 @@
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--tab-sm {
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--tag {
@@ -353,6 +365,8 @@
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--appHeader-subLabel {
@@ -360,4 +374,6 @@
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }

--- a/src/components/Text/Text.module.css
+++ b/src/components/Text/Text.module.css
@@ -87,11 +87,13 @@
 }
 
 .text--title-xl {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-500-font-size);
   --text-line-height: var(--eds-typography-preset-500-line-height);
-  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-weight: 500;
   --text-letter-spacing: 2%;
+
+  transform: translateY(-1px);
 
   @media screen and (min-width: $eds-bp-md) {
     --text-font-size: var(--eds-typography-preset-700-font-size);
@@ -100,10 +102,13 @@
 }
 
 .text--title-lg {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-300-font-size);
   --text-line-height: var(--eds-typography-preset-300-line-height);
   --text-font-weight: 500;
   --text-letter-spacing: 2%;
+
+  transform: translateY(-1px);
 
   @media screen and (min-width: $eds-bp-md) {
     --text-font-size: var(--eds-typography-preset-400-font-size);
@@ -112,10 +117,13 @@
 }
 
 .text--title-md {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 500;
   --text-letter-spacing: 2%;
+
+  transform: translateY(-1px);
 }
 
 .text--title-sm {
@@ -128,6 +136,7 @@
 }
 
 .text--title-xs {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 500;
@@ -137,51 +146,75 @@
 }
 
 .text--body-xl {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-600-font-size);
   --text-line-height: var(--eds-typography-preset-600-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--body-xl-bold {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-600-font-size);
   --text-line-height: var(--eds-typography-preset-600-line-height);
   --text-font-weight: 700;
+
+  transform: translateY(-1px);
 }
 
 .text--body-lg {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-400-font-size);
   --text-line-height: var(--eds-typography-preset-400-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--body-lg-bold {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-400-font-size);
   --text-line-height: var(--eds-typography-preset-400-line-height);
   --text-font-weight: 700;
+
+  transform: translateY(-1px);
 }
 
 .text--body-md {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--body-md-bold {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 700;
+
+  transform: translateY(-1px);
 }
 
 .text--body-sm {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--body-sm-bold {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 700;
+
+  transform: translateY(-1px);
 }
 
 .text--body-xs {
@@ -201,21 +234,30 @@
 }
 
 .text--label-xl {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-600-font-size);
   --text-line-height: var(--eds-typography-preset-600-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--label-lg {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--label-md {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--label-sm {
@@ -270,16 +312,22 @@
 }
 
 .text--input-md {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--input {
   /* TODO(next-major): consider removing */
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-200-font-size);
   --text-line-height: var(--eds-typography-preset-200-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--tab-lg-active {
@@ -287,15 +335,21 @@
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 500;
+
+  transform: translateY(-1px);
 }
 
 .text--tab-lg {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-100-font-size);
   --text-line-height: var(--eds-typography-preset-100-line-height);
   --text-font-weight: 400;
+
+  transform: translateY(-1px);
 }
 
 .text--tab-sm-active {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 500;
@@ -304,6 +358,7 @@
 }
 
 .text--tab-sm {
+  --text-font-family: var(--eds-typography-font-family-1);
   --text-font-size: var(--eds-typography-preset-075-font-size);
   --text-line-height: var(--eds-typography-preset-075-line-height);
   --text-font-weight: 400;

--- a/src/components/ToastNotification/ToastNotification.module.css
+++ b/src/components/ToastNotification/ToastNotification.module.css
@@ -24,9 +24,6 @@
 }
 
 .toast__icon {
-  /* manual offset for alignment */
-  transform: translateY(1px);
-
   flex-shrink: 0;
 
   .toast--status-critical & {


### PR DESCRIPTION
`parabolica-text` renders pushed down by ~1px for some reason, which causes obvious misalignments in smaller elements. add the GPU-accelerated offsets in `Text` instead of spreading the contagion of offets across more and more components.

Stop-gap: we may need to add additional tokens to track future positioning offsets so this behavior is themeable.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
