### PR TITLE
docs(ProgressBar): add usage and accessibility guidance

### DIFF
--- a/src/components/ProgressBar/ProgressBar.stories.ts
+++ b/src/components/ProgressBar/ProgressBar.stories.ts
@@ -7,6 +7,10 @@ export default {
   title: 'Components/ProgressBar',
   component: ProgressBar,
   parameters: {
+    docs: {
+      subtitle:
+        'Component used to visually represent user progress through a series of steps.',
+    },
     layout: 'centered',
   },
   tags: ['beta', 'version:1.0.1'],

--- a/src/components/ProgressBar/ProgressBar.stories.ts
+++ b/src/components/ProgressBar/ProgressBar.stories.ts
@@ -9,7 +9,7 @@ export default {
   parameters: {
     docs: {
       subtitle:
-        'Component used to visually represent user progress through a series of steps.',
+        'Component used to visually represent user progress through a series of discrete portions, or a percentage.',
     },
     layout: 'centered',
   },

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -67,9 +67,37 @@ const PROGRESS_BAR_MINIMUM = 0;
 /**
  * BETA: This component is still a work in progress and is subject to change.
  *
- * Components used to visually represent user progress through a series of steps. Not to be confused with the `LoadingIndicator`.
+ * ## Usage
  *
- * `ProgressBar` can be the child of a container like `Modal` or `Card`. When used in such a container, `context`=`embedded` should be used to ensure the left and right edges of the progressBar sit flush within the edges of the container.
+ * Show the level of completeness for a given task or process. Indicate the percentage of
+ * completion for a discrete number of steps. Not to be confused with the `LoadingIndicator`, which
+ * covers waiting rather than measured progress.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Standalone | The default. Shows the bar with its labels above or beside it, set by `labelLayout`. | Page-level progress after a user action. |
+ * | Embedded | `context="embedded"` drops the labels and lets the bar sit flush with its container's edges. | A bar along the edge of a `Modal` or `Card`. |
+ *
+ * `ProgressBar` can be the child of a container like `Modal` or `Card`. When used in such a
+ * container, `context`=`embedded` should be used to ensure the left and right edges of the
+ * progressBar sit flush within the edges of the container.
+ *
+ * `value` is read against `max` (default `1`) and clamped to that range, so the bar cannot report
+ * below zero or above 100%. Supply `valueLabel` to replace the computed percentage with your own
+ * text, or pass an empty string to suppress it.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `ProgressBar` when content can be progressively completed and is triggered by user action (e.g., a click of a button) at the page level.
+ * * Use `ProgressBar` to show a measure within a form or other display, where the bar is static and reflects useful details.
+ * * Give every bar a name. The type requires either a visible `descriptionLabel` or an `aria-label`, which matters most for `context="embedded"`, where no visible label renders.
+ *
+ * ### Don'ts
+ *
+ * * Avoid using `ProgressBar` when you have a wizard like experience. Use `VisualPageIndicator` instead.
+ * * Avoid `ProgressBar` without labels for user feedback.
  */
 export const ProgressBar = ({
   className,

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -96,7 +96,7 @@ const PROGRESS_BAR_MINIMUM = 0;
  *
  * ### Don'ts
  *
- * * Avoid using `ProgressBar` when you have a wizard like experience. Use `VisualPageIndicator` instead.
+ * * Avoid using `ProgressBar` when you have a wizard-like, paginated experience. Use `VisualPageIndicator` instead.
  * * Avoid `ProgressBar` without labels for user feedback.
  */
 export const ProgressBar = ({

--- a/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
+++ b/src/components/ProgressBar/__snapshots__/ProgressBar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ProgressBar /> Default story renders snapshot 1`] = `
 <div


### PR DESCRIPTION
Fills in the `ProgressBar` docblock following the pattern established in #2567. Content comes from [EDS-2104](https://czi.atlassian.net/browse/EDS-2104).

**Kept three things from the existing docblock**, none of which the ticket mentions: the BETA notice (same call as #2590), the "not to be confused with `LoadingIndicator`" distinction, and the `context="embedded"` container guidance. All three would have been lost to a wholesale replacement.

Additions beyond the ticket, all verified in code:

- **A Type/Use table** on `context`, which is the component's real axis: standalone shows labels per `labelLayout`, embedded drops them and sits flush with the container edge.
- **Value clamping.** `value` is read against `max` (default `1`) and clamped, so the bar can't report below 0% or above 100%. There are four tests covering exactly this.
- **The label requirement, and why it matters most when embedded.** `ProgressBarProps` uses `EitherInclusive`, so at least one of `descriptionLabel` or `aria-label` is required. That's the concrete answer to the ticket's "avoid `ProgressBar` without labels" don't: embedded bars render no visible label, so `aria-label` is the only thing naming them. Added as a Do.

Confirmed `VisualPageIndicator` exists before referencing it in the Don't.

---

**Found a likely bug while reading, not fixed here.**

`ProgressBar.tsx:111-118` runs:

```
assertEdsUsage(
  [
    context === 'embedded' && !!descriptionLabel,
    context === 'embedded' && !!value,
  ],
  'Labels are not allowed when context is embedded',
  'error',
);
```

The second check fires on `value`, not `valueLabel`. `value` is a required prop and the entire point of the component, so **every embedded `ProgressBar` with nonzero progress logs a `console.error` reading "Labels are not allowed when context is embedded"** — a message that has nothing to do with `value`. Given the first check tests `descriptionLabel`, the second was almost certainly meant to test `valueLabel`.

It's gone unnoticed because `ProgressBar.test.tsx:9-15` mocks out `console.error` and `console.warn` in `beforeEach` "to suppress logging in tests," and the file carries a `TODO(next-major): add in tests for assertions`. The existing `is not rendered when the bar is embedded` test renders exactly this case (`context="embedded" value={0.33}`) and the error is swallowed.

Note it's `'error'` level, not the default warn, so it's noisier than most assertions here. Happy to file it.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 18 ProgressBar tests and 10 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2104]: https://czi.atlassian.net/browse/EDS-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ