### PR TITLE
fix(AppHeader): change color transition to be faster than the motion

### DIFF
--- a/src/components/AppHeader/AppHeader.module.css
+++ b/src/components/AppHeader/AppHeader.module.css
@@ -314,7 +314,7 @@
     left: calc(var(--eds-spacing-size-4) * 1px);
 
     /* EaseInOutQuad - https://matthewlein.com/tools/ceaser */
-    transition: all calc(var(--eds-anim-move-medium) * 1s) cubic-bezier(0.455, 0.030, 0.515, 0.955);
+    transition: all calc(var(--eds-anim-move-medium) * 1s) cubic-bezier(0.455, 0.030, 0.515, 0.955), background-color calc(var(--eds-anim-fade-quick) * 1s) ease-in-out;
   }
 
   .app-header__nav-item--is-current.app-header__nav-item--link {

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -24,7 +24,7 @@ export default {
     },
   },
 
-  tags: ['autodocs', 'version:1.7'],
+  tags: ['autodocs', 'version:1.7.1'],
 } as Meta<typeof AppHeader>;
 
 type Story = StoryObj<typeof AppHeader>;


### PR DESCRIPTION
- before this change, when setting links to current, the dot obscures the text for a moment
- this speeds up the fade out of the dot such that it is opaque before reaching the text

<!--
  Paste in description, or re-format the commit message body to describe the change
-->

https://github.com/user-attachments/assets/d84b46c2-d909-4382-a773-897957730f9a


### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
