### PR TITLE
docs(TextareaField): restore content lost in the zeroheight migration

### DIFF
--- a/src/components/TextareaField/TextareaField.tsx
+++ b/src/components/TextareaField/TextareaField.tsx
@@ -151,12 +151,13 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
  *
  * * Always have a visible label when adding a hint.
  * * Use short, instructional labels when necessary and use sentence case.
- * * Use `fieldNote` helper text when necessary, favoring examples over instructions.
+ * * Use `fieldNote` helper text when necessary, and use examples rather than instructions whenever possible (e.g., `yourname@emaildomain.com`).
  * * For errors, provide instructions for fixing the issue and explain what is happening.
  *
  * ### Don'ts
  *
  * * Don't use colons or periods at the end of labels, and don't omit labels.
+ * * Don't have a hint without a visible label.
  * * Don't force the use of helper text—there is frequently no need for it.
  * * Don't place placeholder text within the field, as it can cause accessibility issues.
  */


### PR DESCRIPTION
Addresses [EDS-2109](https://czi.atlassian.net/browse/EDS-2109), which flagged that TextareaField's do's and don'ts were truncated when they moved from zeroheight into Storybook, and that we may have thrown away content Heather wrote deliberately.

## What was checked against zeroheight

**The USES table is fine.** All six rows (Standard, Auto-resizing, Fixed-size, Read-only, Disabled, Monospaced) match zeroheight exactly, descriptions and examples included. No change made.

**The helper-text Do had been collapsed.** Zeroheight reads "Use examples rather than instructions whenever possible. ex. `yourname@emaildomain.com`"; Storybook had flattened it to "favoring examples over instructions," dropping the concrete example. Restored the example while keeping the `fieldNote` reference the Storybook version added, since that's component-specific and worth keeping:

> Use `fieldNote` helper text when necessary, and use examples rather than instructions whenever possible (e.g., `yourname@emaildomain.com`).

**The Hints pair had lost its Don't.** Zeroheight has a Do/Don't image pair: "Always have a visible label when adding a hint" / "Don't have a hint without a visible label." Only the Do survived the migration. Added the Don't back.

It's an inverse restatement of the Do, so it adds no new rule. I restored it anyway because the ticket's concern is specifically about dropped content, and the Do/Don't pairing is how the guidance was authored. Easy to drop if you'd rather not carry the redundancy.

## Scope

Confirmed with Andrew that the zeroheight page holds nothing further for TextareaField, so this is the complete restoration rather than a first pass.

## Related, not addressed here

`InputField` came through the same migration and shows the same divergence. Its docs *kept* the concrete email example and a "Don't stack field notes on top of error messages" don't that TextareaField lacks, while TextareaField has two bullets InputField lacks. The two have drifted in both directions, which suggests the migration loss isn't confined to this component. EDS-2040's review list may already cover it; worth a sibling ticket if not.

### Test Plan:

Docs-only change, no runtime behavior touched.

- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details: `tsc --noEmit` clean, eslint clean, prettier clean. All 18 TextareaField tests and 14 snapshots pass unchanged.
- [ ] Accepted all chromatic snapshot changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2109]: https://czi.atlassian.net/browse/EDS-2109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ