### PR TITLE
feat(Combobox): add beta Combobox component

### DIFF
--- a/src/components/Combobox/Combobox.module.css
+++ b/src/components/Combobox/Combobox.module.css
@@ -31,6 +31,7 @@
  */
 .combobox__options {
   max-height: 25vh;
+  width: calc(var(--input-width) + var(--button-width) + 32px);
   z-index: var(--eds-z-index-top);
 }
 

--- a/src/components/Combobox/Combobox.module.css
+++ b/src/components/Combobox/Combobox.module.css
@@ -1,0 +1,275 @@
+@import '../../design-tokens/mixins.css';
+
+/*------------------------------------*\
+    # COMBOBOX
+\*------------------------------------*/
+
+/**
+ * Combobox field used to filter a list of options by typing, and select from the result.
+ */
+.combobox {
+  position: relative;
+}
+
+/**
+ * Wraps the Label and the optional/required hint.
+ */
+.combobox__overline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  margin-bottom: calc(var(--eds-spacing-size-half) * 1px);
+  gap: calc(var(--eds-spacing-size-half) * 1px);
+}
+
+.combobox__overline--no-label {
+  justify-content: flex-start;
+}
+
+/**
+ * The container for the individual combobox options.
+ */
+.combobox__options {
+  max-height: 25vh;
+  z-index: var(--eds-z-index-top);
+}
+
+.combobox--label-layout-vertical {
+  flex-direction: column;
+}
+
+.combobox--label-layout-horizontal {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+
+  gap: calc(var(--eds-spacing-size-1) * 1px);
+}
+
+/**
+ * The bordered field holding the text input and the toggle button. Matches the appearance of
+ * the `Select` trigger button, but its states are driven by the nested input rather than by
+ * the wrapper itself.
+ */
+.combobox-input {
+  width: 100%;
+  padding: calc(var(--eds-spacing-size-1-and-half) * 1px);
+
+  border: 1px solid light-dark(var(--eds-theme-color-border-utility-default-low-emphasis), var(--eds-dark-theme-color-border-utility-default-low-emphasis));
+  border-radius: calc(var(--eds-theme-border-radius-objects-sm) * 1px);
+
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: calc(var(--eds-spacing-size-1) * 1px);
+
+  color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  background-color: light-dark(var(--eds-theme-color-background-input), var(--eds-dark-theme-color-background-input));
+
+  transition: border-color calc(var(--eds-anim-fade-quick) * 1s) ease-in-out;
+
+  @media screen and (prefers-reduced-motion) {
+    transition: none;
+  }
+
+  /* 
+  &:hover:not(:has(.combobox-input__field:disabled)) {
+    border-color: light-dark(var(--eds-theme-color-border-utility-default-low-emphasis-hover), var(--eds-dark-theme-color-border-utility-default-low-emphasis-hover));
+  } */
+
+  /**
+   * The focusable element is the nested input, so the field border reacts to focus within it.
+   */
+  &:focus-within {
+    border-color: light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+    outline: 1px solid light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
+  }
+
+  &:has(.combobox-input__field:disabled) {
+    border-color: light-dark(var(--eds-theme-color-border-utility-disabled), var(--eds-dark-theme-color-border-utility-disabled));
+    background-color: light-dark(var(--eds-theme-color-background-utility-disabled-low-emphasis), var(--eds-dark-theme-color-background-utility-disabled-low-emphasis));
+  }
+}
+
+/**
+ * Once the field holds selection chips, its contents wrap onto more than one line rather than
+ * squeezing the text field down to nothing.
+ */
+.combobox-input--has-chips {
+  flex-wrap: wrap;
+  row-gap: calc(var(--eds-spacing-size-1) * 1px);
+
+  & .combobox-input__field {
+    /* Wrap onto a new line rather than shrinking away once chips fill the row */
+    min-width: calc(var(--eds-spacing-size-8) * 1px);
+  }
+
+  /* Keep the toggle at the end of the field, whichever line it lands on */
+  & .combobox-input__button {
+    margin-left: auto;
+  }
+}
+
+/**
+ * The values picked so far, shown ahead of the text field when `multiple` is set.
+ */
+.combobox-input__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: calc(var(--eds-spacing-size-1) * 1px);
+
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+
+  list-style: none;
+}
+
+/**
+ * The editable text field. It borrows the input typography but not the input border, since the
+ * wrapper draws that.
+ */
+.combobox-input__field {
+  /* preset: input-md */
+  font: 400 var(--eds-typography-preset-200) var(--eds-typography-font-family-1);
+
+  display: inline-block;
+
+  appearance: none;
+  -webkit-appearance: none;
+
+  flex: 1 1 auto;
+  min-width: 0;
+  width: var(--combobox__input-width, 1px);
+
+  border: none;
+  outline: none;
+  padding: 0;
+  margin: 0;
+
+  /* add additional alignment space toward top for the current fonts in use */
+  transform: translateY(-1px);
+
+  color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  background-color: transparent;
+
+  &:disabled {
+    cursor: not-allowed;
+    color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+  }
+}
+
+.combobox-input__field--truncated {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+/**
+ * The toggle that reveals the full, unfiltered option list.
+ */
+.combobox-input__button {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  cursor: pointer;
+
+  color: inherit;
+  background: none;
+
+  &:disabled {
+    cursor: not-allowed;
+    color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+  }
+}
+
+/**
+ * The caret icon to decorate the option list toggle, animated to rotate.
+ */
+.combobox-input__icon {
+  flex-shrink: 0;
+  transform: rotate(0);
+
+  transition: transform calc(var(--eds-anim-move-medium) * 1s) ease-out;
+
+  @media (prefers-reduced-motion) {
+    transition: none;
+  }
+}
+
+.combobox-input__icon--reversed {
+  transform: rotate(180deg);
+}
+
+.combobox__footer {
+  display: flex;
+  justify-content: space-between;
+}
+
+.combobox--has-fieldNote {
+  margin-bottom: calc(var(--eds-spacing-size-half) * 1px);
+}
+
+/**
+ * Label on top of the combobox field to label it.
+ */
+.combobox__label {
+  color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+}
+
+.combobox__subLabel {
+  color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
+  flex: 1 0 100%;
+}
+
+.combobox__label--disabled {
+  color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+}
+
+.combobox__option {
+  color: light-dark(var(--eds-theme-color-text-utility-interactive-secondary), var(--eds-dark-theme-color-text-utility-interactive-secondary));
+}
+
+.combobox__option-text {
+  color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+}
+
+.combobox__required-text {
+  color: light-dark(var(--eds-theme-color-text-utility-default-secondary), var(--eds-dark-theme-color-text-utility-default-secondary));
+}
+
+.combobox__required-text--disabled {
+  color: light-dark(var(--eds-theme-color-text-utility-disabled-primary), var(--eds-dark-theme-color-text-utility-disabled-primary));
+}
+
+.combobox-input--error {
+  border-color: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+
+  &:hover:not(:has(.combobox-input__field:disabled)) {
+    border-color: light-dark(var(--eds-theme-color-border-utility-critical-hover), var(--eds-dark-theme-color-border-utility-critical-hover));
+  }
+
+  &:focus-within {
+    border-color: light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+    outline: 1px solid light-dark(var(--eds-theme-color-border-utility-critical), var(--eds-dark-theme-color-border-utility-critical));
+  }
+}
+
+.combobox-input--warning {
+  border-color: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
+
+  &:hover:not(:has(.combobox-input__field:disabled)) {
+    border-color: light-dark(var(--eds-theme-color-border-utility-warning-hover), var(--eds-dark-theme-color-border-utility-warning-hover));
+  }
+
+  &:focus-within {
+    border-color: light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
+    outline: 1px solid light-dark(var(--eds-theme-color-border-utility-warning), var(--eds-dark-theme-color-border-utility-warning));
+  }
+}

--- a/src/components/Combobox/Combobox.module.css
+++ b/src/components/Combobox/Combobox.module.css
@@ -31,7 +31,7 @@
  */
 .combobox__options {
   max-height: 25vh;
-  width: calc(var(--input-width) + var(--button-width) + 32px);
+  min-width: calc(var(--input-width) + var(--button-width) + 32px);
   z-index: var(--eds-z-index-top);
 }
 

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -1,0 +1,900 @@
+import type { StoryObj, Meta } from '@storybook/react-webpack5';
+// Importing this here, since using @storybook/test below leads to superfluous act() warnings
+import { userEvent, within } from '@storybook/testing-library';
+import React, { useState } from 'react';
+import { expect } from 'storybook/test';
+import { Combobox } from './Combobox';
+
+const meta: Meta<typeof Combobox> = {
+  title: 'Components/Combobox',
+  component: Combobox,
+  parameters: {
+    docs: {
+      subtitle:
+        'A text field paired with a list of options. Typing filters the list, and the user may select one or more of the matches.',
+    },
+    layout: 'centered',
+    // Using this motion preference for components where they trigger animations on mount
+    chromatic: { delay: 500, prefersReducedMotion: 'reduce' },
+  },
+  argTypes: {
+    multiple: {
+      description: 'Whether multiple values are allowed in this instance',
+    },
+    value: {
+      table: {
+        description: 'The value of the combobox field (when controlled)',
+      },
+    },
+    defaultValue: {
+      description:
+        'The default value of the combobox field (when uncontrolled)',
+    },
+    immediate: {
+      description:
+        'Whether the option list opens as soon as the field receives focus, instead of waiting for a keystroke',
+    },
+    __demoMode: {
+      table: {
+        disable: true,
+      },
+    },
+    children: {
+      control: false,
+    },
+    onChange: {
+      description:
+        'Optional change handler. Fires when a value is selected (and passes in the selected value, or list of values when `multiple`)',
+    },
+    onClose: {
+      description:
+        'Optional handler that fires when the option list closes, useful for resetting the query',
+    },
+  },
+  tags: ['autodocs', 'beta', 'version:1.0.0'],
+};
+
+export default meta;
+
+type ComboboxOption = {
+  key: string;
+  label: string;
+  subLabel?: string;
+};
+
+const exampleOptions: ComboboxOption[] = [
+  {
+    key: '1',
+    label: 'Dogs',
+    subLabel: "Who's a good boy?",
+  },
+  {
+    key: '2',
+    label: 'Cats',
+    subLabel: 'Super independent.',
+  },
+  {
+    key: '3',
+    label: 'Birds',
+    subLabel: 'Living relics!',
+  },
+  {
+    key: '4',
+    label: 'Rabbits',
+    subLabel: 'Langomorphs are rad.',
+  },
+];
+
+const longOptionList: ComboboxOption[] = Array(30)
+  .fill('test')
+  .map((option, index) => ({
+    key: `${option}-${index}`,
+    label: `${option}${index}`,
+  }));
+
+type DemoProps = React.ComponentProps<typeof Combobox> & {
+  'data-testid'?: string;
+  options?: ComboboxOption[];
+  /**
+   * Passed through to `Combobox.Input`, so stories can show truncation and placeholders.
+   */
+  inputProps?: Partial<React.ComponentProps<typeof Combobox.Input>>;
+  /**
+   * Alignment override for the option list, matching `Combobox.Options`
+   */
+  optionsAnchor?: React.ComponentProps<typeof Combobox.Options>['anchor'];
+  /**
+   * Whether to render the options with their `subLabel`
+   */
+  showSubLabels?: boolean;
+};
+
+/**
+ * `Combobox` does not filter for you: only the consumer knows how the option data is shaped.
+ * This demo wrapper holds the query in state and filters a local list, which is the pattern we
+ * expect most consumers to use.
+ */
+const ComboboxDemo = ({
+  options = exampleOptions,
+  inputProps,
+  optionsAnchor,
+  showSubLabels,
+  ...other
+}: DemoProps) => {
+  const [query, setQuery] = useState('');
+
+  const filteredOptions = query
+    ? options.filter((option) =>
+        option.label.toLowerCase().includes(query.toLowerCase()),
+      )
+    : options;
+
+  return (
+    <Combobox onClose={() => setQuery('')} {...other}>
+      <Combobox.Input
+        data-testid="input-button"
+        displayValue={(option) => (option as ComboboxOption)?.label ?? ''}
+        onChange={(event) => setQuery(event.target.value)}
+        {...inputProps}
+      />
+      <Combobox.Options anchor={optionsAnchor} className="w-60">
+        {filteredOptions.length === 0 ? (
+          <Combobox.Option disabled value="">
+            No matches
+          </Combobox.Option>
+        ) : (
+          filteredOptions.map((option) => (
+            <Combobox.Option
+              key={option.key}
+              subLabel={showSubLabels ? option.subLabel : undefined}
+              value={option}
+            >
+              {option.label}
+            </Combobox.Option>
+          ))
+        )}
+      </Combobox.Options>
+    </Combobox>
+  );
+};
+
+/**
+ * Play function to open the option list using the field's toggle button
+ */
+const openMenu: StoryObj['play'] = async (playOptions) => {
+  const { canvasElement } = playOptions;
+  const canvas = within(canvasElement);
+
+  const toggleButton = await canvas.findByTestId('input-button');
+  await userEvent.click(toggleButton);
+  await userEvent.keyboard('{ArrowDown}');
+};
+
+/**
+ * Play function that types into the field to narrow the option list. The field already shows the
+ * current selection, so the query replaces it rather than appending to it.
+ */
+const typeQuery = (query: string): StoryObj['play'] => {
+  return async (playOptions) => {
+    const { canvasElement } = playOptions;
+    const canvas = within(canvasElement);
+
+    const input = await canvas.findByRole('combobox');
+    await userEvent.clear(input);
+    await userEvent.type(input, query);
+  };
+};
+
+/**
+ * Play function to use with interactive stories
+ */
+const selectCat: StoryObj['play'] = async (playOptions) => {
+  const { canvasElement } = playOptions;
+  const canvas = within(canvasElement);
+  const toggleButton = await canvas.findByTestId('input-button');
+
+  await openMenu(playOptions);
+
+  // Target the body of the iframe since it is portal'd
+  const popoverCanvas = within(document.body);
+
+  const bestOption = await popoverCanvas.findByText('Cats');
+  await userEvent.click(bestOption);
+
+  // Reopen the option list; selecting an option closed it.
+  await userEvent.click(toggleButton);
+};
+
+/**
+ * The simplest and default case. The field shows the current selection via `displayValue`, and
+ * every keystroke fires `onChange` on `Combobox.Input` so the consumer can filter the options.
+ *
+ * **NOTE**: for combobox value data types, `{label: string}` is required, but any other key/value pairs are allowed.
+ *
+ * For detailed code examples, refer to the [stories code in GitHub](https://github.com/chanzuckerberg/edu-design-system/blob/main/src/components/Combobox/Combobox.stories.tsx).
+ */
+export const Default: StoryObj<DemoProps> = {
+  render: (args) => <ComboboxDemo {...args} />,
+  args: {
+    label: 'Favorite Animal',
+    'data-testid': 'combobox',
+    defaultValue: exampleOptions[0],
+    name: 'combobox',
+    className: 'w-60',
+  },
+};
+
+export const HorizontalLabel: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    labelLayout: 'horizontal',
+    label: 'Animal?',
+  },
+};
+
+/**
+ * Typing in the field narrows the option list. This story types "Ca" to leave only one match.
+ */
+export const FilteredByQuery: StoryObj<DemoProps> = {
+  ...Default,
+  play: typeQuery('Ca'),
+  parameters: {
+    ...Default.parameters,
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * Because filtering is the consumer's job, so is the empty state. Always render something when
+ * nothing matches, so the field doesn't look broken. Here a disabled option says "No matches".
+ */
+export const NoMatches: StoryObj<DemoProps> = {
+  ...Default,
+  play: async (playOptions) => {
+    await typeQuery('zzz')?.(playOptions);
+
+    const popoverCanvas = within(document.body);
+    await expect(await popoverCanvas.findByText('No matches')).toBeVisible();
+  },
+  parameters: {
+    ...Default.parameters,
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * You can select a different option to show when rendered.
+ */
+export const WithSelectedOption: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    defaultValue: exampleOptions[1],
+  },
+};
+
+/**
+ * Use the `by` option to determine the selection (when using objects for the value list). This helps when you want to compare by value, not reference.
+ * - The type comparison can be by a named key in the object `by={'key'}` or using a comparison function
+ *
+ * See: https://headlessui.com/react/combobox#binding-objects-as-values
+ */
+export const WithSelectedBy: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...WithSelectedOption.args,
+    defaultValue: { ...exampleOptions[1] },
+    by: 'key',
+  },
+};
+
+/**
+ * You can add a `name` prop to generate form fields for the value object.
+ *
+ * In this example, the field name is `"interactive-combobox"`, and the value is an object storing `{label: string, key: string}`.
+ *
+ * This will generate hidden fields with names:
+ * * `interactive-combobox[label]`
+ * * `interactive-combobox[key]`
+ */
+export const WithFieldName: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    name: 'interactive-combobox',
+    subLabel: 'Additional descriptive text',
+  },
+  parameters: {
+    docs: {
+      source: {
+        code: `
+const [query, setQuery] = useState('');
+const filtered = options.filter((option) => option.label.includes(query));
+
+<Combobox label="Favorite Animal" name="interactive-combobox" onChange={...}>
+  <Combobox.Input
+    displayValue={(option) => option?.label ?? ''}
+    onChange={(event) => setQuery(event.target.value)}
+  />
+  <Combobox.Options>
+    {filtered.map((option) => (
+      <Combobox.Option key={option.key} value={option}>
+        {option.label}
+      </Combobox.Option>
+    ))}
+  </Combobox.Options>
+</Combobox>`,
+      },
+    },
+  },
+};
+
+export const WithFieldNote: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    fieldNote: 'Choose your beast',
+  },
+};
+
+/**
+ * This demonstrates how combobox items can also have an optional subLabel attached to give more details about the option.
+ */
+export const WithSubLabels: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    fieldNote: 'Choose your beast',
+    optionsClassName: 'w-[384px]',
+    showSubLabels: true,
+  },
+  parameters: {
+    ...Default.parameters,
+    snapshot: {
+      skip: true,
+    },
+  },
+  play: openMenu,
+};
+
+/**
+ * By default the option list waits for a keystroke before opening. Pass `immediate` to open the
+ * full list as soon as the field receives focus.
+ *
+ * See: https://headlessui.com/react/combobox#opening-the-combobox-immediately
+ */
+export const ImmediatelyOpen: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    immediate: true,
+  },
+  play: async (playOptions) => {
+    const canvas = within(playOptions.canvasElement);
+    const input = await canvas.findByRole('combobox');
+
+    await userEvent.click(input);
+    await expect(input.getAttribute('aria-expanded')).toEqual('true');
+  },
+  parameters: {
+    ...Default.parameters,
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * A placeholder tells the user the field is searchable before they've typed anything. Use it
+ * sparingly, and never as a replacement for the label.
+ */
+export const WithPlaceholder: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    defaultValue: undefined,
+    inputProps: {
+      placeholder: 'Search animals',
+    },
+  },
+};
+
+/**
+ * When `multiple` is set, the text field holds the query rather than the selection, so the
+ * values picked so far render ahead of it as `InputChip`s. Each chip's close button drops that
+ * value from the selection.
+ */
+const MultipleComboboxDemo = ({
+  options = exampleOptions,
+  inputProps,
+  ...other
+}: DemoProps) => {
+  const [query, setQuery] = useState('');
+
+  const filteredOptions = query
+    ? options.filter((option) =>
+        option.label.toLowerCase().includes(query.toLowerCase()),
+      )
+    : options;
+
+  return (
+    <Combobox onClose={() => setQuery('')} {...other}>
+      <Combobox.Input
+        onChange={(event) => setQuery(event.target.value)}
+        {...inputProps}
+        data-testid="input-button"
+      />
+      <Combobox.Options className="w-[240px]">
+        {filteredOptions.map((option) => (
+          <Combobox.Option key={option.key} value={option}>
+            {option.label}
+          </Combobox.Option>
+        ))}
+      </Combobox.Options>
+    </Combobox>
+  );
+};
+
+/**
+ * You can select multiple values by passing `multiple` to the parent element. When doing this,
+ * make sure all props that use the value (e.g., `value` and `defaultValue`) should use an array instead
+ * of an object or value for the individual `Combobox.Option` entries.
+ *
+ * Each selected value shows up in the field as a removable chip. Chip text comes from the value's
+ * `label` by default; pass `chipLabel` to `Combobox.Input` when your values are shaped differently.
+ * Chips come off via their close button or via backspace in an empty field (see
+ * `MultipleRemoveWithBackspace`).
+ *
+ * Hidden form inputs are generated for each option selected and take the following form:
+ * - `name[arrayIndex][key]`
+ * - `name[arrayIndex][value]`
+ */
+export const Multiple: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    label: 'Favorite Animal(s)',
+    multiple: true,
+    'data-testid': 'combobox',
+    defaultValue: [exampleOptions[0]],
+    className: 'w-[240px]',
+    name: 'multiple-combobox',
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+  play: openMenu,
+};
+
+/**
+ * Pressing backspace in an empty field removes the last chip, so a selection can be undone
+ * without reaching for the mouse. Backspace edits the query first; only once the field is empty
+ * does it start removing chips.
+ *
+ * **NOTE**: this behavior is ours, not HeadlessUI's. HeadlessUI does not bind backspace on the
+ * combobox input as of v2.2, so there is nothing to conflict with today, but a future HeadlessUI
+ * release could claim that key. We mark the event as handled to reduce the chance of both firing.
+ * If you see a chip and something else both react to one backspace, this is the first place to
+ * look. Pass your own `onKeyDown` to `Combobox.Input` and call `preventDefault()` to opt out.
+ *
+ * TODO-AH: remove typed text after selecting a value
+ */
+export const MultipleRemoveWithBackspace: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    ...Multiple.args,
+    defaultValue: [exampleOptions[0], exampleOptions[1]],
+    className: 'w-[320px]',
+  },
+  play: async (playOptions) => {
+    const canvas = within(playOptions.canvasElement);
+
+    const input = await canvas.findByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.keyboard('{Backspace}');
+
+    // The last chip is gone; the first one stays put
+    await expect(canvas.queryByText('Cats')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Dogs')).toBeVisible();
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * The field wraps onto more than one line as chips accumulate, so a long selection stays fully
+ * visible instead of scrolling out of view.
+ */
+export const MultipleWithManySelected: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    ...Multiple.args,
+    defaultValue: exampleOptions,
+    className: 'w-[240px]',
+  },
+};
+
+/**
+ * Chips can carry a leading icon by way of `chipLeadingComponent` on `Combobox.Input`.
+ */
+export const MultipleWithChipIcons: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    ...Multiple.args,
+    defaultValue: [exampleOptions[0], exampleOptions[1]],
+    className: 'w-[320px]',
+    inputProps: {
+      chipLeadingComponent: () => 'person-encircled',
+    },
+  },
+};
+
+/**
+ * Set `showChips` to false on `Combobox.Input` when you'd rather surface the selection yourself,
+ * which is the behavior a plain HeadlessUI combobox gives you.
+ */
+export const MultipleWithoutChips: StoryObj<DemoProps> = {
+  render: (args) => <MultipleWithoutChipsDemo {...args} />,
+  args: {
+    ...Multiple.args,
+    className: 'w-[240px]',
+  },
+};
+
+const MultipleWithoutChipsDemo = ({
+  options = exampleOptions,
+  ...other
+}: DemoProps) => {
+  const [selected, setSelected] = useState<ComboboxOption[]>(
+    (other.defaultValue as unknown as ComboboxOption[]) ?? [],
+  );
+
+  return (
+    <MultipleComboboxDemo
+      {...other}
+      fieldNote={`${selected.length > 0 ? selected.length : 'none'} selected`}
+      inputProps={{ showChips: false }}
+      onChange={(value) => setSelected(value as ComboboxOption[])}
+      options={options}
+    />
+  );
+};
+
+/**
+ * Passing a function as `children` gives you HeadlessUI's render prop, exposing `open`, `value`,
+ * and `disabled`. Use it when you need to react to the field's state outside of the field
+ * itself. `Combobox.InputWrapper` keeps the EDS field appearance when you render your own
+ * `Combobox.Input`.
+ */
+const RenderPropComboboxDemo = ({
+  options = exampleOptions,
+  ...other
+}: DemoProps) => {
+  const [query, setQuery] = useState('');
+
+  const filteredOptions = query
+    ? options.filter((option) =>
+        option.label.toLowerCase().includes(query.toLowerCase()),
+      )
+    : options;
+
+  return (
+    <Combobox onClose={() => setQuery('')} {...other}>
+      {({ open, value }) => (
+        <>
+          <Combobox.Label>Favorite Animal</Combobox.Label>
+          <Combobox.Input
+            displayValue={(option) => (option as ComboboxOption)?.label ?? ''}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <Combobox.Options>
+            {filteredOptions.map((option) => (
+              <Combobox.Option key={option.key} value={option}>
+                {option.label}
+              </Combobox.Option>
+            ))}
+          </Combobox.Options>
+          <p className="mt-spacing-size-1">
+            {open ? 'Picking' : 'Picked'}: {(value as ComboboxOption)?.label}
+          </p>
+        </>
+      )}
+    </Combobox>
+  );
+};
+
+export const WithRenderProp: StoryObj<DemoProps> = {
+  render: (args) => <RenderPropComboboxDemo {...args} />,
+  args: {
+    'data-testid': 'combobox',
+    defaultValue: exampleOptions[0],
+    name: 'render-prop-combobox',
+    className: 'w-60',
+  },
+};
+
+const longLabelOption: ComboboxOption = {
+  key: 'long',
+  label: 'A very long option label that will not fit',
+};
+
+/**
+ * The component provides some basic styles to handle long text in the provided field. Use
+ * `shouldTruncate` on `.Input` to truncate the text with an ellipsis.
+ */
+export const WithTruncation: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    className: 'w-[160px]',
+    defaultValue: longLabelOption,
+    options: [longLabelOption, ...exampleOptions],
+    inputProps: {
+      shouldTruncate: true,
+    },
+  },
+};
+
+/**
+ * The field trigger width can be set with utility classes. By default, the option list will expand to match the width.
+ */
+export const AdjustedWidth: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    className: 'w-[240px]',
+  },
+};
+
+/**
+ * We lock the maximum height of the option list to 1/4 of the available screen height. Scrolling is allowed in the list, and
+ * keyboard navigation (showing the items off the edge of the screen) is handled when used.
+ */
+export const LongOptionList: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    className: 'w-[240px]',
+    defaultValue: longOptionList[3],
+    options: longOptionList,
+  },
+  play: async (playOptions) => {
+    const canvas = within(playOptions.canvasElement);
+    const input = await canvas.findByRole('combobox');
+
+    await openMenu(playOptions);
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}');
+
+    await expect(input.getAttribute('aria-expanded')).toEqual('true');
+  },
+  parameters: {
+    layout: 'centered',
+    chromatic: { delay: 450 },
+    snapshot: {
+      skip: true,
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="p-spacing-size-4 pb-spacing-size-8">{Story()}</div>
+    ),
+  ],
+};
+
+/**
+ * If you want a different width for the field and the option list, you can control them separately.
+ */
+export const SeparateFieldAndMenuWidth: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    className: 'w-[160px]',
+    optionsClassName: 'w-[384px]',
+  },
+  play: async (playOptions) => {
+    const canvas = within(playOptions.canvasElement);
+    const input = await canvas.findByRole('combobox');
+
+    await openMenu(playOptions);
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}');
+
+    await expect(input.getAttribute('aria-expanded')).toEqual('true');
+  },
+  parameters: {
+    chromatic: {
+      diffIncludeAntiAliasing: false,
+      diffThreshold: 0.75,
+    },
+    docs: {
+      ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
+    },
+  },
+  decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
+};
+
+/**
+ * Each Combobox can be marked as disabled. This will update the visual treatment to indicate the field cannot be changed (but by default
+ * will show the selected value).
+ */
+export const Disabled: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    subLabel: 'Some descriptive text',
+    disabled: true,
+  },
+  parameters: {
+    a11y: {
+      config: {
+        rules: [
+          // Disabled input does not need to meet color contrast
+          {
+            id: 'color-contrast',
+            enabled: false,
+          },
+        ],
+      },
+    },
+    docs: {
+      ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * Combobox fields can be marked as required by using the `required` prop.
+ */
+export const Required: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    required: true,
+    showHint: true,
+    className: 'w-[384px]',
+    subLabel: 'Some descriptive text',
+  },
+};
+
+/**
+ * Fields can be marked as optional by using `required` as false, but `showHint` as true.
+ */
+export const Optional: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    required: false,
+    showHint: true,
+    subLabel: 'Some descriptive text',
+    className: 'w-[384px]',
+  },
+};
+
+/**
+ * You can supply an error field note by specifying the status of "critical".
+ */
+export const Error: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Required.args,
+    status: 'critical',
+    fieldNote: 'Some text describing error',
+  },
+};
+
+/**
+ * You can supply a warning field note by specifying the status of "warning".
+ */
+export const Warning: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Optional.args,
+    status: 'warning',
+    fieldNote: 'Some text describing warning',
+  },
+};
+
+/**
+ * Having a visible label is not necessary. In those cases, use `aria-label` to set an accessible label for the field
+ */
+export const NoVisibleLabel: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    label: undefined,
+    'aria-label': 'hidden label',
+  },
+};
+
+/**
+ * No visible label is required. In such cases, you must use an equivalent label for accessibility, like `aria-label`.
+ */
+export const NoVisibleLabelButRequired: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    label: undefined,
+    'aria-label': 'hidden label',
+    required: true,
+    className: 'w-[384px]',
+  },
+};
+
+/**
+ * `Combobox` can be both disabled and required.
+ */
+export const DisabledRequired: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    disabled: true,
+    required: true,
+    showHint: true,
+    className: 'w-[384px]',
+  },
+  parameters: {
+    docs: {
+      ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * Options for each `Combobox` can be aligned on different sides of the field.
+ *
+ * More information: https://headlessui.com/react/combobox#positioning-the-options
+ */
+export const OptionsRightAligned: StoryObj<DemoProps> = {
+  ...Default,
+  args: {
+    ...Default.args,
+    optionsClassName: 'w-[384px]',
+    optionsAnchor: { to: 'top end', gap: 20, offset: 44 },
+  },
+  play: openMenu,
+  decorators: [
+    (Story) => (
+      <div className="p-spacing-size-4 pb-spacing-size-8">{Story()}</div>
+    ),
+  ],
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
+ * This shows the contents of `Combobox` upon render. Mostly to demonstrate it is possible, to capture a snapshot of the appearance.
+ */
+export const OpenByDefault: StoryObj<DemoProps> = {
+  ...Default,
+  parameters: {
+    layout: 'centered',
+    chromatic: { delay: 300, disableSnapshot: true },
+    docs: {
+      ...Default.parameters?.docs,
+    },
+    snapshot: {
+      skip: true,
+    },
+  },
+  play: selectCat,
+};

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -224,6 +224,22 @@ export const Default: StoryObj<DemoProps> = {
   },
 };
 
+/**
+ * Use the `immediate` prop to make it so that the options are shown to the user once the cursor
+ * enters the input.
+ */
+export const Immediate: StoryObj<DemoProps> = {
+  render: (args) => <ComboboxDemo {...args} />,
+  args: {
+    label: 'Favorite Animal',
+    'data-testid': 'combobox',
+    defaultValue: exampleOptions[0],
+    name: 'combobox',
+    className: 'w-60',
+    immediate: true,
+  },
+};
+
 export const HorizontalLabel: StoryObj<DemoProps> = {
   ...Default,
   args: {

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -861,7 +861,7 @@ export const DisabledRequired: StoryObj<DemoProps> = {
  *
  * More information: https://headlessui.com/react/combobox#positioning-the-options
  */
-export const OptionsRightAligned: StoryObj<DemoProps> = {
+export const OptionsEndAligned: StoryObj<DemoProps> = {
   ...Default,
   args: {
     ...Default.args,

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -447,7 +447,8 @@ const MultipleComboboxDemo = ({
  * Each selected value shows up in the field as a removable chip. Chip text comes from the value's
  * `label` by default; pass `chipLabel` to `Combobox.Input` when your values are shaped differently.
  * Chips come off via their close button or via backspace in an empty field (see
- * `MultipleRemoveWithBackspace`).
+ * `MultipleRemoveWithBackspace`). Picking an option selects the query that found it, so the next
+ * keystroke starts a new search (see `MultipleSelectsQueryOnAdd`).
  *
  * Hidden form inputs are generated for each option selected and take the following form:
  * - `name[arrayIndex][key]`
@@ -472,6 +473,39 @@ export const Multiple: StoryObj<DemoProps> = {
 };
 
 /**
+ * The query that found an option stays in the field once that option is picked, so we select it.
+ * Typing again starts a new search in place of the one already spent, and a single backspace
+ * clears it. Anyone who'd rather keep building on the query can press the right arrow first.
+ */
+export const MultipleSelectsQueryOnAdd: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    ...Multiple.args,
+    defaultValue: [],
+    className: 'w-[320px]',
+  },
+  play: async (playOptions) => {
+    const canvas = within(playOptions.canvasElement);
+    // The option list is portaled out of the story canvas, so look for options in the document
+    const body = within(playOptions.canvasElement.ownerDocument.body);
+
+    const input: HTMLInputElement = await canvas.findByRole('combobox');
+    await userEvent.type(input, 'Cats');
+    await userEvent.click(await body.findByRole('option', { name: /Cats/ }));
+
+    // The query is still in the field, but selected, so the next keystroke takes its place
+    await expect(input).toHaveValue('Cats');
+    await expect(input.selectionStart).toBe(0);
+    await expect(input.selectionEnd).toBe('Cats'.length);
+  },
+  parameters: {
+    snapshot: {
+      skip: true,
+    },
+  },
+};
+
+/**
  * Pressing backspace in an empty field removes the last chip, so a selection can be undone
  * without reaching for the mouse. Backspace edits the query first; only once the field is empty
  * does it start removing chips.
@@ -481,8 +515,6 @@ export const Multiple: StoryObj<DemoProps> = {
  * release could claim that key. We mark the event as handled to reduce the chance of both firing.
  * If you see a chip and something else both react to one backspace, this is the first place to
  * look. Pass your own `onKeyDown` to `Combobox.Input` and call `preventDefault()` to opt out.
- *
- * TODO-AH: remove typed text after selecting a value
  */
 export const MultipleRemoveWithBackspace: StoryObj<DemoProps> = {
   render: (args) => <MultipleComboboxDemo {...args} />,

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -350,7 +350,6 @@ export const WithSubLabels: StoryObj<DemoProps> = {
   args: {
     ...Default.args,
     fieldNote: 'Choose your beast',
-    optionsClassName: 'w-[384px]',
     showSubLabels: true,
   },
   parameters: {
@@ -540,13 +539,14 @@ export const MultipleWithChipIcons: StoryObj<DemoProps> = {
 
 /**
  * Set `showChips` to false on `Combobox.Input` when you'd rather surface the selection yourself,
- * which is the behavior a plain HeadlessUI combobox gives you.
+ * which is the behavior a plain HeadlessUI combobox gives you. This can be used to display a summary
+ * or other text instead of selectable chips.
  */
 export const MultipleWithoutChips: StoryObj<DemoProps> = {
   render: (args) => <MultipleWithoutChipsDemo {...args} />,
   args: {
     ...Multiple.args,
-    className: 'w-[240px]',
+    className: 'w-[384px]',
   },
 };
 
@@ -561,8 +561,16 @@ const MultipleWithoutChipsDemo = ({
   return (
     <MultipleComboboxDemo
       {...other}
-      fieldNote={`${selected.length > 0 ? selected.length : 'none'} selected`}
-      inputProps={{ showChips: false }}
+      fieldNote={
+        'Selected: ' +
+        (selected.length < 1
+          ? 'None'
+          : selected.map((selection) => selection.label).join(', '))
+      }
+      inputProps={{
+        showChips: false,
+        placeholder: `${selected.length > 0 ? selected.length : 'none'} selected`,
+      }}
       onChange={(value) => setSelected(value as ComboboxOption[])}
       options={options}
     />
@@ -865,8 +873,7 @@ export const OptionsEndAligned: StoryObj<DemoProps> = {
   ...Default,
   args: {
     ...Default.args,
-    optionsClassName: 'w-[384px]',
-    optionsAnchor: { to: 'top end', gap: 20, offset: 44 },
+    optionsAnchor: { to: 'bottom end', gap: 20, offset: 44 },
   },
   play: openMenu,
   decorators: [

--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -1,0 +1,518 @@
+import { generateSnapshots } from '@chanzuckerberg/story-utils';
+import { composeStory } from '@storybook/react-webpack5';
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockResizeObserver } from 'jsdom-testing-mocks';
+import React, { useState } from 'react';
+import { Combobox } from './Combobox';
+import * as stories from './Combobox.stories';
+import type { StoryFile } from '../../../.storybook/utility-types';
+
+mockResizeObserver();
+
+// These stories assert on their own interactions in `play`, so they'd fight the shared
+// snapshot setup below.
+const { FilteredByQuery, ImmediatelyOpen, NoMatches, ...closedStories } =
+  stories;
+
+const DisabledComponent = composeStory(closedStories.Disabled, stories.default);
+
+const exampleOptions = [
+  {
+    key: '1',
+    label: 'Option 1',
+  },
+  {
+    key: '2',
+    label: 'Option 2',
+  },
+  {
+    key: '3',
+    label: 'Option 3',
+  },
+];
+
+/**
+ * Minimal consumer-shaped Combobox: filtering lives outside the component, so tests need a
+ * wrapper that owns the query the same way a real consumer would.
+ */
+const TestCombobox = ({
+  inputProps,
+  onChange,
+  ...other
+}: Partial<React.ComponentProps<typeof Combobox>> & {
+  inputProps?: Partial<React.ComponentProps<typeof Combobox.Input>>;
+}) => {
+  const [query, setQuery] = useState('');
+
+  const filteredOptions = query
+    ? exampleOptions.filter((option) =>
+        option.label.toLowerCase().includes(query.toLowerCase()),
+      )
+    : exampleOptions;
+
+  return (
+    <Combobox
+      aria-label="test"
+      data-testid="combobox"
+      name="test-combobox"
+      onChange={onChange}
+      {...other}
+    >
+      <Combobox.Input
+        displayValue={(option) =>
+          (option as (typeof exampleOptions)[number])?.label ?? ''
+        }
+        onChange={(event) => setQuery(event.target.value)}
+        {...inputProps}
+      />
+      <Combobox.Options>
+        {filteredOptions.map((option) => (
+          <Combobox.Option key={option.key} value={option}>
+            {option.label}
+          </Combobox.Option>
+        ))}
+      </Combobox.Options>
+    </Combobox>
+  );
+};
+
+/**
+ * Multi-select needs the consumer to own the value, the same way it would in a real form.
+ */
+const TestMultipleCombobox = ({
+  onChange,
+  ...other
+}: Partial<React.ComponentProps<typeof Combobox>> & {
+  inputProps?: Partial<React.ComponentProps<typeof Combobox.Input>>;
+}) => {
+  const [selected, setSelected] = useState(
+    (other.defaultValue as unknown as typeof exampleOptions) ?? [],
+  );
+
+  return (
+    <TestCombobox
+      {...other}
+      multiple
+      onChange={(value) => {
+        setSelected(value as unknown as typeof exampleOptions);
+        onChange?.(value);
+      }}
+      value={selected}
+    />
+  );
+};
+
+describe('<Combobox />', () => {
+  describe('Generated Snapshots', () => {
+    generateSnapshots(closedStories as StoryFile, {
+      getElement: async () => {
+        const user = userEvent.setup();
+        // The toggle is always last in the field. Its accessible name varies (HeadlessUI names
+        // it from the field's label when there is one), and chips put their own remove buttons
+        // ahead of it, so neither name nor first-match is a reliable way to find it.
+        const buttons = await screen.findAllByRole('button');
+        const openButton = buttons[buttons.length - 1];
+        await user.click(openButton);
+        await screen.findAllByRole('option');
+        return screen.getByTestId('combobox');
+      },
+    });
+  });
+
+  it('does not open a list when clicked and disabled', async () => {
+    const user = userEvent.setup();
+    render(<DisabledComponent />);
+
+    const openTrigger = await screen.findByRole('button');
+
+    await user.click(openTrigger);
+
+    // see if there are any options, which there should not be
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+
+  it('does not throw an error if combobox uses <Combobox.Label>', () => {
+    const comboboxWithComboboxLabel = (
+      <Combobox name="non-throwing-combobox" onChange={() => undefined}>
+        <Combobox.Label>Options:</Combobox.Label>
+        <Combobox.Input />
+
+        <Combobox.Options>
+          {exampleOptions.map((option) => (
+            <Combobox.Option key={option.key} value={option}>
+              {option.label}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+      </Combobox>
+    );
+    const renderMethod = () => {
+      render(comboboxWithComboboxLabel);
+    };
+
+    expect(renderMethod).not.toThrow(Error);
+  });
+
+  it('applies the accessible name from the root aria-label to the text field', () => {
+    render(<TestCombobox value={exampleOptions[0]} />);
+
+    expect(screen.getByRole('combobox')).toHaveAccessibleName('test');
+  });
+
+  it('narrows the option list as the user types', async () => {
+    const user = userEvent.setup();
+    render(<TestCombobox value={exampleOptions[0]} />);
+
+    const input = await screen.findByRole('combobox');
+
+    // The field already shows the selection, so clear it before typing a new query
+    await user.clear(input);
+    await user.type(input, 'Option 2');
+
+    const options = await screen.findAllByRole('option');
+    expect(options).toHaveLength(1);
+    expect(options[0]).toHaveTextContent('Option 2');
+  });
+
+  it('shows the current selection in the field via displayValue', async () => {
+    render(<TestCombobox value={exampleOptions[1]} />);
+
+    expect(await screen.findByRole('combobox')).toHaveValue('Option 2');
+  });
+
+  it('names the option list toggle when there is no visible label', () => {
+    render(<TestCombobox value={exampleOptions[0]} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName('Show options');
+  });
+
+  it('names the option list toggle from the visible label when there is one', () => {
+    render(<TestCombobox label="Pick one" value={exampleOptions[0]} />);
+
+    expect(screen.getByRole('button')).toHaveAccessibleName(/Pick one/);
+  });
+
+  it('generates a hidden field when used with a name', () => {
+    const { container } = render(<TestCombobox value={exampleOptions[0]} />);
+
+    // eslint-disable-next-line testing-library/no-container
+    expect(container.querySelector('input[type="hidden"]')).toBeInTheDocument();
+  });
+
+  describe('multiple', () => {
+    it('shows a chip for each selected value', () => {
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0], exampleOptions[2]]}
+        />,
+      );
+
+      expect(screen.getAllByRole('listitem')).toHaveLength(2);
+      expect(screen.getByText('Option 1')).toBeInTheDocument();
+      expect(screen.getByText('Option 3')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'remove Option 3' }),
+      ).toBeInTheDocument();
+    });
+
+    it('removes a value when its chip is dismissed', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0], exampleOptions[2]]}
+          onChange={changeHandler}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'remove Option 1' }));
+
+      expect(changeHandler).toHaveBeenCalledWith([exampleOptions[2]]);
+      expect(screen.getAllByRole('listitem')).toHaveLength(1);
+      expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+    });
+
+    it('drops the value from the option list too when uncontrolled', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestCombobox
+          defaultValue={[exampleOptions[0], exampleOptions[2]]}
+          multiple
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'remove Option 1' }));
+
+      // Reopen the list; the removed value must no longer read as selected
+      const buttons = screen.getAllByRole('button');
+      await user.click(buttons[buttons.length - 1]);
+
+      const options = await screen.findAllByRole('option');
+      expect(options[0]).toHaveAttribute('aria-selected', 'false');
+      expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('does not open the option list when a chip is dismissed', async () => {
+      const user = userEvent.setup();
+
+      render(<TestMultipleCombobox defaultValue={[exampleOptions[0]]} />);
+
+      await user.click(screen.getByRole('button', { name: 'remove Option 1' }));
+
+      expect(screen.queryByRole('option')).not.toBeInTheDocument();
+    });
+
+    it('removes the last chip on backspace in an empty field', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0], exampleOptions[2]]}
+          onChange={changeHandler}
+        />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Backspace}');
+
+      expect(changeHandler).toHaveBeenCalledWith([exampleOptions[0]]);
+      // The remove buttons are chip-only, so they distinguish chips from list options
+      expect(
+        screen.queryByRole('button', { name: 'remove Option 3' }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'remove Option 1' }),
+      ).toBeInTheDocument();
+    });
+
+    it('edits the query before it starts removing chips on backspace', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0]]}
+          onChange={changeHandler}
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+      await user.keyboard('Op');
+
+      // First backspace trims the query, leaving the chip alone
+      await user.keyboard('{Backspace}');
+      expect(input).toHaveValue('O');
+      expect(changeHandler).not.toHaveBeenCalled();
+
+      // Second empties the field, third takes the chip
+      await user.keyboard('{Backspace}');
+      expect(input).toHaveValue('');
+      expect(changeHandler).not.toHaveBeenCalled();
+
+      await user.keyboard('{Backspace}');
+      expect(changeHandler).toHaveBeenCalledWith([]);
+      // Scoped to chips: the option list is open, so 'Option 1' is on screen as an option too
+      expect(screen.queryAllByRole('listitem')).toHaveLength(0);
+    });
+
+    it('does nothing on backspace once every chip is gone', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox defaultValue={[]} onChange={changeHandler} />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Backspace}');
+
+      expect(changeHandler).not.toHaveBeenCalled();
+    });
+
+    it('leaves backspace alone in single-select mode', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(<TestCombobox onChange={changeHandler} value={undefined} />);
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Backspace}');
+
+      expect(changeHandler).not.toHaveBeenCalled();
+    });
+
+    it('lets a consumer opt out of backspace removal with preventDefault', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0]]}
+          inputProps={{ onKeyDown: (event) => event.preventDefault() }}
+          onChange={changeHandler}
+        />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Backspace}');
+
+      expect(changeHandler).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: 'remove Option 1' }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not remove chips on backspace when showChips is off', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0]]}
+          inputProps={{ showChips: false }}
+          onChange={changeHandler}
+        />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      await user.keyboard('{Backspace}');
+
+      expect(changeHandler).not.toHaveBeenCalled();
+    });
+
+    it('renders no chips when showChips is off', () => {
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0]]}
+          inputProps={{ showChips: false }}
+        />,
+      );
+
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+    });
+
+    it('renders no chips in single-select mode', () => {
+      render(<TestCombobox value={exampleOptions[0]} />);
+
+      expect(screen.queryByRole('listitem')).not.toBeInTheDocument();
+    });
+
+    it('labels chips with chipLabel when provided', () => {
+      render(
+        <TestMultipleCombobox
+          defaultValue={[exampleOptions[0]]}
+          inputProps={{
+            chipLabel: (value) =>
+              `#${(value as (typeof exampleOptions)[number]).key}`,
+          }}
+        />,
+      );
+
+      expect(screen.getByText('#1')).toBeInTheDocument();
+    });
+
+    it('disables the chip remove buttons when the field is disabled', () => {
+      render(
+        <TestMultipleCombobox defaultValue={[exampleOptions[0]]} disabled />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: 'remove Option 1' }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('event handling', () => {
+    it('handles click on the option list toggle', async () => {
+      const user = userEvent.setup();
+      render(<TestCombobox value={exampleOptions[0]} />);
+
+      const openTrigger = await screen.findByRole('button');
+
+      await user.click(openTrigger);
+
+      expect(await screen.findAllByRole('option')).toHaveLength(
+        exampleOptions.length,
+      );
+    });
+
+    it('handles change on <Combobox/>', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestCombobox onChange={changeHandler} value={exampleOptions[0]} />,
+      );
+
+      const openTrigger = await screen.findByRole('button');
+
+      // It should only fire change once, after the value is actually modified
+      await user.click(openTrigger);
+      expect(changeHandler).toHaveBeenCalledTimes(0);
+
+      // pick the second item
+      await user.keyboard('{arrowdown}');
+      await user.keyboard('{enter}');
+
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles change when children are a render prop', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <Combobox
+          aria-label="test"
+          name="render-prop-combobox"
+          onChange={changeHandler}
+          value={exampleOptions[0]}
+        >
+          {() => (
+            <>
+              <Combobox.Input />
+              <Combobox.Options>
+                {exampleOptions.map((option) => (
+                  <Combobox.Option key={option.key} value={option}>
+                    {option.label}
+                  </Combobox.Option>
+                ))}
+              </Combobox.Options>
+            </>
+          )}
+        </Combobox>,
+      );
+
+      await user.click(screen.getByRole('button'));
+      await user.keyboard('{arrowdown}');
+      await user.keyboard('{enter}');
+
+      expect(changeHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call change when <Combobox/> is picking the same item', async () => {
+      const changeHandler = jest.fn();
+      const user = userEvent.setup();
+
+      render(
+        <TestCombobox onChange={changeHandler} value={exampleOptions[0]} />,
+      );
+
+      const openTrigger = await screen.findByRole('button');
+
+      // It should only fire change once, after the value is actually modified
+      await user.click(openTrigger);
+      expect(changeHandler).toHaveBeenCalledTimes(0);
+
+      // pick the same item
+      await user.keyboard('{enter}');
+
+      expect(changeHandler).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/src/components/Combobox/Combobox.test.tsx
+++ b/src/components/Combobox/Combobox.test.tsx
@@ -255,6 +255,47 @@ describe('<Combobox />', () => {
       expect(options[2]).toHaveAttribute('aria-selected', 'true');
     });
 
+    it('selects the query text once a chip is added', async () => {
+      const user = userEvent.setup();
+
+      render(<TestMultipleCombobox />);
+
+      const input: HTMLInputElement = await screen.findByRole('combobox');
+      await user.type(input, 'Option 2');
+      await user.click(await screen.findByRole('option', { name: /Option 2/ }));
+
+      expect(input).toHaveValue('Option 2');
+      expect(input.selectionStart).toBe(0);
+      expect(input.selectionEnd).toBe('Option 2'.length);
+    });
+
+    it('replaces the spent query when typing continues after a chip is added', async () => {
+      const user = userEvent.setup();
+
+      render(<TestMultipleCombobox />);
+
+      const input: HTMLInputElement = await screen.findByRole('combobox');
+      await user.type(input, 'Option 2');
+      await user.click(await screen.findByRole('option', { name: /Option 2/ }));
+      await user.keyboard('Option 3');
+
+      expect(input).toHaveValue('Option 3');
+      expect(screen.getAllByRole('listitem')).toHaveLength(1);
+    });
+
+    it('does not select the query text when showChips is off', async () => {
+      const user = userEvent.setup();
+
+      render(<TestMultipleCombobox inputProps={{ showChips: false }} />);
+
+      const input: HTMLInputElement = await screen.findByRole('combobox');
+      await user.type(input, 'Option 2');
+      await user.click(await screen.findByRole('option', { name: /Option 2/ }));
+
+      expect(input.selectionStart).toBe('Option 2'.length);
+      expect(input.selectionEnd).toBe('Option 2'.length);
+    });
+
     it('does not open the option list when a chip is dismissed', async () => {
       const user = userEvent.setup();
 

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 
 import React, {
   useContext,
+  useEffect,
   useRef,
   useState,
   type ChangeEventHandler,
@@ -228,7 +229,7 @@ type ComboboxInputProps = Omit<
   /**
    * Whether selected values appear as removable chips inside the field, when `multiple` is set.
    * Turn it off to surface the selection yourself. Also governs whether backspace on an empty
-   * field removes the last chip.
+   * field removes the last chip, and whether adding a chip selects the query text.
    *
    * **Default is `"true"`**.
    */
@@ -327,7 +328,8 @@ const ComboboxRoot = HeadlessCombobox as React.ComponentType<ComboboxProps>;
  * The field is always editable, so users can either type to narrow the list or open the full
  * list with the toggle button. In single-select mode, only one selection can be made. In
  * multi-select mode, one or more selections can be made from the list, and each one shows in
- * the field as a chip. A chip goes away either through its own close button or by pressing
+ * the field as a chip. Adding a chip selects the query text that found it, so the next keystroke
+ * begins a new search. A chip goes away either through its own close button or by pressing
  * backspace in an empty field.
  *
  * ## Content & Accessibility
@@ -666,6 +668,34 @@ const ComboboxInputComponent = function (props: ComboboxInputProps) {
 
   const inputRef = useRef<HTMLInputElement>(null);
   const hasChips = Boolean(showChips && multiple && selectedValues.length > 0);
+
+  /**
+   * Picking an option leaves the query that found it sitting in the field, since HeadlessUI only
+   * rewrites the text for a single-select value. Select that text once the chip appears, so the
+   * next keystroke starts a fresh search instead of appending to a query that's already been
+   * spent. The caret lands at the end for anyone who'd rather keep typing on it.
+   */
+  const chipCountRef = useRef(selectedValues.length);
+
+  useEffect(() => {
+    const previousChipCount = chipCountRef.current;
+    chipCountRef.current = selectedValues.length;
+
+    // Only on a chip being added. Removals (close button, backspace) leave the query alone.
+    if (!showChips || !multiple || selectedValues.length <= previousChipCount) {
+      return;
+    }
+
+    const input = inputRef.current;
+
+    // A selection can also change from outside the field. Reaching for the text then would pull
+    // the caret away from wherever the person actually is, so leave it be.
+    if (!input || input.ownerDocument.activeElement !== input) {
+      return;
+    }
+
+    input.select();
+  }, [multiple, selectedValues.length, showChips]);
 
   /**
    * Backspace on an empty field drops the last chip, which is what people expect from a field

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -727,7 +727,7 @@ const ComboboxInputComponent = function (props: ComboboxInputProps) {
         required={required}
         style={
           {
-            '--combobox__input-width': `calc(${inputRef.current?.value || 0} * 1ch)`,
+            '--combobox__input-width': `calc(${inputRef.current?.value.length || 0} * 1ch)`,
           } as CSSProperties
         }
         {...other}
@@ -777,7 +777,11 @@ const ComboboxOptionComponent = function (props: ComboboxOptionProps) {
     ...other
   } = props;
 
-  const optionItemClassName = clsx(optionClassName, styles['combobox__option']);
+  const optionItemClassName = clsx(
+    className,
+    optionClassName,
+    styles['combobox__option'],
+  );
   const { multiple } = useContext(ComboboxContext);
 
   return (

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 
 import React, {
   useContext,
+  useRef,
   useState,
   type ChangeEventHandler,
   type CSSProperties,
@@ -163,7 +164,7 @@ type ComboboxButtonProps = HeadlessComboboxButtonProps<'button'> & {
   'aria-label'?: string;
   // Design API
   /**
-   * Icon override for component. Default is 'chevron-down'
+   * Icon to use for combobox button, which is only allowed to be 'chevron-down'
    */
   icon?: Extract<IconName, 'chevron-down'>;
 };
@@ -217,7 +218,7 @@ type ComboboxInputProps = Omit<
    */
   chipLeadingComponent?: (item: ComboboxValue) => IconName | ReactNode;
   /**
-   * Icon override for the field's toggle button. Default is 'chevron-down'
+   * Icon to use for combobox button, which is only allowed to be 'chevron-down'
    */
   icon?: Extract<IconName, 'chevron-down'>;
   /**
@@ -251,7 +252,7 @@ type ComboboxInputWrapperProps = {
    */
   hasChips?: boolean;
   /**
-   * Icon override for the field's toggle button. Default is 'chevron-down'
+   * Icon to use for combobox button, which is only allowed to be 'chevron-down'
    */
   icon?: Extract<IconName, 'chevron-down'>;
   /**
@@ -663,6 +664,7 @@ const ComboboxInputComponent = function (props: ComboboxInputProps) {
     inputClassName,
   );
 
+  const inputRef = useRef<HTMLInputElement>(null);
   const hasChips = Boolean(showChips && multiple && selectedValues.length > 0);
 
   /**
@@ -721,10 +723,11 @@ const ComboboxInputComponent = function (props: ComboboxInputProps) {
         aria-label={ariaLabel ?? contextAriaLabel}
         className={fieldClassName}
         onKeyDown={handleKeyDown}
+        ref={inputRef}
         required={required}
         style={
           {
-            '--combobox__input-width': `calc(${other.displayValue?.length || 0} * 1ch)`,
+            '--combobox__input-width': `calc(${inputRef.current?.value || 0} * 1ch)`,
           } as CSSProperties
         }
         {...other}

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -1,0 +1,883 @@
+import {
+  Combobox as HeadlessCombobox,
+  type ComboboxProps as HeadlessComboboxProps,
+  ComboboxButton,
+  type ComboboxButtonProps as HeadlessComboboxButtonProps,
+  ComboboxInput,
+  type ComboboxInputProps as HeadlessComboboxInputProps,
+  ComboboxOption,
+  type ComboboxOptionProps as HeadlessComboboxOptionProps,
+  ComboboxOptions,
+  type ComboboxOptionsProps as HeadlessComboboxOptionsProps,
+  Label,
+} from '@headlessui/react';
+import clsx from 'clsx';
+
+import React, {
+  useContext,
+  useState,
+  type ChangeEventHandler,
+  type CSSProperties,
+  type ElementType,
+  type KeyboardEventHandler,
+  type ReactNode,
+} from 'react';
+
+import type { ExtractProps } from '../../util/utility-types';
+import type { Status } from '../../util/variant-types';
+
+import Checkbox from '../Checkbox';
+import FieldLabel from '../FieldLabel';
+import FieldNote from '../FieldNote';
+import Icon, { type IconName } from '../Icon';
+import InputChip from '../InputChip';
+import PopoverContainer from '../PopoverContainer';
+import PopoverListItem from '../PopoverListItem';
+import type { PopoverListItemProps } from '../PopoverListItem/PopoverListItem';
+import Radio from '../Radio';
+import Text from '../Text';
+
+import styles from './Combobox.module.css';
+
+type ComboboxValue = string | { [k: string]: unknown };
+
+/**
+ * The field holds one value normally, and a list of them when `multiple` is set.
+ */
+type ComboboxSelection = ComboboxValue | ComboboxValue[];
+
+export type ComboboxProps = Omit<
+  HeadlessComboboxProps<ComboboxValue, boolean | undefined, ElementType>,
+  // HeadlessUI derives these from a `multiple` type parameter, which we can't supply at the
+  // component boundary. We restate them in terms of `ComboboxSelection` instead, which keeps
+  // both single and multiple usage readable.
+  'by' | 'defaultValue' | 'onChange' | 'value'
+> & {
+  // Component API
+  /**
+   * Compare option values by a named key, or by a comparison function, instead of by reference.
+   * Useful when the selected value and the option come from different places.
+   *
+   * See: https://headlessui.com/react/combobox#binding-objects-as-values
+   */
+  by?: string | ((a: ComboboxValue, z: ComboboxValue) => boolean);
+  /**
+   * The default value of the combobox field (when uncontrolled)
+   */
+  defaultValue?: ComboboxSelection;
+  /**
+   * Fires when a value is selected. Passes the selected value, or the list of selected values
+   * when `multiple` is set.
+   */
+  onChange?: (value: ComboboxSelection | null) => void;
+  /**
+   * The value of the combobox field (when controlled)
+   */
+  value?: ComboboxSelection;
+  /**
+   * Screen-reader text for the combobox's label.
+   *
+   * When possible, use a visible label by passing a <Combobox.Label> into `children`.
+   * In rare cases where there's no visible label, you must provide an `aria-label` for screen readers.
+   */
+  'aria-label'?: string;
+  /**
+   * Optional className for additional styling.
+   */
+  className?: string;
+  /**
+   * Name of the form element, which triggers the generation of hidden key/value form fields (e.g. `name=$name[$key]`).
+   *
+   * See: https://headlessui.com/react/combobox#using-with-html-forms
+   */
+  name?: string;
+  /**
+   * Optional className for additional options menu styling.
+   *
+   * If optionsClassName is provided please include the width property to define
+   * the options menu width.
+   */
+  optionsClassName?: string;
+  /**
+   * Indicates that field is required for form to be successfully submitted
+   */
+  required?: boolean;
+  // Design API
+  /**
+   * Text under the field used to provide validation hints or error message to describe the input error.
+   */
+  fieldNote?: ReactNode;
+  /**
+   * Visible text label for the component.
+   */
+  label?: string;
+  /**
+   * Whether the label is adjacent to the field (horizontal) or above the field (vertical)
+   *
+   * **Default is `"vertical"`**.
+   */
+  labelLayout?: 'vertical' | 'horizontal';
+  /**
+   * Whether it should show the field hint or not
+   *
+   * **Default is `"false"`**.
+   */
+  showHint?: boolean;
+  /**
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
+   */
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
+  /**
+   * Add additional descriptive text for the field name
+   */
+  subLabel?: ReactNode;
+};
+
+type ComboboxLabelProps = ExtractProps<typeof Label> & {
+  disabled?: boolean;
+  required?: boolean;
+  showHint?: boolean;
+  /**
+   * Add additional descriptive text for the field name
+   */
+  subLabel?: ReactNode;
+};
+
+type ComboboxOptionsProps = HeadlessComboboxOptionsProps<'div'>;
+
+type ComboboxOptionProps = HeadlessComboboxOptionProps<'div', ComboboxValue> &
+  Pick<PopoverListItemProps, 'subLabel'> & {
+    optionClassName?: string;
+  };
+
+type ComboboxButtonProps = HeadlessComboboxButtonProps<'button'> & {
+  // Component API
+  /**
+   * Screen-reader text for the toggle, used when the field has no visible label. When there
+   * is one, HeadlessUI names the toggle from that label and this is ignored.
+   *
+   * **Default is `"Show options"`**.
+   */
+  'aria-label'?: string;
+  // Design API
+  /**
+   * Icon override for component. Default is 'chevron-down'
+   */
+  icon?: Extract<IconName, 'chevron-down'>;
+};
+
+type ComboboxInputProps = Omit<
+  HeadlessComboboxInputProps<'input', ComboboxValue>,
+  'displayValue' | 'onChange'
+> & {
+  // Component API
+  /**
+   * Screen-reader text for the field. Prefer a visible label on `<Combobox>` (or a
+   * `<Combobox.Label>`); this is the escape hatch when there's no visible label.
+   *
+   * Inherited from `<Combobox aria-label="...">` when not set here.
+   */
+  'aria-label'?: string;
+  /**
+   * Optional className for additional styling of the field wrapper.
+   */
+  className?: string;
+  /**
+   * Maps the currently selected value to the text shown in the text field. Receives `null`
+   * when nothing is selected.
+   *
+   * See: https://headlessui.com/react/combobox#binding-objects-as-values
+   */
+  displayValue?: (item: ComboboxValue | null) => string;
+  /**
+   * Optional className for additional styling of the inner `<input>` element.
+   */
+  inputClassName?: string;
+  /**
+   * Fires on every keystroke in the text field. Use it to filter the options passed
+   * to `Combobox.Options`.
+   */
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  /**
+   * Fires on key down in the text field. Runs before the component's own handling, so calling
+   * `preventDefault()` here opts out of backspace-to-remove.
+   */
+  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+  // Design API
+  /**
+   * Maps a selected value to the text shown on its chip, when `multiple` is set.
+   *
+   * **Defaults to the value's `label`**, or the value itself when it's a string.
+   */
+  chipLabel?: (item: ComboboxValue) => string;
+  /**
+   * Leading glyph (icon) or content for a selected value's chip, when `multiple` is set.
+   */
+  chipLeadingComponent?: (item: ComboboxValue) => IconName | ReactNode;
+  /**
+   * Icon override for the field's toggle button. Default is 'chevron-down'
+   */
+  icon?: Extract<IconName, 'chevron-down'>;
+  /**
+   * Whether we should truncate the text displayed in the combobox field
+   */
+  shouldTruncate?: boolean;
+  /**
+   * Whether selected values appear as removable chips inside the field, when `multiple` is set.
+   * Turn it off to surface the selection yourself. Also governs whether backspace on an empty
+   * field removes the last chip.
+   *
+   * **Default is `"true"`**.
+   */
+  showChips?: boolean;
+};
+
+type ComboboxInputWrapperProps = {
+  // Component API
+  /**
+   * The text field (and any other content) placed inside the field's border.
+   */
+  children?: ReactNode;
+  /**
+   * Optional className for additional styling.
+   */
+  className?: string;
+  // Design API
+  /**
+   * Whether the field is holding selection chips, which lets its contents wrap onto more
+   * than one line.
+   */
+  hasChips?: boolean;
+  /**
+   * Icon override for the field's toggle button. Default is 'chevron-down'
+   */
+  icon?: Extract<IconName, 'chevron-down'>;
+  /**
+   * Status for the field state
+   *
+   * **Default is `"default"`**.
+   */
+  status?: 'default' | Extract<Status, 'warning' | 'critical'>;
+};
+
+type ComboboxContextType = {
+  ariaLabel?: string;
+  disabled?: boolean;
+  optionsClassName?: string;
+  /**
+   * Drops one value from the selection. Backs the remove button on each chip.
+   */
+  removeValue?: (value: ComboboxValue) => void;
+  required?: boolean;
+  /**
+   * The current selection, always as a list. Empty unless `multiple` is set.
+   */
+  selectedValues?: ComboboxValue[];
+  status?: ComboboxProps['status'];
+  multiple?: boolean; // pulls from HeadlessUI
+};
+
+/**
+ * Maps a selected value to chip text. Combobox values are either strings or objects carrying a
+ * `label`, which matches what `Select` documents for its own option values.
+ */
+const defaultChipLabel = (value: ComboboxValue) =>
+  typeof value === 'string' ? value : String(value.label ?? '');
+
+let showNameWarning = true;
+
+const ComboboxContext = React.createContext<ComboboxContextType>({});
+
+/**
+ * HeadlessUI infers its value type from a `multiple` type parameter, which we can't supply from
+ * a plain props object. Our own `ComboboxProps` already describes the same shape, so we render
+ * through it directly. Behavior is unchanged; only the inference is pinned down.
+ */
+const ComboboxRoot = HeadlessCombobox as React.ComponentType<ComboboxProps>;
+
+/**
+ * ## Usage
+ *
+ * A text field paired with a list of options. Typing filters the list, so use it where a
+ * `Select` would be unwieldy. Supports controlled and uncontrolled behavior.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standard | Type to filter a list of options; one can be selected. | Country selector. Assignee picker. |
+ * | Multi-select | Type to filter, and select more than one option from the list. | Filter panels. Role or permission assignments. |
+ * | Disabled | Non-interactive; used to show unavailable or inactive states. | Feature-gated selections. Incomplete forms. |
+ * | Preselected | Default selection appears in the field before user interacts. | Recommended settings. "Most common" default. |
+ *
+ * Filtering is left to the consumer, since only the consumer knows how the option data is
+ * shaped and where it comes from. Use `onChange` on `Combobox.Input` to capture the query,
+ * then pass the filtered list to `Combobox.Options`.
+ *
+ * ### Best Practices
+ *
+ * * Use `Combobox` for long lists where typing is faster than scrolling. For 3-10 options, use `Select`.
+ * * Order the menu options logically to make it easier for users to find the option they want. Default to alphabetical order.
+ * * Keep the option list the same width as the field that triggered it.
+ * * Always render something when the filtered list is empty, so the field doesn't look broken.
+ *
+ * ## Interaction
+ *
+ * The field is always editable, so users can either type to narrow the list or open the full
+ * list with the toggle button. In single-select mode, only one selection can be made. In
+ * multi-select mode, one or more selections can be made from the list, and each one shows in
+ * the field as a chip. A chip goes away either through its own close button or by pressing
+ * backspace in an empty field.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use short, precise labels whenever possible.
+ * * Avoid truncated items.
+ * * In short lists, order from most common to least common choices.
+ * * In longer lists use alphabetical order, but if there are 2 or 3 very common selections, consider repeating them at the top of the list.
+ * * Use sentence case.
+ *
+ * ### Don'ts
+ *
+ * * Use periods at the end of labels.
+ * * Place placeholder text within the field; it can cause accessibility issues with color contrast, inconsistent screen-reader behavior, and text disappearing as users type.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.com/react/combobox
+ */
+export function Combobox({
+  'aria-label': ariaLabel,
+  by,
+  children,
+  className,
+  disabled,
+  fieldNote,
+  label,
+  labelLayout = 'vertical',
+  name,
+  optionsClassName,
+  required,
+  showHint,
+  status,
+  onChange: theirOnChange,
+  subLabel,
+  ...other
+}: ComboboxProps) {
+  // TODO: convert this to use assertEdsUsage? (issue as warning)
+  if (process.env.NODE_ENV !== 'production') {
+    if (!name && showNameWarning) {
+      console.warn(
+        "%c`Combobox` won't render a form field unless you include a `name` prop.\n\n See https://headlessui.com/react/combobox#using-with-html-forms for more information",
+        'font-weight: bold',
+      );
+      showNameWarning = false;
+    }
+  }
+
+  // Create a new value to track the internal state of Combobox. Added to work around
+  // behavior inherited from HeadlessUI where it will fire onChange even if there is no change
+  // Adding to support behavior synced to how <select> tags work
+  const [selectedValue, setSelectedValue] = useState<
+    ComboboxSelection | null | undefined
+  >(other.value !== undefined ? other.value : other.defaultValue);
+
+  const componentClassName = clsx(
+    styles['combobox'],
+    fieldNote && styles['combobox--has-fieldNote'],
+    labelLayout && styles[`combobox--label-layout-${labelLayout}`],
+    className,
+  );
+
+  const { defaultValue: theirDefaultValue, ...restProps } = other;
+
+  // Removing a chip has to change what HeadlessUI treats as selected, and it offers no
+  // imperative way in. So for multi-select we drive its value from the copy we already track,
+  // seeded from `defaultValue`. The consumer's uncontrolled API is unchanged.
+  const shouldControlValue =
+    Boolean(other.multiple) && other.value === undefined;
+
+  const handleChange = (changedValue: ComboboxSelection | null) => {
+    if (selectedValue !== changedValue) {
+      setSelectedValue(changedValue);
+      // Use the value from the event because updates to `useState` are queued
+      theirOnChange && theirOnChange(changedValue);
+    }
+  };
+
+  const sharedProps: ComboboxProps = {
+    className: componentClassName,
+    // Provide a wrapping <div> element for the combobox. This is needed so that any props
+    // passed directly to this component have a corresponding DOM element to receive them.
+    // Otherwise we get an error.
+    as: 'div' as const,
+    by,
+    disabled,
+    // HeadlessUI uses `invalid` to mark the field (and its descendants) as invalid for
+    // assistive tech. Derive it from `status` unless the consumer sets it themselves.
+    invalid: other.invalid ?? status === 'critical',
+    name,
+    ...restProps,
+    ...(shouldControlValue
+      ? { value: selectedValue ?? [] }
+      : { defaultValue: theirDefaultValue }),
+    onChange: handleChange,
+  };
+
+  // The chips in the field need to know what's selected. When controlled, the consumer's value
+  // is the source of truth; otherwise we read the copy tracked above.
+  const currentValue = other.value !== undefined ? other.value : selectedValue;
+  const selectedValues =
+    other.multiple && Array.isArray(currentValue) ? currentValue : [];
+
+  /**
+   * Compares two option values the same way HeadlessUI does, honoring `by` so that values
+   * loaded separately from the option list still match.
+   */
+  const isSameValue = (a: ComboboxValue, z: ComboboxValue) => {
+    if (typeof by === 'function') {
+      return by(a, z);
+    }
+
+    if (
+      typeof by === 'string' &&
+      typeof a === 'object' &&
+      typeof z === 'object'
+    ) {
+      return a[by] === z[by];
+    }
+
+    return a === z;
+  };
+
+  const context: ComboboxContextType = {
+    // The accessible name has to land on the `<input>`, not on the wrapping element, so we
+    // hand it down to `Combobox.Input` rather than putting it on the root.
+    ariaLabel,
+    disabled,
+    optionsClassName,
+    removeValue: (valueToRemove) => {
+      const remaining = selectedValues.filter(
+        (value) => !isSameValue(value, valueToRemove),
+      );
+
+      setSelectedValue(remaining);
+      theirOnChange && theirOnChange(remaining);
+    },
+    required,
+    selectedValues,
+    status,
+    multiple: other.multiple,
+  };
+
+  if (typeof children === 'function') {
+    return (
+      <ComboboxContext.Provider value={context}>
+        <ComboboxRoot {...sharedProps}>{children}</ComboboxRoot>
+      </ComboboxContext.Provider>
+    );
+  }
+
+  return (
+    <ComboboxContext.Provider value={context}>
+      <ComboboxRoot {...sharedProps}>
+        {(label || required) && (
+          <Combobox.Label
+            disabled={disabled}
+            required={required}
+            showHint={showHint}
+            subLabel={subLabel}
+          >
+            {label}
+          </Combobox.Label>
+        )}
+        {children}
+      </ComboboxRoot>
+      {fieldNote && (
+        <div className={styles['combobox__footer']}>
+          <FieldNote disabled={disabled} status={status}>
+            {fieldNote}
+          </FieldNote>
+        </div>
+      )}
+    </ComboboxContext.Provider>
+  );
+}
+
+const ComboboxLabelComponent = ({
+  children: label,
+  required,
+  className,
+  disabled,
+  showHint,
+  subLabel,
+}: ComboboxLabelProps) => {
+  const componentClassName = clsx(
+    styles['combobox__label'],
+    disabled && clsx(styles['combobox__label--disabled']),
+    className,
+  );
+
+  const requiredTextClassName = clsx(
+    styles['combobox__required-text'],
+    disabled && styles['combobox__required-text--disabled'],
+  );
+
+  const overlineClassName = clsx(
+    styles['combobox__overline'],
+    !label && styles['combobox__overline--no-label'],
+  );
+
+  const subLabelClassName = clsx(
+    styles['combobox__subLabel'],
+    disabled && styles['combobox__label--disabled'],
+  );
+
+  return (
+    <div className={overlineClassName}>
+      <Label
+        as={FieldLabel}
+        className={componentClassName}
+        disabled={disabled}
+        size="md"
+      >
+        {label}
+      </Label>
+      {required && showHint && (
+        <Text
+          aria-disabled={disabled ?? undefined}
+          as="span"
+          className={requiredTextClassName}
+          preset="body-sm"
+        >
+          (Required)
+        </Text>
+      )}
+      {!required && showHint && (
+        <Text
+          aria-disabled={disabled ?? undefined}
+          as="span"
+          className={requiredTextClassName}
+          preset="body-sm"
+        >
+          (Optional)
+        </Text>
+      )}
+      {label && subLabel && (
+        <div className={subLabelClassName}>
+          {/* TODO: is there a way to coerce HeadlessUI into using aria-describedby like InputField/TextareaField */}
+          <Text as="span" preset="body-sm">
+            {subLabel}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+};
+
+/**
+ * The toggle for the option list. Unlike `Select`, this is not the primary way into the
+ * component: the text field is. It sits at the end of the field and reveals the full,
+ * unfiltered list.
+ */
+const ComboboxButtonComponent = function (props: ComboboxButtonProps) {
+  const {
+    'aria-label': ariaLabel = 'Show options',
+    children,
+    className,
+    icon = 'chevron-down',
+    ...other
+  } = props;
+
+  const componentClassName = clsx(styles['combobox-input__button'], className);
+
+  return (
+    <ComboboxButton
+      // The icon is decorative and the field's label belongs to the text input, so without
+      // this the toggle reaches assistive tech as an unnamed button.
+      aria-label={ariaLabel}
+      className={componentClassName}
+      {...other}
+    >
+      {(renderProps) => {
+        if (typeof children === 'function') {
+          return children(renderProps);
+        }
+
+        // HeadlessUI's render prop has to hand back a single element, so arbitrary children
+        // get wrapped rather than returned as-is.
+        return children ? (
+          <>{children}</>
+        ) : (
+          <Icon
+            className={clsx(
+              styles['combobox-input__icon'],
+              renderProps.open && styles['combobox-input__icon--reversed'],
+            )}
+            name={icon}
+            purpose="decorative"
+            size="24px"
+          />
+        );
+      }}
+    </ComboboxButton>
+  );
+};
+
+/**
+ * The editable text field for the component, wrapped in the bordered field styling along
+ * with the toggle button for the option list.
+ *
+ * When `multiple` is set, the values picked so far appear ahead of the text field as chips,
+ * each one removable. The text field then holds only the query, which is why `displayValue`
+ * has no effect in that mode.
+ */
+const ComboboxInputComponent = function (props: ComboboxInputProps) {
+  const {
+    'aria-label': ariaLabel,
+    chipLabel = defaultChipLabel,
+    chipLeadingComponent,
+    className,
+    icon = 'chevron-down',
+    inputClassName,
+    onKeyDown: theirOnKeyDown,
+    shouldTruncate = false,
+    showChips = true,
+    ...other
+  } = props;
+  const {
+    ariaLabel: contextAriaLabel,
+    disabled,
+    multiple,
+    removeValue,
+    required,
+    selectedValues = [],
+    status,
+  } = useContext(ComboboxContext);
+
+  const fieldClassName = clsx(
+    styles['combobox-input__field'],
+    shouldTruncate && styles['combobox-input__field--truncated'],
+    inputClassName,
+  );
+
+  const hasChips = Boolean(showChips && multiple && selectedValues.length > 0);
+
+  /**
+   * Backspace on an empty field drops the last chip, which is what people expect from a field
+   * full of chips. HeadlessUI doesn't bind Backspace on the combobox input as of v2.2, so
+   * there's nothing to fight with; we still mark the event handled in case that changes.
+   */
+  const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = (event) => {
+    theirOnKeyDown && theirOnKeyDown(event);
+
+    if (
+      !hasChips ||
+      event.key !== 'Backspace' ||
+      event.defaultPrevented ||
+      // Only once the query is gone, so backspace still edits text first
+      event.currentTarget.value !== ''
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    removeValue && removeValue(selectedValues[selectedValues.length - 1]);
+  };
+
+  return (
+    <ComboboxInputWrapper
+      className={className}
+      hasChips={hasChips}
+      icon={icon}
+      status={status}
+    >
+      {hasChips && (
+        // A list, so screen readers announce how many values are currently selected
+        <ul className={styles['combobox-input__chips']}>
+          {selectedValues.map((value, index) => (
+            // The selection is an ordered list and position is what removal acts on, so the
+            // index is the stable identity here
+            // eslint-disable-next-line react/no-array-index-key
+            <li key={`${index}-${chipLabel(value)}`}>
+              <InputChip
+                isDisabled={disabled}
+                label={chipLabel(value)}
+                leadingComponent={chipLeadingComponent?.(value)}
+                onClick={(event) => {
+                  // Without this the click reaches the field and reopens the option list
+                  event.preventDefault();
+                  event.stopPropagation();
+                  removeValue?.(value);
+                }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+      <ComboboxInput
+        aria-label={ariaLabel ?? contextAriaLabel}
+        className={fieldClassName}
+        onKeyDown={handleKeyDown}
+        required={required}
+        style={
+          {
+            '--combobox__input-width': `calc(${other.displayValue?.length || 0} * 1ch)`,
+          } as CSSProperties
+        }
+        {...other}
+      />
+    </ComboboxInputWrapper>
+  );
+};
+
+/**
+ * The content container showing the available options. Pass in the options that match the
+ * current query; `Combobox` does no filtering of its own.
+ */
+const ComboboxOptionsComponent = function (props: ComboboxOptionsProps) {
+  const {
+    anchor = { to: 'bottom start', gap: 24, offset: -12 },
+    className,
+    ...other
+  } = props;
+  const { optionsClassName } = useContext(ComboboxContext);
+
+  const componentClassName = clsx(
+    styles['combobox__options'],
+    className,
+    optionsClassName,
+  );
+
+  return (
+    <ComboboxOptions
+      anchor={anchor}
+      as={PopoverContainer}
+      className={componentClassName}
+      modal={false}
+      {...other}
+    />
+  );
+};
+
+/**
+ * Represents one of the available options for selection
+ */
+const ComboboxOptionComponent = function (props: ComboboxOptionProps) {
+  const {
+    children,
+    className,
+    optionClassName,
+    subLabel: optionSubLabel,
+    ...other
+  } = props;
+
+  const optionItemClassName = clsx(optionClassName, styles['combobox__option']);
+  const { multiple } = useContext(ComboboxContext);
+
+  return (
+    <ComboboxOption
+      // Render as a fragment instead of the default <div>. We're rendering our own element in
+      // the render prop to control active/selected styling, and we don't want to end up with
+      // duplicate elements.
+      as={React.Fragment}
+      {...other}
+    >
+      {typeof children === 'function'
+        ? children
+        : ({ focus, disabled, selected }) => {
+            return (
+              <PopoverListItem
+                __type="selectitem"
+                className={optionItemClassName}
+                isDisabled={disabled}
+                isFocused={focus}
+                leadingContent={
+                  multiple ? (
+                    <Checkbox
+                      aria-hidden="true"
+                      aria-label="checkbox"
+                      checked={selected}
+                      // @ts-expect-error inert properly supported in React 19
+                      inert="true"
+                      readOnly
+                    />
+                  ) : (
+                    <Radio
+                      aria-hidden="true"
+                      aria-label="radio"
+                      checked={selected}
+                      // @ts-expect-error inert properly supported in React 19
+                      inert="true"
+                      readOnly
+                    />
+                  )
+                }
+                subLabel={optionSubLabel}
+              >
+                <span className={styles['combobox__option-text']}>
+                  {children}
+                </span>
+              </PopoverListItem>
+            );
+          }}
+    </ComboboxOption>
+  );
+};
+
+/**
+ * The component providing the field border, background, and the toggle button, with space
+ * for the text field. Use it directly when you need to render your own `ComboboxInput` but
+ * want to keep the EDS field appearance.
+ */
+export const ComboboxInputWrapper = React.forwardRef<
+  HTMLDivElement,
+  ComboboxInputWrapperProps
+>(
+  (
+    {
+      children,
+      className,
+      hasChips,
+      icon = 'chevron-down',
+      status: theirStatus,
+      ...other
+    },
+    ref,
+  ) => {
+    const { status: contextStatus } = useContext(ComboboxContext);
+    const status = theirStatus ?? contextStatus;
+
+    const componentClassName = clsx(
+      styles['combobox-input'],
+      hasChips && styles['combobox-input--has-chips'],
+      status === 'warning' && styles['combobox-input--warning'],
+      status === 'critical' && styles['combobox-input--error'],
+      className,
+    );
+
+    return (
+      <div className={componentClassName} ref={ref} {...other}>
+        {children}
+        <ComboboxButtonComponent icon={icon} />
+      </div>
+    );
+  },
+);
+
+Combobox.displayName = 'Combobox';
+ComboboxButtonComponent.displayName = 'Combobox.Button';
+ComboboxInputComponent.displayName = 'Combobox.Input';
+ComboboxInputWrapper.displayName = 'Combobox.InputWrapper';
+ComboboxLabelComponent.displayName = 'Combobox.Label';
+ComboboxOptionComponent.displayName = 'Combobox.Option';
+ComboboxOptionsComponent.displayName = 'Combobox.Options';
+
+Combobox.Button = ComboboxButtonComponent;
+Combobox.Input = ComboboxInputComponent;
+Combobox.InputWrapper = ComboboxInputWrapper;
+Combobox.Label = ComboboxLabelComponent;
+Combobox.Option = ComboboxOptionComponent;
+Combobox.Options = ComboboxOptionsComponent;

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -1475,7 +1475,7 @@ exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 
       data-open=""
       id="headlessui-combobox-input-:r53:"
       role="combobox"
-      style="--combobox__input-width: calc(Dogs * 1ch);"
+      style="--combobox__input-width: calc(4 * 1ch);"
       type="text"
       value="Dogs"
     />

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`<Combobox /> Generated Snapshots AdjustedWidth story renders snapshot 1
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r65:"
-      id="headlessui-label-:r64:"
+      for="headlessui-combobox-input-:r6l:"
+      id="headlessui-label-:r6k:"
     >
       <span
         class="text text--label-md"
@@ -28,33 +28,33 @@ exports[`<Combobox /> Generated Snapshots AdjustedWidth story renders snapshot 1
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r6a:"
+      aria-activedescendant="headlessui-combobox-option-:r6q:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r67:"
+      aria-controls="headlessui-combobox-options-:r6n:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r64:"
+      aria-labelledby="headlessui-label-:r6k:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r65:"
+      id="headlessui-combobox-input-:r6l:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r67:"
+      aria-controls="headlessui-combobox-options-:r6n:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r64: headlessui-combobox-button-:r66:"
+      aria-labelledby="headlessui-label-:r6k: headlessui-combobox-button-:r6m:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r66:"
+      id="headlessui-combobox-button-:r6m:"
       tabindex="-1"
       type="button"
     >
@@ -169,8 +169,8 @@ exports[`<Combobox /> Generated Snapshots Error story renders snapshot 1`] = `
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r7l:"
-      id="headlessui-label-:r7k:"
+      for="headlessui-combobox-input-:r85:"
+      id="headlessui-label-:r84:"
     >
       <span
         class="text text--label-md"
@@ -197,18 +197,18 @@ exports[`<Combobox /> Generated Snapshots Error story renders snapshot 1`] = `
     class="combobox-input combobox-input--error"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r7q:"
+      aria-activedescendant="headlessui-combobox-option-:r8a:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-controls="headlessui-combobox-options-:r87:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r7k:"
+      aria-labelledby="headlessui-label-:r84:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open invalid focus"
       data-invalid=""
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r7l:"
+      id="headlessui-combobox-input-:r85:"
       required=""
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
@@ -216,17 +216,17 @@ exports[`<Combobox /> Generated Snapshots Error story renders snapshot 1`] = `
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-controls="headlessui-combobox-options-:r87:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r7k: headlessui-combobox-button-:r7m:"
+      aria-labelledby="headlessui-label-:r84: headlessui-combobox-button-:r86:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active invalid"
       data-invalid=""
       data-open=""
-      id="headlessui-combobox-button-:r7m:"
+      id="headlessui-combobox-button-:r86:"
       tabindex="-1"
       type="button"
     >
@@ -263,13 +263,90 @@ exports[`<Combobox /> Generated Snapshots HorizontalLabel story renders snapshot
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
+      for="headlessui-combobox-input-:r13:"
+      id="headlessui-label-:r12:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Animal?
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r18:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r15:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r12:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r13:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r15:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r12: headlessui-combobox-button-:r14:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r14:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Immediate story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
       for="headlessui-combobox-input-:rj:"
       id="headlessui-label-:ri:"
     >
       <span
         class="text text--label-md"
       >
-        Animal?
+        Favorite Animal
       </span>
     </label>
   </div>
@@ -340,8 +417,8 @@ exports[`<Combobox /> Generated Snapshots MultipleWithChipIcons story renders sn
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r43:"
-      id="headlessui-label-:r42:"
+      for="headlessui-combobox-input-:r4j:"
+      id="headlessui-label-:r4i:"
     >
       <span
         class="text text--label-md"
@@ -446,33 +523,33 @@ exports[`<Combobox /> Generated Snapshots MultipleWithChipIcons story renders sn
       </li>
     </ul>
     <input
-      aria-activedescendant="headlessui-combobox-option-:r48:"
+      aria-activedescendant="headlessui-combobox-option-:r4o:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r45:"
+      aria-controls="headlessui-combobox-options-:r4l:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r42:"
+      aria-labelledby="headlessui-label-:r4i:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r43:"
+      id="headlessui-combobox-input-:r4j:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r45:"
+      aria-controls="headlessui-combobox-options-:r4l:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r42: headlessui-combobox-button-:r44:"
+      aria-labelledby="headlessui-label-:r4i: headlessui-combobox-button-:r4k:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r44:"
+      id="headlessui-combobox-button-:r4k:"
       tabindex="-1"
       type="button"
     >
@@ -509,8 +586,8 @@ exports[`<Combobox /> Generated Snapshots MultipleWithManySelected story renders
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r3j:"
-      id="headlessui-label-:r3i:"
+      for="headlessui-combobox-input-:r43:"
+      id="headlessui-label-:r42:"
     >
       <span
         class="text text--label-md"
@@ -659,33 +736,33 @@ exports[`<Combobox /> Generated Snapshots MultipleWithManySelected story renders
       </li>
     </ul>
     <input
-      aria-activedescendant="headlessui-combobox-option-:r3o:"
+      aria-activedescendant="headlessui-combobox-option-:r48:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-controls="headlessui-combobox-options-:r45:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r3i:"
+      aria-labelledby="headlessui-label-:r42:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r3j:"
+      id="headlessui-combobox-input-:r43:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-controls="headlessui-combobox-options-:r45:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r3i: headlessui-combobox-button-:r3k:"
+      aria-labelledby="headlessui-label-:r42: headlessui-combobox-button-:r44:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r3k:"
+      id="headlessui-combobox-button-:r44:"
       tabindex="-1"
       type="button"
     >
@@ -722,8 +799,8 @@ exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders sna
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r4j:"
-      id="headlessui-label-:r4i:"
+      for="headlessui-combobox-input-:r53:"
+      id="headlessui-label-:r52:"
     >
       <span
         class="text text--label-md"
@@ -736,17 +813,17 @@ exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders sna
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r4o:"
+      aria-activedescendant="headlessui-combobox-option-:r58:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r4l:"
+      aria-controls="headlessui-combobox-options-:r55:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r4i:"
+      aria-labelledby="headlessui-label-:r52:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r4j:"
+      id="headlessui-combobox-input-:r53:"
       placeholder="1 selected"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
@@ -754,16 +831,16 @@ exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders sna
       value=""
     />
     <button
-      aria-controls="headlessui-combobox-options-:r4l:"
+      aria-controls="headlessui-combobox-options-:r55:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r4i: headlessui-combobox-button-:r4k:"
+      aria-labelledby="headlessui-label-:r52: headlessui-combobox-button-:r54:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r4k:"
+      id="headlessui-combobox-button-:r54:"
       tabindex="-1"
       type="button"
     >
@@ -797,9 +874,9 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabel story renders snapshot 
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r8p:"
+      aria-activedescendant="headlessui-combobox-option-:r99:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r8m:"
+      aria-controls="headlessui-combobox-options-:r96:"
       aria-expanded="true"
       aria-label="hidden label"
       class="combobox-input__field"
@@ -807,14 +884,14 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabel story renders snapshot 
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r8k:"
+      id="headlessui-combobox-input-:r94:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r8m:"
+      aria-controls="headlessui-combobox-options-:r96:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
@@ -822,7 +899,7 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabel story renders snapshot 
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r8l:"
+      id="headlessui-combobox-button-:r95:"
       tabindex="-1"
       type="button"
     >
@@ -859,8 +936,8 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabelButRequired story render
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r94:"
-      id="headlessui-label-:r93:"
+      for="headlessui-combobox-input-:r9k:"
+      id="headlessui-label-:r9j:"
     >
       <span
         class="text text--label-md"
@@ -871,18 +948,18 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabelButRequired story render
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r99:"
+      aria-activedescendant="headlessui-combobox-option-:r9p:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r96:"
+      aria-controls="headlessui-combobox-options-:r9m:"
       aria-expanded="true"
       aria-label="hidden label"
-      aria-labelledby="headlessui-label-:r93:"
+      aria-labelledby="headlessui-label-:r9j:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r94:"
+      id="headlessui-combobox-input-:r9k:"
       required=""
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
@@ -890,16 +967,16 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabelButRequired story render
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r96:"
+      aria-controls="headlessui-combobox-options-:r9m:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r93: headlessui-combobox-button-:r95:"
+      aria-labelledby="headlessui-label-:r9j: headlessui-combobox-button-:r9l:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r95:"
+      id="headlessui-combobox-button-:r9l:"
       tabindex="-1"
       type="button"
     >
@@ -936,8 +1013,8 @@ exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = 
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r75:"
-      id="headlessui-label-:r74:"
+      for="headlessui-combobox-input-:r7l:"
+      id="headlessui-label-:r7k:"
     >
       <span
         class="text text--label-md"
@@ -964,6 +1041,97 @@ exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = 
     class="combobox-input"
   >
     <input
+      aria-activedescendant="headlessui-combobox-option-:r7q:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r7k:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r7l:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r7k: headlessui-combobox-button-:r7m:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r7m:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Required story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r75:"
+      id="headlessui-label-:r74:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm combobox__required-text"
+    >
+      (Required)
+    </span>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
       aria-activedescendant="headlessui-combobox-option-:r7a:"
       aria-autocomplete="list"
       aria-controls="headlessui-combobox-options-:r77:"
@@ -975,6 +1143,7 @@ exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = 
       data-open=""
       data-testid="input-button"
       id="headlessui-combobox-input-:r75:"
+      required=""
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
@@ -1013,98 +1182,6 @@ exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = 
 </div>
 `;
 
-exports[`<Combobox /> Generated Snapshots Required story renders snapshot 1`] = `
-<div
-  class="combobox combobox--label-layout-vertical w-[384px]"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="combobox"
->
-  <div
-    class="combobox__overline"
-  >
-    <label
-      class="label label--md combobox__label"
-      data-headlessui-state="open"
-      data-open=""
-      for="headlessui-combobox-input-:r6l:"
-      id="headlessui-label-:r6k:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
-    <span
-      class="text text--body-sm combobox__required-text"
-    >
-      (Required)
-    </span>
-    <div
-      class="combobox__subLabel"
-    >
-      <span
-        class="text text--body-sm"
-      >
-        Some descriptive text
-      </span>
-    </div>
-  </div>
-  <div
-    class="combobox-input"
-  >
-    <input
-      aria-activedescendant="headlessui-combobox-option-:r6q:"
-      aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r6n:"
-      aria-expanded="true"
-      aria-labelledby="headlessui-label-:r6k:"
-      class="combobox-input__field"
-      data-focus=""
-      data-headlessui-state="open focus"
-      data-open=""
-      data-testid="input-button"
-      id="headlessui-combobox-input-:r6l:"
-      required=""
-      role="combobox"
-      style="--combobox__input-width: calc(0 * 1ch);"
-      type="text"
-      value="Dogs"
-    />
-    <button
-      aria-controls="headlessui-combobox-options-:r6n:"
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-label="Show options"
-      aria-labelledby="headlessui-label-:r6k: headlessui-combobox-button-:r6m:"
-      class="combobox-input__button"
-      data-active=""
-      data-headlessui-state="open active"
-      data-open=""
-      id="headlessui-combobox-button-:r6m:"
-      tabindex="-1"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon combobox-input__icon combobox-input__icon--reversed"
-        fill="currentColor"
-        height="24px"
-        style="--icon-size: 24px;"
-        viewBox="0 0 24 24"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
 exports[`<Combobox /> Generated Snapshots Warning story renders snapshot 1`] = `
 <div
   class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[384px]"
@@ -1119,8 +1196,8 @@ exports[`<Combobox /> Generated Snapshots Warning story renders snapshot 1`] = `
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r85:"
-      id="headlessui-label-:r84:"
+      for="headlessui-combobox-input-:r8l:"
+      id="headlessui-label-:r8k:"
     >
       <span
         class="text text--label-md"
@@ -1147,33 +1224,33 @@ exports[`<Combobox /> Generated Snapshots Warning story renders snapshot 1`] = `
     class="combobox-input combobox-input--warning"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r8a:"
+      aria-activedescendant="headlessui-combobox-option-:r8q:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r87:"
+      aria-controls="headlessui-combobox-options-:r8n:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r84:"
+      aria-labelledby="headlessui-label-:r8k:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r85:"
+      id="headlessui-combobox-input-:r8l:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r87:"
+      aria-controls="headlessui-combobox-options-:r8n:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r84: headlessui-combobox-button-:r86:"
+      aria-labelledby="headlessui-label-:r8k: headlessui-combobox-button-:r8m:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r86:"
+      id="headlessui-combobox-button-:r8m:"
       tabindex="-1"
       type="button"
     >
@@ -1210,8 +1287,8 @@ exports[`<Combobox /> Generated Snapshots WithFieldName story renders snapshot 1
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r23:"
-      id="headlessui-label-:r22:"
+      for="headlessui-combobox-input-:r2j:"
+      id="headlessui-label-:r2i:"
     >
       <span
         class="text text--label-md"
@@ -1228,83 +1305,6 @@ exports[`<Combobox /> Generated Snapshots WithFieldName story renders snapshot 1
         Additional descriptive text
       </span>
     </div>
-  </div>
-  <div
-    class="combobox-input"
-  >
-    <input
-      aria-activedescendant="headlessui-combobox-option-:r28:"
-      aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r25:"
-      aria-expanded="true"
-      aria-labelledby="headlessui-label-:r22:"
-      class="combobox-input__field"
-      data-focus=""
-      data-headlessui-state="open focus"
-      data-open=""
-      data-testid="input-button"
-      id="headlessui-combobox-input-:r23:"
-      role="combobox"
-      style="--combobox__input-width: calc(0 * 1ch);"
-      type="text"
-      value="Dogs"
-    />
-    <button
-      aria-controls="headlessui-combobox-options-:r25:"
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-label="Show options"
-      aria-labelledby="headlessui-label-:r22: headlessui-combobox-button-:r24:"
-      class="combobox-input__button"
-      data-active=""
-      data-headlessui-state="open active"
-      data-open=""
-      id="headlessui-combobox-button-:r24:"
-      tabindex="-1"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon combobox-input__icon combobox-input__icon--reversed"
-        fill="currentColor"
-        height="24px"
-        style="--icon-size: 24px;"
-        viewBox="0 0 24 24"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
-exports[`<Combobox /> Generated Snapshots WithFieldNote story renders snapshot 1`] = `
-<div
-  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-60"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="combobox"
->
-  <div
-    class="combobox__overline"
-  >
-    <label
-      class="label label--md combobox__label"
-      data-headlessui-state="open"
-      data-open=""
-      for="headlessui-combobox-input-:r2j:"
-      id="headlessui-label-:r2i:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
   </div>
   <div
     class="combobox-input"
@@ -1359,9 +1359,9 @@ exports[`<Combobox /> Generated Snapshots WithFieldNote story renders snapshot 1
 </div>
 `;
 
-exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot 1`] = `
+exports[`<Combobox /> Generated Snapshots WithFieldNote story renders snapshot 1`] = `
 <div
-  class="combobox combobox--label-layout-vertical w-60"
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-60"
   data-headlessui-state="open"
   data-open=""
   data-testid="combobox"
@@ -1398,11 +1398,10 @@ exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot
       data-open=""
       data-testid="input-button"
       id="headlessui-combobox-input-:r33:"
-      placeholder="Search animals"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
-      value=""
+      value="Dogs"
     />
     <button
       aria-controls="headlessui-combobox-options-:r35:"
@@ -1415,6 +1414,84 @@ exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot
       data-headlessui-state="open active"
       data-open=""
       id="headlessui-combobox-button-:r34:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r3j:"
+      id="headlessui-label-:r3i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r3o:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r3i:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r3j:"
+      placeholder="Search animals"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value=""
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r3i: headlessui-combobox-button-:r3k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r3k:"
       tabindex="-1"
       type="button"
     >
@@ -1451,8 +1528,8 @@ exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r53:"
-      id="headlessui-label-:r52:"
+      for="headlessui-combobox-input-:r5j:"
+      id="headlessui-label-:r5i:"
     >
       <span
         class="text text--label-md"
@@ -1465,32 +1542,32 @@ exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r58:"
+      aria-activedescendant="headlessui-combobox-option-:r5o:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r55:"
+      aria-controls="headlessui-combobox-options-:r5l:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r52:"
+      aria-labelledby="headlessui-label-:r5i:"
       class="combobox-input__field"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
-      id="headlessui-combobox-input-:r53:"
+      id="headlessui-combobox-input-:r5j:"
       role="combobox"
       style="--combobox__input-width: calc(4 * 1ch);"
       type="text"
       value="Dogs"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r55:"
+      aria-controls="headlessui-combobox-options-:r5l:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r52: headlessui-combobox-button-:r54:"
+      aria-labelledby="headlessui-label-:r5i: headlessui-combobox-button-:r5k:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r54:"
+      id="headlessui-combobox-button-:r5k:"
       tabindex="-1"
       type="button"
     >
@@ -1521,6 +1598,83 @@ exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 
 `;
 
 exports[`<Combobox /> Generated Snapshots WithSelectedBy story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r23:"
+      id="headlessui-label-:r22:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r2a:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r25:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r22:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r23:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value="Cats"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r25:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r22: headlessui-combobox-button-:r24:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r24:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithSelectedOption story renders snapshot 1`] = `
 <div
   class="combobox combobox--label-layout-vertical w-60"
   data-headlessui-state="open"
@@ -1597,83 +1751,6 @@ exports[`<Combobox /> Generated Snapshots WithSelectedBy story renders snapshot 
 </div>
 `;
 
-exports[`<Combobox /> Generated Snapshots WithSelectedOption story renders snapshot 1`] = `
-<div
-  class="combobox combobox--label-layout-vertical w-60"
-  data-headlessui-state="open"
-  data-open=""
-  data-testid="combobox"
->
-  <div
-    class="combobox__overline"
-  >
-    <label
-      class="label label--md combobox__label"
-      data-headlessui-state="open"
-      data-open=""
-      for="headlessui-combobox-input-:r13:"
-      id="headlessui-label-:r12:"
-    >
-      <span
-        class="text text--label-md"
-      >
-        Favorite Animal
-      </span>
-    </label>
-  </div>
-  <div
-    class="combobox-input"
-  >
-    <input
-      aria-activedescendant="headlessui-combobox-option-:r1a:"
-      aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r15:"
-      aria-expanded="true"
-      aria-labelledby="headlessui-label-:r12:"
-      class="combobox-input__field"
-      data-focus=""
-      data-headlessui-state="open focus"
-      data-open=""
-      data-testid="input-button"
-      id="headlessui-combobox-input-:r13:"
-      role="combobox"
-      style="--combobox__input-width: calc(0 * 1ch);"
-      type="text"
-      value="Cats"
-    />
-    <button
-      aria-controls="headlessui-combobox-options-:r15:"
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-label="Show options"
-      aria-labelledby="headlessui-label-:r12: headlessui-combobox-button-:r14:"
-      class="combobox-input__button"
-      data-active=""
-      data-headlessui-state="open active"
-      data-open=""
-      id="headlessui-combobox-button-:r14:"
-      tabindex="-1"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon combobox-input__icon combobox-input__icon--reversed"
-        fill="currentColor"
-        height="24px"
-        style="--icon-size: 24px;"
-        viewBox="0 0 24 24"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
-        />
-      </svg>
-    </button>
-  </div>
-</div>
-`;
-
 exports[`<Combobox /> Generated Snapshots WithTruncation story renders snapshot 1`] = `
 <div
   class="combobox combobox--label-layout-vertical w-[160px]"
@@ -1688,8 +1765,8 @@ exports[`<Combobox /> Generated Snapshots WithTruncation story renders snapshot 
       class="label label--md combobox__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-combobox-input-:r5j:"
-      id="headlessui-label-:r5i:"
+      for="headlessui-combobox-input-:r63:"
+      id="headlessui-label-:r62:"
     >
       <span
         class="text text--label-md"
@@ -1702,33 +1779,33 @@ exports[`<Combobox /> Generated Snapshots WithTruncation story renders snapshot 
     class="combobox-input"
   >
     <input
-      aria-activedescendant="headlessui-combobox-option-:r5o:"
+      aria-activedescendant="headlessui-combobox-option-:r68:"
       aria-autocomplete="list"
-      aria-controls="headlessui-combobox-options-:r5l:"
+      aria-controls="headlessui-combobox-options-:r65:"
       aria-expanded="true"
-      aria-labelledby="headlessui-label-:r5i:"
+      aria-labelledby="headlessui-label-:r62:"
       class="combobox-input__field combobox-input__field--truncated"
       data-focus=""
       data-headlessui-state="open focus"
       data-open=""
       data-testid="input-button"
-      id="headlessui-combobox-input-:r5j:"
+      id="headlessui-combobox-input-:r63:"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="A very long option label that will not fit"
     />
     <button
-      aria-controls="headlessui-combobox-options-:r5l:"
+      aria-controls="headlessui-combobox-options-:r65:"
       aria-expanded="true"
       aria-haspopup="listbox"
       aria-label="Show options"
-      aria-labelledby="headlessui-label-:r5i: headlessui-combobox-button-:r5k:"
+      aria-labelledby="headlessui-label-:r62: headlessui-combobox-button-:r64:"
       class="combobox-input__button"
       data-active=""
       data-headlessui-state="open active"
       data-open=""
-      id="headlessui-combobox-button-:r5k:"
+      id="headlessui-combobox-button-:r64:"
       tabindex="-1"
       type="button"
     >

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -1,0 +1,1751 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Combobox /> Generated Snapshots AdjustedWidth story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[240px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r65:"
+      id="headlessui-label-:r64:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r6a:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r67:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r64:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r65:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r67:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r64: headlessui-combobox-button-:r66:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r66:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Default story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r3:"
+      id="headlessui-label-:r2:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r8:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r5:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r2:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r3:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r5:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r2: headlessui-combobox-button-:r4:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r4:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Error story renders snapshot 1`] = `
+<div
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open invalid"
+  data-invalid=""
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r7l:"
+      id="headlessui-label-:r7k:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm combobox__required-text"
+    >
+      (Required)
+    </span>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input combobox-input--error"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r7q:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r7k:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open invalid focus"
+      data-invalid=""
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r7l:"
+      required=""
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r7n:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r7k: headlessui-combobox-button-:r7m:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active invalid"
+      data-invalid=""
+      data-open=""
+      id="headlessui-combobox-button-:r7m:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots HorizontalLabel story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-horizontal w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:rj:"
+      id="headlessui-label-:ri:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Animal?
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:ro:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:rl:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:ri:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:rj:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:rl:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:ri: headlessui-combobox-button-:rk:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:rk:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots MultipleWithChipIcons story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[320px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r43:"
+      id="headlessui-label-:r42:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal(s)
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input combobox-input--has-chips"
+  >
+    <ul
+      class="combobox-input__chips"
+    >
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon input-chip__leading-component"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.023 17.2923C6.873 16.6616 7.799 16.1635 8.801 15.798C9.80283 15.4327 10.8692 15.25 12 15.25C13.1308 15.25 14.1972 15.4327 15.199 15.798C16.201 16.1635 17.127 16.6616 17.977 17.2923C18.5987 16.6089 19.0913 15.8179 19.4548 14.9192C19.8183 14.0206 20 13.0475 20 12C20 9.78333 19.2208 7.89583 17.6625 6.3375C16.1042 4.77917 14.2167 4 12 4C9.78333 4 7.89583 4.77917 6.3375 6.3375C4.77917 7.89583 4 9.78333 4 12C4 13.0475 4.18175 14.0206 4.54525 14.9192C4.90875 15.8179 5.40133 16.6089 6.023 17.2923ZM9.6905 11.8095C9.0635 11.1827 8.75 10.4128 8.75 9.5C8.75 8.58717 9.0635 7.81733 9.6905 7.1905C10.3173 6.5635 11.0872 6.25 12 6.25C12.9128 6.25 13.6827 6.5635 14.3095 7.1905C14.9365 7.81733 15.25 8.58717 15.25 9.5C15.25 10.4128 14.9365 11.1827 14.3095 11.8095C13.6827 12.4365 12.9128 12.75 12 12.75C11.0872 12.75 10.3173 12.4365 9.6905 11.8095ZM12 21.5C10.6808 21.5 9.44333 21.2519 8.2875 20.7557C7.13167 20.2596 6.12625 19.5839 5.27125 18.7288C4.41608 17.8738 3.74042 16.8683 3.24425 15.7125C2.74808 14.5567 2.5 13.3192 2.5 12C2.5 10.6808 2.74808 9.44333 3.24425 8.2875C3.74042 7.13167 4.41608 6.12625 5.27125 5.27125C6.12625 4.41608 7.13167 3.74042 8.2875 3.24425C9.44333 2.74808 10.6808 2.5 12 2.5C13.3192 2.5 14.5567 2.74808 15.7125 3.24425C16.8683 3.74042 17.8738 4.41608 18.7288 5.27125C19.5839 6.12625 20.2596 7.13167 20.7557 8.2875C21.2519 9.44333 21.5 10.6808 21.5 12C21.5 13.3192 21.2519 14.5567 20.7557 15.7125C20.2596 16.8683 19.5839 17.8738 18.7288 18.7288C17.8738 19.5839 16.8683 20.2596 15.7125 20.7557C14.5567 21.2519 13.3192 21.5 12 21.5ZM14.6105 19.5645C15.4483 19.274 16.1923 18.8679 16.8423 18.3462C16.1923 17.8436 15.458 17.4519 14.6395 17.1712C13.8208 16.8904 12.941 16.75 12 16.75C11.059 16.75 10.1776 16.8888 9.35575 17.1663C8.53392 17.4439 7.80125 17.8372 7.15775 18.3462C7.80775 18.8679 8.55167 19.274 9.3895 19.5645C10.2273 19.8548 11.0975 20 12 20C12.9025 20 13.7727 19.8548 14.6105 19.5645ZM13.248 10.748C13.5827 10.4135 13.75 9.9975 13.75 9.5C13.75 9.0025 13.5827 8.5865 13.248 8.252C12.9135 7.91733 12.4975 7.75 12 7.75C11.5025 7.75 11.0865 7.91733 10.752 8.252C10.4173 8.5865 10.25 9.0025 10.25 9.5C10.25 9.9975 10.4173 10.4135 10.752 10.748C11.0865 11.0827 11.5025 11.25 12 11.25C12.4975 11.25 12.9135 11.0827 13.248 10.748Z"
+              />
+            </svg>
+            <span
+              class="text text--body-xs"
+            >
+              Dogs
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Dogs
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon input-chip__leading-component"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.023 17.2923C6.873 16.6616 7.799 16.1635 8.801 15.798C9.80283 15.4327 10.8692 15.25 12 15.25C13.1308 15.25 14.1972 15.4327 15.199 15.798C16.201 16.1635 17.127 16.6616 17.977 17.2923C18.5987 16.6089 19.0913 15.8179 19.4548 14.9192C19.8183 14.0206 20 13.0475 20 12C20 9.78333 19.2208 7.89583 17.6625 6.3375C16.1042 4.77917 14.2167 4 12 4C9.78333 4 7.89583 4.77917 6.3375 6.3375C4.77917 7.89583 4 9.78333 4 12C4 13.0475 4.18175 14.0206 4.54525 14.9192C4.90875 15.8179 5.40133 16.6089 6.023 17.2923ZM9.6905 11.8095C9.0635 11.1827 8.75 10.4128 8.75 9.5C8.75 8.58717 9.0635 7.81733 9.6905 7.1905C10.3173 6.5635 11.0872 6.25 12 6.25C12.9128 6.25 13.6827 6.5635 14.3095 7.1905C14.9365 7.81733 15.25 8.58717 15.25 9.5C15.25 10.4128 14.9365 11.1827 14.3095 11.8095C13.6827 12.4365 12.9128 12.75 12 12.75C11.0872 12.75 10.3173 12.4365 9.6905 11.8095ZM12 21.5C10.6808 21.5 9.44333 21.2519 8.2875 20.7557C7.13167 20.2596 6.12625 19.5839 5.27125 18.7288C4.41608 17.8738 3.74042 16.8683 3.24425 15.7125C2.74808 14.5567 2.5 13.3192 2.5 12C2.5 10.6808 2.74808 9.44333 3.24425 8.2875C3.74042 7.13167 4.41608 6.12625 5.27125 5.27125C6.12625 4.41608 7.13167 3.74042 8.2875 3.24425C9.44333 2.74808 10.6808 2.5 12 2.5C13.3192 2.5 14.5567 2.74808 15.7125 3.24425C16.8683 3.74042 17.8738 4.41608 18.7288 5.27125C19.5839 6.12625 20.2596 7.13167 20.7557 8.2875C21.2519 9.44333 21.5 10.6808 21.5 12C21.5 13.3192 21.2519 14.5567 20.7557 15.7125C20.2596 16.8683 19.5839 17.8738 18.7288 18.7288C17.8738 19.5839 16.8683 20.2596 15.7125 20.7557C14.5567 21.2519 13.3192 21.5 12 21.5ZM14.6105 19.5645C15.4483 19.274 16.1923 18.8679 16.8423 18.3462C16.1923 17.8436 15.458 17.4519 14.6395 17.1712C13.8208 16.8904 12.941 16.75 12 16.75C11.059 16.75 10.1776 16.8888 9.35575 17.1663C8.53392 17.4439 7.80125 17.8372 7.15775 18.3462C7.80775 18.8679 8.55167 19.274 9.3895 19.5645C10.2273 19.8548 11.0975 20 12 20C12.9025 20 13.7727 19.8548 14.6105 19.5645ZM13.248 10.748C13.5827 10.4135 13.75 9.9975 13.75 9.5C13.75 9.0025 13.5827 8.5865 13.248 8.252C12.9135 7.91733 12.4975 7.75 12 7.75C11.5025 7.75 11.0865 7.91733 10.752 8.252C10.4173 8.5865 10.25 9.0025 10.25 9.5C10.25 9.9975 10.4173 10.4135 10.752 10.748C11.0865 11.0827 11.5025 11.25 12 11.25C12.4975 11.25 12.9135 11.0827 13.248 10.748Z"
+              />
+            </svg>
+            <span
+              class="text text--body-xs"
+            >
+              Cats
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Cats
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r48:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r45:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r42:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r43:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value=""
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r45:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r42: headlessui-combobox-button-:r44:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r44:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots MultipleWithManySelected story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[240px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r3j:"
+      id="headlessui-label-:r3i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal(s)
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input combobox-input--has-chips"
+  >
+    <ul
+      class="combobox-input__chips"
+    >
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <span
+              class="text text--body-xs"
+            >
+              Dogs
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Dogs
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <span
+              class="text text--body-xs"
+            >
+              Cats
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Cats
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <span
+              class="text text--body-xs"
+            >
+              Birds
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Birds
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <div
+          class="input-chip"
+        >
+          <div
+            class="input-chip__label"
+          >
+            <span
+              class="text text--body-xs"
+            >
+              Rabbits
+            </span>
+          </div>
+          <button
+            class="input-chip__action-button"
+          >
+            <svg
+              class="icon"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Rabbits
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r3o:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r3i:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r3j:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value=""
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r3l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r3i: headlessui-combobox-button-:r3k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r3k:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders snapshot 1`] = `
+<div
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[240px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r4j:"
+      id="headlessui-label-:r4i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal(s)
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r4o:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r4l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r4i:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r4j:"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+      value=""
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r4l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r4i: headlessui-combobox-button-:r4k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r4k:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots NoVisibleLabel story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r8p:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r8m:"
+      aria-expanded="true"
+      aria-label="hidden label"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r8k:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r8m:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r8l:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots NoVisibleLabelButRequired story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline combobox__overline--no-label"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r94:"
+      id="headlessui-label-:r93:"
+    >
+      <span
+        class="text text--label-md"
+      />
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r99:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r96:"
+      aria-expanded="true"
+      aria-label="hidden label"
+      aria-labelledby="headlessui-label-:r93:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r94:"
+      required=""
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r96:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r93: headlessui-combobox-button-:r95:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r95:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r75:"
+      id="headlessui-label-:r74:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm combobox__required-text"
+    >
+      (Optional)
+    </span>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r7a:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r77:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r74:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r75:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r77:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r74: headlessui-combobox-button-:r76:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r76:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Required story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r6l:"
+      id="headlessui-label-:r6k:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm combobox__required-text"
+    >
+      (Required)
+    </span>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r6q:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r6n:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r6k:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r6l:"
+      required=""
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r6n:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r6k: headlessui-combobox-button-:r6m:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r6m:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots Warning story renders snapshot 1`] = `
+<div
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[384px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r85:"
+      id="headlessui-label-:r84:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <span
+      class="text text--body-sm combobox__required-text"
+    >
+      (Optional)
+    </span>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Some descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input combobox-input--warning"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r8a:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r87:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r84:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r85:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r87:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r84: headlessui-combobox-button-:r86:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r86:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithFieldName story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r23:"
+      id="headlessui-label-:r22:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+    <div
+      class="combobox__subLabel"
+    >
+      <span
+        class="text text--body-sm"
+      >
+        Additional descriptive text
+      </span>
+    </div>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r28:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r25:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r22:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r23:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r25:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r22: headlessui-combobox-button-:r24:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r24:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithFieldNote story renders snapshot 1`] = `
+<div
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r2j:"
+      id="headlessui-label-:r2i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r2o:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r2l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r2i:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r2j:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r2l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r2i: headlessui-combobox-button-:r2k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r2k:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r33:"
+      id="headlessui-label-:r32:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r38:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r35:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r32:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r33:"
+      placeholder="Search animals"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value=""
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r35:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r32: headlessui-combobox-button-:r34:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r34:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r53:"
+      id="headlessui-label-:r52:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r58:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r55:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r52:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      id="headlessui-combobox-input-:r53:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Dogs"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r55:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r52: headlessui-combobox-button-:r54:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r54:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+  <p
+    class="mt-spacing-size-1"
+  >
+    Picking
+    : 
+    Dogs
+  </p>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithSelectedBy story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r1j:"
+      id="headlessui-label-:r1i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r1q:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r1l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r1i:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r1j:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Cats"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r1l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r1i: headlessui-combobox-button-:r1k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r1k:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithSelectedOption story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-60"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r13:"
+      id="headlessui-label-:r12:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r1a:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r15:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r12:"
+      class="combobox-input__field"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r13:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="Cats"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r15:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r12: headlessui-combobox-button-:r14:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r14:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Combobox /> Generated Snapshots WithTruncation story renders snapshot 1`] = `
+<div
+  class="combobox combobox--label-layout-vertical w-[160px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="combobox__overline"
+  >
+    <label
+      class="label label--md combobox__label"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-:r5j:"
+      id="headlessui-label-:r5i:"
+    >
+      <span
+        class="text text--label-md"
+      >
+        Favorite Animal
+      </span>
+    </label>
+  </div>
+  <div
+    class="combobox-input"
+  >
+    <input
+      aria-activedescendant="headlessui-combobox-option-:r5o:"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-:r5l:"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-:r5i:"
+      class="combobox-input__field combobox-input__field--truncated"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-:r5j:"
+      role="combobox"
+      style="--combobox__input-width: calc(1 * 1ch);"
+      type="text"
+      value="A very long option label that will not fit"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-:r5l:"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-:r5i: headlessui-combobox-button-:r5k:"
+      class="combobox-input__button"
+      data-active=""
+      data-headlessui-state="open active"
+      data-open=""
+      id="headlessui-combobox-button-:r5k:"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon combobox-input__icon combobox-input__icon--reversed"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`<Combobox /> Generated Snapshots AdjustedWidth story renders snapshot 1
       data-testid="input-button"
       id="headlessui-combobox-input-:r65:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -117,7 +117,7 @@ exports[`<Combobox /> Generated Snapshots Default story renders snapshot 1`] = `
       data-testid="input-button"
       id="headlessui-combobox-input-:r3:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -211,7 +211,7 @@ exports[`<Combobox /> Generated Snapshots Error story renders snapshot 1`] = `
       id="headlessui-combobox-input-:r7l:"
       required=""
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -289,7 +289,7 @@ exports[`<Combobox /> Generated Snapshots HorizontalLabel story renders snapshot
       data-testid="input-button"
       id="headlessui-combobox-input-:rj:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -808,7 +808,7 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabel story renders snapshot 
       data-testid="input-button"
       id="headlessui-combobox-input-:r8k:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -884,7 +884,7 @@ exports[`<Combobox /> Generated Snapshots NoVisibleLabelButRequired story render
       id="headlessui-combobox-input-:r94:"
       required=""
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -975,7 +975,7 @@ exports[`<Combobox /> Generated Snapshots Optional story renders snapshot 1`] = 
       data-testid="input-button"
       id="headlessui-combobox-input-:r75:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1067,7 +1067,7 @@ exports[`<Combobox /> Generated Snapshots Required story renders snapshot 1`] = 
       id="headlessui-combobox-input-:r6l:"
       required=""
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1158,7 +1158,7 @@ exports[`<Combobox /> Generated Snapshots Warning story renders snapshot 1`] = `
       data-testid="input-button"
       id="headlessui-combobox-input-:r85:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1244,7 +1244,7 @@ exports[`<Combobox /> Generated Snapshots WithFieldName story renders snapshot 1
       data-testid="input-button"
       id="headlessui-combobox-input-:r23:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1321,7 +1321,7 @@ exports[`<Combobox /> Generated Snapshots WithFieldNote story renders snapshot 1
       data-testid="input-button"
       id="headlessui-combobox-input-:r2j:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1399,7 +1399,7 @@ exports[`<Combobox /> Generated Snapshots WithPlaceholder story renders snapshot
       id="headlessui-combobox-input-:r33:"
       placeholder="Search animals"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value=""
     />
@@ -1475,7 +1475,7 @@ exports[`<Combobox /> Generated Snapshots WithRenderProp story renders snapshot 
       data-open=""
       id="headlessui-combobox-input-:r53:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(Dogs * 1ch);"
       type="text"
       value="Dogs"
     />
@@ -1559,7 +1559,7 @@ exports[`<Combobox /> Generated Snapshots WithSelectedBy story renders snapshot 
       data-testid="input-button"
       id="headlessui-combobox-input-:r1j:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Cats"
     />
@@ -1636,7 +1636,7 @@ exports[`<Combobox /> Generated Snapshots WithSelectedOption story renders snaps
       data-testid="input-button"
       id="headlessui-combobox-input-:r13:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="Cats"
     />
@@ -1713,7 +1713,7 @@ exports[`<Combobox /> Generated Snapshots WithTruncation story renders snapshot 
       data-testid="input-button"
       id="headlessui-combobox-input-:r5j:"
       role="combobox"
-      style="--combobox__input-width: calc(1 * 1ch);"
+      style="--combobox__input-width: calc(0 * 1ch);"
       type="text"
       value="A very long option label that will not fit"
     />

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -710,7 +710,7 @@ exports[`<Combobox /> Generated Snapshots MultipleWithManySelected story renders
 
 exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders snapshot 1`] = `
 <div
-  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[240px]"
+  class="combobox combobox--has-fieldNote combobox--label-layout-vertical w-[384px]"
   data-headlessui-state="open"
   data-open=""
   data-testid="combobox"
@@ -747,6 +747,7 @@ exports[`<Combobox /> Generated Snapshots MultipleWithoutChips story renders sna
       data-open=""
       data-testid="input-button"
       id="headlessui-combobox-input-:r4j:"
+      placeholder="1 selected"
       role="combobox"
       style="--combobox__input-width: calc(0 * 1ch);"
       type="text"

--- a/src/components/Combobox/index.ts
+++ b/src/components/Combobox/index.ts
@@ -1,0 +1,1 @@
+export { Combobox as default } from './Combobox';

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -81,6 +81,11 @@ const exampleOptions: SelectOption[] = [
     label: 'Birds',
     subLabel: 'Living relics!',
   },
+  {
+    key: '4',
+    label: 'Rabbits',
+    subLabel: 'Langomorphs are rad.',
+  },
 ];
 
 /**
@@ -432,6 +437,7 @@ export const UncontrolledHeadless: StoryObj = {
                   Birds: '🐦🦆🦜',
                   Dogs: '🐶🐕🐩',
                   Cats: '🐈🐱🐈‍⬛',
+                  Rabbits: '🐇🐰',
                 }[value.label as string]
               }
             </button>

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -14,8 +14,8 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r43:"
-      id="headlessui-label-:r42:"
+      for="headlessui-listbox-button-:r4n:"
+      id="headlessui-label-:r4m:"
     >
       <span
         class="text text--label-md"
@@ -25,15 +25,15 @@ exports[`<Select /> Generated Snapshots AdjustedWidth story renders snapshot 1`]
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r44:"
+    aria-controls="headlessui-listbox-options-:r4o:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r42: headlessui-listbox-button-:r43:"
+    aria-labelledby="headlessui-label-:r4m: headlessui-listbox-button-:r4n:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r43:"
+    id="headlessui-listbox-button-:r4n:"
     type="button"
   >
     <span
@@ -132,8 +132,8 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r5a:"
-      id="headlessui-label-:r59:"
+      for="headlessui-listbox-button-:r64:"
+      id="headlessui-label-:r63:"
     >
       <span
         class="text text--label-md"
@@ -157,15 +157,15 @@ exports[`<Select /> Generated Snapshots Error story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r5b:"
+    aria-controls="headlessui-listbox-options-:r65:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r59: headlessui-listbox-button-:r5a:"
+    aria-labelledby="headlessui-label-:r63: headlessui-listbox-button-:r64:"
     class="select-button select-button--error"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r5a:"
+    id="headlessui-listbox-button-:r64:"
     type="button"
   >
     <span
@@ -205,8 +205,8 @@ exports[`<Select /> Generated Snapshots HorizontalLabel story renders snapshot 1
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:rg:"
-      id="headlessui-label-:rf:"
+      for="headlessui-listbox-button-:ri:"
+      id="headlessui-label-:rh:"
     >
       <span
         class="text text--label-md"
@@ -216,15 +216,15 @@ exports[`<Select /> Generated Snapshots HorizontalLabel story renders snapshot 1
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:rh:"
+    aria-controls="headlessui-listbox-options-:rj:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:rf: headlessui-listbox-button-:rg:"
+    aria-labelledby="headlessui-label-:rh: headlessui-listbox-button-:ri:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:rg:"
+    id="headlessui-listbox-button-:ri:"
     type="button"
   >
     <span
@@ -264,8 +264,8 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r3m:"
-      id="headlessui-label-:r3l:"
+      for="headlessui-listbox-button-:r48:"
+      id="headlessui-label-:r47:"
     >
       <span
         class="text text--label-md"
@@ -275,15 +275,15 @@ exports[`<Select /> Generated Snapshots MultipleWithTruncation story renders sna
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r3n:"
+    aria-controls="headlessui-listbox-options-:r49:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r3l: headlessui-listbox-button-:r3m:"
+    aria-labelledby="headlessui-label-:r47: headlessui-listbox-button-:r48:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r3m:"
+    id="headlessui-listbox-button-:r48:"
     type="button"
   >
     <span
@@ -318,14 +318,14 @@ exports[`<Select /> Generated Snapshots NoVisibleLabel story renders snapshot 1`
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r64:"
+    aria-controls="headlessui-listbox-options-:r72:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r63:"
+    id="headlessui-listbox-button-:r71:"
     type="button"
   >
     <span
@@ -365,8 +365,8 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r6g:"
-      id="headlessui-label-:r6f:"
+      for="headlessui-listbox-button-:r7g:"
+      id="headlessui-label-:r7f:"
     >
       <span
         class="text text--label-md"
@@ -374,15 +374,15 @@ exports[`<Select /> Generated Snapshots NoVisibleLabelButRequired story renders 
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r6h:"
+    aria-controls="headlessui-listbox-options-:r7h:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r6f: headlessui-listbox-button-:r6g:"
+    aria-labelledby="headlessui-label-:r7f: headlessui-listbox-button-:r7g:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r6g:"
+    id="headlessui-listbox-button-:r7g:"
     type="button"
   >
     <span
@@ -422,8 +422,8 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r4t:"
-      id="headlessui-label-:r4s:"
+      for="headlessui-listbox-button-:r5l:"
+      id="headlessui-label-:r5k:"
     >
       <span
         class="text text--label-md"
@@ -447,15 +447,15 @@ exports[`<Select /> Generated Snapshots Optional story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r4u:"
+    aria-controls="headlessui-listbox-options-:r5m:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4s: headlessui-listbox-button-:r4t:"
+    aria-labelledby="headlessui-label-:r5k: headlessui-listbox-button-:r5l:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4t:"
+    id="headlessui-listbox-button-:r5l:"
     type="button"
   >
     <span
@@ -495,8 +495,8 @@ exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r4g:"
-      id="headlessui-label-:r4f:"
+      for="headlessui-listbox-button-:r56:"
+      id="headlessui-label-:r55:"
     >
       <span
         class="text text--label-md"
@@ -520,15 +520,15 @@ exports[`<Select /> Generated Snapshots Required story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r4h:"
+    aria-controls="headlessui-listbox-options-:r57:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r4f: headlessui-listbox-button-:r4g:"
+    aria-labelledby="headlessui-label-:r55: headlessui-listbox-button-:r56:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r4g:"
+    id="headlessui-listbox-button-:r56:"
     type="button"
   >
     <span
@@ -562,14 +562,14 @@ exports[`<Select /> Generated Snapshots StyledUncontrolled story renders snapsho
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r3a:"
+    aria-controls="headlessui-listbox-options-:r3q:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r39:"
+    id="headlessui-listbox-button-:r3p:"
     type="button"
   >
     <span
@@ -603,14 +603,14 @@ exports[`<Select /> Generated Snapshots UncontrolledHeadless story renders snaps
   data-testid="dropdown"
 >
   <button
-    aria-controls="headlessui-listbox-options-:r2u:"
+    aria-controls="headlessui-listbox-options-:r3c:"
     aria-expanded="true"
     aria-haspopup="listbox"
     class="fpo"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2t:"
+    id="headlessui-listbox-button-:r3b:"
     type="button"
   >
     🐶🐕🐩
@@ -632,8 +632,8 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r5n:"
-      id="headlessui-label-:r5m:"
+      for="headlessui-listbox-button-:r6j:"
+      id="headlessui-label-:r6i:"
     >
       <span
         class="text text--label-md"
@@ -657,15 +657,15 @@ exports[`<Select /> Generated Snapshots Warning story renders snapshot 1`] = `
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r5o:"
+    aria-controls="headlessui-listbox-options-:r6k:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r5m: headlessui-listbox-button-:r5n:"
+    aria-labelledby="headlessui-label-:r6i: headlessui-listbox-button-:r6j:"
     class="select-button select-button--warning"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r5n:"
+    id="headlessui-listbox-button-:r6j:"
     type="button"
   >
     <span
@@ -705,8 +705,8 @@ exports[`<Select /> Generated Snapshots WithFieldName story renders snapshot 1`]
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r24:"
-      id="headlessui-label-:r23:"
+      for="headlessui-listbox-button-:r2e:"
+      id="headlessui-label-:r2d:"
     >
       <span
         class="text text--label-md"
@@ -725,15 +725,15 @@ exports[`<Select /> Generated Snapshots WithFieldName story renders snapshot 1`]
     </div>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r25:"
+    aria-controls="headlessui-listbox-options-:r2f:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r23: headlessui-listbox-button-:r24:"
+    aria-labelledby="headlessui-label-:r2d: headlessui-listbox-button-:r2e:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r24:"
+    id="headlessui-listbox-button-:r2e:"
     type="button"
   >
     <span
@@ -773,8 +773,8 @@ exports[`<Select /> Generated Snapshots WithFieldNote story renders snapshot 1`]
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r2h:"
-      id="headlessui-label-:r2g:"
+      for="headlessui-listbox-button-:r2t:"
+      id="headlessui-label-:r2s:"
     >
       <span
         class="text text--label-md"
@@ -784,15 +784,15 @@ exports[`<Select /> Generated Snapshots WithFieldNote story renders snapshot 1`]
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r2i:"
+    aria-controls="headlessui-listbox-options-:r2u:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r2g: headlessui-listbox-button-:r2h:"
+    aria-labelledby="headlessui-label-:r2s: headlessui-listbox-button-:r2t:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r2h:"
+    id="headlessui-listbox-button-:r2t:"
     type="button"
   >
     <span
@@ -832,8 +832,8 @@ exports[`<Select /> Generated Snapshots WithSelectedBy story renders snapshot 1`
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r1n:"
-      id="headlessui-label-:r1m:"
+      for="headlessui-listbox-button-:r1v:"
+      id="headlessui-label-:r1u:"
     >
       <span
         class="text text--label-md"
@@ -843,15 +843,15 @@ exports[`<Select /> Generated Snapshots WithSelectedBy story renders snapshot 1`
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r1o:"
+    aria-controls="headlessui-listbox-options-:r20:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r1m: headlessui-listbox-button-:r1n:"
+    aria-labelledby="headlessui-label-:r1u: headlessui-listbox-button-:r1v:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r1n:"
+    id="headlessui-listbox-button-:r1v:"
     type="button"
   >
     <span
@@ -891,8 +891,8 @@ exports[`<Select /> Generated Snapshots WithSelectedOption story renders snapsho
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:r1a:"
-      id="headlessui-label-:r19:"
+      for="headlessui-listbox-button-:r1g:"
+      id="headlessui-label-:r1f:"
     >
       <span
         class="text text--label-md"
@@ -902,15 +902,15 @@ exports[`<Select /> Generated Snapshots WithSelectedOption story renders snapsho
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:r1b:"
+    aria-controls="headlessui-listbox-options-:r1h:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:r19: headlessui-listbox-button-:r1a:"
+    aria-labelledby="headlessui-label-:r1f: headlessui-listbox-button-:r1g:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:r1a:"
+    id="headlessui-listbox-button-:r1g:"
     type="button"
   >
     <span
@@ -950,8 +950,8 @@ exports[`<Select /> Generated Snapshots WithStandardButton story renders snapsho
       class="label label--md select__label"
       data-headlessui-state="open"
       data-open=""
-      for="headlessui-listbox-button-:rt:"
-      id="headlessui-label-:rs:"
+      for="headlessui-listbox-button-:r11:"
+      id="headlessui-label-:r10:"
     >
       <span
         class="text text--label-md"
@@ -961,15 +961,15 @@ exports[`<Select /> Generated Snapshots WithStandardButton story renders snapsho
     </label>
   </div>
   <button
-    aria-controls="headlessui-listbox-options-:ru:"
+    aria-controls="headlessui-listbox-options-:r12:"
     aria-expanded="true"
     aria-haspopup="listbox"
-    aria-labelledby="headlessui-label-:rs: headlessui-listbox-button-:rt:"
+    aria-labelledby="headlessui-label-:r10: headlessui-listbox-button-:r11:"
     class="select-button"
     data-active=""
     data-headlessui-state="open active"
     data-open=""
-    id="headlessui-listbox-button-:rt:"
+    id="headlessui-listbox-button-:r11:"
     type="button"
   >
     <span

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { default as ButtonGroup } from './components/ButtonGroup';
 export { default as Card } from './components/Card';
 export { default as Checkbox } from './components/Checkbox';
 export { default as CodeBlock } from './components/CodeBlock';
+export { default as Combobox } from './components/Combobox';
 export { default as DataTable } from './components/DataTable';
 export { utils as DataTableUtils } from './components/DataTable';
 export { default as FieldLabel } from './components/FieldLabel';


### PR DESCRIPTION
Build a combo box on HeadlessUI's `Combobox`, styled to match `Select` and reusing its prop names and documentation wherever behavior lines up (label, labelLayout, subLabel, fieldNote, showHint, status, required, optionsClassName, name, aria-label).

Subcomponents map onto Select's, with the text field replacing the trigger button: `.Label`, `.Input`, `.InputWrapper` (the analog of `Select.ButtonWrapper`), `.Button` (the option list toggle), `.Options`, and `.Option`. Since the field is always typable, the non-typing trigger variants from Select are not carried over. Filtering stays with the consumer, as HeadlessUI intends.

Multi-select renders each selected value as an `InputChip` inside the field. Chips come off via their close button or via backspace in an empty field. The field wraps as chips accumulate. Backspace handling is ours, not HeadlessUI's, and is documented as a possible future conflict.

Accessibility handled differently from Select on purpose:
- the root `aria-label` is routed to the inner `<input>`, since that is the element that needs the accessible name
- the option list toggle carries its own name when no visible label exists
- `required` reaches the real `<input>` for native validation, and `status: 'critical'` derives HeadlessUI's `invalid`

<!--
  Paste in description, or re-format the commit message body to describe the change
-->

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
