### PR TITLE
docs(Icon): add usage and accessibility guidance

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -13,6 +13,10 @@ const meta: Meta<typeof Icon> = {
   title: 'Components/Icon',
   component: Icon,
   parameters: {
+    docs: {
+      subtitle:
+        'Render arbitrary SVG path data while enforcing good accessibility practices.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -79,10 +79,37 @@ type SvgStyle = CSSProperties & {
 };
 
 /**
- * Render arbitrary SVG path data while enforcing good accessibility practices.
+ * ## Usage
  *
- * Icons are based on [Material Rounded](https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Rounded),
- * and are encoded in a spritemap in `src/icons`.
+ * Small illustrations to highlight and emphasize text and screen elements with visual detail.
+ * Icons align with adjacent text, and will inherit the text's color. Icons can also be embedded
+ * in other components.
+ *
+ * Icons come from a spritemap in `src/icons`; pick one with `name`. To render your own SVG
+ * instead, pass the path data as `children` along with a `viewBox`.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Informative | `purpose="informative"` renders `role="img"` and requires a `title`, so the icon is announced. | A status icon that is the only thing conveying the status. |
+ * | Decorative | `purpose="decorative"` renders `aria-hidden`, so assistive tech skips the icon entirely. | A plus icon next to the word "Add". |
+ *
+ * `color` defaults to `currentColor` so the icon picks up the surrounding text color. Prefer `em`
+ * for `size` so the icon scales with the text it sits beside.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `Icon` to add clarity and character to any buttons, especially those which are closely associated with user actions (e.g., an "add" button may use a plus icon).
+ * * Use decorative icons when paired with adjacent, descriptive text.
+ *
+ * ### Don'ts
+ *
+ * * Never use decorative `Icon` elements in isolation. Icons must have an associated accessible purpose, so when the icon is the only thing carrying the meaning, use `purpose="informative"` and give it a `title`.
+ *
+ * ## Resources
+ *
+ * * https://fonts.google.com/icons?icon.set=Material+Icons&icon.style=Rounded
  */
 export const Icon = (props: IconProps) => {
   const {

--- a/src/components/Icon/__snapshots__/Icon.test.ts.snap
+++ b/src/components/Icon/__snapshots__/Icon.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Icon /> CustomColor story renders snapshot 1`] = `
 <svg


### PR DESCRIPTION
Fills in the `Icon` docblock following the pattern established in #2567. Content comes from [EDS-2100](https://czi.atlassian.net/browse/EDS-2100).

**Kept the Material Rounded reference** from the existing docblock and promoted it to Resources, same as #2594 did with Heading's W3C link. The ticket had no Resources section, but dropping a live reference to where the icon set comes from would have been a loss.

**The ticket's Interaction section was empty** (a bare heading with nothing under it), so there's no Interaction section here. Same call as the empty Resources on #2590.

Three additions beyond the ticket, all verified against the code:

- **A Type/Use table on `purpose`**, which is the component's central distinction and the thing the ticket's do's and don'ts are actually about. `informative` renders `role="img"` with a required `title`; `decorative` renders `aria-hidden`. Both branches are right there in the component body.
- **`color` defaults to `currentColor`**, which is what makes the ticket's "will inherit the text's color" true, and the `em` sizing recommendation that makes "align with adjacent text" true. Both were already noted on the props; surfaced where they explain the usage claims.
- **Named the fix in the Don't.** The ticket says "Never use decorative `Icon` elements in isolation. Icons must have an associated accessible purpose," which states the rule without saying what to do instead. Added the remedy: use `purpose="informative"` with a `title` when the icon is the only thing carrying meaning.

Also documented the `children` + `viewBox` path for custom SVGs, since `name` is optional and the escape hatch isn't obvious from the Properties table alone.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 7 Icon tests and 7 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2100]: https://czi.atlassian.net/browse/EDS-2100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ