### PR TITLE
docs: add usage and other doc.s to component code

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -11,12 +11,21 @@ import '../src/tokens-dist/css/variables-dark.css';
 // Import storybook-specific CSS
 import './css/styleguide-only.css';
 
+import {
+  Title,
+  Subtitle,
+  Description,
+  Controls,
+  Primary,
+  Stories,
+} from '@storybook/addon-docs/blocks';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
 import type {
   Preview,
   StoryFn,
   ReactRenderer,
 } from '@storybook/react-webpack5';
+
 import React from 'react';
 
 import Theme from './Theme';
@@ -43,6 +52,18 @@ export const parameters: Preview['parameters'] = {
   docs: {
     theme: Theme,
     toc: true,
+    // https://storybook.js.org/docs/writing-docs/autodocs#write-a-custom-template
+    page: () => (
+      <>
+        <Title />
+        <Subtitle />
+        <Primary />
+        <h2>Properties</h2>
+        <Controls />
+        <Description />
+        <Stories />
+      </>
+    ),
   },
   backgrounds: {
     options: {

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -12,6 +12,10 @@ export default {
   title: 'Components/Accordion',
   component: Accordion,
   parameters: {
+    docs: {
+      subtitle:
+        'Displays one or more headers stacked on top of one another that reveal or hide associated content.',
+    },
     layout: 'centered',
     controls: { sort: 'requiredFirst' },
     chromatic: {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -147,11 +147,7 @@ const AccordionRowContext = createContext<
 });
 
 /**
- * `import {Accordion} from "@chanzuckerberg/eds;`
- *
  * ## Usage
- *
- * Used to show and hide sections of related content, letting users expand only the parts they need. It's great for:
  *
  * * **Reducing visual clutter**: Especially when dealing with long pages or dense content.
  * * **FAQs**: Users can click to reveal answers one at a time.

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -164,7 +164,7 @@ const AccordionRowContext = createContext<
  *
  * ### Best Practices
  *
- * * Don't mix accordion sizes
+ * * Don't mix accordion sizes.
  * * Don't mix accordions where some have icons and others do not.
  *
  * ## Interaction
@@ -181,7 +181,7 @@ const AccordionRowContext = createContext<
  * * Order stacked accordions by priority and importance.
  * * Use short, descriptive text for the accordion title.
  * * Number the steps in the accordion section sequentially.
- * * use paragraphs and subheads as needed within the accordion body.
+ * * Use paragraphs and subheads as needed within the accordion body.
  * * Use sentence case for titles.
  *
  * ### Don'ts

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -184,7 +184,7 @@ const AccordionRowContext = createContext<
  * * use paragraphs and subheads as needed within the accordion body.
  * * Use sentence case for titles.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use paragraphs of text in the accordion title.
  *

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -149,11 +149,52 @@ const AccordionRowContext = createContext<
 /**
  * `import {Accordion} from "@chanzuckerberg/eds;`
  *
- * Displays one or more headers stacked on top of one another that can reveal or hide associated content.
- * This component is based on the [Disclosure](https://headlessui.com/react/disclosure) component, provided by HeadlessUI.
+ * ## Usage
  *
- * More Information: https://headlessui.com/react/disclosure
+ * Used to show and hide sections of related content, letting users expand only the parts they need. It's great for:
  *
+ * * **Reducing visual clutter**: Especially when dealing with long pages or dense content.
+ * * **FAQs**: Users can click to reveal answers one at a time.
+ * * **Grouped settings**: Like categories of options or configuration panels.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * |Standard|Expands/collapses content vertically when clicked.|FAQs. Lists with optional detail. Simple disclosure sections.|
+ * |Multi-expand|Allows multiple sections to be expanded at once.|Filter panels. Settings grouped by category. Multi-topic summaries.|
+ * |Single-Expand|Only one section can be open at a time (others collapse automatically).|Navigation menus. Step-by-step instructions. Content prioritization.|
+ * |Nested|Accordion items contain sub-accordions inside.|Complex data views. Multi-level navigation or documentation.|
+ * |Summary|Shows a brief summary even when collapsed.|Preview content like stats or status. Highlight key info without expanding.|
+ * |Disabled|Cannot be expanded; often used to show unavailable or locked content.|Permissions-based content. Progress-dependent sections.|
+ *
+ * ### Best Practices
+ *
+ * * Don't mix accordion sizes
+ * * Don't mix accordions where some have icons and others do not.
+ *
+ * ## Interaction
+ *
+ * ### Collapsed and Expanded Rows
+ *
+ * By default, clicking another row does not collapse the row that has already been expanded.
+ * Designers can customize this  to only allow 1 accordion row to be open at a time. However, beware that this interaction can cause the UI to “jump around” in an unpleasant way.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Order stacked accordions by priority and importance.
+ * * Use short, descriptive text for the accordion title.
+ * * Number the steps in the accordion section sequentially.
+ * * use paragraphs and subheads as needed within the accordion body.
+ * * Use sentence case for titles.
+ *
+ * ### Dont's
+ *
+ * * Don't use paragraphs of text in the accordion title.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.com/react/disclosure
  */
 export const Accordion = ({
   children,

--- a/src/components/AppFooter/AppFooter.stories.tsx
+++ b/src/components/AppFooter/AppFooter.stories.tsx
@@ -10,6 +10,10 @@ export default {
   component: AppFooter,
 
   parameters: {
+    docs: {
+      subtitle:
+        'A footer is an navigation component. It can hold links, buttons, company info, copyrights, forms, and many other elements.',
+    },
     chromatic: {
       viewports: [
         chromaticViewports.googlePixel2,

--- a/src/components/AppFooter/AppFooter.stories.tsx
+++ b/src/components/AppFooter/AppFooter.stories.tsx
@@ -12,7 +12,7 @@ export default {
   parameters: {
     docs: {
       subtitle:
-        'A footer is an navigation component. It can hold links, buttons, company info, copyrights, forms, and many other elements.',
+        'A footer is a navigation component. It can hold links, buttons, company info, copyrights, forms, and many other elements.',
     },
     chromatic: {
       viewports: [

--- a/src/components/AppFooter/AppFooter.tsx
+++ b/src/components/AppFooter/AppFooter.tsx
@@ -55,8 +55,6 @@ export type AppFooterEventHandler = (
 ) => void;
 
 /**
- * `import {AppFooter} from "@chanzuckerberg/eds";`
- *
  * ## Usage
  *
  * A footer is a navigation component. It can hold links, buttons, company info, copyrights, forms, and many other elements.

--- a/src/components/AppFooter/AppFooter.tsx
+++ b/src/components/AppFooter/AppFooter.tsx
@@ -57,6 +57,8 @@ export type AppFooterEventHandler = (
 /**
  * `import {AppFooter} from "@chanzuckerberg/eds";`
  *
+ * ## Usage
+ *
  * A footer is a navigation component. It can hold links, buttons, company info, copyrights, forms, and many other elements.
  */
 export const AppFooter = ({

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -14,7 +14,7 @@ export default {
   parameters: {
     docs: {
       subtitle:
-        'The persistent navigation bar that appears at the top of an application provides brand identity, global navigation, and quick access to key actions. It anchors the user experience by ensuring consistent access to core functionality across all pages. It also serves as the <header> for accessibility landmarks.',
+        'The persistent navigation bar that appears at the top or left of an application provides brand identity, global navigation, and quick access to key actions. It anchors the user experience by ensuring consistent access to core functionality across all pages. It also serves as the <header> for accessibility landmarks.',
     },
     chromatic: {
       // Using this motion preference for components where they trigger animations on mount

--- a/src/components/AppHeader/AppHeader.stories.tsx
+++ b/src/components/AppHeader/AppHeader.stories.tsx
@@ -12,6 +12,10 @@ export default {
   component: AppHeader,
 
   parameters: {
+    docs: {
+      subtitle:
+        'The persistent navigation bar that appears at the top of an application provides brand identity, global navigation, and quick access to key actions. It anchors the user experience by ensuring consistent access to core functionality across all pages. It also serves as the <header> for accessibility landmarks.',
+    },
     chromatic: {
       // Using this motion preference for components where they trigger animations on mount
       prefersReducedMotion: 'reduce',

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -244,11 +244,7 @@ function handleShouldClose(
 }
 
 /**
- * `import {AppHeader} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * The persistent navigation bar that appears at the top of an application provides brand identity, global navigation, and quick access to key actions. It anchors the user experience by ensuring consistent access to core functionality across all pages. It also serves as the `<header>` for accessibility landmarks.
  *
  * App headers have three distinct sections with different purposes.
  *

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -246,7 +246,22 @@ function handleShouldClose(
 /**
  * `import {AppHeader} from "@chanzuckerberg/eds";`
  *
- * Provides app-level navigation and serves as the `<header>` element for accessibility landmarks
+ * ## Usage
+ *
+ * The persistent navigation bar that appears at the top of an application provides brand identity, global navigation, and quick access to key actions. It anchors the user experience by ensuring consistent access to core functionality across all pages. It also serves as the `<header>` for accessibility landmarks.
+ *
+ * App headers have three distinct sections with different purposes.
+ *
+ * | Type | Description | Uses |
+ * |------|-------------|------|
+ * | Branding | Displays the product name, logo, or identity elements. | Reinforces brand presence. Ensures users always know where they are. |
+ * | Navigation | Provides access to global navigation items such as menus, links, or search. | Helps users move between top-level sections or features quickly. |
+ * | Utility / Actions | Contains user profile. | Gives users immediate access to high-frequency or contextual actions. |
+ *
+ * ### Best Practices
+ *
+ * * Keep navigation concise and limited to high-level sections.
+ * * Don't overload the header with too many links or rarely used actions.
  */
 export const AppHeader = ({
   className,

--- a/src/components/AppNotification/AppNotification.stories.tsx
+++ b/src/components/AppNotification/AppNotification.stories.tsx
@@ -13,6 +13,9 @@ export default {
   title: 'Components/AppNotification',
   component: AppNotification,
   parameters: {
+    docs: {
+      subtitle: 'A global alert that persists across pages.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/AppNotification/AppNotification.tsx
+++ b/src/components/AppNotification/AppNotification.tsx
@@ -36,11 +36,7 @@ export type AppNotificationProps = {
 };
 
 /**
- * `import {AppNotification} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A global alert that persists across pages.
  *
  * * Use app notifications sparingly for global messages that affect an entire system.
  * * Don't use them for engagement messaging, upselling a new feature, or feedback messaging. Use an inline notification or a toast notification instead.

--- a/src/components/AppNotification/AppNotification.tsx
+++ b/src/components/AppNotification/AppNotification.tsx
@@ -62,7 +62,7 @@ export type AppNotificationProps = {
  * * Keep the title short and descriptive, communicating the main message in sentence case.
  * * Keep the body to 1-2 sentences, using sentence case.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't rely on color to convey meaning.
  * * Don't punctuate the end of the title.

--- a/src/components/AppNotification/AppNotification.tsx
+++ b/src/components/AppNotification/AppNotification.tsx
@@ -38,7 +38,40 @@ export type AppNotificationProps = {
 /**
  * `import {AppNotification} from "@chanzuckerberg/eds";`
  *
- * An alert placed at the top of an application which persists across pages.
+ * ## Usage
+ *
+ * A global alert that persists across pages.
+ *
+ * * Use app notifications sparingly for global messages that affect an entire system.
+ * * Don't use them for engagement messaging, upselling a new feature, or feedback messaging. Use an inline notification or a toast notification instead.
+ * * Don't use for quick confirmation messages. Use a toast component instead because they appear and disappear with little disruption.
+ *
+ * ### Best Practices
+ *
+ * * Do use for a global condition required for the website or app to function, for example, maintenance updates.
+ * * Don't use for quick confirmation messages.
+ *
+ * ## Interaction
+ *
+ * App notifications follow users from screen to screen and remain until dismissed or until the state that caused the notification is resolved. Designers can specify whether the notification is dismissable or persistent. When dismissable, an "X" appears in the top right corner.
+ *
+ * ## Content & Accessibility
+ *
+ * App notification titles should be concise, ideally no more than two lines long.
+ *
+ * ### Do's
+ *
+ * * Focus on a single message or piece of information.
+ * * Ensure users can get the basic message and take action by scanning just the heading and CTA(s).
+ * * Keep the title short and descriptive, communicating the main message in sentence case.
+ * * Keep the body to 1-2 sentences, using sentence case.
+ *
+ * ### Dont's
+ *
+ * * Don't rely on color to convey meaning.
+ * * Don't punctuate the end of the title.
+ * * Don't repeat or paraphrase information in the heading.
+ * * Don't truncate content; if more information is needed, link to it or consider a different component.
  */
 export const AppNotification = ({
   className,

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -112,8 +112,6 @@ export function getInitials(fromName: string): string {
 }
 
 /**
- * `import {Avatar} from "@chanzuckerberg/eds";`
- *
  * Representation of a single, unique user, keyed by the user name
  */
 export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -55,8 +55,6 @@ type Context = {
 
 const BreadcrumbsContext = createContext<Context>({});
 /**
- * `import {Breadcrumbs} from "@chanzuckerberg/eds";`
- *
  * List of Breadcrumb components showing the user where they are in the system and allow them
  * to navigate to parent pages.
  */
@@ -237,8 +235,6 @@ type BreadcrumbItemProps = {
 };
 
 /**
- * `import {BreadcrumbsItem} from "@chanzuckerberg/eds";`
- *
  * A single breadcrumb subcomponent, to be used in the Breadcrumbs component.
  */
 export const BreadcrumbsItem = ({

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -22,6 +22,10 @@ export default {
     },
   },
   parameters: {
+    docs: {
+      subtitle:
+        'Buttons are used to initialize an action. Button labels express what action will occur when the user interacts with it. Also known as action, call to action or CTA.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0.5'],

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -87,12 +87,7 @@ export type ButtonProps<ExtendedElement = unknown> = ButtonHTMLElementProps & {
 } & ExtendedElement;
 
 /**
- * `import {Button} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Buttons are used to initialize an action. Button labels express what action will occur when the
- * user interacts with them. Also known as action, call to action, or CTA.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -89,11 +89,39 @@ export type ButtonProps<ExtendedElement = unknown> = ButtonHTMLElementProps & {
 /**
  * `import {Button} from "@chanzuckerberg/eds";`
  *
- * Component for making buttons that do not navigate the user to another page. Use button to trigger actions, menus,
- * or other in-page activity.
+ * ## Usage
  *
- * - If you need to style a navigation anchor, please use the `Link` component.
- * - If you need the button to use some other tag or component, use the `as` prop.
+ * Buttons are used to initialize an action. Button labels express what action will occur when the
+ * user interacts with them. Also known as action, call to action, or CTA.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Primary default | Main call-to-action with highest visual prominence. | Submit form. Complete purchase. Save changes. |
+ * | Secondary default | Less prominent than primary, used for alternative actions. | Cancel. Edit. Learn more. Go back. |
+ * | Tertiary default | Minimal styling (often text-only); used for low-emphasis actions. | View details. Skip. Optional settings. |
+ * | Critical | Styled to indicate danger. | Delete. Remove. Reset. Sign out. |
+ * | Inverse | Transparent background; used on dark surfaces or inside modals. | De-emphasized actions on colored backgrounds. |
+ * | Icon | Icon-only or icon + tooltip; compact for toolbars or utility actions. | Favorite. Share. Settings. Search. Close. |
+ * | Loading | Temporarily disabled with a spinner or progress indicator. | "Saving…", "Loading…". |
+ *
+ * ### Best Practices
+ *
+ * * Use one primary button per action to highlight the action the user is most likely to take.
+ * * Use secondary buttons alongside a primary button; don't use a secondary button in isolation.
+ * * Use tertiary buttons alongside primary or secondary actions. To use a tertiary button alone, set its `context` to `"standalone"`.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use a label that indicates what will happen after the button is clicked.
+ * * Start with a verb that encourages action.
+ * * Use sentence case and try to stay to 3 or fewer words.
+ * * Use the *{verb} + {noun}* formula, except for common actions like "Done", "Close", "Cancel", "Add", or "Delete".
+ *
+ * ### Dont's
+ *
+ * * Use punctuation.
  */
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -114,7 +114,7 @@ export type ButtonProps<ExtendedElement = unknown> = ButtonHTMLElementProps & {
  * * Use sentence case and try to stay to 3 or fewer words.
  * * Use the *{verb} + {noun}* formula, except for common actions like "Done", "Close", "Cancel", "Add", or "Delete".
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Use punctuation.
  */

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -30,8 +30,6 @@ type ButtonGroupProps = {
 };
 
 /**
- * `import {ButtonGroup} from "@chanzuckerberg/eds";`
- *
  * A container for buttons grouped together horizontally or vertically.
  */
 export function ButtonGroup({

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -13,6 +13,10 @@ export default {
   title: 'Components/Card',
   component: Card,
   parameters: {
+    docs: {
+      subtitle:
+        'Cards are the outer wrapper for a block that typically contains a title, image, text, and/or calls to action. EDS provides subcomponents to help streamline the design and build of common cards. Designers can customize card contents to best fit their product needs.',
+    },
     layout: 'centered',
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -144,7 +144,7 @@ export interface CardCSSProperties extends React.CSSProperties {
  * * Use headings that make the card's purpose clear.
  * * Include essential, summarized information.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't overwhelm the card with too much content; keep it scannable.
  * * Avoid too many call-to-action buttons or links within the same card.

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -126,11 +126,34 @@ export interface CardCSSProperties extends React.CSSProperties {
 /**
  * `import {Card} from "@chanzuckerberg/eds";`
  *
- * Card component is the outer wrapper for the block that typically contains a title, image,
- * text, and/or calls to action.
+ * ## Usage
  *
- * Card is a pattern composed of subComponents. EDS provides subcomponents to help streamline
- * the design and build of common cards. Designers can customize card contents to best fit their product needs.
+ * Cards are the outer wrapper for a block that typically contains a title, image, text, and/or
+ * calls to action. EDS provides subcomponents to help streamline the design and build of common
+ * cards, and designers can customize card contents to best fit their product needs.
+ *
+ * * **Static card**: Group related elements, including some combination of images, text, buttons, input fields, etc.
+ * * **Interactive card**: A selectable or actionable card.
+ *
+ * ### Best Practices
+ *
+ * * Display information so that what the user needs to know first is prioritized.
+ * * Limit call-to-action buttons and/or links, using only one primary call-to-action per card.
+ * * Do not use a card as an action.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Group related information within separate cards.
+ * * Use subheadings, paragraphs, and bullet lists to break up larger amounts of content.
+ * * Use headings that make the card's purpose clear.
+ * * Include essential, summarized information.
+ *
+ * ### Dont's
+ *
+ * * Don't overwhelm the card with too much content; keep it scannable.
+ * * Avoid too many call-to-action buttons or links within the same card.
  */
 export const Card = ({
   containerColor = 'default',

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -124,13 +124,7 @@ export interface CardCSSProperties extends React.CSSProperties {
 
 // TODO: needs useRef for input field (allow react to control things)?
 /**
- * `import {Card} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Cards are the outer wrapper for a block that typically contains a title, image, text, and/or
- * calls to action. EDS provides subcomponents to help streamline the design and build of common
- * cards, and designers can customize card contents to best fit their product needs.
  *
  * * **Static card**: Group related elements, including some combination of images, text, buttons, input fields, etc.
  * * **Interactive card**: A selectable or actionable card.

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Checkbox> = {
     label: 'Checkbox',
   },
   parameters: {
+    docs: {
+      subtitle:
+        'Checkboxes indicate if something is selected or unselected and allow users to choose one or more options.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -155,7 +155,7 @@ const CheckboxInput = React.forwardRef<HTMLInputElement, CheckboxInputProps>(
  * * Only use helper text when necessary to explain the action or its results.
  * * In error messages, describe the issue and what to do about it.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Use helper text by default; consider better group labels first.
  * * Use end punctuation on group labels.

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -120,12 +120,7 @@ const CheckboxInput = React.forwardRef<HTMLInputElement, CheckboxInputProps>(
 );
 
 /**
- * `import {Checkbox} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Checkboxes indicate if something is selected or unselected and allow users to choose one or
- * more options.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -122,10 +122,49 @@ const CheckboxInput = React.forwardRef<HTMLInputElement, CheckboxInputProps>(
 /**
  * `import {Checkbox} from "@chanzuckerberg/eds";`
  *
- * Checkbox control indicating if something is selected or unselected. Uncontrolled by default,
- * it can be used in place of boolean-like form data.
+ * ## Usage
  *
- * **NOTE**: Requires either a visible `label` or `aria-label` prop.
+ * Checkboxes indicate if something is selected or unselected and allow users to choose one or
+ * more options.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | Basic binary control (checked/unchecked). | Accept terms and conditions. Enable/disable a setting. |
+ * | Multi-select | Used in a group to select multiple items independently. | Filter lists. Select options in forms. |
+ * | Tri-state | Supports three states: checked, unchecked, and indeterminate. | Parent checkbox for nested options. |
+ * | Nested | A parent checkbox controls its children; the parent reflects checked, unchecked, or indeterminate. | Selections within categories. |
+ * | Inline | Placed within text or small UI elements. | Inline acknowledgement text. Compact forms. |
+ * | Disabled | Non-interactive checkbox indicating a fixed or unavailable state. | Unavailable options. Permissions indicator. |
+ * | Table | Selects lines or entries in a table. | Rows to perform an action on. |
+ *
+ * ### Best Practices
+ *
+ * * By default, checkboxes should have labels.
+ * * Checkboxes may have no visible label if they are part of another component, such as a table row.
+ * * Checkbox group labels can include an "optional" or "required" hint.
+ *
+ * ## Interaction
+ *
+ * Both the checkbox and its label(s) can trigger the interaction; do not limit the touch target to
+ * the checkbox alone. Checks work independently of one another—selecting one does not deselect the
+ * others unless they have a parent-child relationship. Consider using a radio button if checking one
+ * option should deselect all others.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use group labels to describe the action taken within a group of checkboxes.
+ * * Keep labels to a few words (ideally 3 or fewer) and use sentence case.
+ * * Use the first person when a checkbox indicates the user accepting something, e.g. "I agree to...".
+ * * Only use helper text when necessary to explain the action or its results.
+ * * In error messages, describe the issue and what to do about it.
+ *
+ * ### Dont's
+ *
+ * * Use helper text by default; consider better group labels first.
+ * * Use end punctuation on group labels.
+ * * Truncate labels.
  */
 export const Checkbox = Object.assign(
   forwardRef<HTMLInputElement, CheckboxProps>((props, ref) => {

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -36,8 +36,6 @@ export type CodeBlockProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * `import {CodeBlock} from "@chanzuckerberg/eds";`
- *
  * Component used to render block of code for use alongside other components. Allows for copying code.
  */
 export const CodeBlock = ({

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -20,6 +20,10 @@ export default {
   title: 'Components/DataTable',
   component: DataTable,
   parameters: {
+    docs: {
+      subtitle:
+        'Tables display and organize data in a structured format. They include customizations for size, style, interactivity, and data presentation.',
+    },
     chromatic: {
       viewports: [
         chromaticViewports.ipadMini,

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -197,7 +197,7 @@ const DataTableContext = createContext<Pick<DataTableProps, 'size'>>({
  * * Wrap important content and truncate secondary information.
  * * Use clear, descriptive headers and a meaningful title so screen readers can navigate the table.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Use tables for layout.
  * * Include blank rows or columns; adjust row and column spacing instead.

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -160,9 +160,53 @@ const DataTableContext = createContext<Pick<DataTableProps, 'size'>>({
 /**
  * `import {DataTable} from "@chanzuckerberg/eds";`
  *
- * DataTable represents a full-featured data view for controlling and sorting. It:
- * - handles responsive behaviors
- * - sort behavior on individual columns
+ * ## Usage
+ *
+ * Tables display and organize data in a structured format. They include customizations for size,
+ * style, interactivity, and data presentation.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Basic | Simple table layout with rows and columns; no interactivity. | Static reports. Read-only data display. |
+ * | Selectable rows | Allows row selection via checkboxes or row click. | Bulk actions. Item management. |
+ * | Editable | Inline cell or row editing capabilities. | Spreadsheet-like tools. Admin controls. |
+ * | Expandable rows | Rows can expand to show nested or detailed data. | Order summaries. Transaction breakdowns. |
+ * | Column customization | Users can show/hide or reorder columns. | Power-user features. Data-heavy interfaces. |
+ * | Loading & empty states | Shows skeletons or messaging when data is loading or unavailable. | Dynamic data tables. |
+ *
+ * ### Best Practices
+ *
+ * * Use small tables for compact density or size-constrained containers like modals; use medium tables to balance density and whitespace.
+ * * Use lined tables for static data and striped tables for data entered by users.
+ * * Use section headers to organize data when there are 2 or more categories.
+ * * Use column dividers only when they enhance clarity.
+ * * When `isSortable`, sort by the leading (leftmost) column by default.
+ *
+ * ## Interaction
+ *
+ * Tables scroll horizontally when their width exceeds the available space, and vertically when a
+ * height is set; the first column is sticky by default. Sortable column headers reveal a sort
+ * indicator on hover and toggle between ascending and descending on click, with only one column
+ * sorted at a time. When selectable, a leading column of checkboxes is added; the header checkbox
+ * selects or deselects all rows and shows an indeterminate state for partial selections. Action
+ * cells sit on the trailing edge, contain no more than three (typically tertiary, icon-only)
+ * buttons, and are shown on hover by default.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Write headers that are informative, descriptive, concise, and scannable.
+ * * Include units of measurement in headers so they aren't repeated throughout the columns.
+ * * Use sentence case for headers and columns, and be consistent with decimals.
+ * * Wrap important content and truncate secondary information.
+ * * Use clear, descriptive headers and a meaningful title so screen readers can navigate the table.
+ *
+ * ### Dont's
+ *
+ * * Use tables for layout.
+ * * Include blank rows or columns; adjust row and column spacing instead.
+ * * Use color as the only means of conveying meaning.
  */
 export function DataTable<T>({
   actions,

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -158,12 +158,7 @@ const DataTableContext = createContext<Pick<DataTableProps, 'size'>>({
 });
 
 /**
- * `import {DataTable} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Tables display and organize data in a structured format. They include customizations for size,
- * style, interactivity, and data presentation.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/FieldLabel/FieldLabel.tsx
+++ b/src/components/FieldLabel/FieldLabel.tsx
@@ -37,8 +37,6 @@ export type FieldLabelProps = {
 };
 
 /**
- * `import {FieldLabel} from "@chanzuckerberg/eds";`
- *
  * Label associated with an input element or field.
  */
 export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -44,8 +44,6 @@ export type FieldNoteProps = {
 };
 
 /**
- * `import {FieldNote} from "@chanzuckerberg/eds";`
- *
  * Fieldnote component wraps text to describe other components.
  */
 export const FieldNote = ({

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -89,8 +89,6 @@ type FieldsetLegendProps = {
 const FieldsetContext = createContext<FieldsetSharedProps>({});
 
 /**
- * `import {Fieldset} from "@chanzuckerberg/eds";`
- *
  * A reusable container for a fieldset that includes a legend and
  * one or more form inputs, like radio buttons or checkboxes.
  */

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -50,8 +50,6 @@ const headingPresetMap: Record<HeadingElement, Preset> = {
 };
 
 /**
- * `import {Heading} from "@chanzuckerberg/eds";`
- *
  * A component for styling heading text (`<h1>`-`<h6>`).
  *
  * Be careful to pass the correct heading element via the `as` prop to avoid skipping heading levels because [heading levels increasing by only one level at a time is important for screen reader users.](https://www.w3.org/WAI/tutorials/page-structure/headings/)

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -27,8 +27,6 @@ export type HrProps = {
 };
 
 /**
- * `import {Hr} from "@chanzuckerberg/eds";`
- *
  * Horizontal rule component to present a horizontal line separating content.
  */
 export const Hr = ({ className, size, variant, ...other }: HrProps) => {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -79,8 +79,6 @@ type SvgStyle = CSSProperties & {
 };
 
 /**
- * `import {Icon} from "@chanzuckerberg/eds";`
- *
  * Render arbitrary SVG path data while enforcing good accessibility practices.
  *
  * Icons are based on [Material Rounded](https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Rounded),

--- a/src/components/InlineNotification/InlineNotification.stories.tsx
+++ b/src/components/InlineNotification/InlineNotification.stories.tsx
@@ -7,6 +7,10 @@ export default {
   title: 'Components/InlineNotification',
   component: InlineNotification,
   parameters: {
+    docs: {
+      subtitle:
+        'An alert is placed within a page section to provide a contextual notification. For example, an error that applies to multiple fields within a form.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -35,7 +35,41 @@ type InlineNotificationProps = {
 /**
  * `import {InlineNotification} from "@chanzuckerberg/eds";`
  *
- * An alert placed within a section of a page to provide a contextual notification. For example, an error which applies to multiple fields within a form.
+ * ## Usage
+ *
+ * An alert placed within a section of a page to provide a contextual notification. For example, an
+ * error that applies to multiple fields within a form.
+ *
+ * * To provide feedback to users about their actions, such as summarizing form-level errors after server-side validation.
+ * * To give significant status updates about a task.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Error | Indicates an error next to a specific form field or UI element. | Invalid form input. Required field left empty. |
+ * | Warning | Non-blocking alert about a potential issue. | Weak password. Deprecated selection. |
+ * | Success | Confirms a successful user action related to a specific element. | Successfully saved value. |
+ * | Hint | Provides guidance or clarification without requiring an action. | Input format guidance. Optional field context. |
+ * | Info | Offers neutral, supportive information near the related element. | Explain why a field is disabled. |
+ * | Validation feedback | Real-time response to user input as they type or select. | Password strength meters. |
+ *
+ * ## Interaction
+ *
+ * Inline notifications appear directly above the content they relate to and disappear once the
+ * state that caused the alert has been resolved.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep titles short and descriptive—ideally one line—and communicate the main message in sentence case.
+ * * In the body, explain how to resolve the issue in 1-2 sentences (no more than 2 lines) and include links to more info when necessary.
+ * * Place the notification close to the relevant screen elements so it is understood in context.
+ *
+ * ### Dont's
+ *
+ * * Punctuate the end of the title.
+ * * Repeat or summarize the title in the body.
+ * * Use without an icon indicating the notification type and severity.
  */
 export const InlineNotification = ({
   className,

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -33,12 +33,7 @@ type InlineNotificationProps = {
 };
 
 /**
- * `import {InlineNotification} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * An alert placed within a section of a page to provide a contextual notification. For example, an
- * error that applies to multiple fields within a form.
  *
  * * To provide feedback to users about their actions, such as summarizing form-level errors after server-side validation.
  * * To give significant status updates about a task.

--- a/src/components/InlineNotification/InlineNotification.tsx
+++ b/src/components/InlineNotification/InlineNotification.tsx
@@ -60,7 +60,7 @@ type InlineNotificationProps = {
  * * In the body, explain how to resolve the issue in 1-2 sentences (no more than 2 lines) and include links to more info when necessary.
  * * Place the notification close to the relevant screen elements so it is understood in context.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Punctuate the end of the title.
  * * Repeat or summarize the title in the body.

--- a/src/components/InputChip/InputChip.stories.ts
+++ b/src/components/InputChip/InputChip.stories.ts
@@ -6,6 +6,12 @@ import { InputChip } from './InputChip';
 export default {
   title: 'Components/InputChip',
   component: InputChip,
+  parameters: {
+    docs: {
+      subtitle:
+        'Compact, interactive UI elements used to make selections or display user-generated information.',
+    },
+  },
   argTypes: {
     onClick: {
       control: false,

--- a/src/components/InputChip/InputChip.stories.ts
+++ b/src/components/InputChip/InputChip.stories.ts
@@ -9,7 +9,7 @@ export default {
   parameters: {
     docs: {
       subtitle:
-        'Compact, interactive UI elements used to make selections or display user-generated information.',
+        'Compact, interactive UI element used to display user-generated information.',
     },
   },
   argTypes: {

--- a/src/components/InputChip/InputChip.tsx
+++ b/src/components/InputChip/InputChip.tsx
@@ -36,11 +36,7 @@ export type InputChipProps = {
 };
 
 /**
- * `import {InputChip} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Compact, interactive UI elements used to make selections or display user-generated information.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/InputChip/InputChip.tsx
+++ b/src/components/InputChip/InputChip.tsx
@@ -40,7 +40,6 @@ export type InputChipProps = {
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|
- * | Selection | An interactive chip that can be selected, deselected, or toggled. | Filtering content, selecting multiple items, or representing user controls outside a form (in place of a checkbox, radio, or toggle group). |
  * | Input | A chip that represents user-generated input and can be edited or removed. | Displaying selected tags, keywords, or values in a form or input field, or combining multiple pieces of data such as a name and avatar. |
  *
  * ### Best Practices

--- a/src/components/InputChip/InputChip.tsx
+++ b/src/components/InputChip/InputChip.tsx
@@ -38,7 +38,31 @@ export type InputChipProps = {
 /**
  * `import {InputChip} from "@chanzuckerberg/eds";`
  *
- * Compact, interactive elements used to display user-generated information.
+ * ## Usage
+ *
+ * Compact, interactive UI elements used to make selections or display user-generated information.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Selection | An interactive chip that can be selected, deselected, or toggled. | Filtering content, selecting multiple items, or representing user controls outside a form (in place of a checkbox, radio, or toggle group). |
+ * | Input | A chip that represents user-generated input and can be edited or removed. | Displaying selected tags, keywords, or values in a form or input field, or combining multiple pieces of data such as a name and avatar. |
+ *
+ * ### Best Practices
+ *
+ * * **Displaying multi-selection from a large list**: show selections already made without reopening a long select dropdown. Input chips are most helpful when the list of options exceeds 15 items.
+ * * **Representing search filters or criteria**: show active filters or search parameters to make complex filtering feel organized and easily editable.
+ * * **Handling user-generated or free-form data**: transform user-entered text (e.g., email addresses) into a discrete component that confirms the UI recognizes the input.
+ *
+ * ## Interaction
+ *
+ * Unless used as a toggle, chips should always be presented as a group. Depending on the use, groups can either wrap to multiple lines or scroll horizontally.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep labels to 1-2 words.
+ * * Represent one piece of information per chip (a discrete thing, grouping, or category).
  */
 export const InputChip = ({
   className,

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof InputField> = {
   title: 'Components/InputField',
   component: InputField,
   parameters: {
+    docs: {
+      subtitle:
+        'Input fields are used to gather text-based input. They are represented by a rectangular box where the user can enter and edit their input.',
+    },
     layout: 'centered',
     backgrounds: {
       default: 'background-utility-inverse-high-emphasis',

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -151,11 +151,7 @@ type InputFieldType = ForwardedRefComponent<
 };
 
 /**
- * `import {InputField} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Input fields are used to gather text-based input. They are represented by a rectangular box where the user can enter and edit their input.
  *
  * **NOTE**: This component requires a `label` or `aria-label` prop.
  *

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -166,7 +166,7 @@ type InputFieldType = ForwardedRefComponent<
  *
  * ## Interaction
  *
- * When the text exceeds the available space, it scrolls to show the end of the string. Once the user clicks out of the field, the text scrolls back to the beginning.
+ * When the text exceeds the available space, it scrolls to show the end of the string.
  *
  * ## Content & Accessibility
  *
@@ -177,7 +177,7 @@ type InputFieldType = ForwardedRefComponent<
  * * For errors, provide instructions for fixing the issue and explain what is happening.
  * * Use `fieldNote` for examples or instructions explaining what should be entered.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use colons or periods at the end of labels, and don't omit labels.
  * * Don't use placeholder text within the field; it can cause accessibility issues.

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -153,9 +153,39 @@ type InputFieldType = ForwardedRefComponent<
 /**
  * `import {InputField} from "@chanzuckerberg/eds";`
  *
- * An input with optional labels and error messaging built-in.
+ * ## Usage
  *
- * **NOTE**: This component requires `label` or `aria-label` prop
+ * Input fields are used to gather text-based input. They are represented by a rectangular box where the user can enter and edit their input.
+ *
+ * **NOTE**: This component requires a `label` or `aria-label` prop.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Text | Standard single-line input for free-form text. | Name fields, search bars, tags. |
+ * | Search | Optimized for searching, often with a search icon or clear button. | Site/app search bars, filter queries. |
+ * | Date/Time | Opens a date/time picker depending on browser support. | Scheduling. |
+ * | Masked | Formats input while typing. | Passwords, phone numbers, credit card entries. |
+ * | Disabled/Read-Only | Prevents user interaction or editing. | Prefilled info, summary/review forms. |
+ * | Validation | Displays real-time validation (e.g., success, error states). | Required fields, format enforcement. |
+ *
+ * ## Interaction
+ *
+ * When the text exceeds the available space, it scrolls to show the end of the string. Once the user clicks out of the field, the text scrolls back to the beginning.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use short, precise labels in sentence case.
+ * * Use helper text only when necessary, preferring examples (e.g., yourname@emaildomain.com) over instructions.
+ * * For errors, provide instructions for fixing the issue and explain what is happening.
+ * * Use `fieldNote` for examples or instructions explaining what should be entered.
+ *
+ * ### Dont's
+ *
+ * * Don't use colons or periods at the end of labels, and don't omit labels.
+ * * Don't use placeholder text within the field; it can cause accessibility issues.
+ * * Don't stack field notes on top of error messages.
  */
 export const InputField: InputFieldType = forwardRef(
   (

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -37,8 +37,6 @@ export type LabelProps = {
 };
 
 /**
- * `import {Label} from "@chanzuckerberg/eds";`
- *
  * Label component used as legends for field groups (e.g., radio/checkbox fields).
  */
 export const Label = ({

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -6,6 +6,10 @@ export default {
   title: 'Components/Link',
   component: Link,
   parameters: {
+    docs: {
+      subtitle:
+        'Links take users to another place, and usually appear within or directly following a paragraph or sentence.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -62,11 +62,7 @@ export type LinkProps<ExtendedElement = unknown> =
   } & ExtendedElement;
 
 /**
- * `import {Link} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Links take users to another place, and usually appear within or directly following a paragraph or sentence.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -64,9 +64,42 @@ export type LinkProps<ExtendedElement = unknown> =
 /**
  * `import {Link} from "@chanzuckerberg/eds";`
  *
- * Component for making styled anchor tags. Links allow users to navigate within or between a web page(s) or app(s).
+ * ## Usage
  *
- * Inline links inherit the color of the surrounding container, while when using `context` set to `standalone`, links have specific colors.
+ * Links take users to another place, and usually appear within or directly following a paragraph or sentence.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Inline | Embedded in body text, styled with an underline. | Reference external docs, "Learn more" links, citing sources. |
+ * | Standalone | Appears on its own, often in navs or action areas. | Footer links, header navigation, CTA-style links (when not using a button). |
+ * | External | Opens to a different domain or website; often includes an icon or notice. | Links to external sites, third-party tools, privacy policy or support articles. |
+ * | Internal navigation | Navigates within the app or website (SPA routing or anchor-based). | Page-to-page navigation, in-page jump links. |
+ * | Breadcrumb | Represents a step in a navigation trail. | Hierarchical navigation, backtracking in nested pages. |
+ * | Disabled | Styled like a link but non-interactive. | Unavailable destinations, permission-based restrictions. |
+ *
+ * ### Best Practices
+ *
+ * * **Do** use links primarily to support navigation, directing users to another page or a different portion of the same page.
+ * * **Don't** use links as actions that change data or state, or that trigger a high-emphasis action; use `Button` instead.
+ * * **Do** display the external ("open-in-new") icon when the link text needs support to convey an external domain.
+ * * **Don't** use other icons to represent an external link.
+ * * **Do** display an underline on inline links to reinforce interactivity and accessibility.
+ * * **Don't** use the low emphasis variant in inline contexts, as it can fail to convey interactivity.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use a meaningful, descriptive label that clearly indicates the link's destination.
+ * * Make sure the link reflects the content people will find at the destination.
+ * * Use "Learn more" for links to more information, ensuring the preceding content provides context.
+ *
+ * ### Dont's
+ *
+ * * Don't use generic phrases like "click here".
+ * * Don't include leading spaces or end punctuation within the link.
+ * * Don't use the same link text for different destinations on the same page.
+ * * Don't use excessively long link text.
  */
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   (

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -90,7 +90,7 @@ export type LinkProps<ExtendedElement = unknown> =
  * * Make sure the link reflects the content people will find at the destination.
  * * Use "Learn more" for links to more information, ensuring the preceding content provides context.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use generic phrases like "click here".
  * * Don't include leading spaces or end punctuation within the link.

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -79,7 +79,44 @@ const ListItem = (props: ListItemProps) => {
 };
 
 /**
+ * `import {UnorderedList, OrderedList} from "@chanzuckerberg/eds";`
+ *
  * Control a list of text items that are semantically unordered.
+ *
+ * ## Usage
+ *
+ * Structures related content into a skimmable vertical layout.
+ *
+ * * **Unordered**: Used for content where the order is not important.
+ * * **Ordered**: Used for content where the order is important.
+ * * EDS supports 1 level of nesting because our current products don't require deeper nesting.
+ *
+ * ### Unordered Lists
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * |Data presentation|Presents grouped or related information in an organized manner.|A list of user names with their status or profile images.|
+ * |Hierarchical Data|Displays nested items or subcategories.|A file tree or nested comments in a discussion thread.|
+ *
+ * ### Ordered Lists
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * |Steps / Instructions|Lists steps in a specific order.|A step-by-step guide for setting up an account.|
+ * |Nested steps|Breaks a long list of steps into groups of steps that accomplish a discrete action or piece of the overall task.|Long, complex procedures.|
+ *
+ * ### Best Practices
+ *
+ * * Include headings for lists that use custom characters instead of standard bullets or numbering.
+ * * Don't rely on custom character bullets to convey meaning.
+ * * Don't use multiple custom characters for one list item.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep each list item short and to the point.
+ * * Use parallel structure in list items to aid understanding.
  *
  * @param props options for the list to control size and marker type
  * @returns ReactNode

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -79,13 +79,7 @@ const ListItem = (props: ListItemProps) => {
 };
 
 /**
- * `import {UnorderedList, OrderedList} from "@chanzuckerberg/eds";`
- *
- * Control a list of text items that are semantically unordered.
- *
  * ## Usage
- *
- * Structures related content into a skimmable vertical layout.
  *
  * * **Unordered**: Used for content where the order is not important.
  * * **Ordered**: Used for content where the order is important.

--- a/src/components/List/OrderedList.stories.tsx
+++ b/src/components/List/OrderedList.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: 'Components/OrderedList',
   component: OrderedList,
   parameters: {
+    docs: {
+      subtitle: 'Structures related content into a skimmable vertical layout.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/List/UnorderedList.stories.tsx
+++ b/src/components/List/UnorderedList.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: 'Components/UnorderedList',
   component: UnorderedList,
   parameters: {
+    docs: {
+      subtitle: 'Structures related content into a skimmable vertical layout.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/LoadingIndicator/LoadingIndicator.stories.ts
+++ b/src/components/LoadingIndicator/LoadingIndicator.stories.ts
@@ -7,6 +7,10 @@ export default {
   title: 'Components/LoadingIndicator',
   component: LoadingIndicator,
   parameters: {
+    docs: {
+      subtitle:
+        'Loading indicators inform users about the wait time, reason, and status of ongoing processes when the layout is unknown.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0'],

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -52,11 +52,7 @@ const loaderViewportSize = {
 };
 
 /**
- * `import {LoadingIndicator} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Loading indicators inform users about the wait time, reason, and status of ongoing processes when the layout is unknown.
  *
  * * **Indeterminate loaders**: use when a process does not have a specific endpoint (e.g., loading a page or fetching a component's content); the ongoing animation creates the perception of better performance.
  * * **Spinners**: use as a secondary choice of loader to Skeleton states.

--- a/src/components/LoadingIndicator/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator/LoadingIndicator.tsx
@@ -54,9 +54,30 @@ const loaderViewportSize = {
 /**
  * `import {LoadingIndicator} from "@chanzuckerberg/eds";`
  *
- * Loading indicators inform users about the wait time, reason, and status of ongoing processes when the layout is unknown
+ * ## Usage
  *
- * For screen readers, add a custom `aria-label` to describe what is loading.
+ * Loading indicators inform users about the wait time, reason, and status of ongoing processes when the layout is unknown.
+ *
+ * * **Indeterminate loaders**: use when a process does not have a specific endpoint (e.g., loading a page or fetching a component's content); the ongoing animation creates the perception of better performance.
+ * * **Spinners**: use as a secondary choice of loader to Skeleton states.
+ *
+ * | Type | Description | Example |
+ * |------|-------------|---------|
+ * | Spinner (Indeterminate) | Circular animation that loops while content loads without known duration. | Page transitions, unknown-length processes. |
+ * | Progress Bar (Determinate) | Horizontal bar that fills to show loading progress percentage. | File uploads, installers, long-running tasks with known duration. |
+ * | Progress Bar (Indeterminate) | Animated bar without a fixed percentage; shows ongoing activity. | Searching, connecting, polling data with unpredictable timing. |
+ * | Skeleton Loader | Placeholder UI shaped like content. | Content-heavy pages, feeds, dashboards. |
+ * | Dots/Bouncing loader | Animated dots or shapes to suggest activity. | Messaging input, minimal UIs. |
+ * | Inline loader | Small spinner or bar embedded within buttons, fields, or table rows. | "Saving..." or "Submitting..." buttons, table row actions. |
+ * | Fullscreen loader | Large spinner or blocking indicator over the entire screen. | Initial page loads, app boot-up sequences. |
+ * | Overlay loader | Semi-transparent spinner overlay on a section of the UI. | Panel refreshes, card-level async operations. |
+ * | Looping animation/GIF | Custom animated asset or branded loader. | Branded apps, unique user experiences. |
+ * | Success/Failure transition | Loader morphs into a checkmark or error icon. | Submission confirmation. |
+ *
+ * ### Best Practices
+ *
+ * * **Do** use other loaders before using the Spinner.
+ * * **Don't** overload the page with Spinners; minimize usage.
  */
 export const LoadingIndicator = ({
   ariaLabel = 'loading',

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -30,8 +30,6 @@ export type MarkdownProps = Options & {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * `import {Markdown} from "@chanzuckerberg/eds";`
- *
  * Generic Markdown component to wrap convert convent into EDS-compliant represenations. Includes all the base
  * components, plus tables from GitHub-Flavored Markdown. Other features available by using Remark Plugins.
  *

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -15,6 +15,9 @@ export default {
   title: 'Components/Menu',
   component: Menu,
   parameters: {
+    docs: {
+      subtitle: 'A dropdown that reveals or hides a list of actions.',
+    },
     layout: 'centered',
     // Using this motion preference for components where they trigger animations on mount
     chromatic: { delay: 500, prefersReducedMotion: 'reduce' },

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -83,11 +83,7 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
   };
 
 /**
- * `import {Menu} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A dropdown that reveals or hides a list of actions.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -104,7 +104,7 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
  * * Place the most-used options at the top of the menu.
  * * Group similar commands, and order meaningfully in long menus using dividers between sections.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Overload menus; try to stay below 12 options in a menu.
  * * Use helper text with menu options unless absolutely necessary.

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -85,7 +85,34 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
 /**
  * `import {Menu} from "@chanzuckerberg/eds";`
  *
- * A popover that reveals or hides a list of actions. Menu items can contain icons (all should contain one, or none should), and other contents provided by `PopoverListItem`.
+ * ## Usage
+ *
+ * A dropdown that reveals or hides a list of actions.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Dropdown | A list of actions or links that appears when a button or label is clicked. | Filter selectors; user profile actions; navigation inside buttons. |
+ * | Context | Appears on right-click or long-press; offers contextual options. | File actions; custom user interactions. |
+ * | Hamburger | Collapsible navigation menu, often hidden behind an icon. | Mobile nav; space-constrained UIs. |
+ * | Overflow/More | Compact menu for additional actions, often shown as "⋮" or "...". | Table row actions; toolbar options. |
+ *
+ * ## Interaction
+ *
+ * The most common trigger for a Menu is a button with a chevron. An icon-only button might also trigger a Menu, and designers can define a custom trigger.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use short, precise labels.
+ * * Place the most-used options at the top of the menu.
+ * * Group similar commands, and order meaningfully in long menus using dividers between sections.
+ *
+ * ### Dont's
+ *
+ * * Overload menus; try to stay below 12 options in a menu.
+ * * Use helper text with menu options unless absolutely necessary.
+ * * Truncate menu items unless absolutely necessary. If truncation is required, use a tooltip to reveal the full text on hover.
  */
 export const Menu = ({ className, ...other }: MenuProps) => {
   const menuClassNames = clsx(className, styles['menu']);

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -15,6 +15,10 @@ export default {
   title: 'Components/Modal',
   component: Modal,
   parameters: {
+    docs: {
+      subtitle:
+        'Modals display content on top of the page in a separate container, blocking the content underneath. They require user action and can be used to deliver a message or help a user complete a task.',
+    },
     // Using this motion preference for components where they trigger animations on mount
     chromatic: { delay: 500, prefersReducedMotion: 'reduce' },
     layout: 'fullscreen',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -277,11 +277,7 @@ const ModalContent = (props: ModalContentProps) => {
 };
 
 /**
- * `import {Modal} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Modals display content on top of the page in a separate container, blocking the content underneath. They require user action and can be used to deliver a message or help a user complete a task.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -309,7 +309,7 @@ const ModalContent = (props: ModalContentProps) => {
  * * Break up information with section titles for scanability.
  * * Try to avoid scrolling text within a modal.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Include long headings or body text. The more words, the less likely people are to read any of it.
  * * Include long passages of informative text in a modal. Use a short summary and then link to a help article, FAQ etc.

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -279,13 +279,48 @@ const ModalContent = (props: ModalContentProps) => {
 /**
  * `import {Modal} from "@chanzuckerberg/eds";`
  *
- * EDS Wrapper for the HeadlessUI Dialog component
- * @see https://headlessui.dev/react/dialog
+ * ## Usage
  *
- * NOTE: You must have at least one focusable element in the modal contents, for keyboard
- * accessibility reasons. (The close button counts as a focusable element.) Use `initialFocus`
- * to choose a different element.
+ * Modals display content on top of the page in a separate container, blocking the content underneath. They require user action and can be used to deliver a message or help a user complete a task.
  *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | Central overlay with focus trap, used for focused tasks or messages. | Form entry; settings dialogs; confirmations. |
+ * | Confirmation | Asks the user to confirm or cancel a critical action. | Deletion prompts; submitting irreversible actions. |
+ * | Alert | Displays an important message, usually with a single dismiss button. | Error notifications; access denied messages. |
+ * | Full-screen | Takes up the entire viewport for complex or immersive tasks. | Onboarding; mobile workflows; media viewers. |
+ * | Success/Feedback | Provides positive feedback after a completed action. | Success confirmation; "Thanks for submitting" messages. |
+ *
+ * ### Best Practices
+ *
+ * * Modals are disruptive and should be used sparingly.
+ * * Use a modal to request minimal amounts of information from a user. Don't request large forms of information inside a modal.
+ * * Don't use a modal when a separate, designated URL is desired.
+ * * Show one modal at a time. Don't place a modal on top of another modal. This can create usability issues.
+ * * For important error notifications, use Inline Notification or Banner.
+ * * For short messaging confirming successful interactions, such as "Email sent", use Inline Notification or Toast.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use a primary title, body text, and a primary CTA. All other modal content is optional.
+ * * Use a verb-noun question or statement for the primary title.
+ * * Ensure people can scan the heading and CTAs and know what to do even if they skip the body text.
+ * * Keep primary titles and subtitles to a max of 2 lines each.
+ * * Use either a short phrase or a full sentence for subtitles.
+ * * Keep section titles to less than 1 line; preferably a short phrase.
+ * * Break up information with section titles for scanability.
+ * * Try to avoid scrolling text within a modal.
+ *
+ * ### Dont's
+ *
+ * * Include long headings or body text. The more words, the less likely people are to read any of it.
+ * * Include long passages of informative text in a modal. Use a short summary and then link to a help article, FAQ etc.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.dev/react/dialog
  */
 export const Modal = (props: ModalProps) => {
   const {

--- a/src/components/NumberIcon/NumberIcon.stories.tsx
+++ b/src/components/NumberIcon/NumberIcon.stories.tsx
@@ -7,6 +7,10 @@ export default {
   title: 'Components/NumberIcon',
   component: NumberIcon,
   parameters: {
+    docs: {
+      subtitle:
+        'Treats a numeral as an icon by wrapping it in a container and adding color/spacing.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -39,11 +39,7 @@ export type NumberIconProps = {
 };
 
 /**
- * `import {NumberIcon} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Treats a numeral as an icon by wrapping it in a container and adding color/spacing.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/NumberIcon/NumberIcon.tsx
+++ b/src/components/NumberIcon/NumberIcon.tsx
@@ -41,8 +41,20 @@ export type NumberIconProps = {
 /**
  * `import {NumberIcon} from "@chanzuckerberg/eds";`
  *
+ * ## Usage
+ *
  * Treats a numeral as an icon by wrapping it in a container and adding color/spacing.
  *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Progress indicator | Shows where you are in a process that contains multiple distinct steps. | Filter selectors; user profile actions; navigation inside buttons. |
+ * | Steps | Emphasizes steps in a procedure that is outlined on screen. | Process steps. |
+ *
+ * ### Best Practices
+ *
+ * * Be sure the number icon size is consistent throughout your application.
+ * * When used next to text, the number icon should be center-aligned.
+ * * Adding adequate space around the icon allows for legibility and touch. A minimum touch target area of 48px is recommended.
  */
 export const NumberIcon = ({
   className,

--- a/src/components/PageNotification/PageNotification.stories.tsx
+++ b/src/components/PageNotification/PageNotification.stories.tsx
@@ -8,6 +8,10 @@ export default {
   title: 'Components/PageNotification',
   component: PageNotification,
   parameters: {
+    docs: {
+      subtitle:
+        'A page notification communicates a message about the page it appears on.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/PageNotification/PageNotification.tsx
+++ b/src/components/PageNotification/PageNotification.tsx
@@ -65,7 +65,7 @@ export type PageNotificationProps = React.HTMLAttributes<HTMLElement> & {
  * * Title: be short and descriptive, communicate the main message, and use sentence case.
  * * Body: keep to 1-2 sentences and use sentence case.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't rely on color to convey meaning.
  * * Don't punctuate the end of the title.

--- a/src/components/PageNotification/PageNotification.tsx
+++ b/src/components/PageNotification/PageNotification.tsx
@@ -49,7 +49,32 @@ export type PageNotificationProps = React.HTMLAttributes<HTMLElement> & {
 /**
  * `import {PageNotification} from "@chanzuckerberg/eds";`
  *
- * An alert placed at the top of a page which impacts the entire experience on a screen.
+ * ## Usage
+ *
+ * A page notification communicates a message about the page it appears on.
+ *
+ * * Notifications related to a section of a page (like a card, popover, or modal) should use an Inline Notification.
+ * * Page Notifications are intended to display short messages. Ideally, a max of 3 lines.
+ *
+ * ## Interaction
+ *
+ * Designers can specify whether the notification is dismissible or not. A dismissible notification renders with a close icon in the top right.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Focus on a single message or piece of information.
+ * * Ensure users can get the basic message and take action by scanning just the heading and CTA(s).
+ * * Title: be short and descriptive, communicate the main message, and use sentence case.
+ * * Body: keep to 1-2 sentences and use sentence case.
+ *
+ * ### Dont's
+ *
+ * * Don't rely on color to convey meaning.
+ * * Don't punctuate the end of the title.
+ * * Don't repeat or paraphrase information from the heading in the body.
+ * * Don't truncate content; if more information is needed, link to it or consider a different component.
  */
 export const PageNotification = ({
   buttonLayout = 'vertical',

--- a/src/components/PageNotification/PageNotification.tsx
+++ b/src/components/PageNotification/PageNotification.tsx
@@ -47,11 +47,7 @@ export type PageNotificationProps = React.HTMLAttributes<HTMLElement> & {
 };
 
 /**
- * `import {PageNotification} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A page notification communicates a message about the page it appears on.
  *
  * * Notifications related to a section of a page (like a card, popover, or modal) should use an Inline Notification.
  * * Page Notifications are intended to display short messages. Ideally, a max of 3 lines.

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -10,6 +10,10 @@ export default {
   title: 'Components/Popover',
   component: Popover,
   parameters: {
+    docs: {
+      subtitle:
+        'A small, lightweight overlay or floating container that appears over other content to provide additional information, options, or actions without navigating away from the current screen.',
+    },
     layout: 'centered',
     chromatic: {
       // These stories are very flaky, though we're not sure why.

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -53,9 +53,30 @@ export type PopoverButtonProps = {
 /**
  * `import {Popover} from "@chanzuckerberg/eds";`
  *
- * General-purpose floating containers that appear proximal to a trigger point.
+ * ## Usage
  *
- * @see https://headlessui.com/react/popover
+ * A small, lightweight overlay or floating container that appears over other content to provide additional information, options, or actions without navigating away from the current screen.
+ *
+ * * Keeps information close to a button, etc., that triggers it.
+ * * Typically used for showing contextual information or quick actions without taking focus away from the main page.
+ * * Doesn't block interaction with the rest of the page.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Show additional info | Displays extra details or hints related to a UI element. | Showing help text when hovering over an info icon. |
+ * | Form fields / Input | Embeds lightweight form elements in a contextual way. | A popover with a color picker or emoji selector. |
+ *
+ * ### Best Practices
+ *
+ * * Don't use popovers for popup menus. Use a Menu instead.
+ *
+ * ## Interaction
+ *
+ * Popovers open in response to user interaction—click, tap, or hover. They close when clicking outside the popover, pressing `Esc`, selecting an item within the popover, or interacting with the trigger again (for toggling popovers).
+ *
+ * ## Resources
+ *
+ * * https://headlessui.com/react/popover
  */
 export const Popover = ({ ...other }: PopoverProps) => {
   return <HeadlessPopover {...other} />;

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -51,11 +51,7 @@ export type PopoverButtonProps = {
 } & RenderProps<{ open: boolean }>;
 
 /**
- * `import {Popover} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A small, lightweight overlay or floating container that appears over other content to provide additional information, options, or actions without navigating away from the current screen.
  *
  * * Keeps information close to a button, etc., that triggers it.
  * * Typically used for showing contextual information or quick actions without taking focus away from the main page.

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -49,8 +49,6 @@ export type PopoverListItemProps = {
 };
 
 /**
- * `import {PopoverListItem} from "@chanzuckerberg/eds";`
- *
  * This abstracts the structure of an item in a popover, when the popover contains a
  * list of items (e.g., Menus and Selects)
  * - Contains styles for when active/disabled or not

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -66,8 +66,6 @@ const PROGRESS_BAR_MINIMUM = 0;
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * `import {ProgressBar} from "@chanzuckerberg/eds";`
- *
  * Components used to visually represent user progress through a series of steps. Not to be confused with the `LoadingIndicator`.
  *
  * `ProgressBar` can be the child of a container like `Modal` or `Card`. When used in such a container, `context`=`embedded` should be used to ensure the left and right edges of the progressBar sit flush within the edges of the container.

--- a/src/components/Radio/Radio.stories.tsx
+++ b/src/components/Radio/Radio.stories.tsx
@@ -7,6 +7,10 @@ export default {
   title: 'Components/Radio',
   component: Radio,
   parameters: {
+    docs: {
+      subtitle:
+        'A radio button is a round control that allows users to choose one option from a set. Also known as Radio.',
+    },
     layout: 'centered',
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -134,7 +134,7 @@ const RadioInput = ({
  * * Keep labels to a few words (ideally 3 or less).
  * * In error messages, describe the issue and what to do about it.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Use helper text by default; consider better group labels first.
  * * Use end punctuation on group labels.

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -106,9 +106,44 @@ const RadioInput = ({
 /**
  * `import {Radio} from "@chanzuckerberg/eds";`
  *
- * Radio control indicating if one item is selected or unselected from a set of other options. Uncontrolled by default, it can be used in place of a select field in form data.
+ * ## Usage
  *
- * NOTE: This component requires `label` or `aria-label` prop
+ * A radio button is a round control that allows users to choose one option from a set. Also known as Radio.
+ *
+ * NOTE: This component requires a `label` or `aria-label` prop.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | A set of mutually exclusive options where only one can be selected. | Single-choice list of options. |
+ * | Horizontal Radio Group | Lays out options in a horizontal row for compact use. | Filters in toolbars. Simple form choices. |
+ * | Vertical Radio Group | Stacks options vertically for clarity and accessibility. | Longer option lists. Mobile-friendly forms. |
+ * | Disabled | Non-interactive, styled to indicate unavailability. | Feature restrictions. Options based on permissions. |
+ * | Preselected | One option is selected by default. | Guides user to the most common or recommended choice. |
+ *
+ * ### Best Practices
+ *
+ * * By default, radio buttons should have labels. They may have no visible label only if composed into another component, such as a table row. Like text inputs and select components, radio button group labels can include an "optional" or "required" hint.
+ * * Use a radio button when only one item can be selected from a list. When more than one option can be selected, use a checkbox instead.
+ * * The radio button group requires error text when `isError: true`.
+ * * Radio buttons should never be standalone. Therefore, they should never include their own error text.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use group labels to describe the action to be taken within groups of radio buttons (e.g. "Select the topic that most interests you").
+ * * Use helper text to explain the action, or results of the action, when necessary.
+ * * Use sentence case for group labels and helper text.
+ * * Use end punctuation for helper text.
+ * * Keep labels to a few words (ideally 3 or less).
+ * * In error messages, describe the issue and what to do about it.
+ *
+ * ### Dont's
+ *
+ * * Use helper text by default; consider better group labels first.
+ * * Use end punctuation on group labels.
+ * * Truncate labels.
+ * * Use end punctuation on an error message that is a sentence fragment.
  */
 export const Radio = ({
   className,

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -104,11 +104,7 @@ const RadioInput = ({
 };
 
 /**
- * `import {Radio} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A radio button is a round control that allows users to choose one option from a set. Also known as Radio.
  *
  * NOTE: This component requires a `label` or `aria-label` prop.
  *

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -81,8 +81,6 @@ export const setShadowStates = (targetData: HTMLDivElement): ShadowStates => {
 };
 
 /**
- * `import {ScrollWrapper} from "@chanzuckerberg/eds";`
- *
  * This is a basic wrapper component that handles functionality to show/hide shadows along either the vertical or horizontal edges.
  * This kicks in once the container's size is smaller than the overall height of the content within. For this to work,
  * the element above the scroll wrapper must have a fixed height. The effect kicks in once the children of the scroll

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -9,6 +9,10 @@ const meta: Meta<typeof Select> = {
   title: 'Components/Select',
   component: Select,
   parameters: {
+    docs: {
+      subtitle:
+        "A popover that reveals or hides a list of options. Depending on the component's configuration, the user may select one or more options.",
+    },
     layout: 'centered',
     // Using this motion preference for components where they trigger animations on mount
     chromatic: { delay: 500, prefersReducedMotion: 'reduce' },

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -209,7 +209,7 @@ const SelectContext = React.createContext<SelectContextType>({});
  * * Use sentence case.
  * * Place the most common choices at the top of the list to assist visually impaired users.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Use periods at the end of labels.
  * * Place placeholder text within the field; it can cause accessibility issues with color contrast, inconsistent screen-reader behavior, and text disappearing as users type.

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -174,11 +174,7 @@ let showNameWarning = true;
 const SelectContext = React.createContext<SelectContextType>({});
 
 /**
- * `import {Select} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A popover that reveals or hides a list of options. Depending on the component's configuration, the user may select one or more options.
  *
  * Supports controlled and uncontrolled behavior, using a render prop in the latter case.
  *

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -176,12 +176,51 @@ const SelectContext = React.createContext<SelectContextType>({});
 /**
  * `import {Select} from "@chanzuckerberg/eds";`
  *
- * A popover component that reveals or hides a list of options from which to select.
+ * ## Usage
+ *
+ * A popover that reveals or hides a list of options. Depending on the component's configuration, the user may select one or more options.
  *
  * Supports controlled and uncontrolled behavior, using a render prop in the latter case.
  *
- * See more at <https://headlessui.com/react/menu>
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | A dropdown list that reveals a set of options; one can be selected. | Country selector. Sort order. Single-choice forms. |
+ * | Searchable | Includes a text input for filtering options in real time. | Long lists (e.g., cities, tags). Large datasets. |
+ * | Multi-select | Allows multiple options to be selected from the list. | Filter panels. Role or permission assignments. |
+ * | Disabled | Non-interactive; used to show unavailable or inactive states. | Feature-gated selections. Incomplete forms. |
+ * | Preselected | Default selection appears before user interacts. | Recommended settings. "Most common" default. |
+ * | Inline | Embedded within table rows or compact UIs. | Editable data tables. Quick action cells. |
  *
+ * ### Best Practices
+ *
+ * * Select can be used in forms and is meant to pick a value from a list of values, whereas Menus can be used for things like commands.
+ * * Order the menu options logically to make it easier for users to find the option they want. Default to alphabetical order.
+ * * Use a Select input for longer lists of options. A Select should never have only 2 options; 3 selections can be acceptable, but consider a Checkbox group or Radio button group instead so users can see all options at once.
+ * * Keep the select menu the same width as the select field that triggered it.
+ *
+ * ## Interaction
+ *
+ * In single-select mode, only one selection can be made. In multi-select mode, one or more selections can be made from the list.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use short, precise labels whenever possible.
+ * * Avoid truncated items.
+ * * In short lists, order from most common to least common choices.
+ * * In longer lists use alphabetical order, but if there are 2 or 3 very common selections, consider repeating them at the top of the list.
+ * * Use sentence case.
+ * * Place the most common choices at the top of the list to assist visually impaired users.
+ *
+ * ### Dont's
+ *
+ * * Use periods at the end of labels.
+ * * Place placeholder text within the field; it can cause accessibility issues with color contrast, inconsistent screen-reader behavior, and text disappearing as users type.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.com/react/menu
  */
 export function Select({
   'aria-label': ariaLabel,

--- a/src/components/SelectionChip/SelectionChip.stories.ts
+++ b/src/components/SelectionChip/SelectionChip.stories.ts
@@ -7,6 +7,10 @@ export default {
   title: 'Components/SelectionChip',
   component: SelectionChip,
   parameters: {
+    docs: {
+      subtitle:
+        'Compact, interactive UI elements used to make selections or display user-generated information.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:1.1'],

--- a/src/components/SelectionChip/SelectionChip.stories.ts
+++ b/src/components/SelectionChip/SelectionChip.stories.ts
@@ -8,8 +8,7 @@ export default {
   component: SelectionChip,
   parameters: {
     docs: {
-      subtitle:
-        'Compact, interactive UI elements used to make selections or display user-generated information.',
+      subtitle: 'Compact, interactive UI element used to make selections.',
     },
     layout: 'centered',
   },

--- a/src/components/SelectionChip/SelectionChip.tsx
+++ b/src/components/SelectionChip/SelectionChip.tsx
@@ -38,11 +38,7 @@ type SelectionChipRefProps = ForwardedRefComponent<
 >;
 
 /**
- * `import {SelectionChip} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Compact, interactive UI elements used to make selections. Can have an optional icon.
  *
  * A selection chip is an interactive chip that can be selected, deselected, or toggled. Use it to represent user controls or selections outside the context of a form, in place of a checkbox group, radio button group, or toggle. Common uses include filtering content and selecting multiple items.
  *

--- a/src/components/SelectionChip/SelectionChip.tsx
+++ b/src/components/SelectionChip/SelectionChip.tsx
@@ -40,21 +40,32 @@ type SelectionChipRefProps = ForwardedRefComponent<
 /**
  * `import {SelectionChip} from "@chanzuckerberg/eds";`
  *
- * Compact, interactive UI elements used to make selections. Can have optional icon.
- *
  * ## Usage
  *
- * `SelectionChip` is used to represent user controls or selections outside the context of a form. `SelectionChip` can be used in place of a checkbox group, radioButton group, or toggle.
- * Unless used as a toggle, `SelectionChip` should always be presented as a group.
+ * Compact, interactive UI elements used to make selections. Can have an optional icon.
  *
- * `SelectionChip` helps users make quick choices that lead to an immediate action. Unlike form inputs that collect information for later use, selection chips support decisions that happen right away. A common example is choosing a clothing size before clicking "Add to Cart" - the size selection directly enables the main action of adding the item to your cart.
+ * A selection chip is an interactive chip that can be selected, deselected, or toggled. Use it to represent user controls or selections outside the context of a form, in place of a checkbox group, radio button group, or toggle. Common uses include filtering content and selecting multiple items.
  *
- * There are a few benefits to using selectionChips over form-based selection, like checkbox or radio button groups:
- * * **Enable Quick Selection**: Use them when you want users to choose from a limited set of related, easily digestible options. For example, selection chips work well for selecting filters or tags in search and content filtering.
- * * **Show Multi-Select Options**: They’re ideal when users need the option to select multiple items at once, especially when toggling on/off multiple states or filters.
- * * **Enhance Readability in Tight Spaces**: Selection chips help maintain readability while maximizing the available screen space, especially on mobile.
- * * **Improve Visual Clarity**: They work best when there’s a need to show clear boundaries around items. Chips with subtle visual indicators like icons or colors can also convey context.
- * * **Replace Dropdowns or Radio Buttons**: When dropdowns or radio buttons feel too clunky or take up too much space, selection chips are a sleek alternative that’s easier to scan.
+ * ### Best Practices
+ *
+ * * **Enable quick selection**: When you want users to choose from a limited set of related, easily digestible options, such as selecting filters or tags in search and content filtering.
+ * * **Show multi-select options**: When users need the option to select multiple items at once, especially when toggling on/off multiple states or filters.
+ * * **Enhance readability in tight spaces**: Selection chips help maintain readability while maximizing available screen space, especially on mobile.
+ * * **Improve visual clarity**: When you need to show clear boundaries around items. Chips with subtle visual indicators like icons or colors can also convey context.
+ * * **Replace dropdowns or radio buttons**: When dropdowns or radio buttons are too clunky or take up too much space.
+ *
+ * ## Interaction
+ *
+ * Unless used as a toggle, chips should always be presented as a group.
+ *
+ * Selection chips don't have built-in error handling. To show that something went wrong with a selection, pair the chips with an `InlineNotification` or `FieldNote` component to display the error message.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep labels to 1-2 words.
+ * * Represent one piece of info per chip. This could be a discrete thing, a grouping, category, etc.
  */
 export const SelectionChip: SelectionChipRefProps = forwardRef(
   (

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -20,8 +20,6 @@ type SkeletonProps = BaseProps & {
 };
 
 /**
- * `import {Skeleton} from "@chanzuckerberg/eds";`
- *
  * Skeleton states inform users about the wait time, reason, and status of ongoing processes, showing the expected layout
  */
 export const Skeleton = ({

--- a/src/components/TabGroup/TabGroup.stories.tsx
+++ b/src/components/TabGroup/TabGroup.stories.tsx
@@ -11,6 +11,10 @@ export default {
   title: 'Components/TabGroup',
   component: TabGroup,
   parameters: {
+    docs: {
+      subtitle:
+        'Tab groups provide navigation between subsections of a page. The content within a Tab group should be related.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -151,7 +151,7 @@ export type TabContextArgs = {
  * * Limit labels to 1 or 2 words.
  * * Use sentence case for each label.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't repeat page-level information as part of the label (e.g. use "All" rather than "All groups").
  * * Don't truncate tab labels; consider alternative labels before settling for truncation.

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -127,11 +127,7 @@ export type TabContextArgs = {
 };
 
 /**
- * `import {TabGroup} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Tab groups provide navigation between subsections of a page. The content within a tab group should be related.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|
@@ -440,8 +436,6 @@ function usePrevious<T>(prop: T) {
 }
 
 /**
- * `import {Tab} from "@chanzuckerberg/eds";`
- *
  * Individual tab within the Tabs component.
  * - Use the `title` prop for text-only tab headers
  * - For more custom tab headers use `<Tab.Button>` which uses a render prop with state information

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -129,10 +129,36 @@ export type TabContextArgs = {
 /**
  * `import {TabGroup} from "@chanzuckerberg/eds";`
  *
- * List of of links where each link toggles open associated information in a tab panel.
+ * ## Usage
  *
- * Individual tabs allow for a simple text tab header using the `title` prop on each `<Tab>` instance.
- * For a more custom tabs, you can use an additonal `<Tab.Button>` sub-component with a render prop exposing `active` and `title`.
+ * Tab groups provide navigation between subsections of a page. The content within a tab group should be related.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard horizontal | A row of clickable labels that switch content panels below. | Settings pages, user profiles, simple content sections. |
+ * | Scrollable | Tabs that scroll horizontally if there are too many to fit. | Mobile views, multi-section tools. |
+ * | Disabled states | Tabs may be inactive or unavailable depending on state or permissions. | Conditional access, incomplete onboarding steps. |
+ * | Dynamic | Tabs added or removed based on user input or system state. | Custom workflows, data-driven interfaces. |
+ *
+ * The minimum number of tabs is 2, with no maximum, but use caution beyond 6 tabs as content can become buried.
+ *
+ * ## Interaction
+ *
+ * When there are too many tabs to fit, the tab group scrolls horizontally and shows a scrolling gradient at the edges. A divider can visually separate the tab group from the content it controls; if a tab group is sticky on scroll (`isSticky`), it must have a divider (`hasDivider`) to maintain visual separation as content moves underneath it.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Order tabs by priority or importance from left to right.
+ * * Ensure labels clearly communicate the contents of the tab.
+ * * Limit labels to 1 or 2 words.
+ * * Use sentence case for each label.
+ *
+ * ### Dont's
+ *
+ * * Don't repeat page-level information as part of the label (e.g. use "All" rather than "All groups").
+ * * Don't truncate tab labels; consider alternative labels before settling for truncation.
  */
 export const TabGroup = ({
   activeIndex = 0,

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -6,6 +6,10 @@ export default {
   title: 'Components/Tag',
   component: Tag,
   parameters: {
+    docs: {
+      subtitle:
+        'Status UI elements that visually represent metadata, attributes, or categorical information about an item. Tags usually represent system-generated information.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -38,13 +38,37 @@ type Props = {
 /**
  * `import {Tag} from "@chanzuckerberg/eds";`
  *
+ * ## Usage
+ *
  * Status UI elements that visually represent metadata, attributes, or categorical information about an item. Tags usually represent system-generated information.
  *
- * Usage and content:
- * * As a best practice, keep labels to 1-2 words. Remember that tags represent discrete pieces of information Don’t overload users with excessive content, which will increase cognitive load.
- * * Use tag status variants which are appropriate for the tag’s content.
- * * Tags should not be used in a semantically incorrect way.Do not select tag status soley based on their color. If clients need color-coded tags which are not tied to a particular status, reach out the EDS.
- * * When using multiple tabs together, separate them with spacing-size-2. This provides sufficient white space for readability.
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | State indicators | Shows the current status of an item or process. | A green "Active" tag for a user profile. |
+ * | Availability | Indicates if something is available or not. | "Available" or "Unavailable" tag for a product. |
+ * | Progress / Workflow | Marks the stage in a workflow or pipeline. | "In Review," "Draft," or "Completed" tags for a document. |
+ * | Urgency / Priority | Highlights critical items needing attention. | "High Priority" or "Urgent" tag in a task list. |
+ * | Validation status | Shows whether an item passed or failed validation. | "Valid" or "Error" status tags for form inputs. |
+ * | New or updated content | Marks new or recently changed items. | A "New" or "Updated" tag for an article or notification. |
+ *
+ * ### Best Practices
+ *
+ * * Use short labels, keeping them to 1-2 words since tags represent discrete pieces of information.
+ * * When using multiple tags together, separate them with 16px of space.
+ * * Use tag status variants that are appropriate for the tag's content.
+ * * Don't use tags solely for their colors or in a semantically incorrect way. If you need color-coded tags that are not tied to a particular status, reach out to EDS.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep labels to 1-2 words.
+ * * Remember that tags represent discrete pieces of information.
+ *
+ * ### Dont's
+ *
+ * * Don't overload users with excessive content, which increases cognitive load.
+ * * Don't rely on just color to communicate status—add text or icons.
  */
 export const Tag = ({
   className,

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -36,11 +36,7 @@ type Props = {
 };
 
 /**
- * `import {Tag} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * Status UI elements that visually represent metadata, attributes, or categorical information about an item. Tags usually represent system-generated information.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -61,7 +61,7 @@ type Props = {
  * * Keep labels to 1-2 words.
  * * Remember that tags represent discrete pieces of information.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't overload users with excessive content, which increases cognitive load.
  * * Don't rely on just color to communicate status—add text or icons.

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -24,8 +24,6 @@ export type TextProps = {
 } & React.HTMLAttributes<HTMLElement>; // TODO-AH: add in each possible element and spread in <Markdown>
 
 /**
- * `import {Text} from "@chanzuckerberg/eds";`
- *
  * The Text component decorates `<p>` and `<span>` with typographic variants. Use
  * typography presets to style the text via `preset`.
  *

--- a/src/components/TextareaField/TextareaField.stories.tsx
+++ b/src/components/TextareaField/TextareaField.stories.tsx
@@ -19,6 +19,10 @@ praesentium, commodi eligendi asperiores quis dolorum porro.`,
     spellCheck: false,
   },
   parameters: {
+    docs: {
+      subtitle:
+        'A text area lets a user input more text than a standard text field.',
+    },
     layout: 'centered',
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -129,11 +129,39 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 /**
  * `import {TextareaField} from "@chanzuckerberg/eds";`
  *
- * Multi-line text input field with built-in labeling and accessory text to describe
- * the content. When a maximum text count is specified, component also shows relevant
- * text up to the maximum.
+ * ## Usage
  *
- * **NOTE**: This component requires `label` or `aria-label` prop to support accessibility.
+ * A text area lets a user input more text than a standard text field.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | Multi-line input field for entering extended text. | Comments, descriptions, notes fields. |
+ * | Auto-resizing | Expands vertically as the user types. | Messaging apps, forms with flexible input length. |
+ * | Fixed-size | Has a set number of rows and does not resize. | Forms with a consistent layout, limited-screen environments. |
+ * | Read-only | Displays pre-filled content that cannot be edited. | Code blocks, audit logs, view-only mode. |
+ * | Disabled | Grayed out and non-editable; indicates inaccessibility. | Conditional logic states, feature restrictions. |
+ * | Monospaced | Uses a monospaced font, often for structured text or code. | Code snippets, JSON input, command editors. |
+ *
+ * **NOTE**: This component requires a `label` or `aria-label` prop to support accessibility.
+ *
+ * ## Interaction
+ *
+ * When the amount of text exceeds the available space, the text scrolls to show the end of the string. Once the user clicks out of the field, the text scrolls back up to the beginning.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Always have a visible label when adding a hint.
+ * * Use short, instructional labels when necessary and use sentence case.
+ * * Use `fieldNote` helper text when necessary, favoring examples over instructions.
+ * * For errors, provide instructions for fixing the issue and explain what is happening.
+ *
+ * ### Dont's
+ *
+ * * Don't use colons or periods at the end of labels, and don't omit labels.
+ * * Don't force the use of helper text—there is frequently no need for it.
+ * * Don't place placeholder text within the field, as it can cause accessibility issues.
  */
 export const TextareaField: TextareaFieldType = forwardRef(
   (

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -142,7 +142,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
  *
  * ## Interaction
  *
- * When the amount of text exceeds the available space, the text scrolls to show the end of the string. Once the user clicks out of the field, the text scrolls back up to the beginning.
+ * When the amount of text exceeds the available space, the text scrolls to show the end of the string.
  *
  * ## Content & Accessibility
  *
@@ -153,7 +153,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
  * * Use `fieldNote` helper text when necessary, favoring examples over instructions.
  * * For errors, provide instructions for fixing the issue and explain what is happening.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use colons or periods at the end of labels, and don't omit labels.
  * * Don't force the use of helper text—there is frequently no need for it.

--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -127,11 +127,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 );
 
 /**
- * `import {TextareaField} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A text area lets a user input more text than a standard text field.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/ToastNotification/ToastNotification.stories.tsx
+++ b/src/components/ToastNotification/ToastNotification.stories.tsx
@@ -12,6 +12,10 @@ export default {
   title: 'Components/ToastNotification',
   component: ToastNotification,
   parameters: {
+    docs: {
+      subtitle:
+        "A brief, temporary notification. They're meant to be noticed without disrupting a user's experience or requiring an action to be taken.",
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -54,7 +54,7 @@ export type ToastNotificationProps = {
  *
  * ## Interaction
  *
- * Toast notifications can be manually dismissed or auto-dismissed using the `dismissType` prop; auto toasts are automatically dismissed after 8 seconds. They slide in and out from the top right of the screen, placed 16px from the top and side of the viewport, fading in with the `eds-anim-fade-long` token and out with the `eds-animation-fade-quick` token.
+ * Toast notifications can be manually dismissed or auto-dismissed using the `dismissType` prop; auto toasts are automatically dismissed after 8 seconds. They slide in and out from the top right of the screen, placed 16px from the top and side of the viewport, fading in with the `eds-anim-fade-long` token and out with the `eds-anim-fade-quick` token.
  *
  * ## Content & Accessibility
  *
@@ -64,7 +64,7 @@ export type ToastNotificationProps = {
  * * Use simple phrases or sentence fragments, in sentence case.
  * * Aim for 1 line of text or less.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use more than 2 lines of text; if more is required, find another way to provide the information.
  * * Don't include any information in a toast that may be needed again.

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -43,11 +43,7 @@ export type ToastNotificationProps = {
 };
 
 /**
- * `import {ToastNotification} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A brief, temporary notification. Toasts are meant to be noticed without disrupting a user's experience or requiring an action to be taken.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -45,19 +45,34 @@ export type ToastNotificationProps = {
 /**
  * `import {ToastNotification} from "@chanzuckerberg/eds";`
  *
- * Toasts display brief, temporary notifications. They're meant to be noticed without disrupting a user's experience or requiring an action to be taken.
+ * ## Usage
  *
- * ## Sizing
+ * A brief, temporary notification. Toasts are meant to be noticed without disrupting a user's experience or requiring an action to be taken.
  *
- * Toast notifications use a fixed max width of 384px and their height depends on the length of the notification message. As noted in the content guidelines, limit toast notifications to two lines of text.
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Success | Confirms a successful action. | Form submitted, settings saved, message sent. |
+ * | Error | Alerts the user to a failure or problem. | Failed save, API error, input validation failure. |
+ * | Warning | Warns about potential issues without blocking progress. | Unsaved changes, feature deprecation, connectivity issues. |
+ * | Info | Shares neutral or contextual information. | Tip or hint, background updates, non-critical status. |
  *
- * ## Dismissal
+ * ## Interaction
  *
- * Toast notifications can be manually dismissed or auto-dismissed using the dismissType prop. Auto toasts are automatically dismissed after 8 seconds by default.
+ * Toast notifications can be manually dismissed or auto-dismissed using the `dismissType` prop; auto toasts are automatically dismissed after 8 seconds. They slide in and out from the top right of the screen, placed 16px from the top and side of the viewport, fading in with the `eds-anim-fade-long` token and out with the `eds-animation-fade-quick` token.
  *
- * ## Placement and Behavior
+ * ## Content & Accessibility
  *
- * Toast notifications slide in and out from the borrom right of the screen. The toast should be placed 24 px away from the top and side of the viewport. The toast notification fades in with the token eds-anim-fade-long and fade out with token eds-animation-fade-quick.
+ * ### Do's
+ *
+ * * Keep the toast to a single, simple message such as a confirmation.
+ * * Use simple phrases or sentence fragments, in sentence case.
+ * * Aim for 1 line of text or less.
+ *
+ * ### Dont's
+ *
+ * * Don't use more than 2 lines of text; if more is required, find another way to provide the information.
+ * * Don't include any information in a toast that may be needed again.
+ * * Don't punctuate incomplete sentences, and don't rely on color to convey meaning.
  */
 export const ToastNotification = ({
   className,

--- a/src/components/ToastNotification/ToastNotification.tsx
+++ b/src/components/ToastNotification/ToastNotification.tsx
@@ -54,7 +54,7 @@ export type ToastNotificationProps = {
  *
  * ## Interaction
  *
- * Toast notifications can be manually dismissed or auto-dismissed using the `dismissType` prop; auto toasts are automatically dismissed after 8 seconds. They slide in and out from the top right of the screen, placed 16px from the top and side of the viewport, fading in with the `eds-anim-fade-long` token and out with the `eds-anim-fade-quick` token.
+ * Toast notifications can be manually dismissed or auto-dismissed using the `dismissType` prop; auto toasts are automatically dismissed after 8 seconds. When building with `ToastNotification`, each should slide in and out from the top right of the screen, placed 16px from the bottom and right side of the viewport, fading in with the `eds-anim-fade-long` token and out with the `eds-anim-fade-quick` token.
  *
  * ## Content & Accessibility
  *

--- a/src/components/Toggle/Toggle.stories.tsx
+++ b/src/components/Toggle/Toggle.stories.tsx
@@ -25,6 +25,10 @@ const meta: Meta<typeof Toggle> = {
     checked: false,
   },
   parameters: {
+    docs: {
+      subtitle:
+        'A control that toggles between two binary states like on/off or yes/no.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:1.4'],

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -125,7 +125,7 @@ const ToggleWrapper = (props: ExtractProps<typeof Field>) => (
  * * Ensure labels are clear without surrounding information for context.
  * * Include alt text for toggles that don't have a label.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't add end punctuation to the primary label.
  * * Don't mix full-sentence and partial-sentence secondary labels.

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -98,9 +98,45 @@ const ToggleWrapper = (props: ExtractProps<typeof Field>) => (
 /**
  * `import {Toggle} from "@chanzuckerberg/eds";`
  *
- * Toggle wrapping the Headless UI Switch component https://headlessui.dev/react/switch, generally used as an input for controlling between two states.
+ * ## Usage
  *
- * **NOTE**: This component requires `label` or `aria-label` prop
+ * A control that toggles between two binary states like on/off or yes/no.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Enable/Disable a feature | Turns a feature on or off. | Dark mode toggle in a settings menu. |
+ * | Show/Hide content | Reveals or hides additional UI elements. | Show/hide advanced search filters. |
+ * | Activate notifications | Turns notifications on or off. | Push notifications toggle in a mobile app. |
+ * | Privacy & security settings | Adjusts user privacy or security preferences. | Allow/block location sharing. |
+ * | Subscription/opt-in settings | Lets users opt in or out of subscriptions. | Newsletter sign-up toggle. |
+ * | Account preferences | Changes user-specific account features. | Two-factor authentication toggle. |
+ * | Mode switching | Switches between different UI modes. | Toggle between grid view and list view. |
+ * | Accessibility options | Improves usability for accessibility. | High contrast mode toggle. |
+ *
+ * **NOTE**: This component requires a `label` or `aria-label` prop.
+ *
+ * ### Best Practices
+ *
+ * * Use only for binary yes/no or on/off options.
+ * * Don't use a toggle to perform a single action.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Write labels in sentence case.
+ * * Use punctuation in full-sentence secondary labels, and punctuate all secondary labels in a list the same way.
+ * * Ensure labels are clear without surrounding information for context.
+ * * Include alt text for toggles that don't have a label.
+ *
+ * ### Dont's
+ *
+ * * Don't add end punctuation to the primary label.
+ * * Don't mix full-sentence and partial-sentence secondary labels.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.dev/react/switch
  */
 export const Toggle = ({ label, subLabel, ...other }: ToggleProps) => {
   const wrapperClassName = clsx(

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -96,11 +96,7 @@ const ToggleWrapper = (props: ExtractProps<typeof Field>) => (
 );
 
 /**
- * `import {Toggle} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A control that toggles between two binary states like on/off or yes/no.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -43,6 +43,10 @@ export default {
     },
   },
   parameters: {
+    docs: {
+      subtitle:
+        'A tooltip is a floating, non-actionable label used to explain a user interface element or feature. It can be triggered by hovering over an element.',
+    },
     layout: 'centered',
     chromatic: {
       delay: 750,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -147,9 +147,9 @@ type Plugin = Plugins[number];
  * ### Best Practices
  *
  * * Don't put tooltips on actions except for icon-only buttons.
- * * Don't style text inside a tooltip.
+ * * Keep tooltip content simple; avoid complex/custom typography styling inside a tooltip.
  * * When an icon's meaning is not immediately obvious or universally recognized, use a tooltip as a hint or clarification.
- * * Don't use tooltips to communicate critical information such as form errors; consider the Toast component instead.
+ * * Don't use tooltips to communicate critical information such as form errors; consider `ToastNotification` instead.
  * * Tooltips aren't meant for a first-time user experience; consider a NUX to guide onboarding.
  * * Display one tooltip at a time.
  *
@@ -171,7 +171,7 @@ type Plugin = Plugins[number];
  * * Don't use tooltips to communicate error messages or other critical information.
  * * Don't put essential task instructions in tooltips.
  * * Don't use tooltips to restate text that is already on the screen.
- * * Don't pair tooltips with disabled elements.
+ * * Don't pair tooltips with disabled elements directly, as it may not receive pointer events. Attach to a wrapper element instead.
  *
  * ## Resources
  *

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -137,10 +137,50 @@ type Plugin = Plugins[number];
 /**
  * `import {Tooltip} from "@chanzuckerberg/eds";`
  *
- * A floating information box, attached to other components on the page. Used to display option, additional information.
+ * ## Usage
  *
- * @see https://atomiks.github.io/tippyjs/
- * @see https://github.com/atomiks/tippyjs-react
+ * A tooltip is a floating, non-actionable label used to explain a user interface element or feature. It can be triggered by hovering over an element.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | Brief text that appears on hover or focus, near a UI element. | Labeling icon-only buttons, explaining uncommon terms. |
+ * | Interactive | Includes styled content such as links, formatting, or icons. | Short instructions, embedded documentation, "Learn more" links. |
+ * | Disabled element | Visible even on elements that are not interactive. | Explaining why a button is disabled. |
+ * | Contextual | Shows information specific to the user's current context or state. | Explaining dynamic UI states, custom user guidance. |
+ *
+ * ### Best Practices
+ *
+ * * Don't put tooltips on actions except for icon-only buttons.
+ * * Don't style text inside a tooltip.
+ * * When an icon's meaning is not immediately obvious or universally recognized, use a tooltip as a hint or clarification.
+ * * Don't use tooltips to communicate critical information such as form errors; consider the Toast component instead.
+ * * Tooltips aren't meant for a first-time user experience; consider a NUX to guide onboarding.
+ * * Display one tooltip at a time.
+ *
+ * ## Interaction
+ *
+ * A tooltip is triggered by hovering over an element. The most common example of a trigger is an icon, but hovering over a text link can also trigger a tooltip.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Keep tooltips to 3 lines or less.
+ * * Keep icon label tooltips to 2-3 words with no end punctuation.
+ * * Use full sentences for definitions and instructive tooltips, with sentence case and end punctuation.
+ * * Start instructional tooltips with a verb.
+ *
+ * ### Dont's
+ *
+ * * Don't use tooltips to communicate error messages or other critical information.
+ * * Don't put essential task instructions in tooltips.
+ * * Don't use tooltips to restate text that is already on the screen.
+ * * Don't pair tooltips with disabled elements.
+ *
+ * ## Resources
+ *
+ * * https://atomiks.github.io/tippyjs/
+ * * https://github.com/atomiks/tippyjs-react
  */
 export const Tooltip = ({
   childNotInteractive,

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -135,11 +135,7 @@ type Plugins = NonNullable<React.ComponentProps<typeof Tippy>['plugins']>;
 type Plugin = Plugins[number];
 
 /**
- * `import {Tooltip} from "@chanzuckerberg/eds";`
- *
  * ## Usage
- *
- * A tooltip is a floating, non-actionable label used to explain a user interface element or feature. It can be triggered by hovering over an element.
  *
  * | Type/Use | Description | Example |
  * |----------|-------------|---------|

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -155,7 +155,7 @@ type Plugin = Plugins[number];
  *
  * ## Interaction
  *
- * A tooltip is triggered by hovering over an element. The most common example of a trigger is an icon, but hovering over a text link can also trigger a tooltip.
+ * A tooltip is triggered by hovering over or focusing an element. The most common example of a trigger is an icon, but hovering over a text link can also trigger a tooltip.
  *
  * ## Content & Accessibility
  *
@@ -166,7 +166,7 @@ type Plugin = Plugins[number];
  * * Use full sentences for definitions and instructive tooltips, with sentence case and end punctuation.
  * * Start instructional tooltips with a verb.
  *
- * ### Dont's
+ * ### Don'ts
  *
  * * Don't use tooltips to communicate error messages or other critical information.
  * * Don't put essential task instructions in tooltips.

--- a/src/components/VisualPageIndicator/VisualPageIndicator.tsx
+++ b/src/components/VisualPageIndicator/VisualPageIndicator.tsx
@@ -22,8 +22,6 @@ export type VisualPageIndicatorProps = {
 };
 
 /**
- * `import {VisualPageIndicator} from "@chanzuckerberg/eds";`
- *
  * Static visual cue to help users understand their current position within a series of content or pages.
  */
 export const VisualPageIndicator = ({


### PR DESCRIPTION
Pull documentation from our documentation system (ZeroHeight) into the component descriptions.

* Add usage, dos/donts, and any additional tables and links.
* update existing doc.s for correctness

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
