### PR TITLE
fix(SelectionChip): change parent of pseudo element before

### DIFF
--- a/src/components/SelectionChip/SelectionChip.module.css
+++ b/src/components/SelectionChip/SelectionChip.module.css
@@ -44,7 +44,7 @@
   outline: none;
 }
 
-.selection-chip__input::before {
+.selection-chip::before {
   content: ' ';
   position: absolute;
   width: 8px;
@@ -55,6 +55,7 @@
   transform: translate(0, -50%) scale(0.75);
   transform-origin: center;
   left: 20px;
+  top: 50%;
 
   /* EaseInOutQuad - https://matthewlein.com/tools/ceaser */
   transition: all calc(var(--eds-anim-move-medium) * 1s) cubic-bezier(0.455, 0.030, 0.515, 0.955);
@@ -93,7 +94,7 @@
 .selection-chip:hover {
   --selection-chip__bg: light-dark(var(--eds-theme-color-background-utility-default-no-emphasis-hover), var(--eds-dark-theme-color-background-utility-default-no-emphasis-hover));
 
-  .selection-chip__input::before {
+  &::before {
     background-color: light-dark(var(--eds-theme-color-background-utility-default-low-emphasis-hover), var(--eds-dark-theme-color-background-utility-default-low-emphasis-hover));
     left: calc(var(--eds-spacing-size-1-and-half) * 1px);
   }
@@ -118,12 +119,12 @@
   box-shadow: inset 0 0 0 1px var(--selection-chip__border);
 
   &.selection-chip--disabled {
-    .selection-chip__input::before {
+    &::before {
       background-color: light-dark(var(--eds-theme-color-icon-utility-disabled-primary), var(--eds-dark-theme-color-icon-utility-disabled-primary));
     }
   }
 
-  .selection-chip__input::before {
+  &::before {
     background-color: light-dark(var(--eds-theme-color-background-visual-page-indicator-current), var(--eds-dark-theme-color-background-visual-page-indicator-current));
     left: calc(var(--eds-spacing-size-1-and-half) * 1px);
 
@@ -140,7 +141,7 @@
   --selection-chip__border: light-dark(var(--eds-theme-color-border-utility-interactive-hover), var(--eds-dark-theme-color-border-utility-interactive-hover));
   --selection-chip__bg: light-dark(var(--eds-theme-color-background-utility-interactive-low-emphasis-hover), var(--eds-dark-theme-color-background-utility-interactive-low-emphasis-hover));
 
-  .selection-chip__input::before {
+  &::before {
     transform: translate(0, -50%) scale(1);
   }
 }

--- a/src/components/SelectionChip/SelectionChip.module.css
+++ b/src/components/SelectionChip/SelectionChip.module.css
@@ -107,8 +107,8 @@
 .selection-chip:active {
   --selection-chip__bg: light-dark(var(--eds-theme-color-background-utility-default-no-emphasis-active), var(--eds-dark-theme-color-background-utility-default-no-emphasis-active));
 
-  .selection-chip__input::before {
-    background-color: calc(var(--eds-theme-color-background-utility-default-low-emphasis-active));
+  &::before {
+    background-color: light-dark(var(--eds-theme-color-background-utility-default-low-emphasis-active), var(--eds-dark-theme-color-background-utility-default-low-emphasis-active));
   }
 
 }


### PR DESCRIPTION
the selection dot does not appear in firefox b/c it was initially attached to an `input` element (technically speaking, `input` doesn't allow for `content` and cannot receive `::before`. Blink/Webkit engines support this behavior.

Attach the pseudo element to the parent container, which is a standard container that can have content.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
