### PR TITLE
docs(CodeBlock): add usage, interaction, and accessibility guidance

### DIFF
--- a/src/components/CodeBlock/CodeBlock.stories.ts
+++ b/src/components/CodeBlock/CodeBlock.stories.ts
@@ -9,6 +9,10 @@ export default {
   component: CodeBlock,
   tags: ['beta', 'version:1.0'],
   parameters: {
+    docs: {
+      subtitle:
+        'Component used to render a block of code for use alongside other components. Allows for copying code.',
+    },
     a11y: {
       config: {
         rules: [

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -36,7 +36,36 @@ export type CodeBlockProps = {
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * Component used to render block of code for use alongside other components. Allows for copying code.
+ * ## Usage
+ *
+ * Show a block of formatted code, with syntax highlighting, in a block container.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Read-only | The snippet is displayed on its own, with no copy affordance. | Illustrating syntax inline with surrounding prose. |
+ * | Icon copy | `copyStyle="icon"` adds an icon-only button that copies the snippet. | Dense layouts where a labeled button would crowd the block. |
+ * | Text copy | `copyStyle="text"` adds a labeled button that copies the snippet. | Snippets the reader is expected to run, like install commands. |
+ *
+ * ## Interaction
+ *
+ * `CodeBlock` allows for displaying syntax highlighting with a fixed theme. It also includes the
+ * ability to show a copy button which, when clicked, will copy the code block to the user's
+ * clipboard.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `CodeBlock` when you want to format and display any multi-line code to the user.
+ * * Use `CodeBlock` when a single-line code block applies to command line snippets, or other code which has complex, lengthy text.
+ *
+ * ### Don'ts
+ *
+ * * Avoid using `CodeBlock` for single-word code snippets. Instead use the `Text` component with one of the `code-*` presets.
+ *
+ * ## Resources
+ *
+ * * https://github.com/react-syntax-highlighter/react-syntax-highlighter
  */
 export const CodeBlock = ({
   children,

--- a/src/components/CodeBlock/__snapshots__/CodeBlock.test.ts.snap
+++ b/src/components/CodeBlock/__snapshots__/CodeBlock.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<CodeBlock /> CurlExample story renders snapshot 1`] = `
 <div


### PR DESCRIPTION
Fills in the `CodeBlock` docblock following the pattern established in #2567: usage summary and variant table, interaction notes, do's and don'ts, and a reference link. Content comes from [EDS-2094](https://czi.atlassian.net/browse/EDS-2094).

Judgment calls worth a look:

- **The ticket's Resources section was empty.** I filled it with the `react-syntax-highlighter` repo, matching how other components link their underlying library (Accordion and Popover → headlessui, Avatar → graphemer). Swap or drop it if something else was intended.
- **The ticket's Don't says "use `Text` component with a code prefix."** There's no `code` prop or `as="code"` on `Text`, but there are `code-xl` through `code-xs` typography presets, so I wrote it as "the `Text` component with one of the `code-*` presets." Flagging in case a different affordance was meant.
- **Added a Type/Use table the ticket didn't ask for**, matching the house pattern. Rows are grounded in the real API — the three `copyStyle` states — rather than new design guidance.
- **No Best Practices section.** The ticket didn't supply any and I didn't want to invent design guidance. Toggle omits Interaction for the same reason, so a missing section has precedent.
- **Kept the BETA notice.** Newer beta components (Combobox) carry beta status only via the `beta` story tag, which `CodeBlock` already has, so the docblock line is arguably redundant. Removing a "subject to change" warning felt like the team's call, not mine.

Also moved the one-line description to the story's `docs.subtitle` so it still renders on the docs page, consistent with the other components that do this.

The snapshot header URL change (`goo.gl/fbAQLP` → `jestjs.io/docs/snapshot-testing`) is an automatic jest artifact from running the tests, not an authored change.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 6 CodeBlock tests and 6 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2094]: https://czi.atlassian.net/browse/EDS-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ