### PR TITLE
docs(PopoverListItem): add usage guidance

### DIFF
--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -11,6 +11,10 @@ export default {
   title: 'Components/PopoverListItem',
   component: PopoverListItem,
   parameters: {
+    docs: {
+      subtitle:
+        'Structure and styles for an individual item in a popover that contains a list of items.',
+    },
     layout: 'centered',
   },
   tags: ['autodocs', 'version:2.1.1'],

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -49,13 +49,18 @@ export type PopoverListItemProps = {
 };
 
 /**
- * This abstracts the structure of an item in a popover, when the popover contains a
- * list of items (e.g., Menus and Selects)
- * - Contains styles for when active/disabled or not
- * - contains styles for when there is an icon on the left
+ * ## Usage
  *
- * Given headless implements listbox options as a renderProp, this can work for both
- * Listbox and Menu examples, in the latter case not specifying an icon
+ * Styles and containers for individual elements in internal Popover-like components (e.g., `Menu`,
+ * `Select`). This should not be used directly by consumers.
+ *
+ * Each item lays out four optional slots: `leadingContent` at the start, the `children` label,
+ * `subLabel` beneath the label, and `trailingContent` at the end.
+ *
+ * `Menu`, `Select`, and `Combobox` compose this for you and drive the `isFocused`, `isDisabled`,
+ * and `isDestructiveAction` states from their own render props. Because HeadlessUI implements
+ * listbox options as a render prop, the same item works for both listbox and menu shapes. Reach
+ * for those components rather than this one.
  */
 export const PopoverListItem = React.forwardRef<
   HTMLDivElement,


### PR DESCRIPTION
Fills in the `PopoverListItem` docblock following the pattern established in #2567. Content comes from [EDS-2103](https://czi.atlassian.net/browse/EDS-2103), which supplied only a Usage paragraph. Sibling of #2598.

**Kept the HeadlessUI render-prop rationale** from the previous docblock, since it explains why one item component serves both listbox and menu shapes. Dropped the old bullet about "when there is an icon on the left" — `icon` is `@deprecated` in favor of `leadingContent`, and the stories already hide it from the Properties table.

Additions beyond the ticket, all verified:

- **The four content slots** (`leadingContent`, `children`, `subLabel`, `trailingContent`), which is the actual layout contract and isn't obvious from reading prop descriptions one at a time.
- **Who composes it and what drives its state.** `Menu`, `Select`, and `Combobox` all render it and supply `isFocused` / `isDisabled` / `isDestructiveAction` from their own render props. The ticket names Menu and Select; Combobox uses it too (`Combobox.tsx:829`).

**No Type/Use table**, same call as #2591 and #2595. The two props that would define the axes are both deliberately hidden from the Properties table by the stories: `__type` (the private selectitem/listitem/label/separator/caption switch) and the deprecated `icon`. Building a table out of them would re-advertise exactly what the stories hide, for a component the docs explicitly tell you not to use directly.

This connects to #2598: the focused treatment I noted as living on the items rather than the container is `isFocused` here, driving `.popover-list-item--focused`.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. `PopoverListItem` has no test file of its own (pre-existing), so I ran its three consumers: Menu, Select, and Combobox pass, 91 tests and 51 snapshots unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2103]: https://czi.atlassian.net/browse/EDS-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ