### PR TITLE
docs(Heading): add usage and accessibility guidance

### DIFF
--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -7,6 +7,9 @@ export default {
   title: 'Components/Heading',
   component: Heading,
   parameters: {
+    docs: {
+      subtitle: 'A component for styling heading text (`<h1>`-`<h6>`).',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0'],

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -50,9 +50,31 @@ const headingPresetMap: Record<HeadingElement, Preset> = {
 };
 
 /**
- * A component for styling heading text (`<h1>`-`<h6>`).
+ * ## Usage
  *
- * Be careful to pass the correct heading element via the `as` prop to avoid skipping heading levels because [heading levels increasing by only one level at a time is important for screen reader users.](https://www.w3.org/WAI/tutorials/page-structure/headings/)
+ * Heading is strictly used to style heading tags used in a page. Typography presets are defined
+ * for each heading level (h1-h6) and can be overridden.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Semantic level | `as` picks which tag renders, and brings the default preset for that level with it. | `h1` for the page title, `h2` for a section within it. |
+ * | Restyled | `preset` overrides the default typography without changing which tag renders. | A section heading that needs to read smaller than its level implies. |
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `Heading` in place of any `h1`-`h6` HTML tag.
+ * * Pass the correct heading element via `as` to avoid skipping heading levels, because heading levels increasing by only one level at a time is important for screen reader users.
+ *
+ * ### Don'ts
+ *
+ * * Avoid all direct usage of `h1`-`h6` tags. Render them through `Heading` and its `as` prop instead.
+ * * Don't reach for `preset` to change the heading level. Change `as` so the visual order and the document outline stay in step.
+ *
+ * ## Resources
+ *
+ * * https://www.w3.org/WAI/tutorials/page-structure/headings/
  */
 export const Heading = forwardRef(
   (

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Heading /> Default story renders snapshot 1`] = `
 <h1


### PR DESCRIPTION
Fills in the `Heading` docblock following the pattern established in #2567. Content comes from [EDS-2098](https://czi.atlassian.net/browse/EDS-2098).

**Preserved the existing accessibility warning.** `Heading` already had a good note about not skipping heading levels, with a W3C link. The ticket didn't mention it, but dropping it would have been a real loss, so it's folded into the Do's and its link promoted to Resources. That's where the Resources section comes from; the ticket had none.

One rephrasing: the ticket's Don't reads "Avoid ALL usages of `h1` - `h6` tags," which taken literally would rule out the component itself, since `Heading` renders exactly those tags via `as`. Written as "Avoid all direct usage of `h1`-`h6` tags. Render them through `Heading` and its `as` prop instead."

Two additions beyond the ticket:

- **A Type/Use table**, matching the house pattern. The two rows are the real axes of the API: `as` for the semantic level (which carries that level's default preset) and `preset` to restyle without changing the tag.
- **A second Don't** warning against using `preset` to fake a heading level, which is the natural misuse of an overridable preset and the flip side of the existing level-skipping warning.

**Deliberately not included:** the `as` → default preset mapping from `headingPresetMap`. The stories already document it one level at a time ("When using `h1`, the default preset maps to `headline-lg`"), so repeating it in the docblock would be a second copy to keep in sync.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 10 Heading tests and 8 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2098]: https://czi.atlassian.net/browse/EDS-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ