### PR TITLE
test: use FPO blocks in the *Content slot stories

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -67,6 +67,12 @@
       }
     },
     {
+      "files": ["src/storyUtils/**/*.{ts,tsx}"],
+      "rules": {
+        "@chanzuckerberg/stories/no-components-without-story": "off"
+      }
+    },
+    {
       "files": ["src/**/*.stories.{ts,tsx}"],
       "rules": {
         "no-restricted-imports": [

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -4,6 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite' with {
 import React from 'react';
 
 import { Accordion } from './Accordion';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import { chromaticViewports } from '../../util/viewports';
 import Icon from '../Icon';
 import NumberIcon from '../NumberIcon';
@@ -321,6 +322,70 @@ export const WithCustomIndicator: Story = {
             <Text preset="body-md">
               Passing a node renders it as-is. The node carries its own
               accessible treatment.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+      </>
+    ),
+  },
+};
+
+/**
+ * All three content slots on `Accordion.Button` take arbitrary content, not only an icon
+ * name. The blocks below stand in for whatever you supply: `leadingContent` and
+ * `trailingContent` flank the title, and `indicatorContent` replaces the expand/collapse
+ * caret, so it rotates with the row.
+ */
+export const WithFpoContentSlots: Story = {
+  args: {
+    children: (
+      <>
+        <Accordion.Row hasLeadingContent>
+          <Accordion.Button
+            leadingContent={<FpoBlock size={24} />}
+            title="Leading content"
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              `leadingContent` sits before the title, in the space reserved by
+              `hasLeadingContent` on the row.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button
+            title="Trailing content"
+            trailingContent={<FpoBlock size={24} />}
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              `trailingContent` sits after the title and before the indicator.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row>
+          <Accordion.Button
+            indicatorContent={<FpoBlock size={24} />}
+            title="Indicator content"
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              `indicatorContent` replaces the caret and rotates when the row
+              opens, so pick something that reads well upside down.
+            </Text>
+          </Accordion.Panel>
+        </Accordion.Row>
+        <Accordion.Row defaultOpen hasLeadingContent>
+          <Accordion.Button
+            indicatorContent={<FpoBlock size={24} />}
+            leadingContent={<FpoBlock size={24} />}
+            title="All three at once"
+            trailingContent={<FpoBlock size={24} />}
+          />
+          <Accordion.Panel>
+            <Text preset="body-md">
+              Shown open, to check the slots still line up once the indicator
+              has rotated.
             </Text>
           </Accordion.Panel>
         </Accordion.Row>

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -490,6 +490,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           class="_accordion-button__leading-content_86d7df"
         >
           <span
+            aria-hidden="true"
             class="fpo"
             style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
           >
@@ -545,6 +546,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           </span>
         </h2>
         <span
+          aria-hidden="true"
           class="fpo"
           style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
         >
@@ -593,6 +595,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           class="_accordion-button__indicator_86d7df"
         >
           <span
+            aria-hidden="true"
             class="fpo"
             style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
           >
@@ -619,6 +622,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           class="_accordion-button__leading-content_86d7df"
         >
           <span
+            aria-hidden="true"
             class="fpo"
             style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
           >
@@ -635,6 +639,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           </span>
         </h2>
         <span
+          aria-hidden="true"
           class="fpo"
           style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
         >
@@ -644,6 +649,7 @@ exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
           class="_accordion-button__indicator_86d7df _accordion-button__indicator--open_86d7df"
         >
           <span
+            aria-hidden="true"
             class="fpo"
             style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
           >

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -468,6 +468,210 @@ exports[`<Accordion /> > WithCustomIndicator story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Accordion /> > WithFpoContentSlots story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="w-[600px]"
+  >
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_q_"
+        type="button"
+      >
+        <span
+          class="_accordion-button__leading-content_86d7df"
+        >
+          <span
+            class="fpo"
+            style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+          >
+            FPO
+          </span>
+        </span>
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Leading content
+          </span>
+        </h2>
+        <svg
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
+          fill="currentColor"
+          height="24px"
+          role="img"
+          style="--icon-size: 24px;"
+          viewBox="0 0 24 24"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_s_"
+        type="button"
+      >
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Trailing content
+          </span>
+        </h2>
+        <span
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+        <svg
+          class="_icon_779da8 _accordion-button__indicator_86d7df"
+          fill="currentColor"
+          height="24px"
+          role="img"
+          style="--icon-size: 24px;"
+          viewBox="0 0 24 24"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            show content
+          </title>
+          <path
+            d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+          />
+        </svg>
+      </button>
+    </div>
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state=""
+    >
+      <button
+        aria-expanded="false"
+        class="_accordion-button_86d7df"
+        data-headlessui-state=""
+        id="headlessui-disclosure-button-_r_u_"
+        type="button"
+      >
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            Indicator content
+          </span>
+        </h2>
+        <span
+          class="_accordion-button__indicator_86d7df"
+        >
+          <span
+            class="fpo"
+            style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+          >
+            FPO
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      class="_accordion-row_86d7df"
+      data-headlessui-state="open"
+      data-open=""
+    >
+      <button
+        aria-controls="headlessui-disclosure-panel-_r_11_"
+        aria-expanded="true"
+        class="_accordion-button_86d7df"
+        data-headlessui-state="open"
+        data-open=""
+        id="headlessui-disclosure-button-_r_10_"
+        type="button"
+      >
+        <span
+          class="_accordion-button__leading-content_86d7df"
+        >
+          <span
+            class="fpo"
+            style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+          >
+            FPO
+          </span>
+        </span>
+        <h2
+          class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__heading_86d7df"
+        >
+          <span
+            class="_text_b3eba3 _text--title-md_b3eba3 _accordion-button__title_86d7df"
+          >
+            All three at once
+          </span>
+        </h2>
+        <span
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+        <span
+          class="_accordion-button__indicator_86d7df _accordion-button__indicator--open_86d7df"
+        >
+          <span
+            class="fpo"
+            style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+          >
+            FPO
+          </span>
+        </span>
+      </button>
+      <div
+        class="_accordion-panel_86d7df _accordion-panel--leading-content_86d7df"
+        data-headlessui-state="open"
+        data-open=""
+        id="headlessui-disclosure-panel-_r_11_"
+      >
+        <span
+          class="_text_b3eba3 _text--body-md_b3eba3"
+        >
+          <p
+            class="_text_b3eba3 _text--body-md_b3eba3"
+          >
+            Shown open, to check the slots still line up once the indicator has rotated.
+          </p>
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<Accordion /> > WithLargeHeader story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"

--- a/src/components/DataTable/DataTable.stories.tsx
+++ b/src/components/DataTable/DataTable.stories.tsx
@@ -13,6 +13,7 @@ import {
 // We import all of the utilities from tanstack here, and this can contain other custom utilities
 import { utils as DataTableUtils } from '../../components/DataTable';
 
+import FpoBlock from '../../storyUtils/FpoBlock';
 import { chromaticViewports } from '../../util/viewports';
 import Button from '../Button';
 import Checkbox from '../Checkbox';
@@ -975,5 +976,64 @@ export const WithLongCaption: StoryObj<Args> = {
         rank="secondary"
       />
     ),
+  },
+};
+
+// A cell's `leadingContent` renders its icon at 16px, so the FPO blocks below match
+// that rather than pushing the row height out.
+const fpoColumns = [
+  columnHelper.accessor('firstName', {
+    header: () => (
+      <DataTable.HeaderCell
+        leadingContent={<FpoBlock size={16} />}
+        subLabel="Given Name"
+      >
+        First Name
+      </DataTable.HeaderCell>
+    ),
+    cell: (info) => (
+      <DataTable.DataCell leadingContent={<FpoBlock size={16} />}>
+        {info.getValue()}
+      </DataTable.DataCell>
+    ),
+  }),
+  columnHelper.accessor((row) => row.lastName, {
+    id: 'lastName',
+    header: () => (
+      <DataTable.HeaderCell subLabel="Surname">Last Name</DataTable.HeaderCell>
+    ),
+    cell: (info) => <DataTable.DataCell>{info.getValue()}</DataTable.DataCell>,
+  }),
+  columnHelper.accessor('age', {
+    header: () => (
+      <DataTable.HeaderCell alignment="trailing">Age</DataTable.HeaderCell>
+    ),
+    cell: (info) => (
+      <DataTable.DataCell alignment="trailing">
+        {info.renderValue()}
+      </DataTable.DataCell>
+    ),
+  }),
+];
+
+/**
+ * `leadingContent` on `DataTable.HeaderCell` and `DataTable.DataCell` takes arbitrary
+ * content, not only an icon name. The blocks below stand in for whatever you supply, so
+ * the slot itself is the subject rather than the icon that happened to be picked.
+ */
+export const WithFpoLeadingContent: StoryObj<Args> = {
+  args: {
+    caption: 'Leading content slot',
+    subCaption: 'Header cell and data cell both take arbitrary content',
+  },
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const table = DataTableUtils.useReactTable({
+      data: defaultData,
+      columns: fpoColumns,
+      getCoreRowModel: DataTableUtils.getCoreRowModel(),
+    });
+
+    return <DataTable {...args} table={table} />;
   },
 };

--- a/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
@@ -11715,6 +11715,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -11792,6 +11793,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -11843,6 +11845,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -11894,6 +11897,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -11945,6 +11949,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -11996,6 +12001,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12047,6 +12053,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12098,6 +12105,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12149,6 +12157,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12200,6 +12209,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12251,6 +12261,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12302,6 +12313,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />
@@ -12353,6 +12365,7 @@ exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
               class="_data-cell__cell--leading-content_a06dc5"
             >
               <span
+                aria-hidden="true"
                 class="fpo"
                 style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
               />

--- a/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
+++ b/src/components/DataTable/__snapshots__/DataTable.test.ts.snap
@@ -11666,6 +11666,736 @@ exports[`<DataTable /> > WithBasicCaption story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<DataTable /> > WithFpoLeadingContent story renders snapshot 1`] = `
+<div
+  class="_data-table_a06dc5"
+>
+  <div
+    class="_data-table__caption-container_a06dc5 _data-table--size-md_a06dc5"
+  >
+    <div
+      class="_data-table__caption-text_a06dc5"
+    >
+      <div
+        aria-hidden="true"
+        class="_text_b3eba3 _text--title-lg_b3eba3 _data-table__caption_a06dc5"
+      >
+        Leading content slot
+      </div>
+      <div
+        aria-hidden="true"
+        class="_text_b3eba3 _text--body-md_b3eba3 _data-table__subCaption_a06dc5"
+      >
+        Header cell and data cell both take arbitrary content
+      </div>
+    </div>
+  </div>
+  <table
+    class="_data-table__table_a06dc5 _data-table--tableStyle-basic_a06dc5 _data-table--rowStyle-striped_a06dc5 _data-table--size-md_a06dc5"
+  >
+    <caption
+      class="_data-table__aria-caption_a06dc5"
+    >
+      Leading content slot: Header cell and data cell both take arbitrary content
+    </caption>
+    <thead
+      class="_data-table__header-row_a06dc5"
+    >
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <th
+          class="_data-table__header-cell-container_a06dc5"
+          colspan="1"
+        >
+          <div
+            class="_text_b3eba3 _text--body-md_b3eba3 _data-table__header-cell_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              <div
+                class="_text_b3eba3 _text--title-xs_b3eba3"
+              >
+                First Name
+              </div>
+              <span
+                class="_text_b3eba3 _text--body-xs_b3eba3 _data-table__cell-subLabel_a06dc5"
+              >
+                Given Name
+              </span>
+            </div>
+          </div>
+        </th>
+        <th
+          class="_data-table__header-cell-container_a06dc5"
+          colspan="1"
+        >
+          <div
+            class="_text_b3eba3 _text--body-md_b3eba3 _data-table__header-cell_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              <div
+                class="_text_b3eba3 _text--title-xs_b3eba3"
+              >
+                Last Name
+              </div>
+              <span
+                class="_text_b3eba3 _text--body-xs_b3eba3 _data-table__cell-subLabel_a06dc5"
+              >
+                Surname
+              </span>
+            </div>
+          </div>
+        </th>
+        <th
+          class="_data-table__header-cell-container_a06dc5"
+          colspan="1"
+        >
+          <div
+            class="_text_b3eba3 _text--body-md_b3eba3 _data-table__header-cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              <div
+                class="_text_b3eba3 _text--title-xs_b3eba3"
+              >
+                Age
+              </div>
+            </div>
+          </div>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Joe
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Dirte
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              45
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tandy
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Miller
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              40
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tanner
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Lindsey
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              24
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Joe
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Dirte
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              45
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tandy
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Miller
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              40
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tanner
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Lindsey
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              24
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Joe
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Dirte
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              45
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tandy
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Miller
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              40
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tanner
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Lindsey
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              24
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Joe
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Dirte
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              45
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tandy
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Miller
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              40
+            </div>
+          </div>
+        </td>
+      </tr>
+      <tr
+        class="_data-table__row_a06dc5"
+      >
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-cell__cell--leading-content_a06dc5"
+            >
+              <span
+                class="fpo"
+                style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </div>
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Tanner
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-leading_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              Lindsey
+            </div>
+          </div>
+        </td>
+        <td
+          class="_data-table__cell-container_a06dc5"
+        >
+          <div
+            class="_data-table__cell_a06dc5 _data-table__cell--alignment-trailing_a06dc5"
+          >
+            <div
+              class="_data-table__cell-text_a06dc5"
+            >
+              24
+            </div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
 exports[`<DataTable /> > WithFullCaption story renders snapshot 1`] = `
 <div
   class="_data-table_a06dc5"

--- a/src/components/InputField/InputField.stories.tsx
+++ b/src/components/InputField/InputField.stories.tsx
@@ -5,7 +5,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import React from 'react';
 
 import { InputField } from './InputField';
-import Avatar from '../Avatar';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import Button from '../Button';
 
 const meta: Meta<typeof InputField> = {
@@ -454,10 +454,12 @@ export const WithBothMaxAndRecommendedLength: Story = {
 
 /**
  * The leading slot also takes arbitrary content, for cases an EDS icon does not cover.
+ * The block below stands in for whatever you supply, so the slot itself is the subject
+ * rather than the component that happened to be picked.
  */
 export const LeadingContent: Story = {
   args: {
-    leadingContent: <Avatar size="sm" user={{ fullName: 'Ada Lovelace' }} />,
+    leadingContent: <FpoBlock size={24} />,
     'aria-label': 'assignee field',
     placeholder: 'Assign to...',
   },

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -394,6 +394,7 @@ exports[`<InputField /> > LeadingContent story renders snapshot 1`] = `
         class="_input-field__leading-content_4d3b17"
       >
         <span
+          aria-hidden="true"
           class="fpo"
           style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
         >

--- a/src/components/InputField/__snapshots__/InputField.test.tsx.snap
+++ b/src/components/InputField/__snapshots__/InputField.test.tsx.snap
@@ -393,17 +393,12 @@ exports[`<InputField /> > LeadingContent story renders snapshot 1`] = `
       <div
         class="_input-field__leading-content_4d3b17"
       >
-        <div
-          aria-label="Avatar for user Ada Lovelace"
-          class="_avatar_814665 _avatar--sm_814665 _avatar--text_814665 _avatar--color-scheme-1_814665"
-          role="img"
+        <span
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
         >
-          <span
-            class="_text_b3eba3 _text--label-sm_b3eba3"
-          >
-            A
-          </span>
-        </div>
+          FPO
+        </span>
       </div>
     </div>
   </div>

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { PopoverListItem } from './PopoverListItem';
 
+import FpoBlock from '../../storyUtils/FpoBlock';
 import Avatar from '../Avatar';
 import Icon from '../Icon';
 
@@ -188,5 +189,18 @@ export const Label: Story = {
   args: {
     __type: 'label',
     children: 'Account',
+  },
+};
+
+/**
+ * Both slots take arbitrary content, not only an icon. The blocks below stand in for
+ * whatever you supply, so the slot itself is the subject rather than the icon that
+ * happened to be picked.
+ */
+export const WithFpoContentSlots: Story = {
+  args: {
+    ...WithLeadingAndTrailingIcons.args,
+    leadingContent: <FpoBlock size={24} />,
+    trailingContent: <FpoBlock size={24} />,
   },
 };

--- a/src/components/PopoverListItem/__snapshots__/PopoverListItem.test.ts.snap
+++ b/src/components/PopoverListItem/__snapshots__/PopoverListItem.test.ts.snap
@@ -259,6 +259,7 @@ exports[`<PopoverListItem /> > WithFpoContentSlots story renders snapshot 1`] = 
     class="_popover-list-item__leading-content_e0596d"
   >
     <span
+      aria-hidden="true"
       class="fpo"
       style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
     >
@@ -278,6 +279,7 @@ exports[`<PopoverListItem /> > WithFpoContentSlots story renders snapshot 1`] = 
     class="_popover-list-item__trailing-content_e0596d"
   >
     <span
+      aria-hidden="true"
       class="fpo"
       style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
     >

--- a/src/components/PopoverListItem/__snapshots__/PopoverListItem.test.ts.snap
+++ b/src/components/PopoverListItem/__snapshots__/PopoverListItem.test.ts.snap
@@ -251,6 +251,42 @@ exports[`<PopoverListItem /> > Separator story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<PopoverListItem /> > WithFpoContentSlots story renders snapshot 1`] = `
+<div
+  class="_popover-list-item_e0596d"
+>
+  <div
+    class="_popover-list-item__leading-content_e0596d"
+  >
+    <span
+      class="fpo"
+      style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    >
+      FPO
+    </span>
+  </div>
+  <div
+    class="_popover-list-item__menu-labels_e0596d"
+  >
+    <div
+      class="_text_b3eba3 _text--body-md_b3eba3"
+    >
+      Add comment
+    </div>
+  </div>
+  <div
+    class="_popover-list-item__trailing-content_e0596d"
+  >
+    <span
+      class="fpo"
+      style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    >
+      FPO
+    </span>
+  </div>
+</div>
+`;
+
 exports[`<PopoverListItem /> > WithKeyboardShortcut story renders snapshot 1`] = `
 <div
   class="_popover-list-item_e0596d"

--- a/src/components/SelectionChip/SelectionChip.stories.tsx
+++ b/src/components/SelectionChip/SelectionChip.stories.tsx
@@ -4,7 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite' with {
 import React from 'react';
 
 import { SelectionChip } from './SelectionChip';
-import Avatar from '../Avatar';
+import FpoBlock from '../../storyUtils/FpoBlock';
 
 export default {
   title: 'Components/SelectionChip',
@@ -91,10 +91,12 @@ export const UncontrolledChecked: Story = {
 
 /**
  * The leading slot also takes arbitrary content, for cases an EDS icon does not cover.
+ * The block below stands in for whatever you supply, so the slot itself is the subject
+ * rather than the component that happened to be picked.
  */
 export const WithLeadingContent: Story = {
   args: {
     ...Default.args,
-    leadingContent: <Avatar size="sm" user={{ fullName: 'Ada Lovelace' }} />,
+    leadingContent: <FpoBlock size={14} />,
   },
 };

--- a/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
+++ b/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
@@ -208,17 +208,10 @@ exports[`<SelectionChip /> > WithLeadingContent story renders snapshot 1`] = `
   <div
     class="_selection-chip__body_b63b89"
   >
-    <div
-      aria-label="Avatar for user Ada Lovelace"
-      class="_avatar_814665 _avatar--sm_814665 _avatar--text_814665 _avatar--color-scheme-1_814665"
-      role="img"
-    >
-      <span
-        class="_text_b3eba3 _text--label-sm_b3eba3"
-      >
-        A
-      </span>
-    </div>
+    <span
+      class="fpo"
+      style="height: 14px; width: 14px; font-size: 5px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
     <span
       class="_text_b3eba3 _text--label-lg_b3eba3 _selection-chip__label_b63b89"
     >

--- a/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
+++ b/src/components/SelectionChip/__snapshots__/SelectionChip.test.ts.snap
@@ -209,6 +209,7 @@ exports[`<SelectionChip /> > WithLeadingContent story renders snapshot 1`] = `
     class="_selection-chip__body_b63b89"
   >
     <span
+      aria-hidden="true"
       class="fpo"
       style="height: 14px; width: 14px; font-size: 5px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
     />

--- a/src/storyUtils/FpoBlock.tsx
+++ b/src/storyUtils/FpoBlock.tsx
@@ -1,0 +1,76 @@
+import clsx from 'clsx';
+import React from 'react';
+import type { ReactNode } from 'react';
+
+type FpoBlockProps = {
+  /**
+   * Label rendered inside the block. Keep it very short: these slots are sized for an
+   * icon, not a sentence. Hidden below 20px, where it would render as a smudge rather
+   * than as text.
+   */
+  children?: ReactNode;
+  /**
+   * Extra classes for the rare slot that needs more than a size change.
+   */
+  className?: string;
+  /**
+   * Width and height in pixels.
+   *
+   * Always pass the size of the icon the slot itself renders, so the block occupies the
+   * same space the icon did and the story's layout does not change. Those sizes are set
+   * per component, not shared: `IconSlot` is given `24px` in `Accordion` and
+   * `InputField`, `16px` in `DataTable`, and no size at all in `SelectionChip`, where
+   * `Icon` falls back to `1em` and resolves to 14px against the chip's own type. Slots
+   * that take a bare `ReactNode` with no `IconSlot`, like `PopoverListItem`, document a
+   * recommended maximum of 24px.
+   */
+  size?: number;
+};
+
+/**
+ * For Placement Only block, sized to drop into a component's leading, trailing, or
+ * indicator content slot.
+ *
+ * Storybook-only. Stories use this instead of a real icon so the slot itself is the
+ * subject of the story, rather than whichever icon happened to be picked. It reuses the
+ * shared `fpo` class from `.storybook/css/styleguide-only.css` for the placeholder look,
+ * and introduces no new placeholder styling of its own.
+ *
+ * Sizing is applied inline rather than through utility classes on purpose. `.fpo` sets a
+ * 16px padding and 16px type intended for page-sized placeholders, and it loads after
+ * Tailwind, so an equal-specificity utility like `p-0` loses the cascade and the block
+ * renders at ~68px square. At that size it pushes out the height of every row it sits
+ * in. Inline styles win outright, and they also sidestep having two conflicting `w-*`
+ * classes on one element, which this repo has no `tailwind-merge` to resolve.
+ *
+ * Renders a `span` rather than a `div` because several of these slots sit inside a
+ * `button` or a `label`, which only accept phrasing content. `.fpo` already sets
+ * `display: flex`, so the span still lays out as a box.
+ */
+export default function FpoBlock({
+  children = 'FPO',
+  className,
+  size = 24,
+}: FpoBlockProps) {
+  // Below this the label is smaller than it is legible, and reads as a smudge rather
+  // than as text. The dashed block on its own is enough to signal a placeholder.
+  const showsLabel = size >= 20;
+
+  return (
+    <span
+      className={clsx('fpo', className)}
+      style={{
+        height: size,
+        width: size,
+        // Keep the label proportional to the block so "FPO" fits at every size we use.
+        fontSize: Math.round(size * 0.375),
+        flex: 'none',
+        lineHeight: 1,
+        overflow: 'hidden',
+        padding: 0,
+      }}
+    >
+      {showsLabel && children}
+    </span>
+  );
+}

--- a/src/storyUtils/FpoBlock.tsx
+++ b/src/storyUtils/FpoBlock.tsx
@@ -46,6 +46,14 @@ type FpoBlockProps = {
  * Renders a `span` rather than a `div` because several of these slots sit inside a
  * `button` or a `label`, which only accept phrasing content. `.fpo` already sets
  * `display: flex`, so the span still lays out as a box.
+ *
+ * Marked `aria-hidden` because it stands in for a decorative icon, which `IconSlot`
+ * renders `aria-hidden` too. It matters most where a control takes its accessible name
+ * from its own contents: without it, the Accordion row carrying all three slots
+ * announces as "FPO All three at once FPO FPO", and a `PopoverListItem` as
+ * "FPO Add comment FPO". Blocks below the label threshold render no text and so leak
+ * nothing, but they are hidden too, since an empty decorative box is not worth a node in
+ * the accessibility tree either.
  */
 export default function FpoBlock({
   children = 'FPO',
@@ -58,6 +66,7 @@ export default function FpoBlock({
 
   return (
     <span
+      aria-hidden="true"
       className={clsx('fpo', className)}
       style={{
         height: size,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
         'src/bin/migrate/migrations',
         'src/bin/eds-migrate.ts',
         'src/**/*.stories.{ts,tsx}',
+        // Storybook-only helpers, exercised through stories rather than tested directly
+        'src/storyUtils/**',
       ],
     },
     projects: [


### PR DESCRIPTION
Resolves [EDS-2132](https://czi.atlassian.net/browse/EDS-2132).

EDS-2000 turned the leading and trailing icon props into content slots, but the stories still demoed every one of them with a real icon, so the slots read as icon-only. These stories show the slots holding a placeholder instead, which makes the slot itself the subject rather than whichever icon got picked.

### Slots covered

| Component | Slots | Story |
|---|---|---|
| `Accordion.Button` | `leadingContent`, `trailingContent`, `indicatorContent` | new `WithFpoContentSlots` |
| `PopoverListItem` | `leadingContent`, `trailingContent` | new `WithFpoContentSlots` |
| `DataTable.HeaderCell` / `DataCell` | `leadingContent` | new `WithFpoLeadingContent` |
| `InputField` | `leadingContent` | existing `LeadingContent` |
| `SelectionChip` | `leadingContent` | existing `WithLeadingContent` |

### Sizing

Adds a shared `FpoBlock` helper (`src/storyUtils/FpoBlock.tsx`) so sizing stays consistent. It reuses the existing `fpo` class and introduces no new placeholder styling.

Every block is set to the icon size the slot itself renders, so it occupies the space the icon did and no story gets wider or taller. Those sizes are per component, not shared:

- **24px** — `Accordion`, `InputField` (`IconSlot size="24px"`)
- **16px** — `DataTable` (`IconSlot size="16px"`)
- **14px** — `SelectionChip`, where `IconSlot` is given no size at all, so `Icon` falls back to `1em` and resolves against the chip's own type
- **24px** — `PopoverListItem`, which takes a bare `ReactNode` and documents a recommended maximum of 24px

Sizing is applied inline rather than through utility classes. `.fpo` sets a 16px padding and 16px type meant for page-sized placeholders, and it loads after Tailwind, so an equal-specificity utility like `p-0` loses the cascade and the block renders at ~68px square. That pushed accordion rows from 56px to 93px on the first pass.

### Added rather than replaced

Where a slot's existing story documented the icon-name path with a live Storybook control (`InputField`, `SelectionChip`), the FPO block went into that component's existing arbitrary-content story rather than replacing the icon story, so the control survives. That is the tradeoff recorded in EDS-2029. Everywhere else the FPO story is appended at the end of the file, which keeps React's `useId` counter stable and confines the snapshot diff to new entries — Accordion, PopoverListItem, and DataTable are pure additions with zero deletions.

### AppHeader is deferred

Filed as [EDS-2133](https://czi.atlassian.net/browse/EDS-2133). AppHeader's nav items type `leadingContent`/`trailingContent` as `IconName | 'avatar'` and `IconName`, so an FPO block is not assignable without widening them to `IconOrContent`. That is a component API change, complicated by the `'avatar'` sentinel being a flag that pulls from the sibling `user` prop rather than an icon name.

### Test Plan:

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [x] Accepted all chromatic snapshot changes
- [x] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:

Rendered all five stories in Storybook and measured each against its icon equivalent in the browser:

- `SelectionChip` — 107x40 vs 107x40, slot 14x14 both
- `InputField` — 384x48 vs 384x48, slot 24x24 both
- `PopoverListItem` — 200x40 vs 200x40 (story spreads `WithLeadingAndTrailingIcons.args`, so it is a literal swap of the two icons)
- `Accordion` — rows 56px, same as `Default`
- `DataTable` — header 71px, same as `Default`. `Default`'s header has no leading content, mine adds a 16px block to it and the height does not move.

Typecheck, lint, 654 tests, and build all pass locally. Nothing from `src/storyUtils` leaks into `lib/`.

Two config edits, both forced by introducing `src/storyUtils`: `.eslintrc` exempts it from `no-components-without-story` (the repo's own lint message names that folder as where story helpers belong, but it did not exist yet), and `vite.config.ts` excludes it from coverage alongside the existing `*.stories` exclude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EDS-2132]: https://czi.atlassian.net/browse/EDS-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDS-2133]: https://czi.atlassian.net/browse/EDS-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ