### PR TITLE
docs(Label): add usage guidance

### DIFF
--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -8,6 +8,10 @@ export default {
   title: 'Components/Label',
   component: Label,
   parameters: {
+    docs: {
+      subtitle:
+        'Label component used with selection controls (e.g., radio/checkbox fields).',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.0'],

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -37,7 +37,15 @@ export type LabelProps = {
 };
 
 /**
- * Label component used as legends for field groups (e.g., radio/checkbox fields).
+ * ## Usage
+ *
+ * Text styling used for selection controls like `Radio` and `Checkbox`. This component should not
+ * generally be used, except on custom radio or checkbox components.
+ *
+ * Pair `htmlFor` with the control's `id` so the label and the control are associated. `Radio.Label`
+ * is this component, and `Checkbox` and `Toggle` render it for you.
+ *
+ * `labelAfter` is a trailing slot beside the label text, typically used for a `Tooltip`.
  */
 export const Label = ({
   className,

--- a/src/components/Label/__snapshots__/Label.test.ts.snap
+++ b/src/components/Label/__snapshots__/Label.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Label /> Default story renders snapshot 1`] = `
 <label


### PR DESCRIPTION
Fills in the `Label` docblock following the pattern established in #2567. Content comes from [EDS-2101](https://czi.atlassian.net/browse/EDS-2101), which supplied only a Usage paragraph.

**Corrected the one-line description rather than carrying it over.** The old docblock said Label is "used as legends for field groups," but it renders a `<label>`, not a `<legend>`. `Fieldset.Legend` is the legend component. The subtitle now reads "used with selection controls." Flagging because this is a content change, not just a relocation.

Additions beyond the ticket, all verified in code:

- The `htmlFor` / `id` pairing, same contract documented in #2591 for `FieldLabel`.
- `Radio.Label` is this component (`Radio.tsx:197`), and `Checkbox` and `Toggle` render it internally.
- What `labelAfter` is for, since "slot for node to appear directly after field label" isn't self-explanatory in the Properties table.

No Type/Use table: the real variations are `disabled` and `labelAfter`, which the Properties table already covers.

---

**Found a dead prop while writing this, not fixed here.** `required` is declared in `LabelProps`, documented as "Indicates that field is required for form to be successfully submitted," defaulted to `true`, and destructured out of `...other` — then never used. It affects no class name, no attribute, and no rendered output; `required` appears zero times in the component's snapshots. Because it's destructured, it doesn't even fall through to the DOM.

Two consequences worth a maintainer's eye:

1. The `Default` story passes `required: true` and its doc comment says labels "denote... whether that content is marked as required." The docs page currently advertises behavior the component doesn't implement.
2. The default is `true`, so every consumer is implicitly opted into a required state that renders nothing. If this is ever wired up, the default will silently mark everything required.

I left `required` out of the docblock rather than document a prop that does nothing. Same family as EDS-2115 (Fieldset dropping pass-through props). Happy to file it.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. Ran Label plus its three consumers (Radio, Checkbox, Toggle): 28 tests and 26 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2101]: https://czi.atlassian.net/browse/EDS-2101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ