### PR TITLE
docs(FieldNote): add usage guidance

### DIFF
--- a/src/components/FieldNote/FieldNote.stories.tsx
+++ b/src/components/FieldNote/FieldNote.stories.tsx
@@ -9,6 +9,9 @@ export default {
   title: 'Components/FieldNote',
   component: FieldNote,
   parameters: {
+    docs: {
+      subtitle: 'Fieldnote component wraps text to describe other components.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0'],

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -44,7 +44,24 @@ export type FieldNoteProps = {
 };
 
 /**
- * Fieldnote component wraps text to describe other components.
+ * ## Usage
+ *
+ * `FieldNote` is used to add additional context to the attached input control (e.g., `InputField`,
+ * `TextareaField`, `Select`, `Combobox`, etc.). `FieldNote` should not be used in isolation, but
+ * can be used when building a custom input control.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Default | Neutral helper text sitting below the control. | Format hints. Examples of valid input. |
+ * | Warning | `status="warning"` adds a warning icon and treatment. | Input that is accepted but likely not what the user meant. |
+ * | Critical | `status="critical"` adds an error icon and treatment. | Validation failures that block submission. |
+ *
+ * When building a custom control, give the note an `id` and add that `id` to the control's
+ * `aria-describedby` so the note is announced with the control. The EDS controls that render a
+ * `FieldNote` for you already wire this up.
+ *
+ * For guidance on what to put in a note, see the do's and don'ts on the control itself (for
+ * example, `InputField`).
  */
 export const FieldNote = ({
   children,


### PR DESCRIPTION
Fills in the `FieldNote` docblock following the pattern established in #2567. Content comes from [EDS-2096](https://czi.atlassian.net/browse/EDS-2096), whose Usage paragraph is carried over close to verbatim.

Sibling of #2591 (`FieldLabel`), and structured the same way, but this one does get a Type/Use table: unlike `FieldLabel`, `FieldNote` has real variants in `status` (default / warning / critical) rather than just size and disabled.

Two additions beyond the ticket text, both verified in code rather than invented design guidance:

- **The `aria-describedby` contract for standalone use.** `InputField` generates an id for the note and folds it into the control's `aria-describedby` (`InputField.tsx:339-341`, `396`); `TextareaField` does the same. Anyone building a custom control has to wire that up themselves, so it's worth stating.
- **A pointer to control-level content guidance** instead of duplicating it. `InputField` already owns "use `fieldNote` for examples or instructions" and "don't stack field notes on top of error messages."

No Interaction section (the component is static text) and no Resources (the ticket had none, and there's no underlying library to link).

**Unrelated observation, not addressed here:** `status` overrides `icon`. When `status` is `critical` or `warning`, lines 66-74 reassign `iconToUse` and discard whatever was passed as `icon`. The `WithErrorIcon` story passes `icon: 'warning-filled'` with `status: 'critical'` and renders `critical-encircled-filled`. That may well be intended (forcing a consistent status icon), so I left both the behavior and the story alone rather than documenting a possible bug as intended behavior. Worth a separate ticket if it isn't intended.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. `FieldNote` has no test file of its own (pre-existing, same gap as `FieldLabel`), so I ran its consumers instead: InputField, TextareaField, Combobox, and Fieldset all pass, 107 tests and 69 snapshots unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2096]: https://czi.atlassian.net/browse/EDS-2096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ