### PR TITLE
feat!: widen the remaining icon props to content slots

### DIFF
--- a/src/bin/migrate/migrations/18-to-19.test.ts
+++ b/src/bin/migrate/migrations/18-to-19.test.ts
@@ -211,6 +211,64 @@ describe('18-to-19', () => {
     expect(sourceFile.getText()).toEqual(sourceFileText);
   });
 
+  it('moves the deprecated icon prop onto the leading slot', () => {
+    const sourceFile = createTestSourceFile(dedent`
+      import {Menu, PopoverListItem} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Menu>
+            <Menu.Button icon="chevron-down">Actions</Menu.Button>
+            <Menu.Items>
+              <Menu.Item icon="link" href="/docs">Docs</Menu.Item>
+            </Menu.Items>
+            <PopoverListItem icon="arrow-down">Sort</PopoverListItem>
+          </Menu>
+        )
+      }
+    `);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(dedent`
+      import {Menu, PopoverListItem} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Menu>
+            <Menu.Button trailingContent="chevron-down">Actions</Menu.Button>
+            <Menu.Items>
+              <Menu.Item leadingContent="link" href="/docs">Docs</Menu.Item>
+            </Menu.Items>
+            <PopoverListItem leadingContent="arrow-down">Sort</PopoverListItem>
+          </Menu>
+        )
+      }
+    `);
+  });
+
+  it('leaves the icon prop on components that kept it alone', () => {
+    const sourceFileText = dedent`
+      import {Button, Card, Icon} from '@chanzuckerberg/eds';
+
+      export default function Component() {
+        return (
+          <Card>
+            <Card.Header icon="star" title="Saved" />
+            <Button icon="add" iconLayout="left">Add</Button>
+            <Icon name="close" purpose="decorative" />
+          </Card>
+        )
+      }
+    `;
+
+    const sourceFile = createTestSourceFile(sourceFileText);
+
+    migration(sourceFile.getProject());
+
+    expect(sourceFile.getText()).toEqual(sourceFileText);
+  });
+
   it('leaves a same-named component from another package alone', () => {
     const sourceFileText = dedent`
       import {Text} from 'some-other-library';

--- a/src/bin/migrate/migrations/18-to-19.ts
+++ b/src/bin/migrate/migrations/18-to-19.ts
@@ -111,6 +111,20 @@ const leadingIconToContent = [
   },
 ];
 
+/**
+ * `PopoverListItem` and `Menu.Item` each had a deprecated `icon` alongside
+ * `leadingContent`, and both rendered into the same slot. `leadingContent` now routes a
+ * string through `IconSlot` at the same 24px the `icon` prop used, so moving the icon name
+ * across renders exactly what it did before.
+ */
+const iconToLeadingContent = [
+  {
+    type: 'update_name' as const,
+    oldPropName: 'icon',
+    newPropName: 'leadingContent',
+  },
+];
+
 export const PropChanges: EditJsxPropChange[] = [
   {
     componentName: 'Text',
@@ -156,6 +170,29 @@ export const PropChanges: EditJsxPropChange[] = [
   {
     componentName: 'SelectionChip',
     edits: leadingIconToContent,
+  },
+  {
+    componentName: 'PopoverListItem',
+    edits: iconToLeadingContent,
+  },
+  {
+    componentName: 'Menu.Item',
+    edits: iconToLeadingContent,
+  },
+  {
+    /**
+     * `Menu.Button`'s icon renders through `Button` with `iconLayout="right"`, so it fills
+     * the trailing slot. The prop carried a `TODO(next-major)` naming it `leadingContent`,
+     * which describes the wrong side.
+     */
+    componentName: 'Menu.Button',
+    edits: [
+      {
+        type: 'update_name',
+        oldPropName: 'icon',
+        newPropName: 'trailingContent',
+      },
+    ],
   },
 ];
 

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -5,6 +5,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite' with {
 import React from 'react';
 
 import { Avatar } from './Avatar';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import Tooltip from '../Tooltip';
 
 export default {
@@ -221,4 +222,26 @@ export const Fixed: Story = {
     ...Default.args,
     color: 'fixed',
   },
+};
+
+/**
+ * The icon slot takes arbitrary content, not only an EDS icon name. The blocks below stand
+ * in for whatever you supply, so the slot itself is the subject rather than the icon that
+ * happened to be picked.
+ *
+ * `Avatar` sizes its icon from `size`, so each block matches that size's own icon: 16px at
+ * `sm`, 24px at `md`, 32px at `lg`, and 40px at `xl`.
+ */
+export const WithFpoIconContent: Story = {
+  args: {
+    variant: 'icon',
+  },
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <Avatar {...args} icon={<FpoBlock size={16} />} size="sm" />
+      <Avatar {...args} icon={<FpoBlock size={24} />} size="md" />
+      <Avatar {...args} icon={<FpoBlock size={32} />} size="lg" />
+      <Avatar {...args} icon={<FpoBlock size={40} />} size="xl" />
+    </div>
+  ),
 };

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -2,9 +2,9 @@ import clsx from 'clsx';
 import Graphemer from 'graphemer';
 
 import React from 'react';
-import { type UserData } from '../../util/utility-types';
+import { type IconOrContent, type UserData } from '../../util/utility-types';
 import type { Preset, Size } from '../../util/variant-types';
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import Text from '../Text';
 import styles from './Avatar.module.css';
 
@@ -54,9 +54,10 @@ type AvatarProps = {
    */
   color?: 'default' | 'fixed';
   /**
-   * Icon to use when an "icon" variant of the avatar. Default is "person"
+   * Content for the `"icon"` variant of the avatar. Takes an EDS icon name, or any content
+   * to render in its place, sized to match `size`. Default is "person"
    */
-  icon?: IconName;
+  icon?: IconOrContent;
   /**
    * Marking whether the Avatar is intended to be interactive (have focus/hover states)
    */
@@ -249,8 +250,8 @@ export const Avatar = React.forwardRef<HTMLDivElement, AvatarProps>(
           </Text>
         )}
         {variant === 'icon' && (
-          <Icon
-            name={icon}
+          <IconSlot
+            content={icon}
             purpose="decorative"
             size={`${iconSizeMap[size]}px`}
           />

--- a/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
+++ b/src/components/Avatar/__snapshots__/Avatar.test.ts.snap
@@ -284,3 +284,60 @@ exports[`<Avatar /> > WithCustomIcon story renders snapshot 1`] = `
   </svg>
 </div>
 `;
+
+exports[`<Avatar /> > WithFpoIconContent story renders snapshot 1`] = `
+<div
+  class="flex items-center gap-2"
+>
+  <div
+    aria-label="Avatar for unknown user "
+    class="_avatar_814665 _avatar--sm_814665 _avatar--icon_814665 _avatar--color-scheme-4_814665"
+    role="img"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+  </div>
+  <div
+    aria-label="Avatar for unknown user "
+    class="_avatar_814665 _avatar--md_814665 _avatar--icon_814665 _avatar--color-scheme-4_814665"
+    role="img"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    >
+      FPO
+    </span>
+  </div>
+  <div
+    aria-label="Avatar for unknown user "
+    class="_avatar_814665 _avatar--lg_814665 _avatar--icon_814665 _avatar--color-scheme-4_814665"
+    role="img"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 32px; width: 32px; font-size: 12px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    >
+      FPO
+    </span>
+  </div>
+  <div
+    aria-label="Avatar for unknown user "
+    class="_avatar_814665 _avatar--xl_814665 _avatar--icon_814665 _avatar--color-scheme-4_814665"
+    role="img"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 40px; width: 40px; font-size: 15px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    >
+      FPO
+    </span>
+  </div>
+</div>
+`;

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -152,10 +152,10 @@ export const Breadcrumbs = ({
       return (
         <Menu.Item
           href={menuItem.props.href}
-          icon="link"
           // FIXME
           // eslint-disable-next-line react/no-array-index-key
           key={`breadcrumb-menu-item-${index}`}
+          leadingContent="link"
         >
           {menuItem.props.text}
         </Menu.Item>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@storybook/testing-library';
 
 import React from 'react';
 import { Button, type ButtonProps } from './Button';
+import FpoBlock from '../../storyUtils/FpoBlock';
 
 export default {
   title: 'Components/Button',
@@ -342,4 +343,59 @@ export const UsingExtendedLink: StoryObj<ExtendArgs> = {
       </ExtendedButton>
     </div>
   ),
+};
+
+/**
+ * The icon slot takes arbitrary content, not only an EDS icon name. The blocks below stand
+ * in for whatever you supply, so the slot itself is the subject rather than the icon that
+ * happened to be picked.
+ *
+ * `Button` renders a 24px icon at `size="lg"` and 16px below it, so each block matches its
+ * own button.
+ */
+export const WithFpoIconContent: Story = {
+  args: {
+    ...Sizes.args,
+    iconLayout: 'left',
+  },
+  render: (args) => (
+    <div className="flex items-center gap-1">
+      <Button
+        {...args}
+        aria-label="Large button"
+        icon={<FpoBlock size={24} />}
+        size="lg"
+      >
+        Large
+      </Button>
+      <Button
+        {...args}
+        aria-label="Medium button"
+        icon={<FpoBlock size={16} />}
+        size="md"
+      >
+        Medium
+      </Button>
+      <Button
+        {...args}
+        aria-label="Small button"
+        icon={<FpoBlock size={16} />}
+        size="sm"
+      >
+        Small
+      </Button>
+    </div>
+  ),
+};
+
+/**
+ * `iconLayout="icon-only"` takes content the same way. The button still gets its accessible
+ * name from `aria-label`, since the slot is decorative either way.
+ */
+export const WithFpoIconOnlyContent: Story = {
+  args: {
+    ...WithFpoIconContent.args,
+    iconLayout: 'icon-only',
+  },
+  render: WithFpoIconContent.render,
 };

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,8 +1,9 @@
 import clsx from 'clsx';
 import React, { forwardRef } from 'react';
 import { assertEdsUsage } from '../../util/logging';
+import type { IconOrContent } from '../../util/utility-types';
 import type { Size } from '../../util/variant-types';
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import LoadingIndicator from '../LoadingIndicator';
 import Text from '../Text';
 
@@ -60,9 +61,14 @@ export type ButtonProps<ExtendedElement = unknown> = Omit<
   context?: 'default' | 'standalone';
 
   /**
-   * Icon from the set of defined EDS icon set, when `iconLayout` is used.
+   * Content for the icon slot, used when `iconLayout` is set. Takes an EDS icon name, or
+   * any content to render in its place, sized to match `size`.
+   *
+   * Custom content is rendered as-is, so it carries its own accessible treatment. With
+   * `iconLayout="icon-only"` the button still takes its accessible name from `aria-label`,
+   * the same as it does for an icon name.
    */
-  icon?: IconName;
+  icon?: IconOrContent;
 
   /**
    * Allows configuation of the icon's positioning within `Button`.
@@ -213,23 +219,23 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           preset={`label-${size}`}
         >
           {iconLayout === 'icon-only' && (
-            <Icon
-              name={icon}
+            <IconSlot
+              content={icon}
               purpose="decorative"
               size={size === 'lg' ? '24px' : '16px'}
             />
           )}
           {iconLayout === 'left' && (
-            <Icon
-              name={icon}
+            <IconSlot
+              content={icon}
               purpose="decorative"
               size={size === 'lg' ? '24px' : '16px'}
             />
           )}
           {iconLayout !== 'icon-only' && children}
           {iconLayout === 'right' && (
-            <Icon
-              name={icon}
+            <IconSlot
+              content={icon}
               purpose="decorative"
               size={size === 'lg' ? '24px' : '16px'}
             />

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1044,6 +1044,125 @@ exports[`<Button /> > UsingExtendedLink story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Button /> > WithFpoIconContent story renders snapshot 1`] = `
+<div
+  class="p-1"
+>
+  <div
+    class="flex items-center gap-1"
+  >
+    <button
+      aria-label="Large button"
+      class="_button_0829c1 _button--layout-left_0829c1 _button--primary_0829c1 _button--lg_0829c1 _button--size-lg_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-lg_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+        Large
+      </span>
+    </button>
+    <button
+      aria-label="Medium button"
+      class="_button_0829c1 _button--layout-left_0829c1 _button--primary_0829c1 _button--md_0829c1 _button--size-md_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-md_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        />
+        Medium
+      </span>
+    </button>
+    <button
+      aria-label="Small button"
+      class="_button_0829c1 _button--layout-left_0829c1 _button--primary_0829c1 _button--sm_0829c1 _button--size-sm_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-sm_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        />
+        Small
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`<Button /> > WithFpoIconOnlyContent story renders snapshot 1`] = `
+<div
+  class="p-1"
+>
+  <div
+    class="flex items-center gap-1"
+  >
+    <button
+      aria-label="Large button"
+      class="_button_0829c1 _button--layout-icon-only_0829c1 _button--primary_0829c1 _button--lg_0829c1 _button--size-lg_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-lg_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+      </span>
+    </button>
+    <button
+      aria-label="Medium button"
+      class="_button_0829c1 _button--layout-icon-only_0829c1 _button--primary_0829c1 _button--md_0829c1 _button--size-md_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-md_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        />
+      </span>
+    </button>
+    <button
+      aria-label="Small button"
+      class="_button_0829c1 _button--layout-icon-only_0829c1 _button--primary_0829c1 _button--sm_0829c1 _button--size-sm_0829c1 _button--variant-default_0829c1"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-sm_b3eba3 _button__text_0829c1"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        />
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Button /> > passes class names down properly 1`] = `
 <button
   class="_button_0829c1 _button--layout-none_0829c1 _button--primary_0829c1 _button--lg_0829c1 _button--size-lg_0829c1 _button--variant-default_0829c1 exampleClassName"

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@storybook/testing-library';
 import React from 'react';
 
 import { Card } from './Card';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import Button from '../Button';
 import ButtonGroup from '../ButtonGroup';
 import Icon from '../Icon';
@@ -102,20 +103,24 @@ function CardMenu() {
       <Menu.Items data-testid="menu-content">
         <Menu.Item
           href="https://headlessui.com/react/menu#menu-button"
-          icon="link"
+          leadingContent="link"
         >
           Headless UI Docs
         </Menu.Item>
         <Menu.Item
           href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
-          icon="link"
+          leadingContent="link"
         >
           MDN: Menu
         </Menu.Item>
         <Menu.Item href="#index" onClick={() => console.log('Item clicked')}>
           Trigger Action
         </Menu.Item>
-        <Menu.Item disabled href="https://example.org/" icon="warning-filled">
+        <Menu.Item
+          disabled
+          href="https://example.org/"
+          leadingContent="warning-filled"
+        >
           Not Possible (disabled)
         </Menu.Item>
       </Menu.Items>
@@ -360,6 +365,35 @@ export const CancelMembership: Story = {
             </Button>
           </ButtonGroup>
         </Card.Footer>
+      </>
+    ),
+  },
+};
+
+/**
+ * The header's icon slot takes arbitrary content, not only an EDS icon name. The blocks
+ * below stand in for whatever you supply, so the slot itself is the subject rather than the
+ * icon that happened to be picked.
+ *
+ * `Card.Header` renders a 16px icon at `size="sm"` and 24px otherwise, so each block
+ * matches its own header.
+ */
+export const WithFpoHeaderIconContent: Story = {
+  args: {
+    children: (
+      <>
+        <Card.Header
+          icon={<FpoBlock size={16} />}
+          size="sm"
+          subTitle="Small header, 16px slot"
+          title="Text Complexity"
+        />
+        <Card.Header
+          icon={<FpoBlock size={24} />}
+          size="md"
+          subTitle="Medium header, 24px slot"
+          title="Text Complexity"
+        />
       </>
     ),
   },

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -2,10 +2,11 @@ import clsx from 'clsx';
 import type { HTMLAttributes, ReactNode } from 'react';
 import React from 'react';
 
+import type { IconOrContent } from '../../util/utility-types';
 import type { Size } from '../../util/variant-types';
 
 import Heading from '../Heading';
-import Icon, { type IconName } from '../Icon';
+import { hasSlotContent, IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './Card.module.css';
@@ -101,9 +102,10 @@ export type CardHeaderProps = {
    */
   eyebrow?: string;
   /**
-   * Card slot for an icon sitting in front of the card header text
+   * Card slot sitting in front of the card header text. Takes an EDS icon name, or any
+   * content to render in its place, sized to match `size`.
    */
-  icon?: IconName;
+  icon?: IconOrContent;
   /**
    * Overall size treatment of the Card header
    */
@@ -274,10 +276,10 @@ const CardHeader = ({
     </div>
   ) : (
     <div className={componentClassName} {...other}>
-      {icon && (
+      {hasSlotContent(icon) && (
         <div className={styles['header__icon']}>
-          <Icon
-            name={icon}
+          <IconSlot
+            content={icon}
             purpose="decorative"
             size={size === 'sm' ? '16px' : '24px'}
           />

--- a/src/components/Card/__snapshots__/Card.test.ts.snap
+++ b/src/components/Card/__snapshots__/Card.test.ts.snap
@@ -771,6 +771,76 @@ exports[`<Card /> > WithCustomizedHeader story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Card /> > WithFpoHeaderIconContent story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="_card_f66b11 _card--container-style-low_f66b11 _card--container-color-default_f66b11 w-[450px]"
+  >
+    <div
+      class="_card__header_f66b11 _header--size-sm_f66b11"
+    >
+      <div
+        class="_header__icon_f66b11"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        />
+      </div>
+      <div
+        class="_header__text_f66b11"
+      >
+        <h3
+          class="_text_b3eba3 _text--title-sm_b3eba3 _header__title_f66b11 _header--size-sm_f66b11"
+        >
+          Text Complexity
+        </h3>
+        <div
+          class="_text_b3eba3 _text--body-xs_b3eba3 _header__sub-title_f66b11 _header--size-sm_f66b11"
+        >
+          Small header, 16px slot
+        </div>
+      </div>
+    </div>
+    <div
+      class="_card__header_f66b11 _header--size-md_f66b11"
+    >
+      <div
+        class="_header__icon_f66b11"
+      >
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+      </div>
+      <div
+        class="_header__text_f66b11"
+      >
+        <h3
+          class="_text_b3eba3 _text--title-lg_b3eba3 _header__title_f66b11 _header--size-md_f66b11"
+        >
+          Text Complexity
+        </h3>
+        <div
+          class="_text_b3eba3 _text--body-md_b3eba3 _header__sub-title_f66b11 _header--size-md_f66b11"
+        >
+          Medium header, 24px slot
+        </div>
+      </div>
+    </div>
+    <div
+      class="_card__top-stripe_f66b11 _top-stripe--none_f66b11"
+    />
+  </div>
+</div>
+`;
+
 exports[`<Card /> > WithSmallFullHeaderAndIcon story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"

--- a/src/components/Combobox/Combobox.stories.tsx
+++ b/src/components/Combobox/Combobox.stories.tsx
@@ -4,6 +4,7 @@ import { userEvent, within } from '@storybook/testing-library';
 import React, { useState } from 'react';
 import { expect } from 'storybook/test';
 import { Combobox } from './Combobox';
+import FpoBlock from '../../storyUtils/FpoBlock';
 
 const meta: Meta<typeof Combobox> = {
   title: 'Components/Combobox',
@@ -952,4 +953,22 @@ export const OpenByDefault: StoryObj<DemoProps> = {
     },
   },
   play: selectCat,
+};
+
+/**
+ * `chipLeadingComponent` passes straight through to the chip's own leading slot, so it takes
+ * arbitrary content and not only an EDS icon name. The block below stands in for whatever
+ * you supply.
+ *
+ * The chip's slot carries no explicit icon size, so it resolves to 14px against the chip's
+ * own type, and the block matches that.
+ */
+export const MultipleWithFpoChipContent: StoryObj<DemoProps> = {
+  render: (args) => <MultipleComboboxDemo {...args} />,
+  args: {
+    ...MultipleWithChipIcons.args,
+    inputProps: {
+      chipLeadingComponent: () => <FpoBlock size={14} />,
+    },
+  },
 };

--- a/src/components/Combobox/Combobox.tsx
+++ b/src/components/Combobox/Combobox.tsx
@@ -25,7 +25,7 @@ import React, {
   type ReactNode,
 } from 'react';
 
-import type { ExtractProps } from '../../util/utility-types';
+import type { ExtractProps, IconOrContent } from '../../util/utility-types';
 import type { Status } from '../../util/variant-types';
 
 import Checkbox from '../Checkbox';
@@ -217,7 +217,7 @@ type ComboboxInputProps = Omit<
   /**
    * Leading glyph (icon) or content for a selected value's chip, when `multiple` is set.
    */
-  chipLeadingComponent?: (item: ComboboxValue) => IconName | ReactNode;
+  chipLeadingComponent?: (item: ComboboxValue) => IconOrContent;
   /**
    * Icon to use for combobox button, which is only allowed to be 'chevron-down'
    */

--- a/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
+++ b/src/components/Combobox/__snapshots__/Combobox.test.tsx.snap
@@ -577,6 +577,171 @@ exports[`<Combobox /> > Generated Snapshots > MultipleWithChipIcons story render
 </div>
 `;
 
+exports[`<Combobox /> > Generated Snapshots > MultipleWithFpoChipContent story renders snapshot 1`] = `
+<div
+  class="_combobox_ff8210 _combobox--label-layout-vertical_ff8210 w-[320px]"
+  data-headlessui-state="open"
+  data-open=""
+  data-testid="combobox"
+>
+  <div
+    class="_combobox__overline_ff8210"
+  >
+    <label
+      class="_label_76755a _label--md_76755a _combobox__label_ff8210"
+      data-headlessui-state="open"
+      data-open=""
+      for="headlessui-combobox-input-_r_a4_"
+      id="headlessui-label-_r_a3_"
+    >
+      <span
+        class="_text_b3eba3 _text--label-md_b3eba3"
+      >
+        Favorite Animal(s)
+      </span>
+    </label>
+  </div>
+  <div
+    class="_combobox-input_ff8210 _combobox-input--has-chips_ff8210"
+  >
+    <ul
+      class="_combobox-input__chips_ff8210"
+    >
+      <li>
+        <div
+          class="_input-chip_f95fba"
+        >
+          <div
+            class="_input-chip__label_f95fba"
+          >
+            <span
+              class="_input-chip__leading-component_f95fba"
+            >
+              <span
+                aria-hidden="true"
+                class="fpo"
+                style="height: 14px; width: 14px; font-size: 5px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </span>
+            <span
+              class="_text_b3eba3 _text--body-xs_b3eba3"
+            >
+              Dogs
+            </span>
+          </div>
+          <button
+            class="_input-chip__action-button_f95fba"
+          >
+            <svg
+              class="_icon_779da8"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Dogs
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+      <li>
+        <div
+          class="_input-chip_f95fba"
+        >
+          <div
+            class="_input-chip__label_f95fba"
+          >
+            <span
+              class="_input-chip__leading-component_f95fba"
+            >
+              <span
+                aria-hidden="true"
+                class="fpo"
+                style="height: 14px; width: 14px; font-size: 5px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+              />
+            </span>
+            <span
+              class="_text_b3eba3 _text--body-xs_b3eba3"
+            >
+              Cats
+            </span>
+          </div>
+          <button
+            class="_input-chip__action-button_f95fba"
+          >
+            <svg
+              class="_icon_779da8"
+              fill="currentColor"
+              role="img"
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <title>
+                remove Cats
+              </title>
+              <path
+                d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+              />
+            </svg>
+          </button>
+        </div>
+      </li>
+    </ul>
+    <input
+      aria-activedescendant="headlessui-combobox-option-_r_a9_"
+      aria-autocomplete="list"
+      aria-controls="headlessui-combobox-options-_r_a6_"
+      aria-expanded="true"
+      aria-labelledby="headlessui-label-_r_a3_"
+      class="_combobox-input__field_ff8210"
+      data-focus=""
+      data-headlessui-state="open focus"
+      data-open=""
+      data-testid="input-button"
+      id="headlessui-combobox-input-_r_a4_"
+      role="combobox"
+      style="--combobox__input-width: calc(0 * 1ch);"
+      type="text"
+    />
+    <button
+      aria-controls="headlessui-combobox-options-_r_a6_"
+      aria-expanded="true"
+      aria-haspopup="listbox"
+      aria-label="Show options"
+      aria-labelledby="headlessui-label-_r_a3_ headlessui-combobox-button-_r_a5_"
+      class="_combobox-input__button_ff8210"
+      data-active=""
+      data-headlessui-state="open active hover"
+      data-hover=""
+      data-open=""
+      id="headlessui-combobox-button-_r_a5_"
+      tabindex="-1"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="_icon_779da8 _combobox-input__icon_ff8210 _combobox-input__icon--reversed_ff8210"
+        fill="currentColor"
+        height="24px"
+        style="--icon-size: 24px;"
+        viewBox="0 0 24 24"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9999 15.0542L6.34619 9.40043L7.39994 8.34668L11.9999 12.9467L16.5999 8.34668L17.6537 9.40043L11.9999 15.0542Z"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Combobox /> > Generated Snapshots > MultipleWithManySelected story renders snapshot 1`] = `
 <div
   class="_combobox_ff8210 _combobox--label-layout-vertical_ff8210 w-[240px]"

--- a/src/components/FieldNote/FieldNote.stories.tsx
+++ b/src/components/FieldNote/FieldNote.stories.tsx
@@ -4,6 +4,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite' with {
 import React from 'react';
 
 import { FieldNote } from './FieldNote';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import Link from '../Link';
 import Text from '../Text';
 
@@ -32,7 +33,6 @@ export const WithErrorIcon: Story = {
   args: {
     children: 'This is a fieldnote.',
     id: 'field-1',
-    icon: 'warning-filled',
     status: 'critical',
   },
 };
@@ -49,7 +49,6 @@ export const WithWarningIcon: Story = {
   args: {
     children: 'This is a fieldnote.',
     id: 'field-1',
-    icon: 'warning-filled',
     status: 'warning',
   },
 };
@@ -69,5 +68,29 @@ export const WithText: Story = {
       </div>
     ),
     id: 'field-1',
+  },
+};
+
+/**
+ * The leading slot takes arbitrary content, not only an EDS icon name. The block below
+ * stands in for whatever you supply, so the slot itself is the subject rather than the icon
+ * that happened to be picked.
+ */
+export const WithFpoIconContent: Story = {
+  args: {
+    ...Default.args,
+    icon: <FpoBlock size={16} />,
+  },
+};
+
+/**
+ * `status` supplies this slot's default rather than overriding it, so a note can carry the
+ * critical treatment and still show your own content. The status is announced from the
+ * note's own treatment; content you pass carries its own accessible treatment.
+ */
+export const WithFpoIconContentAndStatus: Story = {
+  args: {
+    ...WithFpoIconContent.args,
+    status: 'critical',
   },
 };

--- a/src/components/FieldNote/FieldNote.tsx
+++ b/src/components/FieldNote/FieldNote.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
 import type { ReactNode } from 'react';
 import React from 'react';
+import getIconNameFromStatus from '../../util/getIconNameFromStatus';
+import type { IconOrContent } from '../../util/utility-types';
 import type { Status } from '../../util/variant-types';
-import Icon from '../Icon';
-import type { IconName } from '../Icon';
+import { hasSlotContent, IconSlot } from '../Icon';
 import Text from '../Text';
 import styles from './FieldNote.module.css';
 
@@ -27,14 +28,17 @@ export type FieldNoteProps = {
    */
   disabled?: boolean;
   /**
-   * Icon to use when an "icon" variant of the avatar.
+   * Leading slot for the note. Takes an EDS icon name, or any content to render in its
+   * place at 16px.
    *
-   * **Default is `"critical"`**.
+   * `status` supplies this slot's default, so setting `status` alone renders that status's
+   * icon. An explicit value here wins over that default, and the status treatment (colour,
+   * and the announced "error"/"warning") still applies.
+   *
+   * Custom content is rendered as-is and carries its own accessible treatment, so it does
+   * not receive the status title an icon name would.
    */
-  icon?: Extract<
-    IconName,
-    'critical-encircled-filled' | 'dangerous' | 'warning-filled'
-  >;
+  icon?: IconOrContent;
   /**
    * Status for the field state
    *
@@ -80,15 +84,25 @@ export const FieldNote = ({
     className,
   );
 
-  let iconToUse = icon;
-  let title = 'fieldnote status icon';
-  if (status === 'critical') {
-    iconToUse = 'critical-encircled-filled';
-    title = 'error';
-  } else if (status === 'warning') {
-    iconToUse = 'warning-filled';
-    title = 'warning';
-  }
+  const hasStatusIcon = status === 'critical' || status === 'warning';
+
+  // `status` is a default for the slot, not an override of it. An explicitly passed value
+  // losing to an inferred one is the surprising direction, and it would silently drop a
+  // consumer's own content the moment a status was set.
+  const iconToUse = hasSlotContent(icon)
+    ? icon
+    : hasStatusIcon
+      ? getIconNameFromStatus(status)
+      : undefined;
+
+  // Describes the status rather than whichever icon renders, so it stays correct when a
+  // consumer swaps the icon out. `IconSlot` applies it to an icon name only.
+  const title =
+    status === 'critical'
+      ? 'error'
+      : status === 'warning'
+        ? 'warning'
+        : 'fieldnote status icon';
 
   return (
     <div
@@ -97,15 +111,13 @@ export const FieldNote = ({
       id={id}
       {...other}
     >
-      {(status === 'critical' || status === 'warning' || iconToUse) && (
-        <Icon
-          className={styles['field-note__icon']}
-          name={iconToUse}
-          purpose="informative"
-          size="16px"
-          title={title}
-        />
-      )}
+      <IconSlot
+        className={styles['field-note__icon']}
+        content={iconToUse}
+        purpose="informative"
+        size="16px"
+        title={title}
+      />
       <Text as="span" preset="body-sm">
         {children}
       </Text>

--- a/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
+++ b/src/components/FieldNote/__snapshots__/FieldNote.test.ts.snap
@@ -43,6 +43,50 @@ exports[`<FieldNote /> > WithErrorIcon story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<FieldNote /> > WithFpoIconContent story renders snapshot 1`] = `
+<div
+  class="_field-note_fd2e78"
+  id="field-1"
+>
+  <span
+    class="_field-note__icon_fd2e78"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+  </span>
+  <span
+    class="_text_b3eba3 _text--body-sm_b3eba3"
+  >
+    This is a fieldnote.
+  </span>
+</div>
+`;
+
+exports[`<FieldNote /> > WithFpoIconContentAndStatus story renders snapshot 1`] = `
+<div
+  class="_field-note_fd2e78 _field-note--error_fd2e78"
+  id="field-1"
+>
+  <span
+    class="_field-note__icon_fd2e78"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+  </span>
+  <span
+    class="_text_b3eba3 _text--body-sm_b3eba3"
+  >
+    This is a fieldnote.
+  </span>
+</div>
+`;
+
 exports[`<FieldNote /> > WithLongText story renders snapshot 1`] = `
 <div
   class="_field-note_fd2e78 _field-note--error_fd2e78"

--- a/src/components/InputChip/InputChip.stories.tsx
+++ b/src/components/InputChip/InputChip.stories.tsx
@@ -1,9 +1,10 @@
 import type { StoryObj, Meta } from '@storybook/react-vite' with {
   'resolution-mode': 'import',
 };
-import type React from 'react';
+import React from 'react';
 
 import { InputChip } from './InputChip';
+import FpoBlock from '../../storyUtils/FpoBlock';
 
 export default {
   title: 'Components/InputChip',
@@ -45,5 +46,20 @@ export const Disabled: StoryObj<Args> = {
   args: {
     ...Default.args,
     isDisabled: true,
+  },
+};
+
+/**
+ * The leading slot takes arbitrary content, not only an EDS icon name. The block below
+ * stands in for whatever you supply, so the slot itself is the subject rather than the icon
+ * that happened to be picked.
+ *
+ * The slot's icon carries no explicit size, so it falls back to `1em` and resolves to 14px
+ * against the chip's own type. The block matches that.
+ */
+export const WithFpoLeadingContent: StoryObj<Args> = {
+  args: {
+    ...Default.args,
+    leadingComponent: <FpoBlock size={14} />,
   },
 };

--- a/src/components/InputChip/InputChip.tsx
+++ b/src/components/InputChip/InputChip.tsx
@@ -1,7 +1,8 @@
 import clsx from 'clsx';
 import React, { type MouseEventHandler } from 'react';
+import type { IconOrContent } from '../../util/utility-types';
 import type { Size } from '../../util/variant-types';
-import Icon, { type IconName } from '../Icon';
+import Icon, { IconSlot } from '../Icon';
 import Text from '../Text';
 
 import styles from './InputChip.module.css';
@@ -22,9 +23,10 @@ export type InputChipProps = {
    */
   label: string;
   /**
-   * Leading glyph (icon) for the chip
+   * Leading slot for the chip. Takes an EDS icon name, or any content to render in its
+   * place at the chip's own type size.
    */
-  leadingComponent: IconName | React.ReactNode;
+  leadingComponent?: IconOrContent;
   /**
    * click handler for the action button on the chip (ex: to dismiss or remove the chip from the screen)
    */
@@ -77,13 +79,11 @@ export const InputChip = ({
   return (
     <div className={componentClassName} {...other}>
       <div className={styles['input-chip__label']}>
-        {leadingComponent && typeof leadingComponent === 'string' && (
-          <Icon
-            className={styles['input-chip__leading-component']}
-            name={leadingComponent as IconName}
-            purpose="decorative"
-          />
-        )}
+        <IconSlot
+          className={styles['input-chip__leading-component']}
+          content={leadingComponent}
+          purpose="decorative"
+        />
         <Text as="span" preset="body-xs">
           {label}
         </Text>

--- a/src/components/InputChip/__snapshots__/InputChip.test.ts.snap
+++ b/src/components/InputChip/__snapshots__/InputChip.test.ts.snap
@@ -69,6 +69,49 @@ exports[`<InputChip /> > Disabled story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<InputChip /> > WithFpoLeadingContent story renders snapshot 1`] = `
+<div
+  class="_input-chip_f95fba"
+>
+  <div
+    class="_input-chip__label_f95fba"
+  >
+    <span
+      class="_input-chip__leading-component_f95fba"
+    >
+      <span
+        aria-hidden="true"
+        class="fpo"
+        style="height: 14px; width: 14px; font-size: 5px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+      />
+    </span>
+    <span
+      class="_text_b3eba3 _text--body-xs_b3eba3"
+    >
+      Chip Label
+    </span>
+  </div>
+  <button
+    class="_input-chip__action-button_f95fba"
+  >
+    <svg
+      class="_icon_779da8"
+      fill="currentColor"
+      role="img"
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title>
+        remove Chip Label
+      </title>
+      <path
+        d="M6.39994 18.6542L5.34619 17.6004L10.9462 12.0004L5.34619 6.40043L6.39994 5.34668L11.9999 10.9467L17.5999 5.34668L18.6537 6.40043L13.0537 12.0004L18.6537 17.6004L17.5999 18.6542L11.9999 13.0542L6.39994 18.6542Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`<InputChip /> > WithLeadingIcon story renders snapshot 1`] = `
 <div
   class="_input-chip_f95fba"

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -9,6 +9,7 @@ import type { MenuProps } from './Menu';
 import icons from '../../icons/spritemap';
 
 import type { IconName } from '../../icons/spritemap';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import { Avatar } from '../Avatar/Avatar';
 import Button from '../Button';
 import { Icon } from '../Icon/Icon';
@@ -108,8 +109,9 @@ const menuItems = (
 
 /**
  * The Default `Menu` allows for clickable menu items, and provides a default trigger
- * button that applies `Button` with `rank` as `"primary"`, `iconLayout` as `"right"`, `icon`
- * either missing, or set to `"chevron-down"`, and a configurable text label.
+ * button that applies `Button` with `rank` as `"primary"`, `iconLayout` as `"right"`,
+ * `trailingContent` either missing, or set to `"chevron-down"`, and a configurable text
+ * label.
  */
 export const Default: Story = {
   args: {
@@ -163,17 +165,21 @@ export const WithShortButtonText: Story = {
         <Menu.Items data-testid="menu-content">
           <Menu.Item
             href="https://headlessui.com/react/menu#menu-button"
-            icon="link"
+            leadingContent="link"
           >
             Headless UI Docs
           </Menu.Item>
           <Menu.Item
             href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu"
-            icon="link"
+            leadingContent="link"
           >
             MDN: Menu
           </Menu.Item>
-          <Menu.Item disabled href="https://example.org/" icon="warning-filled">
+          <Menu.Item
+            disabled
+            href="https://example.org/"
+            leadingContent="warning-filled"
+          >
             Not Possible (disabled)
           </Menu.Item>
         </Menu.Items>
@@ -258,7 +264,7 @@ export const Opened: Story = {
 };
 
 /**
- * For testing purposes: This triggers an open menu that has no icons.
+ * For testing purposes: This triggers an open menu with the leading slot left empty.
  */
 export const IconlessOpened: Story = {
   ...WithLongButtonText,
@@ -303,3 +309,23 @@ export const MenuWithIconButton: StoryObj<MenuProps & { iconName: IconName }> =
       </Menu>
     ),
   };
+
+/**
+ * `Menu.Button`'s trailing slot takes arbitrary content, not only an EDS icon name. The
+ * block below stands in for whatever you supply, so the slot itself is the subject rather
+ * than the chevron that would otherwise fill it.
+ *
+ * The slot renders through `Button` at its default `size="lg"`, so the block is 24px.
+ */
+export const WithFpoButtonTrailingContent: Story = {
+  args: {
+    children: (
+      <>
+        <Menu.Button trailingContent={<FpoBlock size={24} />}>
+          Actions
+        </Menu.Button>
+        {menuItems}
+      </>
+    ),
+  },
+};

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -194,7 +194,7 @@ const MenuItems = ({
 };
 
 /**
- * An individual option that represent an action in the menu. Can contain leading content, label, sublabel, and action (onClick).
+ * An individual option that represents an action in the menu. Can contain leading content, label, sublabel, and action (onClick).
  *
  * NOTE: for menus, all menu items should fill the leading slot, or none should; mixing the two is discouraged.
  *

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -16,10 +16,9 @@ import type {
 } from 'react';
 import React from 'react';
 
-import type { ExtractProps } from '../../util/utility-types';
+import type { ExtractProps, IconOrContent } from '../../util/utility-types';
 
 import Button from '../Button';
-import { type IconName } from '../Icon';
 
 import PopoverContainer from '../PopoverContainer';
 
@@ -46,9 +45,10 @@ export type MenuButtonProps = {
    */
   className?: string;
   /**
-   * Icon override for component. Default is 'chevron-down'
+   * Trailing slot for the button, sitting after `children`. Takes an EDS icon name, or any
+   * content to render in its place. Default is 'chevron-down'
    */
-  icon?: Extract<IconName, 'chevron-down'>; // TODO(next-major): change to `leadingContent`
+  trailingContent?: IconOrContent;
 };
 
 export type MenuSeparatorProps = ExtractProps<typeof HeadlessMenuSeparator>;
@@ -65,11 +65,6 @@ export type MenuItemProps = ExtractProps<typeof HeadlessMenuItem> &
      * Target URL for the menu item action
      */
     href?: string;
-    /**
-     * Icons are able to appear next to each Option in the Options list if it is relevant; before using any icons, please refer to the appropriate icon usage guidelines. Deprecated in favor of `leadingContent`
-     * @deprecated
-     */
-    icon?: IconName;
     /**
      * Configurable action for the menu item upon click
      */
@@ -122,7 +117,7 @@ export const Menu = ({ className, ...other }: MenuProps) => {
 const MenuButton = ({
   children,
   className,
-  icon = 'chevron-down',
+  trailingContent = 'chevron-down',
   ...other
 }: MenuButtonProps) => {
   const buttonClassNames = clsx(styles['menu__button'], className);
@@ -130,7 +125,7 @@ const MenuButton = ({
     <HeadlessMenuButton as={React.Fragment}>
       <Button
         className={buttonClassNames}
-        icon={icon}
+        icon={trailingContent}
         iconLayout="right"
         rank="primary"
         {...other}
@@ -199,9 +194,9 @@ const MenuItems = ({
 };
 
 /**
- * An individual option that represent an action in the menu. Can contain an icon, label, sublabel, and action (onClick).
+ * An individual option that represent an action in the menu. Can contain leading content, label, sublabel, and action (onClick).
  *
- * NOTE: for menus, all menu items should have an icon, or no icon; mixing icon state is discouraged.
+ * NOTE: for menus, all menu items should fill the leading slot, or none should; mixing the two is discouraged.
  *
  * @see https://headlessui.com/react/menu#menu-item
  */
@@ -212,7 +207,6 @@ const MenuItem = ({
   onClick,
   target,
   // Props from PopoverListItem
-  icon,
   isDestructiveAction,
   isFocused,
   isDisabled,
@@ -243,7 +237,6 @@ const MenuItem = ({
           <PopoverListItem
             __type={__type}
             className={className}
-            icon={icon}
             isDestructiveAction={isDestructiveAction}
             isDisabled={disabled}
             isFocused={focus}

--- a/src/components/Menu/__snapshots__/Menu.test.tsx.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.tsx.snap
@@ -159,6 +159,39 @@ exports[`<Menu /> > WithCustomSecondaryButton story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<Menu /> > WithFpoButtonTrailingContent story renders snapshot 1`] = `
+<div
+  class="p-spacing-size-4"
+>
+  <div
+    class="_menu_33ee5b"
+    data-headlessui-state=""
+  >
+    <button
+      aria-expanded="false"
+      aria-haspopup="menu"
+      class="_button_0829c1 _button--layout-right_0829c1 _button--primary_0829c1 _button--lg_0829c1 _button--size-lg_0829c1 _button--variant-default_0829c1 _menu__button_33ee5b"
+      data-headlessui-state=""
+      id="headlessui-menu-button-_r_1c_"
+      type="button"
+    >
+      <span
+        class="_text_b3eba3 _text--label-lg_b3eba3 _button__text_0829c1"
+      >
+        Actions
+        <span
+          aria-hidden="true"
+          class="fpo"
+          style="height: 24px; width: 24px; font-size: 9px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+        >
+          FPO
+        </span>
+      </span>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`<Menu /> > WithLongButtonText story renders snapshot 1`] = `
 <div
   class="p-spacing-size-4"

--- a/src/components/PopoverContainer/PopoverContainer.stories.tsx
+++ b/src/components/PopoverContainer/PopoverContainer.stories.tsx
@@ -33,12 +33,12 @@ export const Default: StoryObj<typeof PopoverContainer> = {
     children: (
       <>
         <div aria-label="test items" role="group">
-          <PopoverListItem icon="arrow-down">test 1</PopoverListItem>
-          <PopoverListItem icon="arrow-left">test 2</PopoverListItem>
-          <PopoverListItem icon="arrow-up">test 3</PopoverListItem>
+          <PopoverListItem leadingContent="arrow-down">test 1</PopoverListItem>
+          <PopoverListItem leadingContent="arrow-left">test 2</PopoverListItem>
+          <PopoverListItem leadingContent="arrow-up">test 3</PopoverListItem>
         </div>
         <div aria-label="actions" role="group">
-          <PopoverListItem icon="arrow-right" isDestructiveAction>
+          <PopoverListItem isDestructiveAction leadingContent="arrow-right">
             Delete All
           </PopoverListItem>
         </div>

--- a/src/components/PopoverListItem/PopoverListItem.stories.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.stories.tsx
@@ -22,9 +22,6 @@ export default {
   },
   tags: ['autodocs', 'version:2.1.1'],
   argTypes: {
-    icon: {
-      table: { disable: true },
-    },
     leadingContent: {
       control: false,
     },
@@ -63,7 +60,7 @@ export const DefaultWithTrailingContent: Story = {
 };
 
 /**
- * Note: using `__type` list item b/c there is no icon to display. Other types preserve icon space for checkboxes.
+ * Note: using `__type` list item b/c there is no leading content to display. Other types preserve that space for checkboxes.
  */
 export const WithNoIcon: Story = {
   args: {
@@ -78,7 +75,7 @@ export const WithNoIcon: Story = {
 /**
  * Popover list items can be disabled, and ignore all user interaction.
  *
- * Note: using `__type` list item b/c there is no icon to display
+ * Note: using `__type` list item b/c there is no leading content to display
  */
 export const Disabled: Story = {
   args: {

--- a/src/components/PopoverListItem/PopoverListItem.tsx
+++ b/src/components/PopoverListItem/PopoverListItem.tsx
@@ -1,7 +1,9 @@
 import clsx from 'clsx';
 import React, { type ReactNode } from 'react';
 
-import Icon, { type IconName } from '../Icon';
+import type { IconOrContent } from '../../util/utility-types';
+
+import { hasSlotContent, IconSlot } from '../Icon';
 import Text from '../Text';
 import styles from './PopoverListItem.module.css';
 
@@ -18,11 +20,6 @@ export type PopoverListItemProps = {
   __type?: 'selectitem' | 'listitem' | 'label' | 'separator' | 'caption';
   // Design API
   /**
-   * Icon from the set of defined EDS icon set. This prop is deprecated in favor of `leadingContent`.
-   * @deprecated
-   */
-  icon?: IconName;
-  /**
    * Handling behavior for whether the marked menu item is destructive or not (deletes, removes, etc.)
    */
   isDestructiveAction?: boolean;
@@ -35,9 +32,10 @@ export type PopoverListItemProps = {
    */
   isDisabled?: boolean;
   /**
-   * Content (icon, text, other component) to appear at the start of the list item. Recommended maximum size of 24 pixels.
+   * Content to appear at the start of the list item. Takes an EDS icon name, or any content
+   * to render in its place at 24px.
    */
-  leadingContent?: ReactNode;
+  leadingContent?: IconOrContent;
   /**
    * Text below the main menu item call-to-action, briefly describing the menu item's function
    */
@@ -73,7 +71,6 @@ export const PopoverListItem = React.forwardRef<
       isDisabled = false,
       isFocused = false,
       children,
-      icon,
       leadingContent,
       subLabel,
       trailingContent,
@@ -104,10 +101,13 @@ export const PopoverListItem = React.forwardRef<
         {...ariaIsDisabled}
         ref={ref}
       >
-        {icon || leadingContent ? (
+        {hasSlotContent(leadingContent) ? (
           <div className={styles['popover-list-item__leading-content']}>
-            {icon && <Icon name={icon} purpose="decorative" size="24px" />}
-            {leadingContent}
+            <IconSlot
+              content={leadingContent}
+              purpose="decorative"
+              size="24px"
+            />
           </div>
         ) : (
           <div className={styles['popover-list-item__no-icon']}></div>

--- a/src/components/TabGroup/TabGroup.stories.tsx
+++ b/src/components/TabGroup/TabGroup.stories.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import { within } from 'storybook/test';
 
 import { TabGroup } from './TabGroup';
+import FpoBlock from '../../storyUtils/FpoBlock';
 import { chromaticViewports } from '../../util/viewports';
 import Heading from '../Heading';
 import Text from '../Text';
@@ -418,5 +419,43 @@ export const ScrollMiddle: StoryObj<Args> = {
       value: 'googlePixel2',
       isRotated: false,
     },
+  },
+};
+
+/**
+ * A tab's leading slot takes arbitrary content, not only an EDS icon name. The blocks below
+ * stand in for whatever you supply, so the slot itself is the subject rather than the icon
+ * that happened to be picked.
+ */
+export const WithFpoTabContent: StoryObj<Args> = {
+  args: {
+    ...Centered.args,
+    children: (
+      <>
+        <TabGroup.Tab icon={<FpoBlock size={16} />} title="Tab Title 1">
+          <div className="max-w-[576px]">
+            <Heading as="h3" className="mb-spacing-size-3">
+              Tab 1
+            </Heading>
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Text>
+          </div>
+        </TabGroup.Tab>
+
+        <TabGroup.Tab icon={<FpoBlock size={16} />} title="Tab Title 2">
+          <div className="max-w-[576px]">
+            <Heading as="h3" className="mb-spacing-size-3">
+              Tab 2
+            </Heading>
+            <Text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+              eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </Text>
+          </div>
+        </TabGroup.Tab>
+      </>
+    ),
   },
 };

--- a/src/components/TabGroup/TabGroup.tsx
+++ b/src/components/TabGroup/TabGroup.tsx
@@ -18,9 +18,9 @@ import {
   R_ARROW_KEYCODE,
   D_ARROW_KEYCODE,
 } from '../../util/keycodes';
-import type { RenderProps } from '../../util/utility-types';
+import type { IconOrContent, RenderProps } from '../../util/utility-types';
 import type { Align } from '../../util/variant-types';
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 
 import styles from './TabGroup.module.css';
 
@@ -107,9 +107,10 @@ export type TabProps = {
    */
   title: string;
   /**
-   * Icon name from the defined set of EDS icons
+   * Leading slot for the tab. Takes an EDS icon name, or any content to render in its
+   * place at 16px.
    */
-  icon?: IconName;
+  icon?: IconOrContent;
 };
 
 type TabButtonProps = RenderProps<TabContextArgs>;
@@ -381,14 +382,12 @@ export const TabGroup = ({
                   role="tab"
                   tabIndex={isActive ? 0 : -1}
                 >
-                  {tab.props.icon && (
-                    <Icon
-                      className={styles['tab__icon']}
-                      name={tab.props.icon}
-                      purpose="decorative"
-                      size="16px"
-                    />
-                  )}
+                  <IconSlot
+                    className={styles['tab__icon']}
+                    content={tab.props.icon}
+                    purpose="decorative"
+                    size="16px"
+                  />
                   {typeof tabButton?.props.children === 'function'
                     ? tabButton.props.children({
                         isActive,

--- a/src/components/TabGroup/__snapshots__/TabGroup.test.tsx.snap
+++ b/src/components/TabGroup/__snapshots__/TabGroup.test.tsx.snap
@@ -484,6 +484,103 @@ exports[`<TabGroup /> > TabWidthFull story renders snapshot 1`] = `
 </div>
 `;
 
+exports[`<TabGroup /> > WithFpoTabContent story renders snapshot 1`] = `
+<div
+  class="_tabs_5bfe90"
+>
+  <div
+    class="_tabs__header_5bfe90 _tabs--has-divider_5bfe90 _tabs__header--variant-default_5bfe90"
+  >
+    <ul
+      class="_tabs__list_5bfe90 _tabs--has-divider_5bfe90 _tabs__list--align-center_5bfe90 _tabs__list--variant-default_5bfe90"
+      role="tablist"
+    >
+      <li
+        class="_tabs__item_5bfe90 _eds-is-active_5bfe90"
+        role="presentation"
+      >
+        <a
+          aria-controls="_r_a_"
+          aria-selected="true"
+          class="_tabs__link_5bfe90"
+          href="#_r_a_"
+          id="_r_b_-Tab-Title-1"
+          role="tab"
+          tabindex="0"
+        >
+          <span
+            class="_tab__icon_5bfe90"
+          >
+            <span
+              aria-hidden="true"
+              class="fpo"
+              style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+            />
+          </span>
+          Tab Title 1
+          <div
+            aria-hidden="true"
+            class="_tab__highlight_5bfe90"
+          />
+        </a>
+      </li>
+      <li
+        class="_tabs__item_5bfe90"
+        role="presentation"
+      >
+        <a
+          aria-controls="_r_a_"
+          aria-selected="false"
+          class="_tabs__link_5bfe90"
+          href="#_r_a_"
+          id="_r_b_-Tab-Title-2"
+          role="tab"
+          tabindex="-1"
+        >
+          <span
+            class="_tab__icon_5bfe90"
+          >
+            <span
+              aria-hidden="true"
+              class="fpo"
+              style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+            />
+          </span>
+          Tab Title 2
+          <div
+            aria-hidden="true"
+            class="_tab__highlight_5bfe90"
+          />
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div>
+    <div
+      aria-hidden="false"
+      aria-labelledby="_r_b_-Tab-Title-1"
+      id="_r_a_"
+      role="tabpanel"
+    >
+      <div
+        class="max-w-[576px]"
+      >
+        <h3
+          class="_text_b3eba3 _text--headline-sm_b3eba3 mb-spacing-size-3"
+        >
+          Tab 1
+        </h3>
+        <p
+          class="_text_b3eba3 _text--body-md_b3eba3"
+        >
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`<TabGroup /> > WithTabIcons story renders snapshot 1`] = `
 <div
   class="_tabs_5bfe90"

--- a/src/components/Tag/Tag.stories.tsx
+++ b/src/components/Tag/Tag.stories.tsx
@@ -3,6 +3,7 @@ import type { StoryObj, Meta } from '@storybook/react-vite' with {
 };
 import React from 'react';
 import { Tag } from './Tag';
+import FpoBlock from '../../storyUtils/FpoBlock';
 
 export default {
   title: 'Components/Tag',
@@ -67,5 +68,17 @@ export const LowEmphasisInformational: Story = {
     label: 'API Docs',
     emphasis: 'low',
     status: 'informational',
+  },
+};
+
+/**
+ * The leading slot takes arbitrary content, not only an EDS icon name. The block below
+ * stands in for whatever you supply, so the slot itself is the subject rather than the icon
+ * that happened to be picked.
+ */
+export const WithFpoIconContent: Story = {
+  ...Default,
+  args: {
+    icon: <FpoBlock size={16} />,
   },
 };

--- a/src/components/Tag/Tag.tsx
+++ b/src/components/Tag/Tag.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
 import React from 'react';
 import { assertEdsUsage } from '../../util/logging';
+import type { IconOrContent } from '../../util/utility-types';
 import type { Emphasis, Status } from '../../util/variant-types';
 
-import Icon, { type IconName } from '../Icon';
+import { IconSlot } from '../Icon';
 import { InternalText } from '../Text/Text';
 
 import styles from './Tag.module.css';
@@ -30,9 +31,10 @@ type Props = {
    */
   emphasis?: Emphasis;
   /**
-   * Icon name from the defined set of EDS icons
+   * Leading slot for the tag. Takes an EDS icon name, or any content to render in its
+   * place at 16px.
    */
-  icon?: IconName;
+  icon?: IconOrContent;
   /**
    * The text contents of the tag, nested inside the component.
    */
@@ -118,7 +120,7 @@ export const Tag = ({
       preset="tag"
       style={style}
     >
-      {icon && <Icon name={icon} purpose="decorative" size="16px" />}
+      <IconSlot content={icon} purpose="decorative" size="16px" />
       {label && <span className={styles['tag__body']}>{label}</span>}
     </InternalText>
   );

--- a/src/components/Tag/__snapshots__/Tag.test.ts.snap
+++ b/src/components/Tag/__snapshots__/Tag.test.ts.snap
@@ -69,6 +69,69 @@ exports[`<Tag /> > LowEmphasisInformational story renders snapshot 1`] = `
 </span>
 `;
 
+exports[`<Tag /> > WithFpoIconContent story renders snapshot 1`] = `
+<div
+  class="gap-spacing-size-2 flex"
+>
+  <span
+    class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-informational_f57044"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+    <span
+      class="_tag__body_f57044"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-favorable_f57044"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+    <span
+      class="_tag__body_f57044"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-warning_f57044"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+    <span
+      class="_tag__body_f57044"
+    >
+      Tag text
+    </span>
+  </span>
+  <span
+    class="_text_b3eba3 _text--tag_b3eba3 _tag_f57044 _tag--emphasis-high_f57044 _tag--status-critical_f57044"
+  >
+    <span
+      aria-hidden="true"
+      class="fpo"
+      style="height: 16px; width: 16px; font-size: 6px; line-height: 1; overflow: hidden; padding: 0px; flex-grow: 0; flex-shrink: 0; flex-basis: auto;"
+    />
+    <span
+      class="_tag__body_f57044"
+    >
+      Tag text
+    </span>
+  </span>
+</div>
+`;
+
 exports[`<Tag /> > WithIcon story renders snapshot 1`] = `
 <div
   class="gap-spacing-size-2 flex"

--- a/src/storyUtils/FpoBlock.tsx
+++ b/src/storyUtils/FpoBlock.tsx
@@ -18,11 +18,11 @@ type FpoBlockProps = {
    *
    * Always pass the size of the icon the slot itself renders, so the block occupies the
    * same space the icon did and the story's layout does not change. Those sizes are set
-   * per component, not shared: `IconSlot` is given `24px` in `Accordion` and
-   * `InputField`, `16px` in `DataTable`, and no size at all in `SelectionChip`, where
-   * `Icon` falls back to `1em` and resolves to 14px against the chip's own type. Slots
-   * that take a bare `ReactNode` with no `IconSlot`, like `PopoverListItem`, document a
-   * recommended maximum of 24px.
+   * per component, not shared: `IconSlot` is given `24px` in `Accordion`, `InputField`,
+   * and `PopoverListItem`, `16px` in `DataTable`, and no size at all in `SelectionChip`
+   * and `InputChip`, where `Icon` falls back to `1em` and resolves to 14px against the
+   * chip's own type. `Avatar`, `Button`, and `Card` size their slot from the component's
+   * own `size` prop, so those need a block per size.
    */
   size?: number;
 };


### PR DESCRIPTION
EDS-2000 turned the leading and trailing icon props into content slots backed by `IconSlot`, and stopped there. Every standalone `icon` prop was still `IconName` only, so the same slot idea was applied inconsistently: `PopoverListItem.leadingContent` took an avatar while `Avatar.icon`, `Button.icon`, `Card.icon`, and `Tag.icon` took a string and nothing else.

These props now take `IconOrContent` and render through `IconSlot`, so a string is still an EDS icon name and anything else renders as-is: `Avatar.icon`, `Button.icon`, `Card.Header.icon`, `FieldNote.icon`, `InputChip.leadingComponent`, `Menu.Button.trailingContent`, `PopoverListItem.leadingContent`, `TabGroup.Tab.icon`, and `Tag.icon`. `Icon.name` stays `IconName` — it is the thing doing the rendering, not a slot.

Passing an icon name renders exactly what it did before, which the snapshots show: the diff to every pre-existing story is zero, and the snapshot diff is insertions only.

### `InputChip.leadingComponent` was broken

It was already typed `IconName | ReactNode`, but the render only handled the string branch, so passing a node type-checked and rendered nothing at all. It now renders. `Combobox.chipLeadingComponent` passes straight through to it, so that path is covered and typed the same way.

### Decisions the ticket left open

**`FieldNote`** — `status` used to overwrite `icon` outright. It now supplies the slot's default instead, so an explicit value wins. An explicitly passed prop losing to an inferred one is the surprising direction, and keeping the override would have silently dropped a consumer's content the moment a status was set, which is the same failure `InputChip` had. The status title ("error"/"warning") still describes the status rather than the glyph, so it stays correct when the icon is swapped. The two stories that set `icon` and `status` together were documenting the old override and their `icon` value never rendered, so it is dropped and they render as before. The status icon now comes from `getIconNameFromStatus` rather than a map repeated inline.

**`PopoverListItem.icon` removed.** Worth flagging: `leadingContent` there was a bare `ReactNode` with no `IconSlot`, so the ticket's premise that EDS-2000 had already converted it was not right — a string rendered as raw text. Routing it through `IconSlot` at the same 24px the deprecated prop used makes the two interchangeable, which is what lets the migration be a plain rename. `Menu.Item.icon` went with it.

**`Menu.Button.icon` → `trailingContent`**, not `leadingContent` as its `TODO(next-major)` said. It renders through `Button` with `iconLayout="right"`, so it fills the trailing slot and the TODO named the wrong side. It was also `Extract<IconName, 'chevron-down'>`, a one-value union, so the prop could not change anything until now.

**AppHeader is deliberately left narrow.** The ticket's table listed `NavItem.icon`, but EDS-2133 closed as won't-do because that nav data has to stay serializable, and `NavItem` is plain data, so widening it would reopen what that ticket settled. Its `TODO(next-major)` about icon handling stays for the same reason.

### Stories

Each converted slot gets a story with an FPO block at that slot's own icon size, appended at the end of its stories file so React's `useId` counter stays stable and the snapshot diff is insertions only. `Avatar`, `Button`, and `Card` size their slot from the component's own `size` prop, so those stories carry a block per size.

### Test Plan:

- [x] Wrote/updated [automated tests](https://czi.atlassian.net/wiki/x/Hbl1H)
- [ ] Accepted all chromatic snapshot changes
- [ ] CI tests / new tests are not applicable
- [x] Manually tested my changes, and here are the details:

Lint, typecheck, tests (667 passing), and build all pass. Migration entries added to `18-to-19.ts` with tests, including a guard that `Button.icon` and `Card.Header.icon` are *not* rewritten.

Measured every new FPO story's host element against its icon equivalent in the browser — all exact matches:

| Component | Host | Slot |
|---|---|---|
| Avatar sm/md/lg/xl | 24 / 32 / 48 / 64 square | 16 / 24 / 32 / 40 |
| Button lg/md/sm | 115.22×48, 111.13×32, 75.11×24 | 24 / 16 / 16 |
| Button icon-only | 48 / 32 / 24 square | 24 / 16 / 16 |
| Card.Header sm/md | 400×38, 400×48 | 16 / 24 |
| Tag | 99.45×24, 61.45×18 | 16 |
| TabGroup tabs | 113.47×52, 115.15×52 | 16 |
| FieldNote | 139.77×20 | 16 |
| InputChip | 128.46×36, 97.46×36, 31×36 | 14 (`1em` against the chip's type) |
| Menu trigger | 129.06×48 | 24 |
| PopoverListItem | 200×40 | 24 / 24 |

Card had no existing `Card.Header icon=` story to compare against, so I added a temporary one to measure and removed it.

Chromatic will show intentional diffs for the new FPO stories only.

### Not in scope

`popover-list-item__no-icon` is now a misnomer. The CSS class renames for EDS-2000 landed as their own commit (38ae8d0b), and renaming this one would churn snapshots, so it is left for a follow-up.

BREAKING CHANGE: `PopoverListItem` and `Menu.Item` no longer accept `icon`, and `Menu.Button` no longer accepts `icon`. Run `npx eds-migrate 18-to-19` to move them to `leadingContent` and `trailingContent`. A string passed to `PopoverListItem.leadingContent` is now read as an EDS icon name rather than rendered as text; pass a `Text` node instead if you meant a label.

EDS-2134

🤖 Generated with [Claude Code](https://claude.com/claude-code)
