### PR TITLE
docs(PopoverContainer): add usage, interaction, and accessibility guidance

### DIFF
--- a/src/components/PopoverContainer/PopoverContainer.stories.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.stories.tsx
@@ -8,6 +8,10 @@ export default {
   title: 'Components/PopoverContainer',
   component: PopoverContainer,
   parameters: {
+    docs: {
+      subtitle:
+        'A standardized container for the content shown by popover components.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/PopoverContainer/PopoverContainer.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.tsx
@@ -15,6 +15,43 @@ export type PopoverContainerProps = {
   children: ReactNode;
 };
 
+/**
+ * ## Usage
+ *
+ * Show a standardized wrapper for content shown by popover components, like `Popover`, `Menu`, and
+ * `Select`. Define the container's appearance separate from the items within.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Render target | Passed as `as` to a HeadlessUI panel, so the panel itself renders as the container. | `Menu.Items`, `Select` options, `Combobox` options, `AppHeader` navigation. |
+ * | Direct wrapper | Rendered directly around the content of another component's panel. | `Popover.Content`. |
+ *
+ * Adjacent children with `role="group"` are separated by a divider automatically, so grouped menu
+ * content does not need its own separators.
+ *
+ * ## Interaction
+ *
+ * On render, this will use a subtle animation to highlight and draw the user's attention. The
+ * animation is skipped for anyone who has asked for reduced motion.
+ *
+ * The container suppresses its own focus outline. Focus treatment belongs to the items inside it,
+ * such as `PopoverListItem`.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `PopoverContainer` when creating any component that contains brief content similar in size to a Menu popover, or Select field popover. This could be ancillary content on a page where the trigger (e.g., a button) makes it clear what will be revealed.
+ *
+ * ### Don'ts
+ *
+ * * Avoid using `PopoverContainer` for large amounts of content. Consider `Modal` instead.
+ * * Avoid using `PopoverContainer` for on-page experiences that do not have a trigger to reveal the content. Consider `Card` (with `elevation`) instead.
+ *
+ * ## Resources
+ *
+ * * https://headlessui.com/react/popover#popover
+ */
 export const PopoverContainer = React.forwardRef<
   HTMLDivElement,
   PopoverContainerProps


### PR DESCRIPTION
Fills in the `PopoverContainer` docblock following the pattern established in #2567. Content comes from [EDS-2102](https://czi.atlassian.net/browse/EDS-2102): usage, interaction, do's and don'ts, and the HeadlessUI reference.

This component had **no docblock at all**, so the story's `docs.subtitle` is newly written rather than relocated from an existing description.

---

**One claim from the ticket is not in the code, so I left it out.**

The ticket's second Interaction bullet says "Certain components may add a focus ring to the container when selected, like `Menu`." I could not find that:

- `Menu.tsx:195` passes `as={PopoverContainer}` with no `className` at all.
- `Menu.module.css` contains no focus styles.
- `PopoverContainer.module.css` does the opposite: `&:focus-visible { outline: none; }`.
- The focused treatment actually lives on the items, in `PopoverListItem.module.css` (`.popover-list-item--focused`).

Rather than document behavior that isn't there, I wrote what the code does: the container suppresses its own outline, and focus treatment belongs to the items inside it. If the intent was the item-level ring, this is already covered; if a container-level ring is genuinely wanted, that's a feature request rather than a docs change.

Three additions beyond the ticket, all verified:

- **A Type/Use table.** The component has only `className` and `children`, so a prop-based table would be empty. The real axis is composition: passed as `as` to a HeadlessUI panel (Menu, Select, Combobox, AppHeader) versus rendered directly (`Popover.Content`).
- **Automatic group dividers.** The CSS gives adjacent `role="group"` children a top border. That's a genuine authoring affordance documented nowhere else.
- **Reduced-motion behavior.** The entrance animation is real (`fade-in` keyframes), and it's disabled under `prefers-reduced-motion: reduce`. Worth stating alongside the ticket's animation sentence.

The ticket names Popover, Menu, and Select as consumers; `AppHeader` and `Combobox` use it too, so the table reflects all five.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. `PopoverContainer` has no test file of its own (pre-existing, same gap as `FieldLabel` and `FieldNote`), so I ran all five consumers: Menu, Select, Popover, Combobox, and AppHeader pass, 111 tests and 62 snapshots unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2102]: https://czi.atlassian.net/browse/EDS-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ