### PR TITLE
docs(DataTable): add links to TanStack ref and FAQ

### DIFF
--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -56,6 +56,7 @@ type Person = DataTableWithStatus<{
 }>;
 
 // Specifying the example (static) data for the table to use with tanstack primitives
+// Note: Only use stable data references to prevent infinite loops during render. See https://tanstack.com/table/latest/docs/faq
 const defaultData: Person[] = [
   {
     firstName: 'Joe',

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -176,6 +176,7 @@ const DataTableContext = createContext<Pick<DataTableProps, 'size'>>({
  * * Use section headers to organize data when there are 2 or more categories.
  * * Use column dividers only when they enhance clarity.
  * * When `isSortable`, sort by the leading (leftmost) column by default.
+ * * Make sure to only use stable data references for columns/data passed to `useReactTable`: see Resources below.
  *
  * ## Interaction
  *
@@ -202,6 +203,12 @@ const DataTableContext = createContext<Pick<DataTableProps, 'size'>>({
  * * Use tables for layout.
  * * Include blank rows or columns; adjust row and column spacing instead.
  * * Use color as the only means of conveying meaning.
+ *
+ * ### Resources
+ *
+ * * https://tanstack.com/table/latest
+ * * https://tanstack.com/table/latest/docs/faq
+ *
  */
 export function DataTable<T>({
   actions,


### PR DESCRIPTION
Add inline and documentation references to `DataTable` calling out a warning to avoid infinite re-render loops.

* https://tanstack.com/table/latest/docs/faq
* https://tanstack.com/table/latest

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [ ] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
