### PR TITLE
feat(AppFooter)!: drop the -color suffix from the color custom properties

### DIFF
--- a/src/components/AppFooter/AppFooter.module.css
+++ b/src/components/AppFooter/AppFooter.module.css
@@ -6,18 +6,18 @@
  * AppFooter
  */
 .app-footer {
-  background-color: var(--app-footer__bg-color);
-  color: var(--app-footer__fg-color);
+  background-color: var(--app-footer__bg);
+  color: var(--app-footer__fg);
 }
 
 .app-footer--emphasis-low {
-  --app-footer__fg-color: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
-  --app-footer__bg-color: light-dark(var(--eds-theme-color-background-utility-default-no-emphasis), var(--eds-dark-theme-color-background-utility-default-no-emphasis));
+  --app-footer__fg: light-dark(var(--eds-theme-color-text-utility-default-primary), var(--eds-dark-theme-color-text-utility-default-primary));
+  --app-footer__bg: light-dark(var(--eds-theme-color-background-utility-default-no-emphasis), var(--eds-dark-theme-color-background-utility-default-no-emphasis));
 }
 
 .app-footer--emphasis-high {
-  --app-footer__fg-color: light-dark(var(--eds-theme-color-text-utility-inverse), var(--eds-dark-theme-color-text-utility-inverse));
-  --app-footer__bg-color: light-dark(var(--eds-theme-color-background-utility-default-high-emphasis), var(--eds-dark-theme-color-background-utility-default-high-emphasis));
+  --app-footer__fg: light-dark(var(--eds-theme-color-text-utility-inverse), var(--eds-dark-theme-color-text-utility-inverse));
+  --app-footer__bg: light-dark(var(--eds-theme-color-background-utility-default-high-emphasis), var(--eds-dark-theme-color-background-utility-default-high-emphasis));
 }
 
 .app-footer__home-link {

--- a/src/components/AppFooter/AppFooter.stories.tsx
+++ b/src/components/AppFooter/AppFooter.stories.tsx
@@ -51,7 +51,7 @@ export default {
     ],
   },
 
-  tags: ['autodocs', 'beta', 'version:1.1.0'],
+  tags: ['autodocs', 'beta', 'version:2.0.0'],
 } as Meta<typeof AppFooter>;
 
 type Story = StoryObj<typeof AppFooter>;
@@ -104,5 +104,23 @@ export const HighEmphasis: Story = {
   args: {
     ...WithCopyright.args,
     emphasis: 'high',
+  },
+};
+
+/**
+ * Each emphasis sets its own colors, and `--app-footer__bg` / `--app-footer__fg` override those
+ * for either one. Pass them through the `style` prop.
+ *
+ * Reach for a theme token in real usage. The literal colors here are only to make the point
+ * unmistakable: neither emphasis uses them, so the footer below is colored by the override
+ * rather than by its emphasis.
+ */
+export const CustomColors: Story = {
+  args: {
+    ...WithCopyright.args,
+    style: {
+      '--app-footer__bg': 'rebeccapurple',
+      '--app-footer__fg': 'papayawhip',
+    },
   },
 };

--- a/src/components/AppFooter/AppFooter.test.tsx
+++ b/src/components/AppFooter/AppFooter.test.tsx
@@ -12,7 +12,7 @@ import {
   beforeEach,
   afterEach,
 } from 'vitest';
-import { AppFooter } from './AppFooter';
+import { AppFooter, type AppFooterCSSProperties } from './AppFooter';
 
 import * as stories from './AppFooter.stories';
 import type { StoryFile } from '../../../.storybook/utility-types';
@@ -26,6 +26,30 @@ const CUSTOM_BG = 'rebeccapurple';
 const CUSTOM_FG = 'papayawhip';
 
 const EMPHASES = ['low', 'high'] as const;
+
+/**
+ * The two properties, each paired with the other one, so every case runs against both and a
+ * property set on its own cannot quietly leak into the other.
+ */
+const CUSTOM_PROPERTIES: {
+  name: string;
+  value: string;
+  style: AppFooterCSSProperties;
+  otherName: string;
+}[] = [
+  {
+    name: '--app-footer__bg',
+    value: CUSTOM_BG,
+    style: { '--app-footer__bg': CUSTOM_BG },
+    otherName: '--app-footer__fg',
+  },
+  {
+    name: '--app-footer__fg',
+    value: CUSTOM_FG,
+    style: { '--app-footer__fg': CUSTOM_FG },
+    otherName: '--app-footer__bg',
+  },
+];
 
 const NAV_ITEMS: NavLink[] = [
   {
@@ -79,20 +103,19 @@ describe('<AppFooter />', () => {
       },
     );
 
-    it('accepts either one on its own', () => {
-      const { container } = render(
-        <AppFooter
-          navItems={NAV_ITEMS}
-          style={{ '--app-footer__bg': CUSTOM_BG }}
-          title="text"
-        />,
-      );
+    it.each(CUSTOM_PROPERTIES)(
+      'accepts $name on its own, leaving $otherName to its default',
+      ({ name, value, style, otherName }) => {
+        const { container } = render(
+          <AppFooter navItems={NAV_ITEMS} style={style} title="text" />,
+        );
 
-      const footer = container.firstElementChild as HTMLElement;
+        const footer = container.firstElementChild as HTMLElement;
 
-      expect(footer).toHaveStyle({ '--app-footer__bg': CUSTOM_BG });
-      expect(footer.style.getPropertyValue('--app-footer__fg')).toBe('');
-    });
+        expect(footer.style.getPropertyValue(name)).toBe(value);
+        expect(footer.style.getPropertyValue(otherName)).toBe('');
+      },
+    );
 
     it('keeps them alongside the regular CSS properties on the style prop', () => {
       const { container } = render(
@@ -115,7 +138,7 @@ describe('<AppFooter />', () => {
     });
 
     it('does not accept the pre-v19 `-color` suffixed names', () => {
-      const { container } = render(
+      const { container: bgContainer } = render(
         <AppFooter
           navItems={NAV_ITEMS}
           // @ts-expect-error renamed in v19; `-color` was dropped to match the other components
@@ -123,12 +146,28 @@ describe('<AppFooter />', () => {
           title="text"
         />,
       );
+      const { container: fgContainer } = render(
+        <AppFooter
+          navItems={NAV_ITEMS}
+          // @ts-expect-error renamed in v19; `-color` was dropped to match the other components
+          style={{ '--app-footer__fg-color': CUSTOM_FG }}
+          title="text"
+        />,
+      );
 
-      expect(
-        (container.firstElementChild as HTMLElement).style.getPropertyValue(
-          '--app-footer__bg',
-        ),
-      ).toBe('');
+      const bgFooter = bgContainer.firstElementChild as HTMLElement;
+      const fgFooter = fgContainer.firstElementChild as HTMLElement;
+
+      // React passes any `--` prefixed key straight through, so the old names still reach the
+      // DOM. They just no longer drive anything, which is what these assert.
+      expect(bgFooter.style.getPropertyValue('--app-footer__bg')).toBe('');
+      expect(bgFooter.style.getPropertyValue('--app-footer__bg-color')).toBe(
+        CUSTOM_BG,
+      );
+      expect(fgFooter.style.getPropertyValue('--app-footer__fg')).toBe('');
+      expect(fgFooter.style.getPropertyValue('--app-footer__fg-color')).toBe(
+        CUSTOM_FG,
+      );
     });
   });
 

--- a/src/components/AppFooter/AppFooter.test.tsx
+++ b/src/components/AppFooter/AppFooter.test.tsx
@@ -16,9 +16,121 @@ import { AppFooter } from './AppFooter';
 
 import * as stories from './AppFooter.stories';
 import type { StoryFile } from '../../../.storybook/utility-types';
+import type { NavLink } from '../../util/utility-types';
+
+/**
+ * Valid colors that no theme token resolves to, so an assertion cannot pass on an emphasis
+ * default by coincidence.
+ */
+const CUSTOM_BG = 'rebeccapurple';
+const CUSTOM_FG = 'papayawhip';
+
+const EMPHASES = ['low', 'high'] as const;
+
+const NAV_ITEMS: NavLink[] = [
+  {
+    type: 'link',
+    name: 'Support',
+    href: '#support',
+  },
+];
 
 describe('<AppFooter />', () => {
   generateSnapshots(stories as StoryFile);
+
+  describe('the color custom properties', () => {
+    it('leaves them alone when the caller does not set them, so the emphasis default applies', () => {
+      const { container } = render(
+        <AppFooter navItems={NAV_ITEMS} title="text" />,
+      );
+
+      const footer = container.firstElementChild as HTMLElement;
+
+      expect(footer.style.getPropertyValue('--app-footer__bg')).toBe('');
+      expect(footer.style.getPropertyValue('--app-footer__fg')).toBe('');
+    });
+
+    it.each(EMPHASES)(
+      'takes a caller value over the %s emphasis colors',
+      (emphasis) => {
+        const { container } = render(
+          <AppFooter
+            emphasis={emphasis}
+            navItems={NAV_ITEMS}
+            style={{
+              '--app-footer__bg': CUSTOM_BG,
+              '--app-footer__fg': CUSTOM_FG,
+            }}
+            title="text"
+          />,
+        );
+
+        const footer = container.firstElementChild as HTMLElement;
+
+        // The emphasis class declares the defaults and the caller's inline value lands on the
+        // same element, which is what lets the inline value win. This asserts the two coexist;
+        // that the cascade resolves in the caller's favor is covered by the Chromatic snapshot
+        // of the `CustomColors` story, since jsdom does not apply the stylesheet.
+        expect(footer.className).toContain(`app-footer--emphasis-${emphasis}`);
+        expect(footer).toHaveStyle({
+          '--app-footer__bg': CUSTOM_BG,
+          '--app-footer__fg': CUSTOM_FG,
+        });
+      },
+    );
+
+    it('accepts either one on its own', () => {
+      const { container } = render(
+        <AppFooter
+          navItems={NAV_ITEMS}
+          style={{ '--app-footer__bg': CUSTOM_BG }}
+          title="text"
+        />,
+      );
+
+      const footer = container.firstElementChild as HTMLElement;
+
+      expect(footer).toHaveStyle({ '--app-footer__bg': CUSTOM_BG });
+      expect(footer.style.getPropertyValue('--app-footer__fg')).toBe('');
+    });
+
+    it('keeps them alongside the regular CSS properties on the style prop', () => {
+      const { container } = render(
+        <AppFooter
+          navItems={NAV_ITEMS}
+          style={{
+            '--app-footer__bg': CUSTOM_BG,
+            '--app-footer__fg': CUSTOM_FG,
+            position: 'sticky',
+          }}
+          title="text"
+        />,
+      );
+
+      expect(container.firstElementChild).toHaveStyle({
+        '--app-footer__bg': CUSTOM_BG,
+        '--app-footer__fg': CUSTOM_FG,
+        position: 'sticky',
+      });
+    });
+
+    it('does not accept the pre-v19 `-color` suffixed names', () => {
+      const { container } = render(
+        <AppFooter
+          navItems={NAV_ITEMS}
+          // @ts-expect-error renamed in v19; `-color` was dropped to match the other components
+          style={{ '--app-footer__bg-color': CUSTOM_BG }}
+          title="text"
+        />,
+      );
+
+      expect(
+        (container.firstElementChild as HTMLElement).style.getPropertyValue(
+          '--app-footer__bg',
+        ),
+      ).toBe('');
+    });
+  });
 
   describe('event handling', () => {
     it('handles clicks on footer logo', async () => {

--- a/src/components/AppFooter/AppFooter.tsx
+++ b/src/components/AppFooter/AppFooter.tsx
@@ -35,8 +35,8 @@ export type AppFooterProps = Omit<
   /**
    * CSS properties defined for the HTML element. Includes the component's CSS Custom Properties:
    *
-   * - `--app-footer__bg-color`
-   * - `--app-footer__fg-color`
+   * - `--app-footer__bg`
+   * - `--app-footer__fg`
    */
   style?: AppFooterCSSProperties;
   // Design API
@@ -60,12 +60,12 @@ export interface AppFooterCSSProperties extends React.CSSProperties {
   /**
    * Custom property to customize the background color of this component (e.g., background color)
    */
-  '--app-footer__bg-color'?: string;
+  '--app-footer__bg'?: string;
 
   /**
    * Custom property to customize the foreground color of this component (e.g., text, icon, etc.)
    */
-  '--app-footer__fg-color'?: string;
+  '--app-footer__fg'?: string;
 }
 
 export type AppFooterEventHandler = (

--- a/src/components/AppFooter/__snapshots__/AppFooter.test.tsx.snap
+++ b/src/components/AppFooter/__snapshots__/AppFooter.test.tsx.snap
@@ -1,5 +1,79 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`<AppFooter /> > CustomColors story renders snapshot 1`] = `
+<footer
+  class="_app-footer_693f0c _app-footer--emphasis-high_693f0c"
+  style="--app-footer__bg: rebeccapurple; --app-footer__fg: papayawhip;"
+>
+  <div
+    class="_app-footer__wrapper_693f0c"
+  >
+    <div
+      class="_app-footer__colophon_693f0c"
+    >
+      <div
+        class="_app-footer__title_693f0c"
+      >
+        <div
+          class="fpo h-[40px] w-[176px]"
+        >
+          Logo goes here
+        </div>
+      </div>
+      <div
+        class="_text_b3eba3 _text--body-xs_b3eba3 _app-footer__copyright_693f0c"
+      >
+        Copyright © 2026
+      </div>
+    </div>
+    <menu
+      class="_app-footer__nav-items_693f0c"
+    >
+      <li
+        class="_app-footer__nav-item_693f0c"
+      >
+        <a
+          class="_link_d78ce8 _link--context-standalone_d78ce8 _link--emphasis-low_d78ce8 _link--size-xs_d78ce8 _link--variant-inverse_d78ce8"
+          href="#support"
+        >
+          Support
+        </a>
+      </li>
+      <li
+        class="_app-footer__nav-item_693f0c"
+      >
+        <a
+          class="_link_d78ce8 _link--context-standalone_d78ce8 _link--emphasis-low_d78ce8 _link--size-xs_d78ce8 _link--variant-inverse_d78ce8"
+          href="#tos"
+        >
+          Terms of Use
+        </a>
+      </li>
+      <li
+        class="_app-footer__nav-item_693f0c"
+      >
+        <a
+          class="_link_d78ce8 _link--context-standalone_d78ce8 _link--emphasis-low_d78ce8 _link--size-xs_d78ce8 _link--variant-inverse_d78ce8"
+          href="#privacy"
+        >
+          Privacy Policy
+        </a>
+      </li>
+      <li
+        class="_app-footer__nav-item_693f0c"
+      >
+        <a
+          class="_link_d78ce8 _link--context-standalone_d78ce8 _link--emphasis-low_d78ce8 _link--size-xs_d78ce8 _link--variant-inverse_d78ce8"
+          href="#guidelines"
+        >
+          Community Guidelines
+        </a>
+      </li>
+    </menu>
+  </div>
+</footer>
+`;
+
 exports[`<AppFooter /> > Default story renders snapshot 1`] = `
 <footer
   class="_app-footer_693f0c _app-footer--emphasis-high_693f0c"


### PR DESCRIPTION
Closes [EDS-2129](https://czi.atlassian.net/browse/EDS-2129).

`--app-footer__bg-color` / `--app-footer__fg-color` become `--app-footer__bg` / `--app-footer__fg`.

## Why

AppFooter was the only component carrying the `-color` suffix. Every other component that exposes colors this way uses the bare names, so someone who learned the API from one component could not guess AppFooter's:

```
--button__bg      --avatar__bg      --tag__bg      --toast__bg
--button__fg      --avatar__fg      --tag__fg      --toast__fg
--button__border  --avatar__border  --tag__border  --toast__icon
```

Follow-on to #2618, which opened these properties up on the `style` prop. This is the naming cleanup that should have gone with it.

## Breaking change

Anyone setting either property has to rename it, whether through the `style` prop or in their own CSS. The rename is mechanical and **no values changed**.

| Before | After |
| --- | --- |
| `--app-footer__bg-color` | `--app-footer__bg` |
| `--app-footer__fg-color` | `--app-footer__fg` |

No codemod entry in `18-to-19.ts`. The existing transforms handle JSX props and imports, not keys inside a style object literal, so this would need a new transform — and even then it could not reach a consumer's own CSS. Same call as the Accordion `size` removal in #2617. Follow-up for the transform is [EDS-2130](https://czi.atlassian.net/browse/EDS-2130).

## Tests

The ticket asked for coverage that these override what they're supposed to. jsdom does not apply the stylesheet, so that splits in two.

The unit tests assert the emphasis class and the caller's inline value land on the same element, which is the thing that lets the inline value win — plus the untouched case, each property on its own with the other left to its default, and the pair alongside a regular CSS property. Every case runs against both `--app-footer__bg` and `--app-footer__fg`.

A `@ts-expect-error` per old name fails the build if the type ever accepts one again. These need one object literal each: TypeScript reports only the first excess property in a literal, so a single directive over both names would suppress the whole object's check and leave the second name unchecked. Verified both are load-bearing by re-adding the old names to `AppFooterCSSProperties` and confirming an unused-directive error for each.

The cascade is covered by a new `CustomColors` story, verified in Storybook:

| | `--app-footer__bg` | `--app-footer__fg` |
| --- | --- | --- |
| `CustomColors` (override) | `rgb(102, 51, 153)` | `rgb(255, 239, 213)` |
| `HighEmphasis` (default) | `rgb(36, 36, 35)` | `rgb(255, 255, 255)` |
| `LowEmphasis` (default) | `rgba(255, 255, 255, 0)` | `rgb(58, 58, 55)` |

Both emphasis rows match their pre-rename values, so no visual change is expected on the existing stories. Chromatic should show one addition and no diffs.

`yarn test` 621 passed, `yarn types` and `yarn lint` clean.

## Version

Component tag takes a major, `1.1.0` -> `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2129]: https://czi.atlassian.net/browse/EDS-2129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EDS-2130]: https://czi.atlassian.net/browse/EDS-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
