### PR TITLE
docs(FieldLabel): add usage guidance

### DIFF
--- a/src/components/FieldLabel/FieldLabel.stories.ts
+++ b/src/components/FieldLabel/FieldLabel.stories.ts
@@ -9,6 +9,9 @@ export default {
     children: 'Label',
   },
   parameters: {
+    docs: {
+      subtitle: 'Label associated with an input element or field.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0.1'],

--- a/src/components/FieldLabel/FieldLabel.tsx
+++ b/src/components/FieldLabel/FieldLabel.tsx
@@ -37,7 +37,18 @@ export type FieldLabelProps = {
 };
 
 /**
- * Label associated with an input element or field.
+ * ## Usage
+ *
+ * `FieldLabel` is used to add a label to EDS's controls (e.g., `InputField`, `TextareaField`,
+ * `Select`, `Combobox`). This component should not be used in isolation, but can be used to label
+ * any custom input controls.
+ *
+ * Pair `htmlFor` with the control's `id` so the label and the control are associated. The EDS
+ * controls that render a label for you also expose it as a subcomponent, so `InputField.Label` and
+ * `TextareaField.Label` are this component.
+ *
+ * For guidance on how to word a label, see the do's and don'ts on the control itself (for example,
+ * `InputField`).
  */
 export const FieldLabel = React.forwardRef<HTMLLabelElement, FieldLabelProps>(
   ({ children, className, htmlFor, size = 'lg', disabled, ...other }, ref) => {


### PR DESCRIPTION
Fills in the `FieldLabel` docblock following the pattern established in #2567. Content comes from [EDS-2095](https://czi.atlassian.net/browse/EDS-2095), whose Usage paragraph is carried over close to verbatim.

This one is deliberately thinner than the sibling docs PRs, and the omissions are the part worth reviewing:

- **No Type/Use table.** `FieldLabel`'s only variations are `size` and `disabled`, which Storybook already renders in the Properties table directly above the description. A table of "Small / Medium / Large / Disabled" would just duplicate it. Every other component I've done in this epic got a table, so flagging the inconsistency as intentional.
- **No Content & Accessibility section.** `InputField` already owns the label-wording do's and don'ts ("use short, precise labels in sentence case", "don't use colons or periods at the end of labels"). Repeating them here creates two places to keep in sync, so I linked to the control instead.
- **No Resources section.** The ticket had none and there's no underlying library to point at; it renders a plain `<label>`.

Two things I added beyond the ticket text, both verifiable in code rather than design guidance:

- The `htmlFor` / `id` pairing, which is the component's actual contract.
- That `InputField.Label` and `TextareaField.Label` *are* this component (`InputField.tsx:462`, `TextareaField.tsx:333`). `Select.Label` is a separate wrapper that renders `as={FieldLabel}`, so I left it out of that sentence.

Happy to expand any of the omitted sections if design wants them filled in.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. `FieldLabel` has no test file of its own (pre-existing, not introduced here), so I ran its consumers instead: InputField, TextareaField, and Select all pass, 76 tests and 61 snapshots unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2095]: https://czi.atlassian.net/browse/EDS-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ