### PR TITLE
docs(Text): add usage and accessibility guidance

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -8,6 +8,10 @@ export default {
   title: 'Components/Text',
   component: Text,
   parameters: {
+    docs: {
+      subtitle:
+        'The Text component decorates `<p>`, `<span>`, and `<div>` with typographic variants.',
+    },
     layout: 'centered',
   },
   argTypes: {

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -24,10 +24,32 @@ export type TextProps = {
 } & React.HTMLAttributes<HTMLElement>; // TODO-AH: add in each possible element and spread in <Markdown>
 
 /**
- * The Text component decorates `<p>` and `<span>` with typographic variants. Use
- * typography presets to style the text via `preset`.
+ * ## Usage
  *
- * For headers, please use `Heading`.
+ * `Text` is strictly used to style non-heading tags used in a page. Typography presets cover body
+ * copy, labels, captions, overlines, code, and other treatments.
+ *
+ * | Type/Use | Description | Example |
+ * |----------|-------------|---------|
+ * | Paragraph | The default. `as="p"` for a standalone block of copy. | Body text, descriptions, help text. |
+ * | Span | `as="span"` for text that sits inline within a larger block. | A label beside an icon, inline emphasis. |
+ * | Div | `as="div"` when the text needs to wrap other block content. | Text composed alongside nested layout. |
+ *
+ * Set the treatment with `preset`, which defaults to `body-md`. The preset scale is shared across
+ * the design system, so heading-level values appear in it too. Reach for `Heading` when you need
+ * heading semantics; `Text` only renders `p`, `span`, and `div`.
+ *
+ * ## Content & Accessibility
+ *
+ * ### Do's
+ *
+ * * Use `Text` for all typographical treatments, and specify a block (`<div>` / `<p>`) tag, or `<span>` as desired.
+ *
+ * ### Don'ts
+ *
+ * * Never use any utility classes on raw HTML tags.
+ * * Never use TailwindCSS or other styles on raw HTML tags.
+ * * Don't use a heading preset on `Text` to imitate a heading. It changes the look without adding the semantics, so the document outline stays wrong. Use `Heading` instead.
  */
 export const Text = forwardRef(
   (

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -47,8 +47,7 @@ export type TextProps = {
  *
  * ### Don'ts
  *
- * * Never use any utility classes on raw HTML tags.
- * * Never use TailwindCSS or other styles on raw HTML tags.
+ * * Never use TailwindCSS or other styles on raw HTML tags to style/format typography.
  * * Don't use a heading preset on `Text` to imitate a heading. It changes the look without adding the semantics, so the document outline stays wrong. Use `Heading` instead.
  */
 export const Text = forwardRef(


### PR DESCRIPTION
Fills in the `Text` docblock following the pattern established in #2567. Content comes from [EDS-2107](https://czi.atlassian.net/browse/EDS-2107).

**One claim in the ticket describes `Heading`, not `Text`.** The Usage line reads "Typography presets are defined for each heading level (h1-h6), code, and other treatments" — nearly the same sentence as [EDS-2098](https://czi.atlassian.net/browse/EDS-2098), where it was correct. `Text`'s `as` prop is typed `'p' | 'span' | 'div'`; it cannot render a heading at all. Written as "body copy, labels, captions, overlines, code, and other treatments," which is what the preset scale actually offers here.

**Kept the "for headers, please use `Heading`" pointer** from the existing docblock, since the ticket drops it and it's the natural companion to the correction above.

Two additions beyond the ticket:

- **A Type/Use table** on the three renderable tags, which is the component's real axis and the thing the ticket's own Do is about ("specify a block (`<div>` / `<p>`) tag, or `<span>` as desired").
- **A third Don't:** don't use a heading preset on `Text` to imitate a heading. The `Preset` union is shared design-system-wide, so `headline-lg` and friends *are* accepted here — they just change the look without adding the semantics, leaving the document outline wrong. This is the `Text` side of the warning #2594 added to `Heading`.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. `Text` is consumed across most of the library, so I ran the **full** suite rather than a subset: 571 tests and 368 snapshots pass, 48 of 49 suites green.
- [ ] Accepted all chromatic snapshot changes

**Note on the one failing suite:** `scripts/stylelint/rules/no-tier-1-color-variable.test.mjs` fails with `SyntaxError: Cannot use import statement outside a module`. I verified this is pre-existing by stashing my changes and re-running it against clean `next`, where it fails identically. It's a jest/ESM transform config issue in the stylelint rule tests, unrelated to this PR, and it collects 0 tests rather than failing an assertion. Worth its own ticket if it isn't already known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2107]: https://czi.atlassian.net/browse/EDS-2107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDS-2098]: https://czi.atlassian.net/browse/EDS-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ