### PR TITLE
feat(Accordion, DataTable, InputField, SelectionChip)!: rename leading icon props to content props

### DIFF
--- a/src/bin/migrate/migrations/18-to-19.test.ts
+++ b/src/bin/migrate/migrations/18-to-19.test.ts
@@ -165,6 +165,34 @@ describe('18-to-19', () => {
     `);
   });
 
+  it('renames the Accordion row leading content flag', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {Accordion} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Accordion.Row hasLeadingIcon>
+            <Accordion.Button title="Row" />
+          </Accordion.Row>
+        )
+      }
+    `);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {Accordion} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Accordion.Row hasLeadingContent>
+            <Accordion.Button title="Row" />
+          </Accordion.Row>
+        )
+      }
+    `);
+  });
+
   it('leaves the Accordion trailing slot alone', () => {
     const sourceFileText = dedent`
       import {Accordion} from '@chanzuckerberg/eds';

--- a/src/bin/migrate/migrations/18-to-19.test.ts
+++ b/src/bin/migrate/migrations/18-to-19.test.ts
@@ -141,13 +141,37 @@ describe('18-to-19', () => {
     `);
   });
 
-  it('leaves the Accordion expand indicator override alone', () => {
-    const sourceFileText = dedent`
+  it('renames the Accordion expand indicator override', () => {
+    const sourceFile = createTestSourceFile(dedent`
       import {Accordion} from '@chanzuckerberg/eds';
 
       export default function Component() {
         return (
           <Accordion.Button title="Row" trailingIcon="chevron-down" />
+        )
+      }
+    `);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {Accordion} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Accordion.Button title="Row" indicatorContent="chevron-down" />
+        )
+      }
+    `);
+  });
+
+  it('leaves the Accordion trailing slot alone', () => {
+    const sourceFileText = dedent`
+      import {Accordion} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Accordion.Button title="Row" trailingContent={<Tag>New</Tag>} />
         )
       }
     `;

--- a/src/bin/migrate/migrations/18-to-19.test.ts
+++ b/src/bin/migrate/migrations/18-to-19.test.ts
@@ -79,6 +79,86 @@ describe('18-to-19', () => {
     expect(sourceFile.getText()).toEqual(sourceFileText);
   });
 
+  it('renames the leading icon prop to a content prop', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {InputField, SelectionChip} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <div>
+            <InputField leadingIcon="search" placeholder="Search..." />
+            <SelectionChip label="Add" leadingIcon="add" />
+          </div>
+        )
+      }
+    `);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {InputField, SelectionChip} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <div>
+            <InputField leadingContent="search" placeholder="Search..." />
+            <SelectionChip label="Add" leadingContent="add" />
+          </div>
+        )
+      }
+    `);
+  });
+
+  it('renames the leading icon prop on subcomponents', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {Accordion, DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <div>
+            <Accordion.Button leadingIcon={<Icon name="star" purpose="decorative" />} title="Row" />
+            <DataTable.HeaderCell leadingIcon="person-add">Name</DataTable.HeaderCell>
+            <DataTable.DataCell leadingIcon="person-add">Ada</DataTable.DataCell>
+          </div>
+        )
+      }
+    `);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {Accordion, DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <div>
+            <Accordion.Button leadingContent={<Icon name="star" purpose="decorative" />} title="Row" />
+            <DataTable.HeaderCell leadingContent="person-add">Name</DataTable.HeaderCell>
+            <DataTable.DataCell leadingContent="person-add">Ada</DataTable.DataCell>
+          </div>
+        )
+      }
+    `);
+  });
+
+  it('leaves the Accordion expand indicator override alone', () => {
+    const sourceFileText = dedent`
+      import {Accordion} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Accordion.Button title="Row" trailingIcon="chevron-down" />
+        )
+      }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(sourceFileText);
+  });
+
   it('leaves a same-named component from another package alone', () => {
     const sourceFileText = dedent`
       import {Text} from 'some-other-library';

--- a/src/bin/migrate/migrations/18-to-19.ts
+++ b/src/bin/migrate/migrations/18-to-19.ts
@@ -63,6 +63,15 @@ const presetEdits = presetReplacements.map(
 );
 
 /**
+ * The leading slot on these components is now a content slot: it still takes an EDS
+ * icon name, and also takes a node. Only the prop name changed, so passing the same
+ * icon name under the new name renders exactly what it did before.
+ *
+ * `Accordion.Button` keeps its `trailingIcon`, which overrides the expand/collapse
+ * chevron. That component already has a separate `trailingContent` slot, so there is
+ * no `trailingIcon` to rename onto it.
+ */
+/**
  * Known prop changes for updated components from EDS v18 to v19
  *
  * Given a component, list out the changes of props and values.
@@ -91,6 +100,14 @@ const presetEdits = presetReplacements.map(
  * <ComponentName propName="valueB" />
  * ```
  */
+const leadingIconToContent = [
+  {
+    type: 'update_name' as const,
+    oldPropName: 'leadingIcon',
+    newPropName: 'leadingContent',
+  },
+];
+
 export const PropChanges: EditJsxPropChange[] = [
   {
     componentName: 'Text',
@@ -99,6 +116,26 @@ export const PropChanges: EditJsxPropChange[] = [
   {
     componentName: 'Heading',
     edits: presetEdits,
+  },
+  {
+    componentName: 'Accordion.Button',
+    edits: leadingIconToContent,
+  },
+  {
+    componentName: 'DataTable.DataCell',
+    edits: leadingIconToContent,
+  },
+  {
+    componentName: 'DataTable.HeaderCell',
+    edits: leadingIconToContent,
+  },
+  {
+    componentName: 'InputField',
+    edits: leadingIconToContent,
+  },
+  {
+    componentName: 'SelectionChip',
+    edits: leadingIconToContent,
   },
 ];
 

--- a/src/bin/migrate/migrations/18-to-19.ts
+++ b/src/bin/migrate/migrations/18-to-19.ts
@@ -67,9 +67,9 @@ const presetEdits = presetReplacements.map(
  * icon name, and also takes a node. Only the prop name changed, so passing the same
  * icon name under the new name renders exactly what it did before.
  *
- * `Accordion.Button` keeps its `trailingIcon`, which overrides the expand/collapse
- * chevron. That component already has a separate `trailingContent` slot, so there is
- * no `trailingIcon` to rename onto it.
+ * `Accordion.Button`'s `trailingIcon` overrides the expand/collapse chevron rather than
+ * filling a trailing slot, and the component already has a separate `trailingContent`
+ * slot. It becomes `indicatorContent`, which names what it actually controls.
  */
 /**
  * Known prop changes for updated components from EDS v18 to v19
@@ -119,7 +119,14 @@ export const PropChanges: EditJsxPropChange[] = [
   },
   {
     componentName: 'Accordion.Button',
-    edits: leadingIconToContent,
+    edits: [
+      ...leadingIconToContent,
+      {
+        type: 'update_name',
+        oldPropName: 'trailingIcon',
+        newPropName: 'indicatorContent',
+      },
+    ],
   },
   {
     componentName: 'DataTable.DataCell',

--- a/src/bin/migrate/migrations/18-to-19.ts
+++ b/src/bin/migrate/migrations/18-to-19.ts
@@ -70,6 +70,9 @@ const presetEdits = presetReplacements.map(
  * `Accordion.Button`'s `trailingIcon` overrides the expand/collapse chevron rather than
  * filling a trailing slot, and the component already has a separate `trailingContent`
  * slot. It becomes `indicatorContent`, which names what it actually controls.
+ *
+ * `Accordion.Row`'s `hasLeadingIcon` is the boolean companion to the renamed slot, and
+ * sits beside an existing `hasTrailingContent`, so it follows to `hasLeadingContent`.
  */
 /**
  * Known prop changes for updated components from EDS v18 to v19
@@ -125,6 +128,16 @@ export const PropChanges: EditJsxPropChange[] = [
         type: 'update_name',
         oldPropName: 'trailingIcon',
         newPropName: 'indicatorContent',
+      },
+    ],
+  },
+  {
+    componentName: 'Accordion.Row',
+    edits: [
+      {
+        type: 'update_name',
+        oldPropName: 'hasLeadingIcon',
+        newPropName: 'hasLeadingContent',
       },
     ],
   },

--- a/src/bin/migrate/transforms/edit-jsx-prop.test.ts
+++ b/src/bin/migrate/transforms/edit-jsx-prop.test.ts
@@ -493,6 +493,108 @@ describe('transform', () => {
     `);
   });
 
+  it('edits props on a subcomponent reached through its root import', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <DataTable.DataCell leadingIcon="person-add">Ada</DataTable.DataCell>
+        )
+      }
+    `);
+
+    transform({
+      file: sourceFile,
+      changes: [
+        {
+          componentName: 'DataTable.DataCell',
+          edits: [
+            {
+              type: 'update_name',
+              oldPropName: 'leadingIcon',
+              newPropName: 'leadingContent',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <DataTable.DataCell leadingContent="person-add">Ada</DataTable.DataCell>
+        )
+      }
+    `);
+  });
+
+  it('applies every change that shares one root import', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <DataTable subcaption="By team">
+            <DataTable.HeaderCell leadingIcon="person-add">Name</DataTable.HeaderCell>
+            <DataTable.DataCell leadingIcon="person-add">Ada</DataTable.DataCell>
+          </DataTable>
+        )
+      }
+    `);
+
+    transform({
+      file: sourceFile,
+      changes: [
+        {
+          componentName: 'DataTable',
+          edits: [
+            {
+              type: 'update_name',
+              oldPropName: 'subcaption',
+              newPropName: 'subCaption',
+            },
+          ],
+        },
+        {
+          componentName: 'DataTable.HeaderCell',
+          edits: [
+            {
+              type: 'update_name',
+              oldPropName: 'leadingIcon',
+              newPropName: 'leadingContent',
+            },
+          ],
+        },
+        {
+          componentName: 'DataTable.DataCell',
+          edits: [
+            {
+              type: 'update_name',
+              oldPropName: 'leadingIcon',
+              newPropName: 'leadingContent',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {DataTable} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <DataTable subCaption="By team">
+            <DataTable.HeaderCell leadingContent="person-add">Name</DataTable.HeaderCell>
+            <DataTable.DataCell leadingContent="person-add">Ada</DataTable.DataCell>
+          </DataTable>
+        )
+      }
+    `);
+  });
+
   it('does not modify props from Non-EDS components', () => {
     const sourceFileText = dedent`
     import {Link} from '~/components/Link';

--- a/src/bin/migrate/transforms/edit-jsx-prop.ts
+++ b/src/bin/migrate/transforms/edit-jsx-prop.ts
@@ -108,6 +108,14 @@ function updatePropValue(
   }
 }
 
+/**
+ * The imported identifier a component name hangs off of. `DataTable.DataCell` is
+ * reached through the `DataTable` import, and `Button` through its own.
+ */
+function getRootName(componentName: string) {
+  return componentName.split('.')[0];
+}
+
 export type Change = {
   componentName: string;
   edits: Edit[];
@@ -129,18 +137,20 @@ export default function transform({ file, changes }: TransformOptions) {
 
   // Only apply changes to EDS Imported components because EDS consumers may have
   // their own components with the same names as our components.
+  //
+  // A change can name a subcomponent, as in `DataTable.DataCell`. Only the root of
+  // that name is imported, so match on the root and let the tag name check below
+  // pick the specific subcomponent.
   const changesToApply: Change[] = [];
   importDeclarations.forEach((importDeclaration) => {
     const namedImports = importDeclaration.getNamedImports();
     namedImports.forEach((namedImport) => {
-      const change = changes.find(
+      const matches = changes.filter(
         (change) =>
-          change.componentName.toLowerCase() ===
+          getRootName(change.componentName).toLowerCase() ===
           namedImport.getName().toLowerCase(),
       );
-      if (change) {
-        changesToApply.push(change);
-      }
+      changesToApply.push(...matches);
     });
   });
 

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -104,7 +104,7 @@ export const WithLeadingNumberIcon: Story = {
         <Accordion.Row hasLeadingIcon>
           <Accordion.Button
             data-testid="accordion-button"
-            leadingIcon={
+            leadingContent={
               <NumberIcon
                 aria-label="Numero uno"
                 number={1}
@@ -126,7 +126,7 @@ export const WithLeadingNumberIcon: Story = {
         <Accordion.Row hasLeadingIcon>
           <Accordion.Button
             data-testid="accordion-button"
-            leadingIcon={
+            leadingContent={
               <NumberIcon
                 aria-label="Numero uno"
                 number={1}
@@ -148,7 +148,7 @@ export const WithLeadingNumberIcon: Story = {
         <Accordion.Row hasLeadingIcon>
           <Accordion.Button
             data-testid="accordion-button"
-            leadingIcon={
+            leadingContent={
               <NumberIcon
                 aria-label="Numero uno"
                 number={1}
@@ -200,7 +200,7 @@ export const HasLeadingIcon: Story = {
       <Accordion.Row hasLeadingIcon>
         <Accordion.Button
           data-testid="accordion-button"
-          leadingIcon={
+          leadingContent={
             <Icon name="person-encircled" purpose="decorative" size="24px" />
           }
           subTitle="Quam lacus maecenas nibh malesuada."

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -293,13 +293,22 @@ export const WithCustomIndicator: Story = {
       <>
         <Accordion.Row>
           <Accordion.Button
-            indicatorContent="chevron-down-double"
-            title="Icon name"
+            indicatorContent="chevron-down"
+            title="Chevron down (the default)"
           />
           <Accordion.Panel>
             <Text preset="body-md">
               Passing an icon name renders it through `Icon`, announced as
               show/hide content.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button indicatorContent="chevron-up" title="Chevron up" />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              Starting from the other orientation flips which way the indicator
+              rotates.
             </Text>
           </Accordion.Panel>
         </Accordion.Row>

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -101,7 +101,7 @@ export const WithLeadingNumberIcon: Story = {
     ...Default.args,
     children: (
       <>
-        <Accordion.Row hasLeadingIcon>
+        <Accordion.Row hasLeadingContent>
           <Accordion.Button
             data-testid="accordion-button"
             leadingContent={
@@ -123,7 +123,7 @@ export const WithLeadingNumberIcon: Story = {
             </Text>
           </Accordion.Panel>
         </Accordion.Row>
-        <Accordion.Row hasLeadingIcon>
+        <Accordion.Row hasLeadingContent>
           <Accordion.Button
             data-testid="accordion-button"
             leadingContent={
@@ -145,7 +145,7 @@ export const WithLeadingNumberIcon: Story = {
             </Text>
           </Accordion.Panel>
         </Accordion.Row>
-        <Accordion.Row hasLeadingIcon>
+        <Accordion.Row hasLeadingContent>
           <Accordion.Button
             data-testid="accordion-button"
             leadingContent={
@@ -197,7 +197,7 @@ export const HasLeadingIcon: Story = {
   args: {
     ...Default.args,
     children: (
-      <Accordion.Row hasLeadingIcon>
+      <Accordion.Row hasLeadingContent>
         <Accordion.Button
           data-testid="accordion-button"
           leadingContent={

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -281,3 +281,41 @@ export const WithLargeHeader: Story = {
     ),
   },
 };
+
+/**
+ * The expand/collapse indicator can be overridden with another EDS icon, or with custom
+ * content. Either way it rotates when the row opens, so pick something that reads well
+ * upside down.
+ */
+export const WithCustomIndicator: Story = {
+  args: {
+    children: (
+      <>
+        <Accordion.Row>
+          <Accordion.Button
+            indicatorContent="chevron-down-double"
+            title="Icon name"
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              Passing an icon name renders it through `Icon`, announced as
+              show/hide content.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button
+            indicatorContent={<Tag label="3 new" status="favorable" />}
+            title="Custom content"
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              Passing a node renders it as-is. The node carries its own
+              accessible treatment.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+      </>
+    ),
+  },
+};

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -11,7 +11,7 @@ import { assertEdsUsage } from '../../util/logging';
 import type { IconOrContent } from '../../util/utility-types';
 
 import Heading, { type HeadingElement } from '../Heading';
-import { IconSlot } from '../Icon';
+import { hasSlotContent, IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './Accordion.module.css';
@@ -259,7 +259,7 @@ const AccordionButton = ({
           }}
           {...other}
         >
-          {leadingContent && (
+          {hasSlotContent(leadingContent) && (
             <span className={styles['accordion-button__leading-icon']}>
               {leadingContent}
             </span>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,9 +8,10 @@ import React, { createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
 import { ENTER_KEYCODE, SPACEBAR_KEYCODE } from '../../util/keycodes';
 import { assertEdsUsage } from '../../util/logging';
+import type { IconOrContent } from '../../util/utility-types';
 
 import Heading, { type HeadingElement } from '../Heading';
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './Accordion.module.css';
@@ -75,11 +76,16 @@ type AccordionButtonProps = {
    */
   trailingContent?: ReactNode;
   /**
-   * Icon override for component's expand/collapse indicator.
+   * Override for the component's expand/collapse indicator. Pass an EDS icon name to
+   * render an icon, or a node to render it as-is.
+   *
+   * The indicator rotates when the row opens, and an icon name is announced as
+   * "show content"/"hide content". Custom content carries its own accessible
+   * treatment.
    *
    * **Default is `"chevron-down"`**.
    */
-  trailingIcon?: Extract<IconName, 'chevron-down'>;
+  indicatorContent?: IconOrContent;
 };
 
 type AccordionPanelProps = {
@@ -203,7 +209,7 @@ const AccordionButton = ({
   headingAs,
   leadingContent,
   title,
-  trailingIcon = 'chevron-down',
+  indicatorContent = 'chevron-down',
   trailingContent,
   subTitle,
   onClose,
@@ -285,12 +291,12 @@ const AccordionButton = ({
           </Heading>
           {trailingContent}
           {isExpandable && (
-            <Icon
+            <IconSlot
               className={clsx(
                 styles['accordion-button__trailing-icon'],
                 open && styles['accordion-button__trailing-icon--open'],
               )}
-              name={trailingIcon}
+              content={indicatorContent}
               purpose="informative"
               size="24px"
               title={open ? 'hide content' : 'show content'}

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -59,9 +59,9 @@ type AccordionButtonProps = {
    */
   headingAs?: HeadingElement;
   /**
-   * Icon to preceed the text in an accordion header
+   * Slot which precedes the text in an accordion header
    */
-  leadingIcon?: ReactNode;
+  leadingContent?: ReactNode;
   /**
    * Secondary text used to describe the content in more detail
    */
@@ -201,7 +201,7 @@ const AccordionButton = ({
   children,
   className,
   headingAs,
-  leadingIcon, // TODO(next-major): rename to `leadingContent`
+  leadingContent,
   title,
   trailingIcon = 'chevron-down',
   trailingContent,
@@ -253,9 +253,9 @@ const AccordionButton = ({
           }}
           {...other}
         >
-          {leadingIcon && (
+          {leadingContent && (
             <span className={styles['accordion-button__leading-icon']}>
-              {leadingIcon}
+              {leadingContent}
             </span>
           )}
           <Heading

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -119,7 +119,7 @@ type AccordionRowProps = {
   /**
    * Whether the row has content on the row's trigger that leads in front of the title
    */
-  hasLeadingIcon?: boolean;
+  hasLeadingContent?: boolean;
   /**
    * Whether the row has a content on the row's trigger that trails the title
    */
@@ -135,11 +135,11 @@ const AccordionContext = createContext<{
 const AccordionRowContext = createContext<
   Pick<
     AccordionRowProps,
-    'isExpandable' | 'hasLeadingIcon' | 'hasTrailingContent'
+    'isExpandable' | 'hasLeadingContent' | 'hasTrailingContent'
   >
 >({
   isExpandable: true,
-  hasLeadingIcon: false,
+  hasLeadingContent: false,
   hasTrailingContent: false,
 });
 
@@ -313,12 +313,12 @@ const AccordionPanel = ({
   children,
   ...other
 }: AccordionPanelProps) => {
-  const { isExpandable, hasLeadingIcon } = useContext(AccordionRowContext);
+  const { isExpandable, hasLeadingContent } = useContext(AccordionRowContext);
 
   const componentClassName = clsx(
     styles['accordion-panel'],
     !isExpandable && styles['accordion-panel--hidden'],
-    hasLeadingIcon && styles['accordion-panel--leading-icon'],
+    hasLeadingContent && styles['accordion-panel--leading-icon'],
     className,
   );
 
@@ -338,13 +338,13 @@ const AccordionRow = ({
   defaultOpen,
   children,
   isExpandable = true,
-  hasLeadingIcon,
+  hasLeadingContent,
   hasTrailingContent,
   ...other
 }: AccordionRowProps) => {
   const componentClassName = clsx(styles['accordion-row'], className);
   return (
-    <AccordionRowContext.Provider value={{ isExpandable, hasLeadingIcon }}>
+    <AccordionRowContext.Provider value={{ isExpandable, hasLeadingContent }}>
       <Disclosure defaultOpen={defaultOpen}>
         {({ open }) => (
           <div className={componentClassName} {...other}>

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -344,6 +344,91 @@ exports[`<Accordion /> > UsingRenderProp story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="w-[600px]"
+  >
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_k_"
+        type="button"
+      >
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Icon name
+          </span>
+        </h2>
+        <svg
+          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          fill="currentColor"
+          height="24px"
+          role="img"
+          style="--icon-size: 24px;"
+          viewBox="0 0 24 24"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M11.9999 18.6345L6.34619 12.9808L7.39994 11.927L11.9999 16.5115L16.5999 11.927L17.6537 12.9808L11.9999 18.6345ZM11.9999 12.6538L6.34619 7.00004L7.39994 5.94629L11.9999 10.5308L16.5999 5.94629L17.6537 7.00004L11.9999 12.6538Z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_m_"
+        type="button"
+      >
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Custom content
+          </span>
+        </h2>
+        <span
+          class="_accordion-button__trailing-icon_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-favorable_f57044"
+          >
+            <span
+              class="_tag__body_f57044"
+            >
+              3 new
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Accordion /> > WithLargeHeader story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -368,7 +368,7 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
           <span
             class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
           >
-            Icon name
+            Chevron down (the default)
           </span>
         </h2>
         <svg
@@ -385,7 +385,7 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
             show content
           </title>
           <path
-            d="M11.9999 18.6345L6.34619 12.9808L7.39994 11.927L11.9999 16.5115L16.5999 11.927L17.6537 12.9808L11.9999 18.6345ZM11.9999 12.6538L6.34619 7.00004L7.39994 5.94629L11.9999 10.5308L16.5999 5.94629L17.6537 7.00004L11.9999 12.6538Z"
+            d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
           />
         </svg>
       </button>
@@ -399,6 +399,45 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
         class="_accordion-button_86d7df"
         data-headlessui-state=""
         id="headlessui-disclosure-button-_r_m_"
+        type="button"
+      >
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Chevron up
+          </span>
+        </h2>
+        <svg
+          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          fill="currentColor"
+          height="24px"
+          role="img"
+          style="--icon-size: 24px;"
+          viewBox="0 0 24 24"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M11.9999 10.4542L7.39994 15.0542L6.34619 14.0004L11.9999 8.34668L17.6537 14.0004L16.5999 15.0542L11.9999 10.4542Z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_o_"
         type="button"
       >
         <h2

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -372,7 +372,7 @@ export const Selectable: StoryObj<Args> = {
         columnHelper.accessor('firstName', {
           header: () => (
             <DataTable.HeaderCell
-              leadingIcon="person-add"
+              leadingContent="person-add"
               sortDirection="ascending"
               subLabel="Given Name"
             >
@@ -380,7 +380,7 @@ export const Selectable: StoryObj<Args> = {
             </DataTable.HeaderCell>
           ),
           cell: (info) => (
-            <DataTable.DataCell leadingIcon="person-add">
+            <DataTable.DataCell leadingContent="person-add">
               {info.getValue()}
             </DataTable.DataCell>
           ),
@@ -523,7 +523,7 @@ export const VerticalDivider: StoryObj<Args> = {
           header: () => (
             <DataTable.HeaderCell
               hasHorizontalDivider
-              leadingIcon="person-add"
+              leadingContent="person-add"
               sortDirection="ascending"
               subLabel="Given Name"
             >
@@ -531,7 +531,10 @@ export const VerticalDivider: StoryObj<Args> = {
             </DataTable.HeaderCell>
           ),
           cell: (info) => (
-            <DataTable.DataCell hasHorizontalDivider leadingIcon="person-add">
+            <DataTable.DataCell
+              hasHorizontalDivider
+              leadingContent="person-add"
+            >
               {info.getValue()}
             </DataTable.DataCell>
           ),

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -42,7 +42,7 @@ export default {
       control: false,
     },
   },
-  tags: ['autodocs', 'version:2.1.0'],
+  tags: ['autodocs', 'version:3.0.0'],
 } as Meta<Args>;
 
 type Args = DataTableProps;

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -8,11 +8,13 @@ import React, {
 } from 'react';
 
 import getIconNameFromStatus from '../../util/getIconNameFromStatus';
+import type { IconOrContent } from '../../util/utility-types';
 import type { EDSBase, Size, Status, Align } from '../../util/variant-types';
 
 import Button, { type ButtonProps } from '../Button';
 import ButtonGroup from '../ButtonGroup';
-import { Icon, type IconName } from '../Icon/Icon';
+import { Icon } from '../Icon/Icon';
+import { IconSlot } from '../Icon/IconSlot';
 import InputField from '../InputField';
 import Text from '../Text';
 
@@ -111,9 +113,10 @@ export type DataTableHeaderCellProps = EDSBase & {
    */
   isSortable?: boolean;
   /**
-   * An icon that prefixes the field input.
+   * Content that prefixes the cell text. Pass an EDS icon name to render a decorative
+   * icon, or a node to render it as-is.
    */
-  leadingIcon?: IconName;
+  leadingContent?: IconOrContent;
   /**
    * SubLabel to use next to table cell text content
    *
@@ -451,7 +454,7 @@ export const DataTableHeaderCell = ({
   className,
   hasHorizontalDivider,
   isSortable,
-  leadingIcon,
+  leadingContent,
   sortDirection = 'default',
   onSortClick,
   subLabel,
@@ -467,11 +470,10 @@ export const DataTableHeaderCell = ({
     )}
     {...rest}
   >
-    {leadingIcon && (
-      <Icon
+    {leadingContent && (
+      <IconSlot
         className={styles['data-cell__cell--icon']}
-        name={leadingIcon}
-        purpose="decorative"
+        content={leadingContent}
         size="16px"
       />
     )}
@@ -508,7 +510,7 @@ export const DataTableDataCell = ({
   children,
   className,
   hasHorizontalDivider,
-  leadingIcon,
+  leadingContent,
   subLabel,
   ...rest
 }: DataTableDataCellProps) => {
@@ -519,11 +521,10 @@ export const DataTableDataCell = ({
   );
   return (
     <div className={dataCellClassName} {...rest}>
-      {leadingIcon && (
-        <Icon
+      {leadingContent && (
+        <IconSlot
           className={styles['data-cell__cell--icon']}
-          name={leadingIcon}
-          purpose="decorative"
+          content={leadingContent}
           size="16px"
         />
       )}
@@ -702,7 +703,7 @@ const DataTableSearch = () => {
     <InputField
       aria-label="search"
       disabled
-      leadingIcon="search"
+      leadingContent="search"
       placeholder="Search..."
       type="search"
     />

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -470,13 +470,12 @@ export const DataTableHeaderCell = ({
     )}
     {...rest}
   >
-    {leadingContent && (
-      <IconSlot
-        className={styles['data-cell__cell--icon']}
-        content={leadingContent}
-        size="16px"
-      />
-    )}
+    <IconSlot
+      as="div"
+      className={styles['data-cell__cell--icon']}
+      content={leadingContent}
+      size="16px"
+    />
     {(children || subLabel) && (
       <div className={clsx(className, styles['data-table__cell-text'])}>
         <Text as="div" preset="title-xs">
@@ -521,13 +520,12 @@ export const DataTableDataCell = ({
   );
   return (
     <div className={dataCellClassName} {...rest}>
-      {leadingContent && (
-        <IconSlot
-          className={styles['data-cell__cell--icon']}
-          content={leadingContent}
-          size="16px"
-        />
-      )}
+      <IconSlot
+        as="div"
+        className={styles['data-cell__cell--icon']}
+        content={leadingContent}
+        size="16px"
+      />
       {(children || subLabel) && (
         <div className={clsx(className, styles['data-table__cell-text'])}>
           {children}

--- a/src/components/Icon/IconSlot.test.tsx
+++ b/src/components/Icon/IconSlot.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { hasSlotContent, IconSlot } from './IconSlot';
+
+describe('<IconSlot />', () => {
+  it('renders a string as a decorative icon', () => {
+    const { container } = render(<IconSlot content="search" />);
+
+    // A decorative icon is aria-hidden by design, so there is no accessible query for
+    // it. Reaching into the container is the only way to assert it rendered.
+    /* eslint-disable testing-library/no-container */
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden');
+    /* eslint-enable testing-library/no-container */
+  });
+
+  it('gives an informative icon its title', () => {
+    render(
+      <IconSlot content="chevron-down" purpose="informative" title="Expand" />,
+    );
+
+    expect(screen.getByTitle('Expand')).toBeInTheDocument();
+  });
+
+  it('renders custom content as-is, unwrapped when there is no className', () => {
+    const { container } = render(
+      <IconSlot content={<span data-testid="custom">Hi</span>} />,
+    );
+
+    expect(screen.getByTestId('custom')).toBeInTheDocument();
+    expect(container.firstElementChild).toBe(screen.getByTestId('custom'));
+  });
+
+  it('wraps custom content so it can carry the className', () => {
+    const { container } = render(
+      <IconSlot className="wrapper" content={<span>Hi</span>} />,
+    );
+
+    expect(container.firstElementChild?.tagName).toBe('SPAN');
+    expect(container.firstElementChild).toHaveClass('wrapper');
+  });
+
+  it('wraps in the requested element so block content stays valid', () => {
+    const { container } = render(
+      <IconSlot as="div" className="wrapper" content={<div>Hi</div>} />,
+    );
+
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it.each([[null], [undefined], [false], [true], ['']])(
+    'renders nothing for %p',
+    (content) => {
+      const { container } = render(<IconSlot content={content} />);
+
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
+
+  it('renders 0 rather than treating it as absent', () => {
+    // Guards the `{content && ...}` trap: `0` is a valid ReactNode, and a truthiness
+    // check would both skip the slot and leak a stray "0" into the markup.
+    const { container } = render(<IconSlot content={0} />);
+
+    expect(container).toHaveTextContent('0');
+  });
+
+  describe('hasSlotContent', () => {
+    it.each([[null], [undefined], [false], [true], ['']])(
+      'reports %p as empty',
+      (content) => {
+        expect(hasSlotContent(content)).toBe(false);
+      },
+    );
+
+    it.each([[0], ['search'], [<span key="a">Hi</span>]])(
+      'reports %p as present',
+      (content) => {
+        expect(hasSlotContent(content)).toBe(true);
+      },
+    );
+  });
+});

--- a/src/components/Icon/IconSlot.tsx
+++ b/src/components/Icon/IconSlot.tsx
@@ -3,7 +3,7 @@ import { Icon } from './Icon';
 import type { IconName } from './Icon';
 import type { IconOrContent } from '../../util/utility-types';
 
-export type IconSlotProps = {
+type IconSlotPropsBase = {
   /**
    * CSS class names applied to the rendered icon, or to the wrapper around custom
    * content so both branches sit the same way in the layout.
@@ -20,6 +20,22 @@ export type IconSlotProps = {
   size?: string;
 };
 
+export type IconSlotProps = IconSlotPropsBase &
+  (
+    | {
+        /**
+         * Mirrors `Icon`'s `purpose`, and applies only when rendering an icon name.
+         * Custom content carries its own accessible treatment.
+         */
+        purpose?: 'decorative';
+        title?: never;
+      }
+    | {
+        purpose: 'informative';
+        title: string;
+      }
+  );
+
 /**
  * Renders a leading/trailing slot that accepts either an EDS icon name or arbitrary
  * content.
@@ -30,9 +46,14 @@ export type IconSlotProps = {
  * renders through `Icon` with that component's own sizing. Everything else is content
  * and renders untouched.
  *
+ * `purpose` and `title` describe the icon branch only. When a consumer supplies their
+ * own content, they own its accessible treatment.
+ *
  * Not exported from the package. Consumers use the slot props on each component.
  */
-export const IconSlot = ({ className, content, size }: IconSlotProps) => {
+export const IconSlot = (props: IconSlotProps) => {
+  const { className, content, size } = props;
+
   if (content === null || content === undefined || content === false) {
     return null;
   }
@@ -40,10 +61,20 @@ export const IconSlot = ({ className, content, size }: IconSlotProps) => {
   if (typeof content === 'string') {
     // Safe because a string in this slot is an icon name by convention. The union
     // collapses to `ReactNode`, so TypeScript cannot narrow to `IconName` on its own.
-    return (
+    const name = content as IconName;
+
+    return props.purpose === 'informative' ? (
       <Icon
         className={className}
-        name={content as IconName}
+        name={name}
+        purpose="informative"
+        size={size}
+        title={props.title}
+      />
+    ) : (
+      <Icon
+        className={className}
+        name={name}
         purpose="decorative"
         size={size}
       />

--- a/src/components/Icon/IconSlot.tsx
+++ b/src/components/Icon/IconSlot.tsx
@@ -3,7 +3,31 @@ import { Icon } from './Icon';
 import type { IconName } from './Icon';
 import type { IconOrContent } from '../../util/utility-types';
 
+/**
+ * Whether a slot value will render anything.
+ *
+ * These slots take any `ReactNode`, so a plain truthiness check is wrong twice over: it
+ * treats `0` as absent, and `{0 && <El />}` leaks a stray "0" into the markup. Only the
+ * values React itself renders as nothing count as empty here.
+ */
+export function hasSlotContent(content: IconOrContent) {
+  return (
+    content !== null &&
+    content !== undefined &&
+    typeof content !== 'boolean' &&
+    content !== ''
+  );
+}
+
 type IconSlotPropsBase = {
+  /**
+   * Element used to wrap custom content so it can carry `className`.
+   *
+   * Defaults to `span`, which is valid wherever the slot itself is, including inside a
+   * `button`. Use `div` when the slot sits in a flow-content container, so consumers
+   * passing block-level content do not produce a `span` wrapping a `div`.
+   */
+  as?: 'div' | 'span';
   /**
    * CSS class names applied to the rendered icon, or to the wrapper around custom
    * content so both branches sit the same way in the layout.
@@ -52,9 +76,9 @@ export type IconSlotProps = IconSlotPropsBase &
  * Not exported from the package. Consumers use the slot props on each component.
  */
 export const IconSlot = (props: IconSlotProps) => {
-  const { className, content, size } = props;
+  const { as: Wrapper = 'span', className, content, size } = props;
 
-  if (content === null || content === undefined || content === false) {
+  if (!hasSlotContent(content)) {
     return null;
   }
 
@@ -82,7 +106,7 @@ export const IconSlot = (props: IconSlotProps) => {
   }
 
   return className ? (
-    <span className={className}>{content}</span>
+    <Wrapper className={className}>{content}</Wrapper>
   ) : (
     <>{content}</>
   );

--- a/src/components/Icon/IconSlot.tsx
+++ b/src/components/Icon/IconSlot.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Icon } from './Icon';
+import type { IconName } from './Icon';
+import type { IconOrContent } from '../../util/utility-types';
+
+export type IconSlotProps = {
+  /**
+   * CSS class names applied to the rendered icon, or to the wrapper around custom
+   * content so both branches sit the same way in the layout.
+   */
+  className?: string;
+  /**
+   * The slot's value. A string is treated as an EDS icon name; anything else renders
+   * as-is.
+   */
+  content: IconOrContent;
+  /**
+   * Width/height passed through to `Icon` when rendering an icon name.
+   */
+  size?: string;
+};
+
+/**
+ * Renders a leading/trailing slot that accepts either an EDS icon name or arbitrary
+ * content.
+ *
+ * Components that used to take an `IconName` now take `IconOrContent`, so they need to
+ * decide at runtime which of the two they were handed. A string is the only thing a
+ * consumer can pass that is ambiguous, and by convention it means an icon name, so it
+ * renders through `Icon` with that component's own sizing. Everything else is content
+ * and renders untouched.
+ *
+ * Not exported from the package. Consumers use the slot props on each component.
+ */
+export const IconSlot = ({ className, content, size }: IconSlotProps) => {
+  if (content === null || content === undefined || content === false) {
+    return null;
+  }
+
+  if (typeof content === 'string') {
+    // Safe because a string in this slot is an icon name by convention. The union
+    // collapses to `ReactNode`, so TypeScript cannot narrow to `IconName` on its own.
+    return (
+      <Icon
+        className={className}
+        name={content as IconName}
+        purpose="decorative"
+        size={size}
+      />
+    );
+  }
+
+  return className ? (
+    <span className={className}>{content}</span>
+  ) : (
+    <>{content}</>
+  );
+};

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,2 +1,4 @@
 export { Icon as default } from './Icon';
 export type { IconName, IconProps } from './Icon';
+export { IconSlot } from './IconSlot';
+export type { IconSlotProps } from './IconSlot';

--- a/src/components/Icon/index.ts
+++ b/src/components/Icon/index.ts
@@ -1,4 +1,4 @@
 export { Icon as default } from './Icon';
 export type { IconName, IconProps } from './Icon';
-export { IconSlot } from './IconSlot';
+export { hasSlotContent, IconSlot } from './IconSlot';
 export type { IconSlotProps } from './IconSlot';

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -5,6 +5,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import React from 'react';
 
 import { InputField } from './InputField';
+import Avatar from '../Avatar';
 import Button from '../Button';
 
 const meta: Meta<typeof InputField> = {
@@ -153,7 +154,7 @@ export const Disabled: Story = {
  */
 export const LeadingIcon: Story = {
   args: {
-    leadingIcon: 'search',
+    leadingContent: 'search',
     'aria-label': 'search field',
     placeholder: 'Search...',
   },
@@ -449,4 +450,15 @@ export const WithBothMaxAndRecommendedLength: Story = {
     required: true,
   },
   render: (args) => <InputField {...args} />,
+};
+
+/**
+ * The leading slot also takes arbitrary content, for cases an EDS icon does not cover.
+ */
+export const LeadingContent: Story = {
+  args: {
+    leadingContent: <Avatar size="sm" user={{ fullName: 'Ada Lovelace' }} />,
+    'aria-label': 'assignee field',
+    placeholder: 'Assign to...',
+  },
 };

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -45,7 +45,7 @@ const meta: Meta<typeof InputField> = {
     },
   },
   decorators: [(Story) => <div className="p-spacing-size-4">{Story()}</div>],
-  tags: ['autodocs', 'version:2.1.3'],
+  tags: ['autodocs', 'version:3.0.0'],
 };
 
 export default meta;

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -12,7 +12,7 @@ import Button from '../Button';
 import Counter from '../Counter';
 import FieldLabel from '../FieldLabel';
 import FieldNote from '../FieldNote';
-import { IconSlot } from '../Icon';
+import { hasSlotContent, IconSlot } from '../Icon';
 import Input from '../Input';
 import Text from '../Text';
 import styles from './InputField.module.css';
@@ -296,7 +296,8 @@ export const InputField: InputFieldType = forwardRef(
 
     // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
     const inputOverlayClassName = clsx(
-      leadingContent && styles['input-field__input--leading-icon'],
+      hasSlotContent(leadingContent) &&
+        styles['input-field__input--leading-icon'],
       shouldRenderInputWithin && styles['input-field__input--input-within'],
     );
 
@@ -437,7 +438,7 @@ export const InputField: InputFieldType = forwardRef(
               )}
             </div>
           )}
-          {leadingContent && (
+          {hasSlotContent(leadingContent) && (
             <div className={styles['input-field__leading-icon']}>
               <IconSlot content={leadingContent} size="24px" />
             </div>

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -5,13 +5,14 @@ import { getMinValue } from '../../util/getMinValue';
 import type {
   EitherInclusive,
   ForwardedRefComponent,
+  IconOrContent,
 } from '../../util/utility-types';
 import type { Status } from '../../util/variant-types';
 import Button from '../Button';
 import Counter from '../Counter';
 import FieldLabel from '../FieldLabel';
 import FieldNote from '../FieldNote';
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import Input from '../Input';
 import Text from '../Text';
 import styles from './InputField.module.css';
@@ -106,9 +107,10 @@ export type InputFieldProps = React.InputHTMLAttributes<HTMLInputElement> & {
    */
   fieldNote?: ReactNode;
   /**
-   * An icon that prefixes the field input.
+   * Content that prefixes the field input. Pass an EDS icon name to render a decorative
+   * icon, or a node to render it as-is.
    */
-  leadingIcon?: IconName;
+  leadingContent?: IconOrContent;
   /**
    * Placeholder attribute for input. Note: placeholder should be used sparingly
    */
@@ -213,7 +215,7 @@ export const InputField: InputFieldType = forwardRef(
       id,
       inputWithin,
       label,
-      leadingIcon,
+      leadingContent,
       maxLength,
       onChange,
       readOnly,
@@ -294,7 +296,7 @@ export const InputField: InputFieldType = forwardRef(
 
     // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
     const inputOverlayClassName = clsx(
-      leadingIcon && styles['input-field__input--leading-icon'],
+      leadingContent && styles['input-field__input--leading-icon'],
       shouldRenderInputWithin && styles['input-field__input--input-within'],
     );
 
@@ -435,9 +437,9 @@ export const InputField: InputFieldType = forwardRef(
               )}
             </div>
           )}
-          {leadingIcon && (
+          {leadingContent && (
             <div className={styles['input-field__leading-icon']}>
-              <Icon name={leadingIcon} purpose="decorative" size="24px" />
+              <IconSlot content={leadingContent} size="24px" />
             </div>
           )}
         </div>

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -371,6 +371,45 @@ exports[`<InputField /> > InputWithinFixedWidth story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<InputField /> > LeadingContent story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="w-[384px]"
+  >
+    <div
+      class="_input-field__body_4d3b17"
+    >
+      <input
+        aria-describedby="_r_27_"
+        aria-invalid="false"
+        aria-label="assignee field"
+        class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+        id="_r_25_"
+        placeholder="Assign to..."
+        type="text"
+      />
+      <div
+        class="_input-field__leading-icon_4d3b17"
+      >
+        <div
+          aria-label="Avatar for user Ada Lovelace"
+          class="_avatar_814665 _avatar--sm_814665 _avatar--text_814665 _avatar--color-scheme-1_814665"
+          role="img"
+        >
+          <span
+            class="_text_b3eba3 _text--label-sm_b3eba3"
+          >
+            A
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<InputField /> > LeadingIcon story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"

--- a/src/components/SelectionChip/SelectionChip.stories.tsx
+++ b/src/components/SelectionChip/SelectionChip.stories.tsx
@@ -1,9 +1,10 @@
 import type { StoryObj, Meta } from '@storybook/react-vite' with {
   'resolution-mode': 'import',
 };
-import type React from 'react';
+import React from 'react';
 
 import { SelectionChip } from './SelectionChip';
+import Avatar from '../Avatar';
 
 export default {
   title: 'Components/SelectionChip',
@@ -42,7 +43,7 @@ export const Selected: Story = {
 export const WithIcon: Story = {
   args: {
     ...Default.args,
-    leadingIcon: 'add',
+    leadingContent: 'add',
   },
 };
 
@@ -85,5 +86,15 @@ export const UncontrolledChecked: Story = {
   args: {
     ...WithIcon.args,
     defaultChecked: true,
+  },
+};
+
+/**
+ * The leading slot also takes arbitrary content, for cases an EDS icon does not cover.
+ */
+export const WithLeadingContent: Story = {
+  args: {
+    ...Default.args,
+    leadingContent: <Avatar size="sm" user={{ fullName: 'Ada Lovelace' }} />,
   },
 };

--- a/src/components/SelectionChip/SelectionChip.stories.tsx
+++ b/src/components/SelectionChip/SelectionChip.stories.tsx
@@ -15,7 +15,7 @@ export default {
     },
     layout: 'centered',
   },
-  tags: ['autodocs', 'version:1.2.0'],
+  tags: ['autodocs', 'version:2.0.0'],
 } as Meta<Args>;
 
 type Args = React.ComponentProps<typeof SelectionChip>;

--- a/src/components/SelectionChip/SelectionChip.tsx
+++ b/src/components/SelectionChip/SelectionChip.tsx
@@ -1,9 +1,12 @@
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 
-import type { ForwardedRefComponent } from '../../util/utility-types';
+import type {
+  ForwardedRefComponent,
+  IconOrContent,
+} from '../../util/utility-types';
 
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './SelectionChip.module.css';
@@ -28,9 +31,10 @@ export type SelectionChipProps = {
    */
   label: string;
   /**
-   * Leading icon for the chip
+   * Content that precedes the label. Pass an EDS icon name to render a decorative
+   * icon, or a node to render it as-is.
    */
-  leadingIcon?: IconName;
+  leadingContent?: IconOrContent;
   /**
    * Chip types (correspond to the equivalent input types)
    */
@@ -97,7 +101,7 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
       id,
       isDisabled,
       label,
-      leadingIcon,
+      leadingContent,
       name,
       onChange,
       type = 'checkbox',
@@ -107,7 +111,7 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
   ) => {
     const componentClassName = clsx(
       styles['selection-chip'],
-      leadingIcon && styles['selection-chip--has-icon'],
+      leadingContent && styles['selection-chip--has-icon'],
       isDisabled && styles['selection-chip--disabled'],
       className,
     );
@@ -134,7 +138,7 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
           type={type}
         />
         <div className={styles['selection-chip__body']}>
-          {leadingIcon && <Icon name={leadingIcon} purpose="decorative" />}
+          {leadingContent && <IconSlot content={leadingContent} />}
           <Text
             as="span"
             className={styles['selection-chip__label']}

--- a/src/components/SelectionChip/SelectionChip.tsx
+++ b/src/components/SelectionChip/SelectionChip.tsx
@@ -6,7 +6,7 @@ import type {
   IconOrContent,
 } from '../../util/utility-types';
 
-import { IconSlot } from '../Icon';
+import { hasSlotContent, IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './SelectionChip.module.css';
@@ -111,7 +111,7 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
   ) => {
     const componentClassName = clsx(
       styles['selection-chip'],
-      leadingContent && styles['selection-chip--has-icon'],
+      hasSlotContent(leadingContent) && styles['selection-chip--has-icon'],
       isDisabled && styles['selection-chip--disabled'],
       className,
     );
@@ -138,7 +138,7 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
           type={type}
         />
         <div className={styles['selection-chip__body']}>
-          {leadingContent && <IconSlot content={leadingContent} />}
+          <IconSlot content={leadingContent} />
           <Text
             as="span"
             className={styles['selection-chip__label']}

--- a/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
+++ b/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
@@ -194,3 +194,36 @@ exports[`<SelectionChip /> > WithIcon story renders snapshot 1`] = `
   </div>
 </label>
 `;
+
+exports[`<SelectionChip /> > WithLeadingContent story renders snapshot 1`] = `
+<label
+  class="_selection-chip_b63b89 _selection-chip--has-icon_b63b89"
+  for="_r_7_"
+>
+  <input
+    class="_selection-chip__input_b63b89"
+    id="_r_7_"
+    type="checkbox"
+  />
+  <div
+    class="_selection-chip__body_b63b89"
+  >
+    <div
+      aria-label="Avatar for user Ada Lovelace"
+      class="_avatar_814665 _avatar--sm_814665 _avatar--text_814665 _avatar--color-scheme-1_814665"
+      role="img"
+    >
+      <span
+        class="_text_b3eba3 _text--label-sm_b3eba3"
+      >
+        A
+      </span>
+    </div>
+    <span
+      class="_text_b3eba3 _text--label-lg_b3eba3 _selection-chip__label_b63b89"
+    >
+      Label
+    </span>
+  </div>
+</label>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ export { default as VisualPageIndicator } from './components/VisualPageIndicator
  * Prop type exports
  */
 export type {
+  IconOrContent,
   NavGroup,
   NavButton,
   NavLink,

--- a/src/util/utility-types.ts
+++ b/src/util/utility-types.ts
@@ -52,6 +52,19 @@ export type RenderProps<RenderPropArgs> = {
   children: ReactNode | ((args: RenderPropArgs) => React.ReactElement);
 };
 
+/**
+ * A leading or trailing slot that takes either the name of an EDS icon or arbitrary
+ * content.
+ *
+ * When given a string, the component renders it as a decorative `<Icon>` sized and
+ * positioned for that component. Anything else renders as-is, so consumers can supply
+ * an avatar, a badge, or any other node in the same slot.
+ *
+ * Note that TypeScript reduces this union to `ReactNode`, since `IconName` is a subset
+ * of `string`. Icon names are documented per prop rather than autocompleted.
+ */
+export type IconOrContent = IconName | ReactNode;
+
 export type UserData = {
   /**
    * The full name of the attached user (e.g., Jane Doe, David S. Pumpkins)


### PR DESCRIPTION
Renames the leading/trailing icon props to content props across `Accordion`, `DataTable`, `InputField`, and `SelectionChip`.

EDS-2000

## Prop changes

| Component | Before | After |
|---|---|---|
| `Accordion.Button` | `leadingIcon?: ReactNode` | `leadingContent?: ReactNode` |
| `Accordion.Button` | `trailingIcon?: Extract<IconName, 'chevron-down'>` | `indicatorContent?: IconOrContent` |
| `Accordion.Row` | `hasLeadingIcon?: boolean` | `hasLeadingContent?: boolean` |
| `DataTable.HeaderCell` | `leadingIcon?: IconName` | `leadingContent?: IconOrContent` |
| `DataTable.DataCell` | `leadingIcon?: IconName` | `leadingContent?: IconOrContent` |
| `InputField` | `leadingIcon?: IconName` | `leadingContent?: IconOrContent` |
| `SelectionChip` | `leadingIcon?: IconName` | `leadingContent?: IconOrContent` |

No prop named `*Icon` is left on any of these components.

## What changed

Props that were typed `IconName` now take a new `IconOrContent`, so the slot still accepts an EDS icon name and also accepts a node. A new internal `IconSlot` picks the branch:

- a string renders through `Icon` with that component's own sizing and purpose, exactly as before
- anything else renders as-is, wrapped in the component's icon class so custom content keeps the same layout

`Accordion.Button`'s `leadingIcon` was already a `ReactNode`, so only its name changed, resolving the `// TODO(next-major)` that named this rename.

`trailingIcon` became `indicatorContent` rather than `trailingContent`: it overrides the expand/collapse indicator rather than filling a trailing slot, and the component already has a separate `trailingContent` slot. The indicator keeps its informative treatment, so an icon name is still announced as "show content"/"hide content"; `IconSlot` gained `purpose`/`title` to carry that through. Custom indicator content still rotates on open, so pick something that reads well upside down, and it carries its own accessible treatment.

`hasLeadingIcon` is the boolean companion to the renamed slot and sat beside an existing `hasTrailingContent`, so it follows to `hasLeadingContent`.

Snapshots across every change are **additive only** — no existing snapshot line changed, which confirms the icon-name paths render identically to before. New stories on `Accordion`, `InputField`, and `SelectionChip` cover the node branch.

## Drive-by fix worth a look

`edit-jsx-prop` silently skipped any change naming a subcomponent. It matched `componentName` against the imported identifier, so `DataTable.DataCell` never matched the `DataTable` import, and it used `find`, so only the first change per import applied. Without this fix the codemod in this PR would no-op on most of these components.

Side effect: the `Accordion.Button` `subtitle` -> `subTitle` rename in the **17-to-18** migration has never actually run, and now would.

## Migration

`18-to-19` rewrites every prop name above. Values are unchanged, so an existing `leadingIcon="search"` becomes `leadingContent="search"` and renders the same icon.

```
npx eds-migrate 18-to-19
```

## Note on the type

`IconOrContent` is `IconName | ReactNode`, which TypeScript reduces to `ReactNode` since `IconName` is a subset of `string`. That means no autocomplete on icon names for these props, and a typo'd name is not caught at compile time. Icon names stay documented per prop. Tightening this is possible but every variant I tried still admits arbitrary strings through `ReactNode`'s `Iterable` member, so I left it as the plain union.

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run` — 632 passed, 1 skipped, 3 new snapshots, no existing snapshot changed
- `yarn lint` clean
- `yarn build` clean

## Ticket checklist

- [x] Code
- [ ] Design
- [ ] Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)