### PR TITLE
docs(Hr): add usage and accessibility guidance

### DIFF
--- a/src/components/Hr/Hr.stories.ts
+++ b/src/components/Hr/Hr.stories.ts
@@ -6,6 +6,10 @@ export default {
   title: 'Components/Hr',
   component: Hr,
   parameters: {
+    docs: {
+      subtitle:
+        'Horizontal rule component to present a horizontal line separating content.',
+    },
     layout: 'centered',
   },
   args: {

--- a/src/components/Hr/Hr.tsx
+++ b/src/components/Hr/Hr.tsx
@@ -27,7 +27,22 @@ export type HrProps = {
 };
 
 /**
- * Horizontal rule component to present a horizontal line separating content.
+ * ## Usage
+ *
+ * Horizontal rules allow for separating vertically adjacent content in a layout.
+ *
+ * `Hr` renders one consistent rule with no supported variations. When a separator needs a
+ * different weight or color, reach for spacing or a border on the surrounding block instead.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use when trying to separate content in adjacent elements in a page instead of applying a bottom border and padding.
+ *
+ * ### Don'ts
+ *
+ * * Never have adjacent `Hr` in a page or layout. Instead, consider using a top and bottom border to a block element.
  */
 export const Hr = ({ className, size, variant, ...other }: HrProps) => {
   const componentClassName = clsx(

--- a/src/components/Hr/__snapshots__/Hr.test.tsx.snap
+++ b/src/components/Hr/__snapshots__/Hr.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Hr /> Default story renders snapshot 1`] = `
 <hr


### PR DESCRIPTION
Fills in the `Hr` docblock following the pattern established in #2567. Content comes from [EDS-2099](https://czi.atlassian.net/browse/EDS-2099), carried over close to verbatim.

Thin, like #2591 (`FieldLabel`), and the omissions are the reviewable part:

- **No Type/Use table.** `Hr`'s only props besides `className` are `size` and `variant`, both marked `@deprecated` and both slated for removal in the next major. A table would enumerate exactly the two things nobody should use.
- **No Resources or Interaction.** The ticket had neither, there's no underlying library, and the component is a static `<hr>`.

**One judgment call worth confirming.** I added a sentence saying `Hr` renders one consistent rule with no supported variations, and pointing at spacing or a container border when a different treatment is needed. I deliberately did *not* name `size` or `variant` while doing it, because `Hr.stories.ts` already hides both from the Properties table via `table: { disable: true }`. Naming them in prose would undo that decision and re-advertise deprecated props to the exact audience the team hid them from. Say the word if you'd rather the deprecation be explicit in the docs.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 3 Hr tests and 1 snapshot pass unchanged, including the two that assert the deprecation warnings still fire.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2099]: https://czi.atlassian.net/browse/EDS-2099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ