### PR TITLE
refactor(Accordion, DataTable, InputField, SelectionChip): rename icon CSS classes to content

### DIFF
--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -11,7 +11,7 @@
 .accordion-panel {
   padding: 0 0 calc(var(--eds-spacing-size-2) * 1px);
 
-  &.accordion-panel--leading-icon {
+  &.accordion-panel--leading-content {
     padding-left: calc(var(--eds-spacing-size-5) * 1px);
   }
 
@@ -57,7 +57,7 @@
  *
  * This non-rotated icon points down and represents closed status.
  */
-.accordion-button__trailing-icon {
+.accordion-button__indicator {
   flex: 0 0 content;
   transform: rotate(0);
   color: light-dark(var(--eds-theme-color-icon-utility-default-secondary), var(--eds-dark-theme-color-icon-utility-default-secondary));
@@ -66,14 +66,14 @@
 /**
  * This rotated icon points up and represents open status.
  */
-.accordion-button__trailing-icon--open {
+.accordion-button__indicator--open {
   transform: rotate(-180deg);
 }
 
 /**
  * Animates the icon rotation when opening and closing.
  */
-.accordion-button>.accordion-button__trailing-icon {
+.accordion-button>.accordion-button__indicator {
   transition: transform calc(var(--eds-anim-move-medium) * 1s) ease-in-out;
 
   @media screen and (prefers-reduced-motion) {
@@ -98,7 +98,7 @@
   outline-color: light-dark(var(--eds-theme-color-border-utility-focus), var(--eds-dark-theme-color-border-utility-focus));
 }
 
-.accordion-button__leading-icon {
+.accordion-button__leading-content {
   color: light-dark(var(--eds-theme-color-icon-utility-default-secondary), var(--eds-dark-theme-color-icon-utility-default-secondary));
 
   /* Targeting NumberIcons and other images used in this specific context */

--- a/src/components/Accordion/Accordion.module.css
+++ b/src/components/Accordion/Accordion.module.css
@@ -19,7 +19,7 @@
 }
 
 /**
- * Accordion Button, wraps the heading and open indicator icon.
+ * Accordion Button, wraps the heading and open indicator.
  */
 .accordion-button {
   display: flex;
@@ -53,9 +53,9 @@
 }
 
 /**
- * Expand more (chevron) icon indicates open or closed status.
+ * Open/closed indicator, a chevron by default.
  *
- * This non-rotated icon points down and represents closed status.
+ * Unrotated, it points down and represents closed status.
  */
 .accordion-button__indicator {
   flex: 0 0 content;
@@ -64,14 +64,14 @@
 }
 
 /**
- * This rotated icon points up and represents open status.
+ * Rotated, it points up and represents open status.
  */
 .accordion-button__indicator--open {
   transform: rotate(-180deg);
 }
 
 /**
- * Animates the icon rotation when opening and closing.
+ * Animates the indicator rotation when opening and closing.
  */
 .accordion-button>.accordion-button__indicator {
   transition: transform calc(var(--eds-anim-move-medium) * 1s) ease-in-out;

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -260,7 +260,7 @@ const AccordionButton = ({
           {...other}
         >
           {hasSlotContent(leadingContent) && (
-            <span className={styles['accordion-button__leading-icon']}>
+            <span className={styles['accordion-button__leading-content']}>
               {leadingContent}
             </span>
           )}
@@ -293,8 +293,8 @@ const AccordionButton = ({
           {isExpandable && (
             <IconSlot
               className={clsx(
-                styles['accordion-button__trailing-icon'],
-                open && styles['accordion-button__trailing-icon--open'],
+                styles['accordion-button__indicator'],
+                open && styles['accordion-button__indicator--open'],
               )}
               content={indicatorContent}
               purpose="informative"
@@ -318,7 +318,7 @@ const AccordionPanel = ({
   const componentClassName = clsx(
     styles['accordion-panel'],
     !isExpandable && styles['accordion-panel--hidden'],
-    hasLeadingContent && styles['accordion-panel--leading-icon'],
+    hasLeadingContent && styles['accordion-panel--leading-content'],
     className,
   );
 

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`<Accordion /> > Default story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -78,7 +78,7 @@ exports[`<Accordion /> > Default story renders snapshot 1`] = `
           </span>
         </span>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -121,7 +121,7 @@ exports[`<Accordion /> > Default story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df _accordion-button__trailing-icon--open_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df _accordion-button__indicator--open_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -180,7 +180,7 @@ exports[`<Accordion /> > HasLeadingIcon story renders snapshot 1`] = `
         type="button"
       >
         <span
-          class="_accordion-button__leading-icon_86d7df"
+          class="_accordion-button__leading-content_86d7df"
         >
           <svg
             aria-hidden="true"
@@ -212,7 +212,7 @@ exports[`<Accordion /> > HasLeadingIcon story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -270,7 +270,7 @@ exports[`<Accordion /> > TitleAndSubtitle story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -322,7 +322,7 @@ exports[`<Accordion /> > UsingRenderProp story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -372,7 +372,7 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -411,7 +411,7 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -450,7 +450,7 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
           </span>
         </h2>
         <span
-          class="_accordion-button__trailing-icon_86d7df"
+          class="_accordion-button__indicator_86d7df"
         >
           <span
             class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-favorable_f57044"
@@ -496,7 +496,7 @@ exports[`<Accordion /> > WithLargeHeader story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -538,7 +538,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
         type="button"
       >
         <span
-          class="_accordion-button__leading-icon_86d7df"
+          class="_accordion-button__leading-content_86d7df"
         >
           <span
             aria-label="Numero uno"
@@ -559,7 +559,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -590,7 +590,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
         type="button"
       >
         <span
-          class="_accordion-button__leading-icon_86d7df"
+          class="_accordion-button__leading-content_86d7df"
         >
           <span
             aria-label="Numero uno"
@@ -611,7 +611,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"
@@ -642,7 +642,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
         type="button"
       >
         <span
-          class="_accordion-button__leading-icon_86d7df"
+          class="_accordion-button__leading-content_86d7df"
         >
           <span
             aria-label="Numero uno"
@@ -663,7 +663,7 @@ exports[`<Accordion /> > WithLeadingNumberIcon story renders snapshot 1`] = `
           </span>
         </h2>
         <svg
-          class="_icon_779da8 _accordion-button__trailing-icon_86d7df"
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
           fill="currentColor"
           height="24px"
           role="img"

--- a/src/components/DataTable/DataTable.module.css
+++ b/src/components/DataTable/DataTable.module.css
@@ -123,7 +123,7 @@
     padding: calc(var(--eds-spacing-size-2) * 1px) calc(var(--eds-spacing-size-1-and-half) * 1px);
   }
 
-  .data-cell__cell--icon {
+  .data-cell__cell--leading-content {
     margin-top: calc(var(--eds-spacing-size-half) * 1px);
     flex-shrink: 0;
 
@@ -173,7 +173,7 @@
     padding: calc(var(--eds-spacing-size-2) * 1px) calc(var(--eds-spacing-size-1-and-half) * 1px);
   }
 
-  .data-cell__cell--icon {
+  .data-cell__cell--leading-content {
     margin-top: calc(var(--eds-spacing-size-quarter) * 1px);
     flex-shrink: 0;
   }

--- a/src/components/DataTable/DataTable.tsx
+++ b/src/components/DataTable/DataTable.tsx
@@ -472,7 +472,7 @@ export const DataTableHeaderCell = ({
   >
     <IconSlot
       as="div"
-      className={styles['data-cell__cell--icon']}
+      className={styles['data-cell__cell--leading-content']}
       content={leadingContent}
       size="16px"
     />
@@ -522,7 +522,7 @@ export const DataTableDataCell = ({
     <div className={dataCellClassName} {...rest}>
       <IconSlot
         as="div"
-        className={styles['data-cell__cell--icon']}
+        className={styles['data-cell__cell--leading-content']}
         content={leadingContent}
         size="16px"
       />

--- a/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
@@ -5548,7 +5548,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -5694,7 +5694,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -5804,7 +5804,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -5914,7 +5914,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6024,7 +6024,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6134,7 +6134,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6244,7 +6244,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6354,7 +6354,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6464,7 +6464,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6574,7 +6574,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6684,7 +6684,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6794,7 +6794,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -6904,7 +6904,7 @@ exports[`<DataTable /> > Selectable story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10196,7 +10196,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10342,7 +10342,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10452,7 +10452,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10562,7 +10562,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10672,7 +10672,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10782,7 +10782,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -10892,7 +10892,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11002,7 +11002,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11112,7 +11112,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11222,7 +11222,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11332,7 +11332,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11442,7 +11442,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11552,7 +11552,7 @@ exports[`<DataTable /> > VerticalDivider story renders snapshot 1`] = `
           >
             <svg
               aria-hidden="true"
-              class="_icon_779da8 _data-cell__cell--icon_a06dc5"
+              class="_icon_779da8 _data-cell__cell--leading-content_a06dc5"
               fill="currentColor"
               height="16px"
               style="--icon-size: 16px;"
@@ -11738,14 +11738,14 @@ exports[`<DataTable /> > WithLongCaption story renders snapshot 1`] = `
             aria-describedby=""
             aria-invalid="false"
             aria-label="search"
-            class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+            class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
             disabled=""
             id="_r_19_"
             placeholder="Search..."
             type="search"
           />
           <div
-            class="_input-field__leading-icon_4d3b17"
+            class="_input-field__leading-content_4d3b17"
           >
             <svg
               aria-hidden="true"
@@ -11902,14 +11902,14 @@ exports[`<DataTable /> > WithSearch story renders snapshot 1`] = `
             aria-describedby=""
             aria-invalid="false"
             aria-label="search"
-            class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+            class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
             disabled=""
             id="_r_q_"
             placeholder="Search..."
             type="search"
           />
           <div
-            class="_input-field__leading-icon_4d3b17"
+            class="_input-field__leading-content_4d3b17"
           >
             <svg
               aria-hidden="true"
@@ -11978,14 +11978,14 @@ exports[`<DataTable /> > WithSearchAndActions story renders snapshot 1`] = `
             aria-describedby=""
             aria-invalid="false"
             aria-label="search"
-            class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+            class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
             disabled=""
             id="_r_t_"
             placeholder="Search..."
             type="search"
           />
           <div
-            class="_input-field__leading-icon_4d3b17"
+            class="_input-field__leading-content_4d3b17"
           >
             <svg
               aria-hidden="true"
@@ -12087,14 +12087,14 @@ exports[`<DataTable /> > WithSearchAndCustomActions story renders snapshot 1`] =
             aria-describedby=""
             aria-invalid="false"
             aria-label="search"
-            class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+            class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
             disabled=""
             id="_r_10_"
             placeholder="Search..."
             type="search"
           />
           <div
-            class="_input-field__leading-icon_4d3b17"
+            class="_input-field__leading-content_4d3b17"
           >
             <svg
               aria-hidden="true"

--- a/src/components/InputField/InputField.module.css
+++ b/src/components/InputField/InputField.module.css
@@ -55,7 +55,7 @@
   max-width: calc(100% - (var(--eds-spacing-size-9) * 1px));
 }
 
-.input-field__leading-icon {
+.input-field__leading-content {
   position: absolute;
   pointer-events: none;
   top: 0;
@@ -75,7 +75,7 @@
   position: relative;
 }
 
-.input-field__input--leading-icon {
+.input-field__input--leading-content {
   padding-left: calc(var(--eds-spacing-size-4-and-half) * 1px);
 }
 

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -294,7 +294,7 @@ export const InputField: InputFieldType = forwardRef(
       fieldNote && styles['input-field--has-fieldNote'],
     );
 
-    // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
+    // Modify the padding of `Input` to account for trailing/leading content and trailing buttons
     const inputOverlayClassName = clsx(
       hasSlotContent(leadingContent) &&
         styles['input-field__input--leading-content'],

--- a/src/components/InputField/InputField.tsx
+++ b/src/components/InputField/InputField.tsx
@@ -297,7 +297,7 @@ export const InputField: InputFieldType = forwardRef(
     // Modify the padding of `Input` to account for trailing/leading icons and trailing buttons
     const inputOverlayClassName = clsx(
       hasSlotContent(leadingContent) &&
-        styles['input-field__input--leading-icon'],
+        styles['input-field__input--leading-content'],
       shouldRenderInputWithin && styles['input-field__input--input-within'],
     );
 
@@ -439,7 +439,7 @@ export const InputField: InputFieldType = forwardRef(
             </div>
           )}
           {hasSlotContent(leadingContent) && (
-            <div className={styles['input-field__leading-icon']}>
+            <div className={styles['input-field__leading-content']}>
               <IconSlot content={leadingContent} size="24px" />
             </div>
           )}

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -385,13 +385,13 @@ exports[`<InputField /> > LeadingContent story renders snapshot 1`] = `
         aria-describedby="_r_27_"
         aria-invalid="false"
         aria-label="assignee field"
-        class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+        class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
         id="_r_25_"
         placeholder="Assign to..."
         type="text"
       />
       <div
-        class="_input-field__leading-icon_4d3b17"
+        class="_input-field__leading-content_4d3b17"
       >
         <div
           aria-label="Avatar for user Ada Lovelace"
@@ -424,13 +424,13 @@ exports[`<InputField /> > LeadingIcon story renders snapshot 1`] = `
         aria-describedby="_r_q_"
         aria-invalid="false"
         aria-label="search field"
-        class="_input_0d9f86 _input-field__input--leading-icon_4d3b17"
+        class="_input_0d9f86 _input-field__input--leading-content_4d3b17"
         id="_r_o_"
         placeholder="Search..."
         type="text"
       />
       <div
-        class="_input-field__leading-icon_4d3b17"
+        class="_input-field__leading-content_4d3b17"
       >
         <svg
           aria-hidden="true"

--- a/src/components/SelectionChip/SelectionChip.module.css
+++ b/src/components/SelectionChip/SelectionChip.module.css
@@ -69,7 +69,7 @@
   box-shadow: inset 0 0 0 1px var(--selection-chip__border);
 }
 
-.selection-chip--has-icon {
+.selection-chip--has-leading-content {
   padding-right: calc(var(--eds-spacing-size-2-and-half) * 1px);
 }
 

--- a/src/components/SelectionChip/SelectionChip.tsx
+++ b/src/components/SelectionChip/SelectionChip.tsx
@@ -111,7 +111,8 @@ export const SelectionChip: SelectionChipRefProps = forwardRef(
   ) => {
     const componentClassName = clsx(
       styles['selection-chip'],
-      hasSlotContent(leadingContent) && styles['selection-chip--has-icon'],
+      hasSlotContent(leadingContent) &&
+        styles['selection-chip--has-leading-content'],
       isDisabled && styles['selection-chip--disabled'],
       className,
     );

--- a/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
+++ b/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`<SelectionChip /> > ControlledChecked story renders snapshot 1`] = `
 <label
-  class="_selection-chip_b63b89 _selection-chip--has-icon_b63b89"
+  class="_selection-chip_b63b89 _selection-chip--has-leading-content_b63b89"
   for="_r_5_"
 >
   <input
@@ -130,7 +130,7 @@ exports[`<SelectionChip /> > Selected story renders snapshot 1`] = `
 
 exports[`<SelectionChip /> > UncontrolledChecked story renders snapshot 1`] = `
 <label
-  class="_selection-chip_b63b89 _selection-chip--has-icon_b63b89"
+  class="_selection-chip_b63b89 _selection-chip--has-leading-content_b63b89"
   for="_r_6_"
 >
   <input
@@ -164,7 +164,7 @@ exports[`<SelectionChip /> > UncontrolledChecked story renders snapshot 1`] = `
 
 exports[`<SelectionChip /> > WithIcon story renders snapshot 1`] = `
 <label
-  class="_selection-chip_b63b89 _selection-chip--has-icon_b63b89"
+  class="_selection-chip_b63b89 _selection-chip--has-leading-content_b63b89"
   for="_r_2_"
 >
   <input
@@ -197,7 +197,7 @@ exports[`<SelectionChip /> > WithIcon story renders snapshot 1`] = `
 
 exports[`<SelectionChip /> > WithLeadingContent story renders snapshot 1`] = `
 <label
-  class="_selection-chip_b63b89 _selection-chip--has-icon_b63b89"
+  class="_selection-chip_b63b89 _selection-chip--has-leading-content_b63b89"
   for="_r_7_"
 >
   <input


### PR DESCRIPTION
Closes [EDS-2131](https://czi.atlassian.net/browse/EDS-2131). Follow-up to #2620 (EDS-2000).

## What and why

EDS-2000 renamed the icon props to content props across Accordion, DataTable, InputField, and SelectionChip. Those slots now take an icon name or arbitrary content, so the CSS module class names that still said "icon" described the old, narrower behavior. They were left alone in #2620 on purpose to keep the API change reviewable.

Cleanup, not a behavior change.

## The renames

Nine classes, each with a matching `styles['...']` lookup in the component TSX.

| File | Old | New |
|---|---|---|
| Accordion.module.css | `accordion-button__leading-icon` | `accordion-button__leading-content` |
| Accordion.module.css | `accordion-button__trailing-icon` | `accordion-button__indicator` |
| Accordion.module.css | `accordion-button__trailing-icon--open` | `accordion-button__indicator--open` |
| Accordion.module.css | `accordion-panel--leading-icon` | `accordion-panel--leading-content` |
| DataTable.module.css | `data-cell__cell--icon` (×2, one per size block) | `data-cell__cell--leading-content` |
| InputField.module.css | `input-field__leading-icon` | `input-field__leading-content` |
| InputField.module.css | `input-field__input--leading-icon` | `input-field__input--leading-content` |
| SelectionChip.module.css | `selection-chip--has-icon` | `selection-chip--has-leading-content` |

`accordion-button__indicator` lands in three places that aren't plain selectors: the `--open` modifier, the nested `&.accordion-panel--leading-content` rule, and the `.accordion-button > .accordion-button__indicator` transition rule.

The `--leading-content` naming matches the existing `popover-list-item__leading-content` on PopoverListItem.

## How I verified it

The real risk here is a missed reference. A stale `styles['old-name']` resolves to `undefined` and silently drops the class, and the typechecker won't catch it, so verification is by grep and by reading the snapshot diff.

- Grepped `leading-icon|trailing-icon|cell--icon|has-icon` across all of `src/` (CSS, TSX, stories, tests, MDX). No hits outside the regenerated snapshots.
- Snapshot diff is **59 removals and 59 insertions, one for one**. Every changed line is a `class="..."` attribute, and each old class maps to exactly one new class in the same position. No line added, none removed, nothing structural, no class dropped.
- `yarn types`, `yarn lint`, `yarn build`, and the full suite (55 files, 651 passed) all pass.

Chromatic on this PR is the visual backstop, since a dropped class shows up as a layout shift.

## Not doing

No migration entry. CSS module names are hashed and not public API, so there's nothing for consumers to codemod.

## Review note

Snapshot churn is the bulk of the diff. The 12 source-file lines are the whole of the actual change; the rest is class hashes.

[EDS-2131]: https://czi.atlassian.net/browse/EDS-2131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ