### PR TITLE
docs(ScrollWrapper): add usage, interaction, and accessibility guidance

### DIFF
--- a/src/components/ScrollWrapper/ScrollWrapper.stories.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.stories.tsx
@@ -8,6 +8,12 @@ import { ScrollWrapper } from './ScrollWrapper';
 export default {
   title: 'Components/ScrollWrapper',
   component: ScrollWrapper,
+  parameters: {
+    docs: {
+      subtitle:
+        'A wrapper that shows and hides shadows along the edges of scrollable content.',
+    },
+  },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
   tags: ['version:1.1'],
 } as Meta<Args>;

--- a/src/components/ScrollWrapper/ScrollWrapper.tsx
+++ b/src/components/ScrollWrapper/ScrollWrapper.tsx
@@ -81,10 +81,48 @@ export const setShadowStates = (targetData: HTMLDivElement): ShadowStates => {
 };
 
 /**
- * This is a basic wrapper component that handles functionality to show/hide shadows along either the vertical or horizontal edges.
- * This kicks in once the container's size is smaller than the overall height of the content within. For this to work,
- * the element above the scroll wrapper must have a fixed height. The effect kicks in once the children of the scroll
- * wrapper expand height above that fixed height.
+ * ## Usage
+ *
+ * Wrap content that has a fixed height but is scrollable, so that users have an indication that
+ * more content is available. Subtle shadows come in several variants.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Vertical | The default. Scrolls on the y axis and shades the top and bottom edges. | Long dialog bodies. Tall option lists. |
+ * | Horizontal | `orientation="horizontal"` scrolls on the x axis and shades the start and end edges. | Wide tables. Toolbars that overflow. |
+ *
+ * `orientation` picks one axis at a time, so a single wrapper shades either the vertical or the
+ * horizontal edges, not both.
+ *
+ * `shadowType` controls the treatment: `cover` (the default) spans the full width of the wrapper,
+ * while `contain` keeps the shadow's edges inside it.
+ *
+ * The effect depends on the container being shorter than its content, so the element above the
+ * scroll wrapper must have a fixed height. Without that, nothing overflows and no shadow appears.
+ *
+ * ## Interaction
+ *
+ * When vertical, scrolling will enable both shadows when there is more content above and below the
+ * current position. When there is only content above the current position (scrolled to the end of
+ * the container), only the top shadow is shown. When scrolled to the very top of the container,
+ * only the bottom shadow is shown. The same logic applies to the horizontal scrolling scenario,
+ * against the start and end edges.
+ *
+ * `Modal` renders a `ScrollWrapper` around its body for you, so its content scrolls without any
+ * extra setup.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `ScrollWrapper` in any overlay components that need to exceed the available screen real estate. This is not for ones that definitely will, but ones that have variable content which could grow to be either too tall or too wide.
+ * * Use `cover` for the shadow type to emphasize and make clear that more content is available.
+ * * Leave the scrollable region in the tab order. It carries `tabIndex={0}` so that people navigating by keyboard can scroll it.
+ *
+ * ### Don'ts
+ *
+ * * Avoid wrapping entire pages with `ScrollWrapper`.
+ * * Never use multiple, adjacent `ScrollWrapper` instances.
  */
 export const ScrollWrapper = ({
   children,

--- a/src/components/ScrollWrapper/__snapshots__/ScrollWrapper.test.ts.snap
+++ b/src/components/ScrollWrapper/__snapshots__/ScrollWrapper.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ScrollWrapper /> ContainVertical story renders snapshot 1`] = `
 <div


### PR DESCRIPTION
Fills in the `ScrollWrapper` docblock following the pattern established in #2567. Content comes from [EDS-2105](https://czi.atlassian.net/browse/EDS-2105).

**Verified the ticket's shadow logic against `setShadowStates` and it's exactly right**, so that Interaction text is carried over close to verbatim. Top shows when `scrollTop !== 0`, bottom when `scrollTop < scrollHeight - clientHeight`, and start/end mirror it on `scrollLeft`.

**Two other claims in the ticket don't match the code, so I wrote the accurate version:**

1. **"Content can be vertically or horizontally scrollable, or both."** `orientation` is typed `'horizontal' | 'vertical'`, and the CSS applies `overflow-y` and `overflow-x` in two mutually exclusive blocks. One wrapper shades one axis. Written as "picks one axis at a time."
2. **"This component comes for free with `Modal`, and several other components."** `Modal.tsx:401` is the only consumer in the entire `src/` tree. Written as just `Modal`.

**Kept the fixed-height requirement** from the existing docblock. It's the main reason the effect silently does nothing, and the ticket doesn't mention it.

Two additions beyond the ticket:

- **A Type/Use table** on the two orientations, plus prose on `shadowType` (`cover` is the default; `contain` keeps shadow edges inside the wrapper).
- **A Do about the tab order.** The inner scroll region carries `tabIndex={0}` with a deliberate `eslint-disable` for `jsx-a11y/no-noninteractive-tabindex`, which is what lets keyboard users scroll it. Worth stating so nobody "cleans up" the lint suppression.

**Small inconsistency, not addressed:** the ticket's Do says to use `cover`, which is also the default, but the one real consumer (`Modal`) passes `shadowType="contain"`. That may well be deliberate for dialogs. I carried the Do over as written rather than second-guess the design guidance.

The story had no `parameters` block at all, so one was added for the subtitle.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. Ran ScrollWrapper plus its one consumer, Modal: 16 tests and 2 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2105]: https://czi.atlassian.net/browse/EDS-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ