### PR TITLE
docs(Fieldset): add usage, accessibility, and composition guidance

### DIFF
--- a/src/components/Fieldset/Fieldset.stories.tsx
+++ b/src/components/Fieldset/Fieldset.stories.tsx
@@ -8,6 +8,10 @@ export default {
   title: 'Components/Fieldset',
   component: Fieldset,
   parameters: {
+    docs: {
+      subtitle:
+        'A reusable container for a fieldset that includes a legend and one or more form inputs, like radio buttons or checkboxes.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -89,8 +89,35 @@ type FieldsetLegendProps = {
 const FieldsetContext = createContext<FieldsetSharedProps>({});
 
 /**
- * A reusable container for a fieldset that includes a legend and
- * one or more form inputs, like radio buttons or checkboxes.
+ * ## Usage
+ *
+ * Label and contain a set of fields, to clearly indicate the fields have a close relationship.
+ * Especially useful when showing `Checkbox` and `Radio` controls in a set. Can show its own label
+ * and field note.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Radio set | Groups mutually exclusive options under a single legend. | Picking one plan, one delivery method, one answer. |
+ * | Checkbox set | Groups related checkboxes that answer one question. | "Select all that apply" questions. |
+ * | With a field note | `fieldNote` adds a description or error below the group, and inherits the group's `status`. | Validation that applies to the set rather than one control. |
+ *
+ * Compose it as a `Fieldset.Legend` to label the group, followed by the controls wrapped in
+ * `Fieldset.Items`. `isDisabled` and `status` set on `Fieldset` flow down to both.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `Fieldset` when you wish to label a set of `Radio` fields, and want to avoid lengthy text in an adjacent element.
+ *
+ * ### Don'ts
+ *
+ * * Avoid using `Fieldset` with non-control content, like blocks of text or other components. Instead, use `Card`.
+ * * Don't use `Fieldset` with `Checkbox` unless the checkboxes are part of an overlapping set (e.g., "Select all that apply" in the label for the `Fieldset`).
+ *
+ * ## Resources
+ *
+ * * https://www.w3.org/WAI/WCAG22/Techniques/html/H71
  */
 export function Fieldset({
   children,

--- a/src/components/Fieldset/__snapshots__/Fieldset.test.tsx.snap
+++ b/src/components/Fieldset/__snapshots__/Fieldset.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Fieldset /> Default story renders snapshot 1`] = `
 <fieldset>


### PR DESCRIPTION
Fills in the `Fieldset` docblock following the pattern established in #2567. Content comes from [EDS-2097](https://czi.atlassian.net/browse/EDS-2097): usage summary, do's and don'ts, and the WCAG H71 reference.

One rephrasing of the ticket text: the second Don't was written as "Only use `Fieldset` with `Checkbox` when the checkboxes are part of an overlapping set," which reads as a Do under a Don'ts heading. Flipped to "Don't use `Fieldset` with `Checkbox` unless..." to match the section without changing the meaning.

Two additions beyond the ticket, both grounded in the code:

- **A Type/Use table**, matching the house pattern. Rows come from the real usage in the stories (radio set, checkbox set, group-level field note) rather than new design guidance. The field-note row notes that `fieldNote` inherits the group's `status`, which is what `Fieldset.tsx:107` does.
- **A composition sentence** covering `Fieldset.Legend` / `Fieldset.Items` and the fact that `isDisabled` and `status` flow down through context. That's the guidance already in the `children` prop comment, surfaced where people will read it.

**Unrelated observation, not addressed here:** `Fieldset` declares `React.HTMLAttributes<HTMLFieldSetElement>` in its props type but never spreads the rest onto the `<fieldset>`. It destructures only `children`, `className`, `fieldNote`, `isDisabled`, and `status`, so an `id`, `data-*`, or `aria-*` passed to `Fieldset` is silently dropped. Both sibling subcomponents do spread `...other`. Looks unintentional, but it's a behavior change rather than a docs fix, so I left it alone. Happy to file a ticket.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 13 Fieldset tests and 12 snapshots pass unchanged (this component, unlike `FieldLabel` and `FieldNote`, does have its own test file).
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2097]: https://czi.atlassian.net/browse/EDS-2097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ