### PR TITLE
fix(InputField): allow embedded input buttons to have flexible widths

### DIFF
--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -25,25 +25,34 @@
 /**
  * Input Field Within
  *
- * A slot to put arbitrary content that appears within the input field border to the right. 
+ * A slot to put arbitrary content that appears within the input field border, at the trailing edge.
  *
  * Typically used for buttons and icon buttons to enable things like show/hide password buttons .
- */
+ *
+ * The trailing padding is derived from the measured width of the slot, so content of any width
+ * clears the text area rather than being clamped to a fixed size. The component sets
+ * `--input-field__input-within-width` from that measurement; the fallback reserves the same
+ * space the previous fixed treatment did, and is what renders before measurement (during SSR,
+ * or when ResizeObserver is unavailable).
+ */
 .input-field__input--input-within {
-  padding-right: calc(var(--eds-spacing-size-12) * 1px);
+  padding-inline-end: calc(
+    var(--input-field__input-within-width, calc(var(--eds-spacing-size-9) * 1px)) +
+      (var(--eds-spacing-size-1-and-half) * 2px)
+  );
 }
 
 .input-field__input-within {
   position: absolute;
-  right: calc(var(--eds-spacing-size-1-and-half) * 1px);
+  inset-inline-end: calc(var(--eds-spacing-size-1-and-half) * 1px);
   top: 0;
   bottom: 0;
   display: grid;
   align-items: center;
   justify-content: center;
 
-  /* max width is padding size minus right position size */
-  max-width: calc(var(--eds-spacing-size-11) * 1px);
+  /* Keep a usable text area, so wide content can never take over the whole field */
+  max-width: calc(100% - (var(--eds-spacing-size-9) * 1px));
 }
 
 .input-field__leading-icon {

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -42,7 +42,7 @@ const meta: Meta<typeof InputField> = {
     },
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
-  tags: ['autodocs', 'version:2.1.1'],
+  tags: ['autodocs', 'version:2.1.2'],
 };
 
 export default meta;
@@ -292,9 +292,10 @@ export const ShowHint: Story = {
 /**
  * You can render certain components **within** an `InputField`, such as a button, icon, or other
  * small component. This facility is used to implement controls that should appear visibly nested
- * within the button, to the right-hand side.
+ * within the field, at the trailing edge.
  *
- * Please keep the text of the button brief (button width < 96px)
+ * The field measures the content you pass and reserves matching space, so the text area always
+ * clears it.
  */
 export const InputWithin: Story = {
   parameters: {
@@ -319,10 +320,10 @@ export const InputWithin: Story = {
 };
 
 /**
- * The button has a maximum width, so if more text is placed in the button than this width can handle, it
- * will be trimmed.
+ * Content in the slot is free to be as wide as it needs. The text area shrinks to match, so a
+ * longer button label is not trimmed.
  *
- * Please keep the text of the button brief (button width < 96px)
+ * Very wide content is still bounded, so that some usable text area always remains.
  */
 export const LongInputWithin: Story = {
   parameters: {
@@ -335,12 +336,42 @@ export const LongInputWithin: Story = {
   },
   render: () => (
     <InputField
+      defaultValue="Text that runs up against the button"
       inputWithin={
         <Button icon="open-in-new" iconLayout="left" rank="secondary" size="sm">
           Button with extra text
         </Button>
       }
       label="Input field with button inside"
+      type="text"
+    />
+  ),
+};
+
+/**
+ * The measured width can be overridden with the `--input-field__input-within-width` CSS custom
+ * property, for cases where a fixed reservation is preferred (for instance, to keep a set of fields
+ * aligned when their embedded buttons have differing labels).
+ */
+export const InputWithinFixedWidth: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      source: {
+        type: 'dynamic',
+      },
+    },
+  },
+  render: () => (
+    <InputField
+      defaultValue="Text that stops at the reserved space"
+      inputWithin={
+        <Button rank="secondary" size="sm">
+          Copy
+        </Button>
+      }
+      label="Input field with a fixed reservation"
+      style={{ '--input-field__input-within-width': '120px' }}
       type="text"
     />
   ),

--- a/src/components/InputField/InputField.test.tsx
+++ b/src/components/InputField/InputField.test.tsx
@@ -110,26 +110,4 @@ describe('<InputField />', () => {
       inputBody.style.getPropertyValue('--input-field__input-within-width'),
     ).toBe('140px');
   });
-
-  it('only reserves trailing space for the password button once there is text to reveal', async () => {
-    const user = userEvent.setup();
-
-    render(
-      <InputField
-        aria-label="label"
-        data-testid="test-input"
-        onChange={jest.fn()}
-        type="password"
-      />,
-    );
-
-    const input = screen.getByTestId('test-input');
-
-    expect(input).not.toHaveClass('input-field__input--input-within');
-
-    input.focus();
-    await user.keyboard('hunter2');
-
-    expect(input).toHaveClass('input-field__input--input-within');
-  });
 });

--- a/src/components/InputField/InputField.test.tsx
+++ b/src/components/InputField/InputField.test.tsx
@@ -1,12 +1,16 @@
 import { generateSnapshots } from '@chanzuckerberg/story-utils';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import userEvent from '@testing-library/user-event';
+import { mockResizeObserver } from 'jsdom-testing-mocks';
 import React from 'react';
 import { InputField } from './InputField';
 
 import * as stories from './InputField.stories';
 import type { StoryFile } from '../../../.storybook/utility-types';
+import Button from '../Button';
+
+const resizeObserver = mockResizeObserver();
 
 describe('<InputField />', () => {
   generateSnapshots(stories as StoryFile);
@@ -74,5 +78,58 @@ describe('<InputField />', () => {
     await user.keyboard(testText);
 
     expect(onChange).toHaveBeenCalledTimes(testText.length);
+  });
+
+  it('reserves trailing space matching the measured width of `inputWithin`', () => {
+    render(
+      <InputField
+        aria-label="label"
+        data-testid="test-input"
+        inputWithin={
+          <Button rank="secondary" size="sm">
+            Button with extra text
+          </Button>
+        }
+      />,
+    );
+
+    const inputWithin = screen.getByRole('button', {
+      name: 'Button with extra text',
+    }).parentElement as HTMLElement;
+    const inputBody = screen.getByTestId('test-input')
+      .parentElement as HTMLElement;
+
+    // Widths beyond the previously fixed 88px maximum are reported in full, and rounded up so a
+    // fractional width cannot leave the content overlapping the text area
+    resizeObserver.mockElementSize(inputWithin, {
+      borderBoxSize: { inlineSize: 139.2, blockSize: 32 },
+    });
+    act(() => resizeObserver.resize(inputWithin));
+
+    expect(
+      inputBody.style.getPropertyValue('--input-field__input-within-width'),
+    ).toBe('140px');
+  });
+
+  it('only reserves trailing space for the password button once there is text to reveal', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <InputField
+        aria-label="label"
+        data-testid="test-input"
+        onChange={jest.fn()}
+        type="password"
+      />,
+    );
+
+    const input = screen.getByTestId('test-input');
+
+    expect(input).not.toHaveClass('input-field__input--input-within');
+
+    input.focus();
+    await user.keyboard('hunter2');
+
+    expect(input).toHaveClass('input-field__input--input-within');
   });
 });

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import { getMinValue } from '../../util/getMinValue';
 import type {
   EitherInclusive,
@@ -39,6 +39,10 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
   inputMode?: React.InputHTMLAttributes<HTMLInputElement>['inputMode'];
   /**
    * Node(s) that can be nested within the input field (e.g., secondary and tertiary `Button` components)
+   *
+   * The space reserved for this content is measured from what you pass in, so the content is free
+   * to be as wide as it needs. To reserve a fixed amount instead, set
+   * `--input-field__input-within-width` via `style`.
    */
   inputWithin?: ReactNode;
   /**
@@ -61,6 +65,12 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    * Toggles the form control's interactivity. When `readOnly` is set to `true`, the form control is not interactive
    */
   readOnly?: boolean;
+  /**
+   * CSS properties defined for the input element. Includes the component's CSS Custom Properties:
+   *
+   * - `--input-field__input-within-width`
+   */
+  style?: InputFieldCSSProperties;
   /**
    * Title attribute on input
    */
@@ -142,6 +152,15 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
     }
   >;
 
+export interface InputFieldCSSProperties extends React.CSSProperties {
+  /**
+   * The space reserved at the trailing edge of the input for `inputWithin` content. The component
+   * measures this from the rendered content, so it only needs setting to override that measurement
+   * with a fixed size.
+   */
+  '--input-field__input-within-width'?: string;
+}
+
 type InputFieldType = ForwardedRefComponent<
   HTMLInputElement,
   InputFieldProps
@@ -217,6 +236,42 @@ export const InputField: InputFieldType = forwardRef(
     const revealShowHideButton = type === 'password';
     const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
+    // The slot renders for caller-provided content and for the password show/hide button
+    const shouldRenderInputWithin = !!(inputWithin || revealShowHideButton);
+
+    // The show/hide button only appears once there is text to reveal, so an otherwise empty slot
+    // should not reserve any space
+    const hasInputWithinContent = !!(
+      inputWithin ||
+      (revealShowHideButton && fieldText)
+    );
+
+    // Measure the slot so the input's trailing padding can track the width of whatever is rendered
+    // in it, rather than constraining that content to a fixed size.
+    const inputWithinRef = useRef<HTMLDivElement>(null);
+    const [inputWithinWidth, setInputWithinWidth] = useState<number>();
+
+    useEffect(() => {
+      const inputWithinNode = inputWithinRef.current;
+
+      if (!inputWithinNode || typeof ResizeObserver === 'undefined') {
+        return;
+      }
+
+      const observer = new ResizeObserver(([entry]) => {
+        // Round up, so a fractional width can't leave the content overlapping the text area
+        setInputWithinWidth(
+          Math.ceil(
+            entry.borderBoxSize?.[0]?.inlineSize ?? entry.contentRect.width,
+          ),
+        );
+      });
+
+      observer.observe(inputWithinNode);
+
+      return () => observer.disconnect();
+    }, [shouldRenderInputWithin]);
+
     // set up base and conditional styles
     const overlineClassName = clsx(
       styles['input-field__overline'],
@@ -246,8 +301,18 @@ export const InputField: InputFieldType = forwardRef(
     // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
     const inputOverlayClassName = clsx(
       leadingIcon && styles['input-field__input--leading-icon'],
-      inputWithin && styles['input-field__input--input-within'],
+      hasInputWithinContent && styles['input-field__input--input-within'],
     );
+
+    // Publish the measured slot width for the input's trailing padding to consume. Left unset until
+    // measured, so the stylesheet's fallback covers the first render (and non-browser environments).
+    // A caller-supplied value in `style` lands on the input itself, so it takes precedence.
+    const inputBodyStyle =
+      inputWithinWidth === undefined
+        ? undefined
+        : ({
+            '--input-field__input-within-width': `${inputWithinWidth}px`,
+          } as InputFieldCSSProperties);
 
     // When field length is specified, handle calculations for current and total size (with styles)
     const fieldLength = fieldText?.toString().length ?? 0;
@@ -340,7 +405,7 @@ export const InputField: InputFieldType = forwardRef(
           </div>
         )}
 
-        <div className={inputBodyClassName}>
+        <div className={inputBodyClassName} style={inputBodyStyle}>
           <Input
             aria-describedby={completeDescribedByVar ?? undefined}
             aria-invalid={!!(status === 'critical')}
@@ -364,8 +429,11 @@ export const InputField: InputFieldType = forwardRef(
             type={isPasswordVisible ? 'text' : type}
             {...other}
           />
-          {(inputWithin || type === 'password') && (
-            <div className={styles['input-field__input-within']}>
+          {shouldRenderInputWithin && (
+            <div
+              className={styles['input-field__input-within']}
+              ref={inputWithinRef}
+            >
               {inputWithin}
               {revealShowHideButton && fieldText && (
                 <Button

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -239,13 +239,6 @@ export const InputField: InputFieldType = forwardRef(
     // The slot renders for caller-provided content and for the password show/hide button
     const shouldRenderInputWithin = !!(inputWithin || revealShowHideButton);
 
-    // The show/hide button only appears once there is text to reveal, so an otherwise empty slot
-    // should not reserve any space
-    const hasInputWithinContent = !!(
-      inputWithin ||
-      (revealShowHideButton && fieldText)
-    );
-
     // Measure the slot so the input's trailing padding can track the width of whatever is rendered
     // in it, rather than constraining that content to a fixed size.
     const inputWithinRef = useRef<HTMLDivElement>(null);
@@ -301,7 +294,7 @@ export const InputField: InputFieldType = forwardRef(
     // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
     const inputOverlayClassName = clsx(
       leadingIcon && styles['input-field__input--leading-icon'],
-      hasInputWithinContent && styles['input-field__input--input-within'],
+      shouldRenderInputWithin && styles['input-field__input--input-within'],
     );
 
     // Publish the measured slot width for the input's trailing padding to consume. Left unset until
@@ -435,7 +428,7 @@ export const InputField: InputFieldType = forwardRef(
               ref={inputWithinRef}
             >
               {inputWithin}
-              {revealShowHideButton && fieldText && (
+              {revealShowHideButton && (
                 <Button
                   aria-label={`${isPasswordVisible ? 'Hide' : 'Show'} password`}
                   icon={isPasswordVisible ? 'eye-closed' : 'eye-open'}

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`<InputField /> ControlledWithinMaxLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r1m:"
+        for=":r1p:"
       >
         <span
           class="text text--label-md"
@@ -37,7 +37,7 @@ exports[`<InputField /> ControlledWithinMaxLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
-          id=":r1o:"
+          id=":r1r:"
         >
           Additional descriptive text for the field.
         </span>
@@ -47,10 +47,10 @@ exports[`<InputField /> ControlledWithinMaxLength story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
-        aria-describedby=":r1o:"
+        aria-describedby=":r1r:"
         aria-invalid="false"
         class="input"
-        id=":r1m:"
+        id=":r1p:"
         maxlength="30"
         required=""
         type="text"
@@ -322,6 +322,56 @@ exports[`<InputField /> InputWithin story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<InputField /> InputWithinFixedWidth story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div>
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--md input-field__label"
+        for=":r1j:"
+      >
+        <span
+          class="text text--label-md"
+        >
+          Input field with a fixed reservation
+        </span>
+      </label>
+    </div>
+    <div
+      class="input-field__body"
+    >
+      <input
+        aria-describedby=""
+        aria-invalid="false"
+        class="input input-field__input--input-within"
+        id=":r1j:"
+        style="--input-field__input-within-width: 120px;"
+        type="text"
+        value="Text that stops at the reserved space"
+      />
+      <div
+        class="input-field__input-within"
+      >
+        <button
+          class="button button--layout-none button--secondary button--sm button--size-sm button--variant-default"
+          type="button"
+        >
+          <span
+            class="text text--label-sm button__text"
+          >
+            Copy
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<InputField /> LeadingIcon story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"
@@ -392,6 +442,7 @@ exports[`<InputField /> LongInputWithin story renders snapshot 1`] = `
         class="input input-field__input--input-within"
         id=":r1g:"
         type="text"
+        value="Text that runs up against the button"
       />
       <div
         class="input-field__input-within"
@@ -887,73 +938,12 @@ exports[`<InputField /> WithAMaxLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r1p:"
-      >
-        <span
-          class="text text--label-md"
-        >
-          test label
-        </span>
-      </label>
-      <div
-        class="text text--body-sm input-field__character-counter"
-      >
-        <span
-          class="input-field--invalid-length"
-        >
-          17
-        </span>
-         
-        / 
-        15
-      </div>
-      <div
-        class="input-field__subLabel"
-      >
-        <span
-          class="text text--body-sm"
-          id=":r1r:"
-        >
-          Additional descriptive text for the field.
-        </span>
-      </div>
-    </div>
-    <div
-      class="input-field__body"
-    >
-      <input
-        aria-describedby=":r1r:"
-        aria-invalid="false"
-        class="input error"
-        id=":r1p:"
-        maxlength="15"
-        required=""
-        type="text"
-        value="Some initial text"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
-<div
-  class="p-spacing-size-4"
->
-  <div
-    class="w-[384px]"
-  >
-    <div
-      class="input-field__overline"
-    >
-      <label
-        class="label label--md input-field__label"
         for=":r1s:"
       >
         <span
           class="text text--label-md"
         >
-          Shortened Length Field
+          test label
         </span>
       </label>
       <div
@@ -987,6 +977,7 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
         aria-invalid="false"
         class="input error"
         id=":r1s:"
+        maxlength="15"
         required=""
         type="text"
         value="Some initial text"
@@ -996,7 +987,7 @@ exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
 </div>
 `;
 
-exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1`] = `
+exports[`<InputField /> WithARecommendedLength story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"
 >
@@ -1013,7 +1004,7 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
         <span
           class="text text--label-md"
         >
-          test label
+          Shortened Length Field
         </span>
       </label>
       <div
@@ -1040,13 +1031,73 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
       </div>
     </div>
     <div
-      class="input-field__body input-field--has-fieldNote"
+      class="input-field__body"
     >
       <input
-        aria-describedby=":r21: :r20:"
+        aria-describedby=":r21:"
         aria-invalid="false"
         class="input error"
         id=":r1v:"
+        required=""
+        type="text"
+        value="Some initial text"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="w-[384px]"
+  >
+    <div
+      class="input-field__overline"
+    >
+      <label
+        class="label label--md input-field__label"
+        for=":r22:"
+      >
+        <span
+          class="text text--label-md"
+        >
+          test label
+        </span>
+      </label>
+      <div
+        class="text text--body-sm input-field__character-counter"
+      >
+        <span
+          class="input-field--invalid-length"
+        >
+          17
+        </span>
+         
+        / 
+        15
+      </div>
+      <div
+        class="input-field__subLabel"
+      >
+        <span
+          class="text text--body-sm"
+          id=":r24:"
+        >
+          Additional descriptive text for the field.
+        </span>
+      </div>
+    </div>
+    <div
+      class="input-field__body input-field--has-fieldNote"
+    >
+      <input
+        aria-describedby=":r24: :r23:"
+        aria-invalid="false"
+        class="input error"
+        id=":r22:"
         maxlength="20"
         required=""
         type="text"
@@ -1058,7 +1109,7 @@ exports[`<InputField /> WithBothMaxAndRecommendedLength story renders snapshot 1
     >
       <div
         class="field-note field-note--error"
-        id=":r20:"
+        id=":r23:"
       >
         <svg
           class="icon field-note__icon"
@@ -1221,7 +1272,7 @@ exports[`<InputField /> WithinMaxLength story renders snapshot 1`] = `
     >
       <label
         class="label label--md input-field__label"
-        for=":r1j:"
+        for=":r1m:"
       >
         <span
           class="text text--label-md"
@@ -1246,7 +1297,7 @@ exports[`<InputField /> WithinMaxLength story renders snapshot 1`] = `
       >
         <span
           class="text text--body-sm"
-          id=":r1l:"
+          id=":r1o:"
         >
           Additional descriptive text for the field.
         </span>
@@ -1256,10 +1307,10 @@ exports[`<InputField /> WithinMaxLength story renders snapshot 1`] = `
       class="input-field__body"
     >
       <input
-        aria-describedby=":r1l:"
+        aria-describedby=":r1o:"
         aria-invalid="false"
         class="input"
-        id=":r1j:"
+        id=":r1m:"
         maxlength="30"
         required=""
         type="text"


### PR DESCRIPTION
`inputWithin` reserved a fixed 96px of trailing padding on the input and clamped its slot to a hard 88px `max-width`, so content wider than that was trimmed regardless of how much room the field actually had.

The slot is now measured with a ResizeObserver, and its width is published as `--input-field__input-within-width` for the input's `padding-inline-end` to consume, so the reserved space tracks whatever is rendered. A `calc(100% - 72px)` cap on the slot keeps a usable text area at narrow field widths, and the stylesheet fallback reproduces the previous fixed reservation for the first render and for non-browser environments.

Callers that want a fixed reservation instead (for example, to align a set of fields whose buttons have differing labels) can set `--input-field__input-within-width` via `style`, which takes precedence over the measurement.

Also reserves space for the password show/hide button, which previously got no padding at all and so overlapped longer values. The reservation only applies once that button is actually rendered, so an empty password field keeps the default padding.

Verified in Storybook: a 167px button now renders untruncated with 12px clearance from the text area (was clamped to 88px), the slot clamps to `100% - 72px` as the field narrows without any observer feedback loop, and a 120px override resolves to 144px of padding over the 57px measurement.

### Test Plan:

<!--
  How did you validate that your changes were implemented correctly? If manually test, how?
-->

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [ ] Manually tested my changes, and here are the details:
