### PR TITLE
docs(VisualPageIndicator): add usage, interaction, and accessibility guidance

### DIFF
--- a/src/components/VisualPageIndicator/VisualPageIndicator.stories.ts
+++ b/src/components/VisualPageIndicator/VisualPageIndicator.stories.ts
@@ -6,6 +6,12 @@ import { VisualPageIndicator } from './VisualPageIndicator';
 export default {
   title: 'Components/VisualPageIndicator',
   component: VisualPageIndicator,
+  parameters: {
+    docs: {
+      subtitle:
+        'Static visual cue to help users understand their current position within a series of content or pages.',
+    },
+  },
   tags: ['autodocs', 'version:1.0'],
 } as Meta<Args>;
 

--- a/src/components/VisualPageIndicator/VisualPageIndicator.tsx
+++ b/src/components/VisualPageIndicator/VisualPageIndicator.tsx
@@ -22,7 +22,40 @@ export type VisualPageIndicatorProps = {
 };
 
 /**
- * Static visual cue to help users understand their current position within a series of content or pages.
+ * ## Usage
+ *
+ * Show to users which step they are on, in a given flow. Help to illustrate current position on
+ * pagination experiences.
+ *
+ * ## Interaction
+ *
+ * Users can specify a number of dots, with each dot representing a discrete page of content in the
+ * user interface. The active dot takes on a different color, to signal that it is the current
+ * "position" within a set.
+ *
+ * The individual dots are not interactive; a user cannot move their position by clicking any
+ * particular dot.
+ *
+ * `totalPageCount` sets how many dots render, and `activePage` marks which one is current. The
+ * index is zero-based, so the last page is `totalPageCount - 1`. Fewer than two dots warns, and an
+ * `activePage` outside the range logs an error.
+ *
+ * ## Content & Accessibility
+ *
+ * This is a visual cue only. The dots render as empty list items with no text, so assistive tech
+ * gets no sense of which step is current. Always state the position in text nearby, for example a
+ * "Step 2 of 5" label alongside the indicator.
+ *
+ * ### Do's
+ *
+ * * Use when there is a wizard-like experience, where there are a fixed number of steps, and you need to indicate which step the user is on, currently.
+ * * For control, add adjacent buttons that let a user navigate to the next/previous step in the flow. This can be tied to logic to update the current dot in the set.
+ * * For `Modal`, the next/previous buttons can be located together and right aligned. In such a layout, "Next" is treated as the primary button and is right most.
+ *
+ * ### Don'ts
+ *
+ * * Avoid using `VisualPageIndicator` without adjoined buttons for control.
+ * * Avoid relying on, or building, any interaction with `VisualPageIndicator`, as the tap / click targets are very small and provide a poor UX.
  */
 export const VisualPageIndicator = ({
   className,

--- a/src/components/VisualPageIndicator/__snapshots__/VisualPageIndicator.test.tsx.snap
+++ b/src/components/VisualPageIndicator/__snapshots__/VisualPageIndicator.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<VisualPageIndicator /> Default story renders snapshot 1`] = `
 <ul


### PR DESCRIPTION
Fills in the `VisualPageIndicator` docblock following the pattern established in #2567. Content comes from [EDS-2108](https://czi.atlassian.net/browse/EDS-2108).

**Every Interaction claim in the ticket checked out**, so that section is carried over close to verbatim. The dots are `<li>` elements with no handlers, no `tabIndex`, and no role, so "not interactive" is literally true. The active dot swaps a background-color token via `.visual-page-indicator--active`.

Two additions beyond the ticket, both verified:

- **The `activePage` contract.** It's zero-based, so the last page is `totalPageCount - 1`. Fewer than two dots warns, and an out-of-range `activePage` logs an error. All three behaviors have existing tests (`errors when active page is above range`, `below range`, `warns when total page count is too small`), so the docs now match what's already asserted.
- **A Content & Accessibility lead-in stating this is a visual cue only.** The dots render as empty list items with no text and no `aria-current`, so a screen reader gets "list, N items" and nothing about position. The recommendation is to state the position in text nearby, e.g. a "Step 2 of 5" label.

On that last point: [EDS-1587](https://czi.atlassian.net/browse/EDS-1587) proposed adding a Storybook example for exactly this ("we should not just use the page indicators as the only way to indicate position in a flow") and was closed **Won't Do**. I read that as declining the *story*, not disputing the guidance, so I documented the guidance in prose rather than proposing new stories. Worth a second opinion if that reading is wrong.

**No Type/Use table.** The component has only `activePage` and `totalPageCount` and no variants, so there's no axis to tabulate. Same call as #2591, #2595, and #2599.

No Resources section; the ticket had none and there's no underlying library.

The story had no `parameters` block, so one was added for the subtitle.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 6 VisualPageIndicator tests and 3 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2108]: https://czi.atlassian.net/browse/EDS-2108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDS-1587]: https://czi.atlassian.net/browse/EDS-1587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ