### PR TITLE
feat(TabGroup): scroll tabs into view upon selection

### DIFF
--- a/src/components/TabGroup/TabGroup.module.css
+++ b/src/components/TabGroup/TabGroup.module.css
@@ -17,7 +17,15 @@
   /* Tab overflow behavior */
   overflow-x: auto;
   position: relative;
-  padding-bottom: calc(var(--eds-spacing-size-2) * 1px);
+  margin-bottom: calc(var(--eds-spacing-size-2) * 1px);
+
+  border-bottom: 1px solid;
+
+
+  &:not(.tabs--has-divider) {
+    border-bottom-color: transparent;
+  }
+
 }
 
 /**
@@ -58,7 +66,6 @@
 .tabs__list {
   list-style: none;
   display: flex;
-  border-bottom: 1px solid;
 
   /* preset: tab-lg */
   font: 400 var(--eds-typography-preset-100) var(--eds-typography-font-family-1);
@@ -66,10 +73,6 @@
   @media all and (max-width: $eds-bp-md) {
     /* preset: tab-sm */
     font: 400 var(--eds-typography-preset-075) var(--eds-typography-font-family-1);
-  }
-
-  &:not(.tabs--has-divider) {
-    border-bottom-color: transparent;
   }
 }
 
@@ -185,9 +188,15 @@
   }
 }
 
-.tabs__list--variant-default {
+.tabs__header--variant-default {
   border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+}
 
+.tab__header--variant-inverse {
+  border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+}
+
+.tabs__list--variant-default {
   .tabs__link {
     color: light-dark(var(--eds-theme-color-text-utility-interactive-primary), var(--eds-dark-theme-color-text-utility-interactive-primary));
 
@@ -211,8 +220,6 @@
 }
 
 .tabs__list--variant-inverse {
-  border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
-
   .tabs__link {
     color: light-dark(var(--eds-theme-color-text-utility-inverse), var(--eds-dark-theme-color-text-utility-inverse));
 

--- a/src/components/TabGroup/TabGroup.module.css
+++ b/src/components/TabGroup/TabGroup.module.css
@@ -192,7 +192,7 @@
   border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 }
 
-.tab__header--variant-inverse {
+.tabs__header--variant-inverse {
   border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
 }
 

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import clamp from 'lodash/clamp';
 import debounce from 'lodash/debounce';
 import React, {
   type ReactNode,
@@ -149,6 +150,9 @@ export const TabGroup = ({
   const activeTabPanelId = React.useId();
   const headerRef = useRef<HTMLDivElement>(null);
   const [activeIndexState, setActiveIndexState] = useState(activeIndex);
+  const [previousIndexState, setPreviousIndexState] = useState<null | number>(
+    null,
+  );
   const [scrollableLeft, setScrollableLeft] = useState<boolean>(false);
   const [scrollableRight, setScrollableRight] = useState<boolean>(false);
 
@@ -178,10 +182,30 @@ export const TabGroup = ({
   const prevActiveIndex = usePrevious(activeIndex);
   useEffect(() => {
     if (prevActiveIndex != null && prevActiveIndex !== activeIndex) {
+      setPreviousIndexState(activeIndex);
       setActiveIndexState(activeIndex);
       tabRefs[activeIndex].current?.focus();
     }
   }, [prevActiveIndex, activeIndex, tabRefs]);
+
+  useEffect(() => {
+    // if previous is less than current, show the one after current
+    // if previous is more than current, show the one before current
+    // clamp to the max/min range of tabRefs
+    if (previousIndexState !== null) {
+      const desiredIndex = clamp(
+        previousIndexState > activeIndexState
+          ? activeIndexState - 1
+          : activeIndexState + 1,
+        0,
+        tabRefs.length - 1,
+      );
+
+      if (tabRefs[desiredIndex].current?.scrollIntoView) {
+        tabRefs[desiredIndex].current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  }, [tabRefs, previousIndexState, activeIndexState]);
 
   /**
    * Handles if scroll fade indicators should be displayed.
@@ -234,6 +258,7 @@ export const TabGroup = ({
   }, [handleTabsScroll]);
 
   function handleClick(index: number) {
+    setPreviousIndexState(activeIndexState);
     setActiveIndexState(index);
 
     if (onChange) {
@@ -273,6 +298,8 @@ export const TabGroup = ({
     styles['tabs__header'],
     scrollableLeft && styles['tabs--scrollable-left'],
     scrollableRight && styles['tabs--scrollable-right'],
+    hasDivider && styles['tabs--has-divider'],
+    variant && styles[`tabs__header--variant-${variant}`],
   );
 
   const activeTabPanel = React.cloneElement(tabs[activeIndexState], {

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -192,6 +192,7 @@ export const TabGroup = ({
     // if previous is less than current, show the one after current
     // if previous is more than current, show the one before current
     // clamp to the max/min range of tabRefs
+    // only apply when scrollable
     if (previousIndexState !== null) {
       const desiredIndex = clamp(
         previousIndexState > activeIndexState
@@ -201,11 +202,25 @@ export const TabGroup = ({
         tabRefs.length - 1,
       );
 
-      if (tabRefs[desiredIndex].current?.scrollIntoView) {
-        tabRefs[desiredIndex].current?.scrollIntoView({ behavior: 'smooth' });
+      if (
+        tabRefs[desiredIndex].current?.scrollIntoView &&
+        (scrollableLeft || scrollableRight)
+      ) {
+        // https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView
+        tabRefs[desiredIndex].current?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+          inline: 'nearest',
+        });
       }
     }
-  }, [tabRefs, previousIndexState, activeIndexState]);
+  }, [
+    tabRefs,
+    previousIndexState,
+    activeIndexState,
+    scrollableLeft,
+    scrollableRight,
+  ]);
 
   /**
    * Handles if scroll fade indicators should be displayed.

--- a/src/components/TabGroup/__snapshots__/TabGroup.test.tsx.snap
+++ b/src/components/TabGroup/__snapshots__/TabGroup.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`<TabGroup /> Centered story renders snapshot 1`] = `
   class="tabs"
 >
   <div
-    class="tabs__header"
+    class="tabs__header tabs--has-divider tabs__header--variant-default"
   >
     <ul
       class="tabs__list tabs--has-divider tabs__list--align-center tabs__list--variant-default"
@@ -125,7 +125,7 @@ exports[`<TabGroup /> Default story renders snapshot 1`] = `
   class="tabs"
 >
   <div
-    class="tabs__header"
+    class="tabs__header tabs--has-divider tabs__header--variant-default"
   >
     <ul
       class="tabs__list tabs--has-divider tabs__list--variant-default"
@@ -248,7 +248,7 @@ exports[`<TabGroup /> InverseVariant story renders snapshot 1`] = `
     class="tabs"
   >
     <div
-      class="tabs__header"
+      class="tabs__header tabs--has-divider tabs__header--variant-inverse"
     >
       <ul
         class="tabs__list tabs--has-divider tabs__list--variant-inverse"
@@ -369,7 +369,7 @@ exports[`<TabGroup /> TabWidthFull story renders snapshot 1`] = `
   class="tabs"
 >
   <div
-    class="tabs__header"
+    class="tabs__header tabs--has-divider tabs__header--variant-default"
   >
     <ul
       class="tabs__list tabs--has-divider tabs__list--align-center tabs__list--variant-default"
@@ -489,7 +489,7 @@ exports[`<TabGroup /> WithTabIcons story renders snapshot 1`] = `
   class="tabs"
 >
   <div
-    class="tabs__header"
+    class="tabs__header tabs--has-divider tabs__header--variant-default"
   >
     <ul
       class="tabs__list tabs--has-divider tabs__list--align-center tabs__list--variant-default"
@@ -631,7 +631,7 @@ exports[`<TabGroup /> WithTabIllustrations story renders snapshot 1`] = `
   class="tabs"
 >
   <div
-    class="tabs__header"
+    class="tabs__header tabs--has-divider tabs__header--variant-default"
   >
     <ul
       class="tabs__list tabs--has-divider tabs__list--align-center tabs__list--variant-default"


### PR DESCRIPTION
Add the following behavior:

* when activating a tab, track the previously selected one in state
* use this to show an additional tab with a smooth scroll, so that users can pick more tabs if needed
* properly handle the underline such that it spans the view properly

https://github.com/user-attachments/assets/38d98320-1781-426b-84ba-9e33489204d2

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
