### PR TITLE
docs(Skeleton): add usage and accessibility guidance

### DIFF
--- a/src/components/Skeleton/Skeleton.stories.tsx
+++ b/src/components/Skeleton/Skeleton.stories.tsx
@@ -8,6 +8,10 @@ export default {
   component: Skeleton,
 
   parameters: {
+    docs: {
+      subtitle:
+        'Skeleton states inform users about the wait time, reason, and status of ongoing processes, showing the expected layout.',
+    },
     layout: 'centered',
   },
 

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -20,7 +20,41 @@ type SkeletonProps = BaseProps & {
 };
 
 /**
- * Skeleton states inform users about the wait time, reason, and status of ongoing processes, showing the expected layout
+ * ## Usage
+ *
+ * Placeholder containers that are used for dynamic pages, to represent a proxy of the page layout
+ * when content finishes loading. Sizing and shape of the skeletons can be styled and adjusted, and
+ * the components can show an animation while on screen.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Block | The default. A rectangle sized by `width` and `height`. | Cards, images, and other blocks of layout. |
+ * | Text | `Skeleton.Text` stands in for a line or paragraph of copy. | Headings, body copy, list rows. |
+ * | Circle | `Skeleton.Circle` takes a single `width` and uses it for both dimensions. | Avatars and other round elements. |
+ *
+ * The shimmer runs by default and can be turned off per instance with `isAnimating={false}`. It is
+ * also disabled automatically for anyone who has asked for reduced motion.
+ *
+ * ## Content & Accessibility
+ *
+ * Every skeleton renders `aria-hidden`, so assistive tech skips the placeholders entirely. Announce
+ * the loading state separately, rather than relying on the skeletons to convey that something is
+ * on its way.
+ *
+ * ### Do's
+ *
+ * * Use `Skeleton` when you have content that may take some time to load, but you know the general shape and positioning of the content.
+ * * For `Skeleton`s using text, it's preferred to use the `ch` size in CSS with an approximate character count similar to the eventual content, so that it scales with the adjacent typography preset used.
+ * * All other `Skeleton` components should prefer using relative size units (`rem`, `em`, `%`) so that they adapt to user zoom settings.
+ *
+ * ### Don'ts
+ *
+ * * Avoid excessive use of `Skeleton`, especially in cases where the page has static content that isn't fetched asynchronously. Only use `Skeleton` for specific chunks of content that may need more time to load.
+ * * Avoid very large `Skeleton` instances (e.g., greater than `25vh` / `25vw`). Consider using multiple smaller `Skeleton` instances, or a background color and centered `LoadingIndicator`.
+ *
+ * ## Resources
+ *
+ * * https://www.lukew.com/ff/entry.asp?1797
  */
 export const Skeleton = ({
   className,

--- a/src/components/Skeleton/__snapshots__/Skeleton.test.ts.snap
+++ b/src/components/Skeleton/__snapshots__/Skeleton.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<Skeleton /> Circle story renders snapshot 1`] = `
 <div


### PR DESCRIPTION
Fills in the `Skeleton` docblock following the pattern established in #2567. Content comes from [EDS-2106](https://czi.atlassian.net/browse/EDS-2106), including the Luke Wroblewski reference.

Three additions beyond the ticket, all verified in code:

- **A Type/Use table** covering the three real variants: block `Skeleton`, `Skeleton.Text`, and `Skeleton.Circle`. Worth noting that `Skeleton.Circle` takes only `width` and applies it to both dimensions (`style={{ width, height: width }}`), which isn't obvious from the Properties table.
- **`aria-hidden` on every variant.** All three hardcode it, so assistive tech skips the placeholders entirely. That means the skeletons convey nothing about loading to a screen reader, and the state has to be announced some other way. This felt important enough to lead the Content & Accessibility section rather than sit in a bullet.
- **Reduced-motion handling.** The shimmer is on by default (`isAnimating = true`) and `Skeleton.module.css:36-40` disables it under `prefers-reduced-motion: reduce`.

Two small copy fixes to the ticket text: `25wh` is written as `25vw` (there's no `wh` unit), and "its preferred" as "it's preferred."

---

**Found the same defect as EDS-2115 in two places here, not fixed.**

`Skeleton.Text` and `Skeleton.Circle` both destructure `...other` and then never spread it onto the rendered `div`:

- `TextSkeleton` — `...other` at line 57, div at 65-70 has only `className` and `style`.
- `CircleSkeleton` — `...other` at line 81, div at 91-95 same.

The base `Skeleton` does spread correctly (line 41), so it's the two subcomponents that silently drop `id`, `data-*`, `aria-*`, and event handlers. Identical shape to [EDS-2115](https://czi.atlassian.net/browse/EDS-2115) (Fieldset), where the root drops props while its two subcomponents spread properly — just inverted here.

That makes three components with this bug so far (Fieldset, Skeleton.Text, Skeleton.Circle), which suggests the repo-wide sweep I proposed as step 5 on EDS-2115 is worth doing. Happy to file this separately or fold it into EDS-2115.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 3 Skeleton tests and 3 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2106]: https://czi.atlassian.net/browse/EDS-2106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDS-2115]: https://czi.atlassian.net/browse/EDS-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ