### PR TITLE
fix(PopoverListItem): appear as disabled when both disabled and destructive

### DIFF
--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -37,6 +37,10 @@
 
   color: light-dark(var(--eds-theme-color-text-utility-disabled-secondary), var(--eds-dark-theme-color-text-utility-disabled-secondary));
   background-color: light-dark(var(--eds-theme-color-background-utility-disabled-no-emphasis), var(--eds-dark-theme-color-background-utility-disabled-no-emphasis));
+
+  .popover-list-item__sub-label {
+    color: light-dark(var(--eds-theme-color-text-utility-disabled-secondary), var(--eds-dark-theme-color-text-utility-disabled-secondary));
+  }
 }
 
 .popover-list-item--type-label,
@@ -105,7 +109,7 @@
   color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
 }
 
-.popover-list-item--destructive-action {
+.popover-list-item--destructive-action:not(.popover-list-item--disabled) {
   color: light-dark(var(--eds-theme-color-text-utility-critical), var(--eds-dark-theme-color-text-utility-critical));
 
   &:hover {

--- a/src/components/PopoverListItem/PopoverListItem.module.css
+++ b/src/components/PopoverListItem/PopoverListItem.module.css
@@ -39,7 +39,7 @@
   background-color: light-dark(var(--eds-theme-color-background-utility-disabled-no-emphasis), var(--eds-dark-theme-color-background-utility-disabled-no-emphasis));
 
   .popover-list-item__sub-label {
-    color: light-dark(var(--eds-theme-color-text-utility-disabled-secondary), var(--eds-dark-theme-color-text-utility-disabled-secondary));
+    color: inherit;
   }
 }
 

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -94,6 +94,16 @@ export const Destructive: Story = {
 };
 
 /**
+ * Popover list items can be marked as destructive while disabled. In such cases, it should appear as disabled.
+ */
+export const DisabledAndDestructive: Story = {
+  args: {
+    ...Disabled.args,
+    ...Destructive.args,
+  },
+};
+
+/**
  * Leading content is a flexible slot, and can contain many elements, including `Avatar`s.
  */
 export const WithLeadingAvatar: Story = {

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -13,7 +13,7 @@ export default {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs', 'version:2.1.0'],
+  tags: ['autodocs', 'version:2.1.1'],
   argTypes: {
     icon: {
       table: { disable: true },
@@ -100,6 +100,7 @@ export const DisabledAndDestructive: Story = {
   args: {
     ...Disabled.args,
     ...Destructive.args,
+    subLabel: 'Permanently remove this item',
   },
 };
 


### PR DESCRIPTION
when `isDisabled` and `isDestructiveAction` are set to `true`, make sure it appears as disabled

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated automated tests / storybook snapshots
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
