### PR TITLE
docs(Breadcrumbs): add usage, interaction, and accessibility guidance

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -20,6 +20,10 @@ export default {
     ),
   },
   parameters: {
+    docs: {
+      subtitle:
+        'List of links showing the user where they are in the system and allowing them to navigate to parent pages.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -54,11 +54,44 @@ type Context = {
 };
 
 const BreadcrumbsContext = createContext<Context>({});
-/**
- * List of Breadcrumb components showing the user where they are in the system and allow them
- * to navigate to parent pages.
- */
 
+/**
+ * ## Usage
+ *
+ * Navigation component used to show hierarchical position and depth of content in a webpage or
+ * application. Can show all available links in the hierarchy, or collapse the links into a menu
+ * as needed.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Full trail | Every ancestor is shown as its own link, separated by `separator`. | Shallow hierarchies that fit the available width. |
+ * | Collapsed | Middle items move into a `Menu` behind an ellipsis when the trail would overflow. | Deep hierarchies. Narrow containers. |
+ * | Back | The parent page is shown as a single back arrow at small breakpoints. | Mobile and other narrow viewports. |
+ *
+ * ### Best Practices
+ *
+ * * Use brief text for breadcrumb item text descriptions.
+ *
+ * ## Interaction
+ *
+ * Each item in `Breadcrumbs` represents one anchor which leads to a parent page in the hierarchy.
+ * Adjacent pages in the information architecture will have the same exact ancestors.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `Breadcrumbs` when pages have a tree structure resulting in 1-3 topmost parent pages, and many children per parent.
+ *
+ * ### Don'ts
+ *
+ * * Avoid having breadcrumbs with hierarchies greater than 10 ancestors. Consider a custom sub-navigation, more top-level links in `AppHeader`, or other grouping to avoid such deep hierarchies.
+ * * Don't go beyond 1-3 words for the text of each breadcrumb.
+ *
+ * ## Resources
+ *
+ * * https://www.nngroup.com/articles/breadcrumbs/
+ */
 export const Breadcrumbs = ({
   'aria-label': ariaLabel = 'breadcrumbs links',
   className,

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Breadcrumbs /> Default story renders snapshot 1`] = `
 <div


### PR DESCRIPTION
Fills in the `Breadcrumbs` docblock following the pattern established in #2567: usage summary and variant table, best practices, interaction notes, do's and don'ts, and a reference link. Content comes from [EDS-2093](https://czi.atlassian.net/browse/EDS-2093).

Two small departures from the ticket text:

- The ticket names the component `Breadcrumb`; the real export is `Breadcrumbs`, so the docs use that.
- The ticket lists "Keep the text for each breadcrumb to 1-3 words" under Don'ts but phrases it as a Do. Flipped the phrasing to match the section.

Also in here:

- **Added a Type/Use table the ticket didn't ask for.** It matches the house pattern (Accordion, Popover, Link, Avatar all have one) and is grounded in the actual component API rather than new design guidance — full trail, collapsed-into-`Menu`, and the back-arrow variant. Happy to drop it if design would rather own that content.
- **Moved the one-line description to the story's `docs.subtitle`** so it still renders on the docs page instead of being lost, consistent with the 28 other components that do this.
- **Removed a blank line between the docblock and `export const Breadcrumbs`.** It was breaking the react-docgen association, which is why the description wasn't reaching Storybook in the first place.

The snapshot header URL change (`goo.gl/fbAQLP` → `jestjs.io/docs/snapshot-testing`) is an automatic jest artifact from running the tests, not an authored change. #2588 carried the identical line.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 8 Breadcrumbs tests and 6 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2093]: https://czi.atlassian.net/browse/EDS-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ